### PR TITLE
latency: standardize per‑turn metrics across TTS + transcribers; aggregate in TaskManager

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1631,20 +1631,6 @@ class TaskManager(BaseManager):
                         meta_info = self.__get_updated_meta_info(meta_info)
                         await self._handle_transcriber_output(next_task, transcriber_message, meta_info)
 
-                        # Append standardized transcriber per-turn latencies if present
-                        try:
-                            first_s = meta_info.get('transcriber_first_result_latency')
-                            total_s = meta_info.get('transcriber_total_stream_duration')
-                            if first_s is not None or total_s is not None:
-                                self.transcriber_latencies['turn_latencies'].append({
-                                    'turn_id': meta_info.get('turn_id') or meta_info.get('request_id'),
-                                    'sequence_id': meta_info.get('sequence_id'),
-                                    'first_result_latency_ms': round(first_s * 1000) if first_s is not None else None,
-                                    'total_stream_duration_ms': round(total_s * 1000) if total_s is not None else None
-                                })
-                        except Exception:
-                            pass
-
                     elif message["data"] == "transcriber_connection_closed":
                         logger.info(f"Transcriber connection has been closed")
                         self.transcriber_duration += message.get("meta_info", {}).get("transcriber_duration", 0) if message["meta_info"] is not None else 0
@@ -1671,20 +1657,6 @@ class TaskManager(BaseManager):
         self.transcriber_duration += message["meta_info"]["transcriber_duration"] if "transcriber_duration" in message["meta_info"] else 0
 
         await self._handle_transcriber_output(next_task, message['data'], meta_info)
-
-        # Append standardized transcriber per-turn latencies for HTTP path
-        try:
-            first_s = meta_info.get('transcriber_first_result_latency')
-            total_s = meta_info.get('transcriber_total_stream_duration')
-            if first_s is not None or total_s is not None:
-                self.transcriber_latencies['turn_latencies'].append({
-                    'turn_id': meta_info.get('turn_id') or meta_info.get('request_id'),
-                    'sequence_id': meta_info.get('sequence_id'),
-                    'first_result_latency_ms': round(first_s * 1000) if first_s is not None else None,
-                    'total_stream_duration_ms': round(total_s * 1000) if total_s is not None else None
-                })
-        except Exception:
-            pass
 
 
     #################################################################
@@ -1753,21 +1725,6 @@ class TaskManager(BaseManager):
                                 engine=self.tools['synthesizer'].get_engine(),
                                 run_id=self.run_id
                             )
-
-                            # Append synthesizer per-turn latencies when end of stream
-                            try:
-                                if meta_info.get('end_of_synthesizer_stream', False):
-                                    first_s = meta_info.get('synthesizer_first_result_latency')
-                                    total_s = meta_info.get('synthesizer_total_stream_duration')
-                                    if first_s is not None or total_s is not None:
-                                        self.synthesizer_latencies['turn_latencies'].append({
-                                            'turn_id': meta_info.get('turn_id'),
-                                            'sequence_id': meta_info.get('sequence_id'),
-                                            'first_result_latency_ms': round(first_s * 1000) if first_s is not None else None,
-                                            'total_stream_duration_ms': round(total_s * 1000) if total_s is not None else None
-                                        })
-                            except Exception:
-                                pass
                         else:
                             logger.info(f"Skipping message with sequence_id: {sequence_id}")
 
@@ -2263,6 +2220,9 @@ class TaskManager(BaseManager):
             if self._is_conversation_task():
                 self.transcriber_latencies['connection_latency_ms'] = self.tools["transcriber"].connection_time
                 self.synthesizer_latencies['connection_latency_ms'] = self.tools["synthesizer"].connection_time
