### PR TITLE
Feature/enum refactor issue 265

### DIFF
--- a/bolna/assistant.py
+++ b/bolna/assistant.py
@@ -1,5 +1,7 @@
 from bolna.models import *
 from bolna.agent_manager import AssistantManager
+from bolna.enums.tasks import AudioFormat, PipelineComponent
+from bolna.enums.providers import TelephonyProvider
 
 class Assistant:
     def __init__(self, name = "trial_agent"):
@@ -14,26 +16,26 @@ class Assistant:
         toolchain_args['pipelines'] = pipelines
         tools_config_args['llm_agent'] = llm_agent
         tools_config_args['input'] = {
-            "format": "wav",
-            "provider": "default"
+            "format": AudioFormat.WAV.value,
+            "provider": TelephonyProvider.DEFAULT.value
         }
 
         tools_config_args['output'] = {
-            "format": "wav",
-            "provider": "default"
+            "format": AudioFormat.WAV.value,
+            "provider": TelephonyProvider.DEFAULT.value
         }
         if transcriber is None:
-            pipelines.append(["llm"])
+            pipelines.append([PipelineComponent.LLM.value])
             tools_config_args['transcriber'] = transcriber
         
-        pipeline = ["transcriber", "llm"]
+        pipeline = [PipelineComponent.TRANSCRIBER.value, PipelineComponent.LLM.value]
         if synthesizer is not None:
-            pipeline.append("synthesizer") 
+            pipeline.append(PipelineComponent.SYNTHESIZER.value) 
             tools_config_args["synthesizer"] = synthesizer
         pipelines.append(pipeline)
 
         if enable_textual_input:
-            pipelines.append(["llm"])
+            pipelines.append([PipelineComponent.LLM.value])
         
         toolchain = ToolsChainModel(execution = "parallel", pipelines = pipelines)
         task = Task(tools_config = ToolsConfig(**tools_config_args), toolchain = toolchain, task_type = task_type).dict()

--- a/bolna/enums/__init__.py
+++ b/bolna/enums/__init__.py
@@ -1,0 +1,64 @@
+"""
+Enums package for Bolna - Centralized constants and enums.
+
+This package provides type-safe enums for all hardcoded values in the Bolna codebase,
+improving maintainability, providing IDE autocompletion, and preventing runtime errors.
+"""
+
+from .providers import (
+    SynthesizerProvider,
+    TranscriberProvider, 
+    LLMProvider,
+    TelephonyProvider
+)
+
+from .models import (
+    OpenAIModel,
+    ModelCapability,
+    JSON_CAPABLE_MODELS,
+    supports_json_mode
+)
+
+from .tasks import (
+    TaskType,
+    AudioFormat,
+    AudioEncoding,
+    ResponseFormat,
+    PipelineComponent,
+    ExecutionType
+)
+
+from .constants import (
+    AgentStatus,
+    AgentType,
+    MessageType,
+    LanguageCode
+)
+
+__all__ = [
+    # Providers
+    "SynthesizerProvider",
+    "TranscriberProvider", 
+    "LLMProvider",
+    "TelephonyProvider",
+    
+    # Models
+    "OpenAIModel",
+    "ModelCapability", 
+    "JSON_CAPABLE_MODELS",
+    "supports_json_mode",
+    
+    # Tasks & Formats
+    "TaskType",
+    "AudioFormat", 
+    "AudioEncoding",
+    "ResponseFormat",
+    "PipelineComponent",
+    "ExecutionType",
+    
+    # Constants
+    "AgentStatus",
+    "AgentType",
+    "MessageType", 
+    "LanguageCode",
+]

