### PR TITLE
docs: add minimal programmatic usage examples and runnable scripts

### DIFF
--- a/examples/simple_assistant.py
+++ b/examples/simple_assistant.py
@@ -1,0 +1,54 @@
+import asyncio
+from bolna.assistant import Assistant
+from bolna.models import (
+    Transcriber,
+    Synthesizer,
+    ElevenLabsConfig,
+    LlmAgent,
+    SimpleLlmAgent,
+)
+
+
+async def main():
+    assistant = Assistant(name="demo_agent")
+
+    # Configure audio input (ASR)
+    transcriber = Transcriber(provider="deepgram", model="nova-2", stream=True, language="en")
+
+    # Configure LLM
+    llm_agent = LlmAgent(
+        agent_type="simple_llm_agent",
+        agent_flow_type="streaming",
+        llm_config=SimpleLlmAgent(
+            provider="openai",
+            model="gpt-4o-mini",
+            temperature=0.3,
+        ),
+    )
+
+    # Configure audio output (TTS)
+    synthesizer = Synthesizer(
+        provider="elevenlabs",
+        provider_config=ElevenLabsConfig(
+            voice="George", voice_id="JBFqnCBsd6RMkjVDRZzb", model="eleven_turbo_v2_5"
+        ),
+        stream=True,
+        audio_format="wav",
+    )
+
+    # Build a single coherent pipeline: transcriber -> llm -> synthesizer
+    assistant.add_task(
+        task_type="conversation",
+        llm_agent=llm_agent,
+        transcriber=transcriber,
+        synthesizer=synthesizer,
+        enable_textual_input=False,
+    )
+
+    # Stream results
+    async for chunk in assistant.execute():
+        print(chunk)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/text_only_assistant.py
+++ b/examples/text_only_assistant.py
@@ -1,0 +1,31 @@
+import asyncio
+from bolna.assistant import Assistant
+from bolna.models import LlmAgent, SimpleLlmAgent
+
+
+async def main():
+    assistant = Assistant(name="text_only_agent")
+
+    llm_agent = LlmAgent(
+        agent_type="simple_llm_agent",
+        agent_flow_type="streaming",
+        llm_config=SimpleLlmAgent(
+            provider="openai",
+            model="gpt-4o-mini",
+            temperature=0.2,
+        ),
+    )
+
+    # No transcriber/synthesizer; enable a text-only pipeline
+    assistant.add_task(
+        task_type="conversation",
+        llm_agent=llm_agent,
+        enable_textual_input=True,
+    )
+
+    async for chunk in assistant.execute():
+        print(chunk)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
### Summary
Adds two new runnable Python examples (simple_assistant.py and text_only_assistant.py) to the documentation, demonstrating programmatic usage of the assistant.

### Changes
- Added "Programmatic usage" section to README.md with:
- A full minimal example (requiring all API keys).
- A text-only example (only requiring OPENAI_API_KEY).
- Included a brief note on the expected streaming output shape from assistant.execute().
- Added cross-reference link to API.md for REST usage.