### PR TITLE
Hotfix/tts text chunker fix

### DIFF
--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -82,7 +82,10 @@ class BaseSynthesizer:
         for char in text:
             buffer += char
             if char in splitters:
-                yield buffer.strip() + " "
+                if buffer != " ":
+                    yield buffer.strip() + " "
+                else:
+                    logger.info(f"In else condition of text chunker where buffer = {buffer}")
                 buffer = ""
 
         if buffer:


### PR DESCRIPTION
In the case of eleven labs when we were chunking the text to send for TTS we had a logical flaw in which we were adding extra spaces. This was leading to an issue when it comes to detecting the end of sythensizer stream logic.