--- a/bolna/enums/constants.py
+++ b/bolna/enums/constants.py
@@ -1,0 +1,119 @@
+"""
+Constants enums for Bolna - Status values, agent types, and other constants.
+
+This module defines status values, agent types, message types, and other constants used in Bolna.
+"""
+
+from enum import Enum
+
+
+class AgentStatus(str, Enum):
+    """Agent status values."""
+    CREATED = "created"
+    SEEDING = "seeding"
+    ACTIVE = "active"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    DELETED = "deleted"
+
+
+class AgentType(str, Enum):
+    """Agent type identifiers."""
+    SIMPLE_LLM_AGENT = "simple_llm_agent"
+    CONVERSATIONAL_AGENT = "conversational_agent"
+    EXTRACTION_AGENT = "extraction_agent"
+    GRAPH_BASED_AGENT = "graph_based_agent"
+    KNOWLEDGEBASE_AGENT = "knowledgebase_agent"
+    MULTI_AGENT = "multiagent"
+    LLM_AGENT_GRAPH = "llm_agent_graph"
+    GRAPH_AGENT = "graph_agent"
+    OTHER = "other"
+
+
+class MessageType(str, Enum):
+    """Message/data type identifiers."""
+    AUDIO = "audio"
+    TEXT = "text"
+    MARK = "mark"
+    PRE_MARK_MESSAGE = "pre_mark_message"
+
+
+class LanguageCode(str, Enum):
+    """Supported language codes."""
+    ENGLISH = "en"
+    GERMAN = "ge"
+    FRENCH = "fr"
+    SPANISH = "es"
+    PORTUGUESE = "pt"
+    ITALIAN = "it"
+    DUTCH = "nl"
+    POLISH = "pl"
+    RUSSIAN = "ru"
+    JAPANESE = "ja"
+    CHINESE = "zh"
+    KOREAN = "ko"
+    ARABIC = "ar"
+    HINDI = "hi"
+
+
+class AgentFlowType(str, Enum):
+    """Agent flow type identifiers."""
+    STREAMING = "streaming"
+    NON_STREAMING = "non_streaming"
+
+
+# Utility functions for backward compatibility
+def get_all_agent_statuses():
+    """Get all agent status values as a list."""
+    return [status.value for status in AgentStatus]
+
+
+def get_all_agent_types():
+    """Get all agent type values as a list."""
+    return [agent_type.value for agent_type in AgentType]
+
+
+def get_all_message_types():
+    """Get all message type values as a list."""
+    return [msg_type.value for msg_type in MessageType]
+
+
+def get_all_language_codes():
+    """Get all language code values as a list."""
+    return [lang.value for lang in LanguageCode]
+
+
+def is_valid_agent_status(status: str) -> bool:
+    """Check if an agent status string is valid."""
+    try:
+        AgentStatus(status)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_agent_type(agent_type: str) -> bool:
+    """Check if an agent type string is valid."""
+    try:
+        AgentType(agent_type)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_message_type(msg_type: str) -> bool:
+    """Check if a message type string is valid."""
+    try:
+        MessageType(msg_type)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_language_code(lang_code: str) -> bool:
+    """Check if a language code string is valid."""
+    try:
+        LanguageCode(lang_code)
+        return True
+    except ValueError:
+        return False