+                
+                self.transcriber_latencies['turn_latencies'] = self.tools["transcriber"].turn_latencies
+                self.synthesizer_latencies['turn_latencies'] = self.tools["synthesizer"].turn_latencies
                 output = {
                     "messages": self.history,
                     "conversation_time": time.time() - self.start_time,

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -13,6 +13,7 @@ class BaseSynthesizer:
         self.internal_queue = asyncio.Queue()
         self.task_manager_instance = task_manager_instance
         self.connection_time = None
+        self.turn_latencies = []
 
     def clear_internal_queue(self):
         logger.info(f"Clearing out internal queue")

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -204,6 +204,13 @@ class RimeSynthesizer(BaseSynthesizer):
 
                     if len(self.text_queue) > 0:
                         self.meta_info = self.text_queue.popleft()
+                        # Compute first-result latency on first audio chunk
+                        try:
+                            if self.meta_info and 'synthesizer_start_time' in self.meta_info and 'synthesizer_first_result_latency' not in self.meta_info:
+                                self.meta_info['synthesizer_first_result_latency'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
+                                self.meta_info['synthesizer_latency'] = self.meta_info['synthesizer_first_result_latency']
+                        except Exception:
+                            pass
                     audio = ""
 
                     if self.use_mulaw:
@@ -228,6 +235,12 @@ class RimeSynthesizer(BaseSynthesizer):
                         logger.info("received null byte and hence end of stream")
                         self.meta_info["end_of_synthesizer_stream"] = True
                         self.first_chunk_generated = False
+                        # Compute total stream duration for this synthesizer turn
+                        try:
+                            if self.meta_info and 'synthesizer_start_time' in self.meta_info:
+                                self.meta_info['synthesizer_total_stream_duration'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
+                        except Exception:
+                            pass
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     yield create_ws_data_packet(audio, self.meta_info)
@@ -310,6 +323,11 @@ class RimeSynthesizer(BaseSynthesizer):
             end_of_llm_stream = "end_of_llm_stream" in meta_info and meta_info["end_of_llm_stream"]
             self.meta_info = copy.deepcopy(meta_info)
             meta_info["text"] = text
+            # Stamp synthesizer turn start time
+            try:
+                meta_info['synthesizer_start_time'] = time.perf_counter()
+            except Exception:
+                pass
             if not self.context_id:
                 self.context_id = str(uuid.uuid4())
             self.sender_task = asyncio.create_task(self.sender(text, meta_info.get("sequence_id"), end_of_llm_stream))

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -45,6 +45,8 @@ class SarvamSynthesizer(BaseSynthesizer):
         self.websocket_holder = {"websocket": None}
         self.sender_task = None
         self.conversation_ended = False
+        self.current_turn_start_time = None
+        self.current_turn_id = None
         self.text_queue = deque()
         self.current_text = ""
 
@@ -223,9 +225,9 @@ class SarvamSynthesizer(BaseSynthesizer):
                         self.meta_info = self.text_queue.popleft()
                         # Compute first-result latency on first audio chunk
                         try:
-                            if self.meta_info and 'synthesizer_start_time' in self.meta_info and 'synthesizer_first_result_latency' not in self.meta_info:
-                                self.meta_info['synthesizer_first_result_latency'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
-                                self.meta_info['synthesizer_latency'] = self.meta_info['synthesizer_first_result_latency']
+                            if self.current_turn_start_time is not None:
+                                first_result_latency = time.perf_counter() - self.current_turn_start_time
+                                self.meta_info['synthesizer_latency'] = first_result_latency
                         except Exception:
                             pass
 
@@ -249,8 +251,16 @@ class SarvamSynthesizer(BaseSynthesizer):
                         self.first_chunk_generated = False
                         # Compute total stream duration for this synthesizer turn
                         try:
-                            if self.meta_info and 'synthesizer_start_time' in self.meta_info:
-                                self.meta_info['synthesizer_total_stream_duration'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
+                            if self.current_turn_start_time is not None:
+                                total_stream_duration = time.perf_counter() - self.current_turn_start_time
+                                self.turn_latencies.append({
+                                    'turn_id': self.current_turn_id,
+                                    'sequence_id': self.current_turn_id,
+                                    'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
+                                    'total_stream_duration_ms': round(total_stream_duration * 1000)
+                                })
+                                self.current_turn_start_time = None
+                                self.current_turn_id = None
                         except Exception:
                             pass
                     else:
@@ -273,7 +283,8 @@ class SarvamSynthesizer(BaseSynthesizer):
             meta_info["text"] = text
             # Stamp synthesizer turn start time
             try:
-                meta_info['synthesizer_start_time'] = time.perf_counter()
+                self.current_turn_start_time = time.perf_counter()
+                self.current_turn_id = meta_info.get('turn_id') or meta_info.get('sequence_id')
             except Exception:
                 pass
             self.sender_task = asyncio.create_task(self.sender(text, meta_info.get("sequence_id"), end_of_llm_stream))

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -37,6 +37,8 @@ class SmallestSynthesizer(BaseSynthesizer):
         self.websocket_holder = {"websocket": None}
         self.sender_task = None
         self.conversation_ended = False
+        self.current_turn_start_time = None
+        self.current_turn_id = None
         self.text_queue = deque()
         self.current_text = ""
 
@@ -91,12 +93,13 @@ class SmallestSynthesizer(BaseSynthesizer):
                         self.meta_info = self.text_queue.popleft()
                     if not self.meta_info:
                         self.meta_info = {}
-                        # Compute first-result latency when first audio chunk arrives for this turn
+
+                    # Compute first-result latency when first audio chunk arrives for this turn
+                    if not self.first_chunk_generated and self.current_turn_start_time is not None:
                         try:
-                            if self.meta_info and 'synthesizer_start_time' in self.meta_info and 'synthesizer_first_result_latency' not in self.meta_info:
-                                self.meta_info['synthesizer_first_result_latency'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
-                                # Flat field used by CSV logs
-                                self.meta_info['synthesizer_latency'] = self.meta_info['synthesizer_first_result_latency']
+                            first_result_latency = time.perf_counter() - self.current_turn_start_time
+                            # Keep flat field for CSV compatibility
+                            self.meta_info['synthesizer_latency'] = first_result_latency
                         except Exception:
                             pass
 
@@ -120,8 +123,17 @@ class SmallestSynthesizer(BaseSynthesizer):
                         self.first_chunk_generated = False
                         # Compute total stream duration for this synthesizer turn
                         try:
-                            if self.meta_info and 'synthesizer_start_time' in self.meta_info:
-                                self.meta_info['synthesizer_total_stream_duration'] = time.perf_counter() - self.meta_info['synthesizer_start_time']
+                            if self.current_turn_start_time is not None:
+                                total_stream_duration = time.perf_counter() - self.current_turn_start_time
+                                self.turn_latencies.append({
+                                    'turn_id': self.current_turn_id,
+                                    'sequence_id': self.current_turn_id,
+                                    'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
+                                    'total_stream_duration_ms': round(total_stream_duration * 1000)
+                                })
+                                # Reset turn tracking
+                                self.current_turn_start_time = None
+                                self.current_turn_id = None
                         except Exception:
                             pass
 
@@ -268,7 +280,8 @@ class SmallestSynthesizer(BaseSynthesizer):
             meta_info["text"] = text
             # Stamp synthesizer turn start time
             try:
-                meta_info['synthesizer_start_time'] = time.perf_counter()
+                self.current_turn_start_time = time.perf_counter()
+                self.current_turn_id = meta_info.get('turn_id') or meta_info.get('sequence_id')
             except Exception:
                 pass
             self.sender_task = asyncio.create_task(self.sender(text, meta_info.get("sequence_id"), end_of_llm_stream))

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -20,6 +20,7 @@ class BaseTranscriber:
         self.previous_request_id = None
         self.current_request_id = None
         self.connection_time = None
+        self.turn_latencies = []
 
     def update_meta_info(self):
         self.meta_info['request_id'] = self.current_request_id if self.current_request_id else None


### PR DESCRIPTION
### Summary
Adds standardized, high‑precision per‑turn latency tracking across synthesizers and transcribers and aggregates these in TaskManager.

### (Field definitions)
- Synthesizer
  - synthesizer_start_time: perf_counter when a TTS turn is enqueued (start of synthesis).
  - synthesizer_first_result_latency: time from start_time to the first audio chunk produced.
  - synthesizer_total_stream_duration: time from start_time to end-of-synthesizer-stream.

- Transcriber
  - transcriber_start_time: perf_counter when an utterance’s first audio is submitted (start of transcription for that turn).
  - transcriber_first_result_latency: time from start_time to the first actionable transcript (interim/final).
  - transcriber_total_stream_duration: time from start_time to the final transcript/utterance end.

### What’s changed
- Synthesizer meta_info per turn:
  - `synthesizer_start_time` (perf_counter seconds)
  - `synthesizer_first_result_latency` (seconds; also mirrored to `synthesizer_latency` for CSV)
  - `synthesizer_total_stream_duration` (seconds)
- Transcriber meta_info per turn:
  - `transcriber_start_time` (perf_counter seconds)
  - `transcriber_first_result_latency` (seconds)
  - `transcriber_total_stream_duration` (seconds)
  - `transcriber_latency` retained for CSV/backward compatibility (equals total for HTTP)
- TaskManager aggregation:
  - Appends standardized per‑turn entries to `transcriber_latencies.turn_latencies` and `synthesizer_latencies.turn_latencies` in milliseconds.

- Providers updated:
  - Synthesizers: Smallest, ElevenLabs, Sarvam, Rime, Azure, Deepgram (HTTP)
  - Transcribers: Deepgram (streaming + HTTP), Azure

### Notes
- Units: seconds in meta_info; TaskManager converts to ms when appending.
- Non‑streaming HTTP paths: first_result == total (by design).
- Connection latency unchanged; this PR focuses on per‑turn metrics.
- Backward compatible: only adds fields; CSV continues to read `*_latency` fields.