### PR TITLE
fix: remove duplicate .env file requirement for telephony servers

### DIFF
--- a/local_setup/dockerfiles/plivo_server.Dockerfile
+++ b/local_setup/dockerfiles/plivo_server.Dockerfile
@@ -19,7 +19,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Copy application files
 COPY telephony_server/plivo_api_server.py /app/
-COPY telephony_server/.env /app/.env
 
 EXPOSE 8002
 

--- a/local_setup/dockerfiles/twilio_server.Dockerfile
+++ b/local_setup/dockerfiles/twilio_server.Dockerfile
@@ -15,7 +15,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     pip install -r requirements.txt
 
 COPY telephony_server/twilio_api_server.py /app/
-COPY telephony_server/.env /app/.env
 
 EXPOSE 8001
 


### PR DESCRIPTION
## Problem
When I try to run this locally, I encounter environment variable issues.
The current setup requires `.env` files in multiple locations:
- `local_setup/.env` (for docker-compose)
- `local_setup/telephony_server/.env` (copied into containers)

This creates confusion and redundancy, as the `docker-compose.yml` already has `env_file` directive configured.

<img width="1919" height="767" alt="image" src="https://github.com/user-attachments/assets/9e2fbf39-1a2a-4412-9dfc-ffd95d50ccad" />


## Solution
- Removed `.env` COPY statements from `twilio_server.Dockerfile` and `plivo_server.Dockerfile`
- Updated documentation in `local_setup/README.md` to clarify single `.env` location
- All environment variables now load from `local_setup/.env` via docker-compose's `env_file` directive

## Changes
- Modified `local_setup/dockerfiles/twilio_server.Dockerfile` - removed duplicate .env copy
- Modified `local_setup/dockerfiles/plivo_server.Dockerfile` - removed duplicate .env copy