--- a/bolna/enums/models.py
+++ b/bolna/enums/models.py
@@ -1,0 +1,141 @@
+"""
+Model enums for Bolna - OpenAI model capabilities and compatibility.
+
+This module fixes the hardcoded OpenAI model compatibility issue and provides
+a scalable way to add new models with their capabilities.
+"""
+
+from enum import Enum
+from typing import Set
+
+
+class OpenAIModel(str, Enum):
+    """OpenAI model identifiers."""
+    # GPT-4 models
+    GPT_4O = "gpt-4o"
+    GPT_4O_MINI = "gpt-4o-mini"
+    GPT_4_TURBO = "gpt-4-turbo"
+    GPT_41_NANO = "gpt-4.1-nano"
+    GPT_4_1106_PREVIEW = "gpt-4-1106-preview"
+    
+    # GPT-3.5 models
+    GPT_35_TURBO = "gpt-3.5-turbo"
+    GPT_35_TURBO_16K = "gpt-3.5-turbo-16k"
+    GPT_35_TURBO_1106 = "gpt-3.5-turbo-1106"
+
+
+class ModelCapability(str, Enum):
+    """Model capabilities for feature checking."""
+    JSON_MODE = "json_mode"
+    FUNCTION_CALLING = "function_calling"
+    STREAMING = "streaming"
+    VISION = "vision"
+
+
+# Models that support JSON mode - fixes the hardcoded list issue
+JSON_CAPABLE_MODELS: Set[OpenAIModel] = {
+    OpenAIModel.GPT_4O,
+    OpenAIModel.GPT_4O_MINI,
+    OpenAIModel.GPT_4_TURBO,
+    OpenAIModel.GPT_41_NANO,  # NEW: Now supports JSON mode!
+    OpenAIModel.GPT_4_1106_PREVIEW,
+    OpenAIModel.GPT_35_TURBO_1106,
+}
+
+# Models that support function calling
+FUNCTION_CALLING_CAPABLE_MODELS: Set[OpenAIModel] = {
+    OpenAIModel.GPT_4O,
+    OpenAIModel.GPT_4O_MINI,
+    OpenAIModel.GPT_4_TURBO,
+    OpenAIModel.GPT_41_NANO,
+    OpenAIModel.GPT_4_1106_PREVIEW,
+    OpenAIModel.GPT_35_TURBO,
+    OpenAIModel.GPT_35_TURBO_1106,
+}
+
+# Models that support streaming
+STREAMING_CAPABLE_MODELS: Set[OpenAIModel] = {
+    # All OpenAI models support streaming
+    model for model in OpenAIModel
+}
+
+# Models that support vision
+VISION_CAPABLE_MODELS: Set[OpenAIModel] = {
+    OpenAIModel.GPT_4O,
+    OpenAIModel.GPT_4O_MINI,
+    OpenAIModel.GPT_4_TURBO,
+    OpenAIModel.GPT_4_1106_PREVIEW,
+}
+
+
+def supports_json_mode(model: str) -> bool:
+    """
+    Check if a model supports JSON mode.
+    
+    This replaces the hardcoded list in openai_llm.py:199 and now supports
+    newer models like gpt-4.1-nano, gpt-4o, gpt-4-turbo.
+    
+    Args:
+        model: Model identifier string
+        
+    Returns:
+        True if model supports JSON mode, False otherwise
+    """
+    try:
+        model_enum = OpenAIModel(model)
+        return model_enum in JSON_CAPABLE_MODELS
+    except ValueError:
+        # Unknown model, assume it doesn't support JSON mode
+        return False
+
+
+def supports_function_calling(model: str) -> bool:
+    """Check if a model supports function calling."""
+    try:
+        model_enum = OpenAIModel(model)
+        return model_enum in FUNCTION_CALLING_CAPABLE_MODELS
+    except ValueError:
+        return False
+
+
+def supports_streaming(model: str) -> bool:
+    """Check if a model supports streaming."""
+    try:
+        model_enum = OpenAIModel(model)
+        return model_enum in STREAMING_CAPABLE_MODELS
+    except ValueError:
+        return False
+
+
+def supports_vision(model: str) -> bool:
+    """Check if a model supports vision capabilities."""
+    try:
+        model_enum = OpenAIModel(model)
+        return model_enum in VISION_CAPABLE_MODELS
+    except ValueError:
+        return False
+
+
+def get_model_capabilities(model: str) -> Set[ModelCapability]:
+    """Get all capabilities for a given model."""
+    capabilities = set()
+    
+    if supports_json_mode(model):
+        capabilities.add(ModelCapability.JSON_MODE)
+    if supports_function_calling(model):
+        capabilities.add(ModelCapability.FUNCTION_CALLING)
+    if supports_streaming(model):
+        capabilities.add(ModelCapability.STREAMING)
+    if supports_vision(model):
+        capabilities.add(ModelCapability.VISION)
+        
+    return capabilities
+
+
+def is_valid_openai_model(model: str) -> bool:
+    """Check if a model string is a valid OpenAI model."""
+    try:
+        OpenAIModel(model)
+        return True
+    except ValueError:
+        return False

