### PR TITLE
fix: add graceful error handling for API authentication failures across providers

### DIFF
--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -3,6 +3,7 @@ import json
 import time
 import logging
 from litellm import acompletion
+from litellm.exceptions import AuthenticationError, RateLimitError, APIError, APIConnectionError
 from dotenv import load_dotenv
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE
@@ -83,7 +84,25 @@ class LiteLLM(BaseLLM):
             "total_stream_duration_ms": None,
         }
 
-        async for chunk in await acompletion(**model_args):
+        try:
+            completion_stream = await acompletion(**model_args)
+        except AuthenticationError as e:
+            logger.error(f"LiteLLM authentication failed: Invalid or expired API key - {e}")
+            raise
+        except RateLimitError as e:
+            logger.error(f"LiteLLM rate limit exceeded: {e}")
+            raise
+        except APIConnectionError as e:
+            logger.error(f"LiteLLM connection error: {e}")
+            raise
+        except APIError as e:
+            logger.error(f"LiteLLM API error: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"LiteLLM unexpected error: {e}")
+            raise
+
+        async for chunk in completion_stream:
             now = now_ms()
             if not first_token_time:
                 first_token_time = now
@@ -212,6 +231,19 @@ class LiteLLM(BaseLLM):
         try:
             completion = await acompletion(**model_args)
             text = completion.choices[0].message.content
+        except AuthenticationError as e:
+            logger.error(f"LiteLLM authentication failed: Invalid or expired API key - {e}")
+            raise
+        except RateLimitError as e:
+            logger.error(f"LiteLLM rate limit exceeded: {e}")
+            raise
+        except APIConnectionError as e:
+            logger.error(f"LiteLLM connection error: {e}")
+            raise
+        except APIError as e:
+            logger.error(f"LiteLLM API error: {e}")
+            raise
         except Exception as e:
-            logger.error(f'Error generating response {e}')
+            logger.error(f'LiteLLM unexpected error generating response: {e}')
+            raise
         return text

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -3,6 +3,7 @@ import copy
 import uuid
 import time
 import websockets
+from websockets.exceptions import InvalidHandshake
 import base64
 import json
 import aiohttp
@@ -244,21 +245,48 @@ class CartesiaSynthesizer(BaseSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await websockets.connect(self.ws_url)
+            websocket = await asyncio.wait_for(
+                websockets.connect(self.ws_url),
+                timeout=10.0
+            )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
             return websocket
+        except asyncio.TimeoutError:
+            logger.error("Timeout while connecting to Cartesia websocket")
+            return None
+        except InvalidHandshake as e:
+            error_msg = str(e)
+            if '401' in error_msg or '403' in error_msg:
+                logger.error(f"Cartesia authentication failed: Invalid or expired API key - {e}")
+            elif '404' in error_msg:
+                logger.error(f"Cartesia endpoint not found: {e}")
+            else:
+                logger.error(f"Cartesia handshake failed: {e}")
+            return None
         except Exception as e:
-            logger.info(f"Failed to connect: {e}")
+            logger.error(f"Failed to connect to Cartesia: {e}")
             return None
 
     async def monitor_connection(self):
         # Periodically check if the connection is still alive
-        while True:
+        consecutive_failures = 0
+        max_failures = 3
+
+        while consecutive_failures < max_failures:
             if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED:
                 logger.info("Re-establishing cartesia connection...")
-                self.websocket_holder["websocket"] = await self.establish_connection()
+                result = await self.establish_connection()
+                if result is None:
+                    consecutive_failures += 1
+                    logger.warning(f"Cartesia connection failed (attempt {consecutive_failures}/{max_failures})")
+                    if consecutive_failures >= max_failures:
+                        logger.error("Max connection failures reached for Cartesia - stopping reconnection attempts")
+                        break
+                else:
+                    self.websocket_holder["websocket"] = result
+                    consecutive_failures = 0  # Reset on success
             await asyncio.sleep(1)
 
     def update_context(self, meta_info):


### PR DESCRIPTION
current blocker in sarvam stt websocket :  We noticed the handshake succeeds with invalid API keys, but connection closes (code 4003) when audio is sent.


