### PR TITLE
docs: fix API.md JSON examples and formatting

### DIFF
--- a/API.md
+++ b/API.md
@@ -18,86 +18,67 @@ Creates a new agent with specified configuration.
 **Request Body:**
 ```json
 {
-{
   "agent_config": {
-      "agent_name": "Alfred",
-      "agent_type": "other",
-      "agent_welcome_message": "How are you doing Bruce?",
-      "tasks": [
-          {
-              "task_type": "conversation",
-              "toolchain": {
-                  "execution": "parallel",
-                  "pipelines": [
-                      [
-                          "transcriber",
-                          "llm",
-                          "synthesizer"
-                      ]
-                  ]
-              },
-              "tools_config": {
-                  "input": {
-                      "format": "wav",
-                      "provider": "twilio"
-                  },
-                  "llm_agent": {
-                      "agent_type": "simple_llm_agent",
-                      "agent_flow_type": "streaming",
-                      "routes": null,
-                      "llm_config": {
-                          "agent_flow_type": "streaming",
-                          "provider": "openai",
-                          "request_json": true,
-                          "model": "gpt-4o-mini"
-                      }
-                  },
-                  "output": {
-                      "format": "wav",
-                      "provider": "twilio"
-                  },
-                  "synthesizer": {
-                      "audio_format": "wav",
-                      "provider": "elevenlabs",
-                      "stream": true,
-                      "provider_config": {
-                          "voice": "George",
-                          "model": "eleven_turbo_v2_5",
-                          "voice_id": "JBFqnCBsd6RMkjVDRZzb"
-                      },
-                      "buffer_size": 100.0
-                  },
-                  "transcriber": {
-                      "encoding": "linear16",
-                      "language": "en",
-                      "provider": "deepgram",
-                      "stream": true
-                  }
-              },
-              "task_config": {
-                  "hangup_after_silence": 30.0
-              }
+    "agent_name": "Alfred",
+    "agent_type": "other",
+    "tasks": [
+      {
+        "task_type": "conversation",
+        "toolchain": {
+          "execution": "parallel",
+          "pipelines": [["transcriber", "llm", "synthesizer"]]
+        },
+        "tools_config": {
+          "input": { "format": "wav", "provider": "twilio" },
+          "output": { "format": "wav", "provider": "twilio" },
+          "transcriber": {
+            "encoding": "linear16",
+            "language": "en",
+            "provider": "deepgram",
+            "stream": true
+          },
+          "llm_agent": {
+            "agent_type": "simple_llm_agent",
+            "agent_flow_type": "streaming",
+            "llm_config": {
+              "provider": "openai",
+              "model": "gpt-4o-mini",
+              "request_json": true
+            }
+          },
+          "synthesizer": {
+            "audio_format": "wav",
+            "provider": "elevenlabs",
+            "stream": true,
+            "provider_config": {
+              "voice": "George",
+              "model": "eleven_turbo_v2_5",
+              "voice_id": "JBFqnCBsd6RMkjVDRZzb"
+            },
+            "buffer_size": 100.0
           }
-      ]
+        },
+        "task_config": {
+          "hangup_after_silence": 30.0
+        }
+      }
+    ],
+    "agent_welcome_message": "How are you doing Bruce?"
   },
   "agent_prompts": {
-      "task_1": {
-          "system_prompt": "Why Do We Fall, Sir? So That We Can Learn To Pick Ourselves Up."
-      }
+    "task_1": {
+      "system_prompt": "Why Do We Fall, Sir? So That We Can Learn To Pick Ourselves Up."
+    }
   }
-}
-
-
-
 }
 ```
 
 **Response:**
-```json
 200 OK
+```json
 {
-    "agent_id": "uuid-string",
-    "state": "created"
+  "agent_id": "uuid-string",
+  "state": "created"
 }
 ```
 
@@ -122,31 +103,34 @@ Deletes an agent from the system.
 - `agent_id` (path) - string, required: Unique identifier of the agent
 
 **Response:**
-```json
 200 OK
+```json
 {
-    "agent_id": "string",
-    "state": "deleted"
+  "agent_id": "string",
+  "state": "deleted"
 }
 ```
 
 
-### Get All Agents
 Retrieves all agents from the system.
 
 **Endpoint:** `GET /all`
 
 **Response:**
-```json
 200 OK
+```json
 {
-    "agents": [
-        {
-            "agent_id": "string",
-            "data": {
-                // Agent configuration object
-            }
-        }
-    ]
+  "agents": [
+    {
+      "agent_id": "string",
+      "data": {
+        "agent_config": {
+          "agent_name": "Alfred",
+          "agent_type": "other",
+          "tasks": []
+        },
+        "agent_prompts": {}
+      }
+    }
+  ]
 }
-```


### PR DESCRIPTION
### Summary
Cleans up and validates JSON examples in API.md to ensure documentation accurately reflects the API structure.

### Changes

- Replaced malformed JSON in the "Create Agent" payload.
- Corrected JSON formatting and removed inline comments in the "Get All Agents" response.
- Moved HTTP status codes ("200 OK") out of JSON code fences for all response examples.