--- a/bolna/enums/providers.py
+++ b/bolna/enums/providers.py
@@ -1,0 +1,116 @@
+"""
+Provider enums for Bolna - Centralized provider constants.
+
+This module defines all supported providers for synthesizers, transcribers, LLMs, and telephony.
+Using these enums ensures type safety and provides IDE autocompletion.
+"""
+
+from enum import Enum
+
+
+class SynthesizerProvider(str, Enum):
+    """Supported Text-to-Speech (TTS) providers."""
+    POLLY = "polly"
+    ELEVENLABS = "elevenlabs"
+    OPENAI = "openai"
+    DEEPGRAM = "deepgram"
+    AZURE_TTS = "azuretts"
+    CARTESIA = "cartesia"
+    SMALLEST = "smallest"
+    SARVAM = "sarvam"
+    RIME = "rime"
+
+
+class TranscriberProvider(str, Enum):
+    """Supported Speech-to-Text (STT) providers."""
+    DEEPGRAM = "deepgram"
+    WHISPER = "whisper"
+    AZURE = "azure"
+    ASSEMBLY_AI = "assemblyai"
+
+
+class LLMProvider(str, Enum):
+    """Supported Large Language Model providers."""
+    OPENAI = "openai"
+    COHERE = "cohere"
+    OLLAMA = "ollama"
+    DEEPINFRA = "deepinfra"
+    TOGETHER = "together"
+    FIREWORKS = "fireworks"
+    AZURE_OPENAI = "azure-openai"
+    PERPLEXITY = "perplexity"
+    VLLM = "vllm"
+    ANYSCALE = "anyscale"
+    CUSTOM = "custom"
+    OLA = "ola"
+    GROQ = "groq"
+    ANTHROPIC = "anthropic"
+    DEEPSEEK = "deepseek"
+    OPENROUTER = "openrouter"
+    AZURE = "azure"  # Backwards compatibility
+
+
+class TelephonyProvider(str, Enum):
+    """Supported telephony/communication providers."""
+    DEFAULT = "default"
+    TWILIO = "twilio"
+    EXOTEL = "exotel"
+    PLIVO = "plivo"
+    DAILY = "daily"
+
+
+# Utility functions for backward compatibility and validation
+def get_all_synthesizer_providers():
+    """Get all synthesizer provider values as a list."""
+    return [provider.value for provider in SynthesizerProvider]
+
+
+def get_all_transcriber_providers():
+    """Get all transcriber provider values as a list."""
+    return [provider.value for provider in TranscriberProvider]
+
+
+def get_all_llm_providers():
+    """Get all LLM provider values as a list."""
+    return [provider.value for provider in LLMProvider]
+
+
+def get_all_telephony_providers():
+    """Get all telephony provider values as a list."""
+    return [provider.value for provider in TelephonyProvider]
+
+
+def is_valid_synthesizer_provider(provider: str) -> bool:
+    """Check if a provider string is a valid synthesizer provider."""
+    try:
+        SynthesizerProvider(provider)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_transcriber_provider(provider: str) -> bool:
+    """Check if a provider string is a valid transcriber provider."""
+    try:
+        TranscriberProvider(provider)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_llm_provider(provider: str) -> bool:
+    """Check if a provider string is a valid LLM provider."""
+    try:
+        LLMProvider(provider)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_telephony_provider(provider: str) -> bool:
+    """Check if a provider string is a valid telephony provider."""
+    try:
+        TelephonyProvider(provider)
+        return True
+    except ValueError:
+        return False

--- a/bolna/enums/tasks.py
+++ b/bolna/enums/tasks.py
@@ -1,0 +1,109 @@
+"""
+Task and format enums for Bolna - Task types, audio formats, and pipeline components.
+
+This module defines task types, audio formats, and pipeline components used throughout Bolna.
+"""
+
+from enum import Enum
+
+
+class TaskType(str, Enum):
+    """Types of tasks that agents can perform."""
+    CONVERSATION = "conversation"
+    EXTRACTION = "extraction"
+    SUMMARIZATION = "summarization"
+    NOTIFICATION = "notification"
+    WEBHOOK = "webhook"
+
+
+class AudioFormat(str, Enum):
+    """Supported audio formats."""
+    WAV = "wav"
+    PCM = "pcm"
+    MP3 = "mp3"
+    FLAC = "flac"
+
+
+class AudioEncoding(str, Enum):
+    """Supported audio encodings."""
+    LINEAR16 = "linear16"
+    MULAW = "mulaw"
+    ALAW = "alaw"
+
+
+class ResponseFormat(str, Enum):
+    """LLM response format types."""
+    TEXT = "text"
+    JSON_OBJECT = "json_object"
+
+
+class PipelineComponent(str, Enum):
+    """Components that can be part of a processing pipeline."""
+    TRANSCRIBER = "transcriber"
+    LLM = "llm"
+    SYNTHESIZER = "synthesizer"
+    INPUT = "input"
+    OUTPUT = "output"
+
+
+class ExecutionType(str, Enum):
+    """Execution strategies for pipelines."""
+    PARALLEL = "parallel"
+    SEQUENTIAL = "sequential"
+
+
+# Utility functions for backward compatibility
+def get_all_task_types():
+    """Get all task type values as a list."""
+    return [task_type.value for task_type in TaskType]
+
+
+def get_all_audio_formats():
+    """Get all audio format values as a list."""
+    return [format.value for format in AudioFormat]
+
+
+def get_all_audio_encodings():
+    """Get all audio encoding values as a list."""
+    return [encoding.value for encoding in AudioEncoding]
+
+
+def get_all_pipeline_components():
+    """Get all pipeline component values as a list."""
+    return [component.value for component in PipelineComponent]
+
+
+def is_valid_task_type(task_type: str) -> bool:
+    """Check if a task type string is valid."""
+    try:
+        TaskType(task_type)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_audio_format(format: str) -> bool:
+    """Check if an audio format string is valid."""
+    try:
+        AudioFormat(format)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_audio_encoding(encoding: str) -> bool:
+    """Check if an audio encoding string is valid."""
+    try:
+        AudioEncoding(encoding)
+        return True
+    except ValueError:
+        return False
+
+
+def is_valid_pipeline_component(component: str) -> bool:
+    """Check if a pipeline component string is valid."""
+    try:
+        PipelineComponent(component)
+        return True
+    except ValueError:
+        return False

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -9,6 +9,10 @@ from bolna.helpers.utils import convert_to_request_log, compute_function_pre_cal
 from .llm import BaseLLM
 from bolna.helpers.logger_config import configure_logger
 
