### PR TITLE
Add latency tracking to Cartesia synthesizer

### DIFF
--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -49,6 +49,8 @@ class CartesiaSynthesizer(BaseSynthesizer):
         self.sequence_id = 0
         self.context_ids_to_ignore = set()
         self.conversation_ended = False
+        self.current_turn_start_time = None
+        self.current_turn_id = None
 
     def get_engine(self):
         return self.model
@@ -209,6 +211,13 @@ class CartesiaSynthesizer(BaseSynthesizer):
             async for message in self.receiver():
                 if len(self.text_queue) > 0:
                     self.meta_info = self.text_queue.popleft()
+                    # Compute first-result latency on first audio chunk
+                    try:
+                        if self.current_turn_start_time is not None:
+                            first_result_latency = time.perf_counter() - self.current_turn_start_time
+                            self.meta_info['synthesizer_latency'] = first_result_latency
+                    except Exception:
+                        pass
                 audio = ""
 
                 if self.use_mulaw:
@@ -234,6 +243,20 @@ class CartesiaSynthesizer(BaseSynthesizer):
                     logger.info("received null byte and hence end of stream")
                     self.meta_info["end_of_synthesizer_stream"] = True
                     self.first_chunk_generated = False
+                    # Compute total stream duration for this synthesizer turn
+                    try:
+                        if self.current_turn_start_time is not None:
+                            total_stream_duration = time.perf_counter() - self.current_turn_start_time
+                            self.turn_latencies.append({
+                                'turn_id': self.current_turn_id,
+                                'sequence_id': self.current_turn_id,
+                                'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
+                                'total_stream_duration_ms': round(total_stream_duration * 1000)
+                            })
+                            self.current_turn_start_time = None
+                            self.current_turn_id = None
+                    except Exception:
+                        pass
 
                 yield create_ws_data_packet(audio, self.meta_info)
 
@@ -278,6 +301,13 @@ class CartesiaSynthesizer(BaseSynthesizer):
             else:
                 if self.turn_id != meta_info.get('turn_id', 0) or self.sequence_id != meta_info.get('sequence_id', 0):
                     self.update_context(meta_info)
+
+            # Stamp synthesizer turn start time
+            try:
+                self.current_turn_start_time = time.perf_counter()
+                self.current_turn_id = meta_info.get('turn_id') or meta_info.get('sequence_id')
+            except Exception:
+                pass
 
             self.sender_task = asyncio.create_task(self.sender(text, meta_info.get('sequence_id'), end_of_llm_stream))
             self.text_queue.append(meta_info)


### PR DESCRIPTION
Added latency metrics tracking to CartesiaSynthesizer to match the ElevenLabs implementation.

Changes made in: bolna/synthesizer/cartesia_synthesizer.py

Added:
- Instance variables for tracking turn start time and turn ID
- First result latency calculation (time from text submission to first audio chunk)
- Total stream duration tracking (complete synthesis time)
- Turn latencies list to store metrics per turn with millisecond precision

This enables consistent latency monitoring across both Cartesia and ElevenLabs synthesizers.