+# Import the new model compatibility system
+from bolna.enums.models import supports_json_mode
+from bolna.enums.tasks import ResponseFormat
+
 logger = configure_logger(__name__)
 load_dotenv()
     
@@ -197,7 +201,14 @@ class OpenAiLLM(BaseLLM):
         return res
 
     def get_response_format(self, is_json_format: bool):
-        if is_json_format and self.model in ('gpt-4-1106-preview', 'gpt-3.5-turbo-1106', 'gpt-4o-mini'):
-            return {"type": "json_object"}
+        """
+        Get response format for OpenAI API calls.
+        
+        This now uses the enum-based model capability system which supports
+        newer models like gpt-4.1-nano, gpt-4o, gpt-4-turbo that were previously
+        hardcoded out.
+        """
+        if is_json_format and supports_json_mode(self.model):
+            return {"type": ResponseFormat.JSON_OBJECT}
         else:
-            return {"type": "text"}
+            return {"type": ResponseFormat.TEXT}

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -107,7 +107,7 @@ class Synthesizer(BaseModel):
     provider_config: Union[PollyConfig, ElevenLabsConfig, AzureConfig, RimeConfig, SmallestConfig, SarvamConfig, CartesiaConfig, DeepgramConfig, OpenAIConfig] = Field(union_mode='smart')
     stream: bool = False
     buffer_size: Optional[int] = 40  # 40 characters in a buffer
-    audio_format: Optional[str] = "pcm"
+    audio_format: Optional[str] = AudioFormat.PCM
     caching: Optional[bool] = True
 
     @field_validator("provider")
@@ -119,7 +119,7 @@ class Synthesizer(BaseModel):
 
 class IOModel(BaseModel):
     provider: str
-    format: Optional[str] = "wav"
+    format: Optional[str] = AudioFormat.WAV
 
     @field_validator("provider")
     def validate_provider(cls, value):

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -4,66 +4,81 @@ from .input_handlers import DefaultInputHandler, TwilioInputHandler, ExotelInput
 from .output_handlers import DefaultOutputHandler, TwilioOutputHandler, ExotelOutputHandler, PlivoOutputHandler
 from .llms import OpenAiLLM, LiteLLM
 
+# Import the new enums
+from .enums.providers import (
+    SynthesizerProvider,
+    TranscriberProvider,
+    LLMProvider,
+    TelephonyProvider
+)
+
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_SYNTHESIZER_MODELS = {
-    'polly': PollySynthesizer,
-    'elevenlabs': ElevenlabsSynthesizer,
-    'openai': OPENAISynthesizer,
-    'deepgram': DeepgramSynthesizer,
-    'azuretts': AzureSynthesizer,
-    'cartesia': CartesiaSynthesizer,
-    'smallest': SmallestSynthesizer,
-    'sarvam': SarvamSynthesizer,
-    'rime': RimeSynthesizer
+    SynthesizerProvider.POLLY: PollySynthesizer,
+    SynthesizerProvider.ELEVENLABS: ElevenlabsSynthesizer,
+    SynthesizerProvider.OPENAI: OPENAISynthesizer,
+    SynthesizerProvider.DEEPGRAM: DeepgramSynthesizer,
+    SynthesizerProvider.AZURE_TTS: AzureSynthesizer,
+    SynthesizerProvider.CARTESIA: CartesiaSynthesizer,
+    SynthesizerProvider.SMALLEST: SmallestSynthesizer,
+    SynthesizerProvider.SARVAM: SarvamSynthesizer,
+    SynthesizerProvider.RIME: RimeSynthesizer
 }
 
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_TRANSCRIBER_PROVIDERS = {
-    'deepgram': DeepgramTranscriber,
-    'azure': AzureTranscriber
+    TranscriberProvider.DEEPGRAM: DeepgramTranscriber,
+    TranscriberProvider.AZURE: AzureTranscriber
 }
 
-#Backwards compatibility
+# Backwards compatibility - kept for existing code
 SUPPORTED_TRANSCRIBER_MODELS = {
-    'deepgram': DeepgramTranscriber
+    TranscriberProvider.DEEPGRAM: DeepgramTranscriber
 }
 
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_LLM_PROVIDERS = {
-    'openai': OpenAiLLM,
-    'cohere': LiteLLM,
-    'ollama': LiteLLM,
-    'deepinfra': LiteLLM,
-    'together': LiteLLM,
-    'fireworks': LiteLLM,
-    'azure-openai': LiteLLM,
-    'perplexity': LiteLLM,
-    'vllm': LiteLLM,
-    'anyscale': LiteLLM,
-    'custom': OpenAiLLM,
-    'ola': OpenAiLLM,
-    'groq': LiteLLM,
-    'anthropic': LiteLLM,
-    'deepseek': LiteLLM,
-    'openrouter': LiteLLM,
-    'azure': LiteLLM #Backwards compatibility
+    LLMProvider.OPENAI: OpenAiLLM,
+    LLMProvider.COHERE: LiteLLM,
+    LLMProvider.OLLAMA: LiteLLM,
+    LLMProvider.DEEPINFRA: LiteLLM,
+    LLMProvider.TOGETHER: LiteLLM,
+    LLMProvider.FIREWORKS: LiteLLM,
+    LLMProvider.AZURE_OPENAI: LiteLLM,
+    LLMProvider.PERPLEXITY: LiteLLM,
+    LLMProvider.VLLM: LiteLLM,
+    LLMProvider.ANYSCALE: LiteLLM,
+    LLMProvider.CUSTOM: OpenAiLLM,
+    LLMProvider.OLA: OpenAiLLM,
+    LLMProvider.GROQ: LiteLLM,
+    LLMProvider.ANTHROPIC: LiteLLM,
+    LLMProvider.DEEPSEEK: LiteLLM,
+    LLMProvider.OPENROUTER: LiteLLM,
+    LLMProvider.AZURE: LiteLLM  # Backwards compatibility
 }
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_INPUT_HANDLERS = {
-    'default': DefaultInputHandler,
-    'twilio': TwilioInputHandler,
-    'exotel': ExotelInputHandler,
-    'plivo': PlivoInputHandler
+    TelephonyProvider.DEFAULT: DefaultInputHandler,
+    TelephonyProvider.TWILIO: TwilioInputHandler,
+    TelephonyProvider.EXOTEL: ExotelInputHandler,
+    TelephonyProvider.PLIVO: PlivoInputHandler
 }
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_INPUT_TELEPHONY_HANDLERS = {
-    'twilio': TwilioInputHandler,
-    'exotel': ExotelInputHandler,
-    'plivo': PlivoInputHandler
+    TelephonyProvider.TWILIO: TwilioInputHandler,
+    TelephonyProvider.EXOTEL: ExotelInputHandler,
+    TelephonyProvider.PLIVO: PlivoInputHandler
 }
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_OUTPUT_HANDLERS = {
-    'default': DefaultOutputHandler,
-    'twilio': TwilioOutputHandler,
-    'exotel': ExotelOutputHandler,
-    'plivo': PlivoOutputHandler
+    TelephonyProvider.DEFAULT: DefaultOutputHandler,
+    TelephonyProvider.TWILIO: TwilioOutputHandler,
+    TelephonyProvider.EXOTEL: ExotelOutputHandler,
+    TelephonyProvider.PLIVO: PlivoOutputHandler
 }
+# Updated to use enums - maintains backward compatibility
 SUPPORTED_OUTPUT_TELEPHONY_HANDLERS = {
-    'twilio': TwilioOutputHandler,
-    'exotel': ExotelOutputHandler,
-    'plivo': PlivoOutputHandler
+    TelephonyProvider.TWILIO: TwilioOutputHandler,
+    TelephonyProvider.EXOTEL: ExotelOutputHandler,
+    TelephonyProvider.PLIVO: PlivoOutputHandler
 }

--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -12,8 +12,6 @@ from bolna.helpers.logger_config import configure_logger
 from bolna.models import *
 from bolna.llms import LiteLLM
 from bolna.agent_manager.assistant_manager import AssistantManager
-
-# Import task type enum
 from bolna.enums.tasks import TaskType
 
 load_dotenv()

--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -13,6 +13,9 @@ from bolna.models import *
 from bolna.llms import LiteLLM
 from bolna.agent_manager.assistant_manager import AssistantManager
 
+# Import task type enum
+from bolna.enums.tasks import TaskType
+
 load_dotenv()
 logger = configure_logger(__name__)
 
@@ -63,7 +66,7 @@ async def create_agent(agent_data: CreateAgentPayload):
     if len(data_for_db['tasks']) > 0:
         logger.info("Setting up follow up tasks")
         for index, task in enumerate(data_for_db['tasks']):
-            if task['task_type'] == "extraction":
+            if task['task_type'] == TaskType.EXTRACTION:
                 extraction_prompt_llm = os.getenv("EXTRACTION_PROMPT_GENERATION_MODEL")
                 extraction_prompt_generation_llm = LiteLLM(model=extraction_prompt_llm, max_tokens=2000)
                 extraction_prompt = await extraction_prompt_generation_llm.generate(
@@ -102,7 +105,7 @@ async def edit_agent(agent_id: str, agent_data: CreateAgentPayload = Body(...)):
 
 
         for index, task in enumerate(new_data.get("tasks", [])):
-            if task.get("task_type") == "extraction":
+            if task.get("task_type") == TaskType.EXTRACTION:
                 extraction_prompt_llm = os.getenv("EXTRACTION_PROMPT_GENERATION_MODEL")
                 if not extraction_prompt_llm:
                     raise HTTPException(status_code=500, detail="Extraction model not configured")


### PR DESCRIPTION
Related: [Issue #265](https://github.com/bolna-ai/bolna/issues/265)

Summary
- Replace scattered string literals with enums across providers, tasks, pipelines, message types, and OpenAI model capabilities.
- Fix JSON-mode handling for newer OpenAI models via capability checks.
- Maintain backward compatibility using str-enums and validation against enum values.

What & Why
- Centralize provider/task/message constants as enums for type-safety, maintainability, and easier extension.
- Remove hardcoded OpenAI JSON-capable list; support models like gpt-4.1-nano, gpt-4o, gpt-4-turbo via `supports_json_mode`.
- Keep existing configs working by accepting legacy strings.

Key Changes
- Enums and helpers
  - `bolna/enums/providers.py`: Synthesizer/Transcriber/LLM/Telephony providers (+ helpers)
  - `bolna/enums/tasks.py`: TaskType, AudioFormat, AudioEncoding, ResponseFormat, PipelineComponent, ExecutionType (+ helpers)
  - `bolna/enums/models.py`: OpenAIModel + capability checks (supports_json_mode, etc.)
  - `bolna/enums/constants.py`: AgentStatus, AgentType, MessageType, LanguageCode (+ helpers)
  - `bolna/enums/__init__.py`: export enums
- Providers mapping
  - `bolna/providers.py`: `SUPPORTED_*` maps keyed by enums (legacy-compatible)
- Model validations & defaults
  - `bolna/models.py`: validators use enum-derived lists; defaults use enums where applicable
- OpenAI JSON mode
  - `bolna/llms/openai_llm.py`: `get_response_format` uses `supports_json_mode` and `ResponseFormat`
- Pipelines and I/O defaults
  - `bolna/assistant.py`: input/output formats and pipeline components use enums (serialized via `.value`)
- Message types
  - `bolna/output_handlers/default.py`: replace type strings with `MessageType`; add null guards for robustness

Backward compatibility
- Enum classes inherit from `str`; existing string-based configs remain valid.
- Validators compare user inputs against enum `.value` collections.

Checklist
- [x] Providers mapped to enums
- [x] Validators use enum-derived lists
- [x] OpenAI JSON-mode via capability check
- [x] Pipelines/IO defaults use enums
- [x] Message types centralized
- [ ] Language code standardization

**Fixes:** Fixes #265 

have tried to avoid over engineering and would love to get feedback on this 
