### PR TITLE
Fix Turn Tracking Standardization

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1582,7 +1582,6 @@ class TaskManager(BaseManager):
         meta_info['turn_id'] = self.turn_id
         meta_info['user_turn_count'] = self.user_turn_count
         meta_info['interruption_count'] = self.interruption_count
-        meta_info['sequence_id'] = self.sequence_id
 
         # Process transcriber turn metrics if present
         if 'transcriber_turn_metrics' in meta_info:

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -80,6 +80,8 @@ class LiteLLM(BaseLLM):
         start_time = now_ms()
         latency_data = {
             "sequence_id": meta_info.get("sequence_id") if meta_info else None,
+            "turn_id": meta_info.get("turn_id") if meta_info else None,
+            "interruption_count": meta_info.get("interruption_count", 0) if meta_info else 0,
             "first_token_latency_ms": None,
             "total_stream_duration_ms": None,
         }
@@ -127,6 +129,8 @@ class LiteLLM(BaseLLM):
 
                 latency_data = {
                     "sequence_id": meta_info.get("sequence_id"),
+                    "turn_id": meta_info.get("turn_id"),
+                    "interruption_count": meta_info.get("interruption_count", 0),
                     "first_token_latency_ms": first_token_time - start_time,
                     "total_stream_duration_ms": None  # Will be filled at end
                 }

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -66,7 +66,7 @@ class OpenAiLLM(BaseLLM):
             "messages": messages,
             "stream": True,
             "stop": ["User:"],
-            "user": f"{self.run_id}#{meta_info['turn_id']}"
+            "user": f"{self.run_id}#turn:{meta_info.get('turn_id', 0)}.int:{meta_info.get('interruption_count', 0)}"
         }
 
         if self.trigger_function_call:
@@ -118,6 +118,8 @@ class OpenAiLLM(BaseLLM):
 
                 latency_data = {
                     "sequence_id": meta_info.get("sequence_id"),
+                    "turn_id": meta_info.get("turn_id"),
+                    "interruption_count": meta_info.get("interruption_count", 0),
                     "first_token_latency_ms": first_token_time - start_time,
                     "total_stream_duration_ms": None  # Will be filled at end
                 }

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -248,8 +248,9 @@ class CartesiaSynthesizer(BaseSynthesizer):
                         if self.current_turn_start_time is not None:
                             total_stream_duration = time.perf_counter() - self.current_turn_start_time
                             self.turn_latencies.append({
-                                'turn_id': self.current_turn_id,
-                                'sequence_id': self.current_turn_id,
+                                'turn_id': self.meta_info.get('turn_id'),
+                                'interruption_count': self.meta_info.get('interruption_count'),
+                                'sequence_id': self.meta_info.get('sequence_id'),
                                 'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
                                 'total_stream_duration_ms': round(total_stream_duration * 1000)
                             })

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -266,13 +266,13 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
                             if self.current_turn_start_time is not None:
                                 total_stream_duration = time.perf_counter() - self.current_turn_start_time
                                 self.turn_latencies.append({
-                                    'turn_id': self.current_turn_id,
-                                    'sequence_id': self.current_turn_id,
+                                    'turn_id': self.meta_info.get('turn_id'),
+                                    'interruption_count': self.meta_info.get('interruption_count'),
+                                    'sequence_id': self.meta_info.get('sequence_id'),
                                     'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
                                     'total_stream_duration_ms': round(total_stream_duration * 1000)
                                 })
                                 self.current_turn_start_time = None
-                                self.current_turn_id = None
                         except Exception:
                             pass
 
@@ -372,7 +372,8 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
             # Stamp synthesizer turn start time
             try:
                 self.current_turn_start_time = time.perf_counter()
-                self.current_turn_id = meta_info.get('turn_id') or meta_info.get('sequence_id')
+                turn_id = meta_info.get('turn_id')
+                self.current_turn_id = turn_id if turn_id is not None else meta_info.get('sequence_id')
             except Exception:
                 pass
             if not self.context_id:

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -281,13 +281,13 @@ class SarvamSynthesizer(BaseSynthesizer):
                             if self.current_turn_start_time is not None:
                                 total_stream_duration = time.perf_counter() - self.current_turn_start_time
                                 self.turn_latencies.append({
-                                    'turn_id': self.current_turn_id,
-                                    'sequence_id': self.current_turn_id,
+                                    'turn_id': self.meta_info.get('turn_id'),
+                                    'interruption_count': self.meta_info.get('interruption_count'),
+                                    'sequence_id': self.meta_info.get('sequence_id'),
                                     'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
                                     'total_stream_duration_ms': round(total_stream_duration * 1000)
                                 })
                                 self.current_turn_start_time = None
-                                self.current_turn_id = None
                         except Exception:
                             pass
                     else:
@@ -311,7 +311,8 @@ class SarvamSynthesizer(BaseSynthesizer):
             # Stamp synthesizer turn start time
             try:
                 self.current_turn_start_time = time.perf_counter()
-                self.current_turn_id = meta_info.get('turn_id') or meta_info.get('sequence_id')
+                turn_id = meta_info.get('turn_id')
+                self.current_turn_id = turn_id if turn_id is not None else meta_info.get('sequence_id')
             except Exception:
                 pass
             self.sender_task = asyncio.create_task(self.sender(text, meta_info.get("sequence_id"), end_of_llm_stream))

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -126,14 +126,14 @@ class SmallestSynthesizer(BaseSynthesizer):
                             if self.current_turn_start_time is not None:
                                 total_stream_duration = time.perf_counter() - self.current_turn_start_time
                                 self.turn_latencies.append({
-                                    'turn_id': self.current_turn_id,
-                                    'sequence_id': self.current_turn_id,
+                                    'turn_id': self.meta_info.get('turn_id'),
+                                    'interruption_count': self.meta_info.get('interruption_count'),
+                                    'sequence_id': self.meta_info.get('sequence_id'),
                                     'first_result_latency_ms': round((self.meta_info.get('synthesizer_latency', 0)) * 1000),
                                     'total_stream_duration_ms': round(total_stream_duration * 1000)
                                 })
                                 # Reset turn tracking
                                 self.current_turn_start_time = None
-                                self.current_turn_id = None
                         except Exception:
                             pass
 

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -377,7 +377,8 @@ class AssemblyAITranscriber(BaseTranscriber):
                                     self.meta_info['transcriber_latency'] = total_stream_duration
                                     turn_info = {
                                         'turn_id': self.current_turn_id,
-                                        'sequence_id': self.current_turn_id,
+                                        'interruption_count': self.meta_info.get('interruption_count'),
+                                        'sequence_id': self.meta_info.get('sequence_id'),
                                         'first_result_latency_ms': round(((self.meta_info or {}).get('transcriber_first_result_latency', 0)) * 1000),
                                         'total_stream_duration_ms': round(total_stream_duration * 1000),
                                         'interim_details': self.current_turn_interim_details

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -375,16 +375,11 @@ class AssemblyAITranscriber(BaseTranscriber):
                                     total_stream_duration = time.perf_counter() - self.current_turn_start_time
                                     self.meta_info['transcriber_total_stream_duration'] = total_stream_duration
                                     self.meta_info['transcriber_latency'] = total_stream_duration
-                                    turn_info = {
-                                        'turn_id': self.current_turn_id,
-                                        'interruption_count': self.meta_info.get('interruption_count'),
-                                        'sequence_id': self.meta_info.get('sequence_id'),
-                                        'first_result_latency_ms': round(((self.meta_info or {}).get('transcriber_first_result_latency', 0)) * 1000),
-                                        'total_stream_duration_ms': round(total_stream_duration * 1000),
+                                    # Pass interim details via meta_info for TaskManager to build latencies
+                                    self.meta_info['transcriber_turn_metrics'] = {
                                         'interim_details': self.current_turn_interim_details
                                     }
-                                    self.turn_latencies.append(turn_info)
-
+                                    # Reset turn tracking
                                     self.current_turn_start_time = None
                                     self.current_turn_id = None
                                     self.current_turn_interim_details = []

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -246,16 +246,12 @@ class AzureTranscriber(BaseTranscriber):
             self.current_turn_interim_details.append(interim_detail)
 
             try:
-                if not self.current_turn_id:
-                    self.current_turn_id = self.meta_info.get('turn_id') or self.meta_info.get('request_id')
-
-                turn_info = {
-                    'turn_id': self.current_turn_id,
-                    'sequence_id': self.current_turn_id,
+                # Pass interim details via meta_info for TaskManager to build latencies
+                self.meta_info['transcriber_turn_metrics'] = {
                     'interim_details': self.current_turn_interim_details
                 }
-                self.turn_latencies.append(turn_info)
 
+                # Reset turn tracking
                 self.current_turn_interim_details = []
                 self.current_turn_start_time = None
                 self.current_turn_id = None

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -20,7 +20,6 @@ class BaseTranscriber:
         self.previous_request_id = None
         self.current_request_id = None
         self.connection_time = None
-        self.turn_latencies = []
 
     def update_meta_info(self):
         self.meta_info['request_id'] = self.current_request_id if self.current_request_id else None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -348,14 +348,11 @@ class DeepgramTranscriber(BaseTranscriber):
                                 "content": self.final_transcript
                             }
 
-                            # Build turn_latencies with new metrics before resetting
+                            # Include timing data in meta_info for TaskManager to process
                             try:
-                                self.turn_latencies.append({
-                                    'turn_id': self.current_turn_id,
-                                    'interruption_count': self.meta_info.get('interruption_count'),
-                                    'sequence_id': self.meta_info.get('sequence_id'),
+                                self.meta_info['transcriber_turn_metrics'] = {
                                     'interim_details': self.current_turn_interim_details
-                                })
+                                }
 
                                 # Complete turn reset
                                 self.speech_start_time = None
@@ -379,14 +376,11 @@ class DeepgramTranscriber(BaseTranscriber):
                             "content": self.final_transcript
                         }
 
-                        # Build turn_latencies with new metrics before resetting
+                        # Include timing data in meta_info for TaskManager to process
                         try:
-                            self.turn_latencies.append({
-                                'turn_id': self.current_turn_id,
-                                'interruption_count': self.meta_info.get('interruption_count'),
-                                'sequence_id': self.meta_info.get('sequence_id'),
+                            self.meta_info['transcriber_turn_metrics'] = {
                                 'interim_details': self.current_turn_interim_details
-                            })
+                            }
 
                             # Complete turn reset
                             self.speech_start_time = None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -352,7 +352,8 @@ class DeepgramTranscriber(BaseTranscriber):
                             try:
                                 self.turn_latencies.append({
                                     'turn_id': self.current_turn_id,
-                                    'sequence_id': self.current_turn_id,
+                                    'interruption_count': self.meta_info.get('interruption_count'),
+                                    'sequence_id': self.meta_info.get('sequence_id'),
                                     'interim_details': self.current_turn_interim_details
                                 })
 
@@ -382,7 +383,8 @@ class DeepgramTranscriber(BaseTranscriber):
                         try:
                             self.turn_latencies.append({
                                 'turn_id': self.current_turn_id,
-                                'sequence_id': self.current_turn_id,
+                                'interruption_count': self.meta_info.get('interruption_count'),
+                                'sequence_id': self.meta_info.get('sequence_id'),
                                 'interim_details': self.current_turn_interim_details
                             })
 

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -255,7 +255,8 @@ class GoogleTranscriber(BaseTranscriber):
                 total_s = (time.perf_counter() - self.current_turn_start_time) if self.current_turn_start_time else 0
                 self.turn_latencies.append({
                     'turn_id': self.current_turn_id,
-                    'sequence_id': self.current_turn_id,
+                    'interruption_count': self.meta_info.get('interruption_count'),
+                    'sequence_id': self.meta_info.get('sequence_id'),
                     'first_result_latency_ms': first_ms,
                     'total_stream_duration_ms': int(round(total_s * 1000))
                 })

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -381,9 +381,10 @@ class SarvamTranscriber(BaseTranscriber):
 
                                 turn_info = {
                                     "turn_id": self.current_turn_id,
-                                    "sequence_id": self.current_turn_id,
+                                    "interruption_count": self.meta_info.get('interruption_count'),
+                                    "sequence_id": self.meta_info.get('sequence_id'),
                                     "first_result_latency_ms": self.turn_first_result_latency,
-                                    "total_stream_duration_ms": total_stream_duration_ms,  
+                                    "total_stream_duration_ms": total_stream_duration_ms,
                                 }
                                 self.turn_latencies.append(turn_info)
                                 self.meta_info["turn_latencies"] = self.turn_latencies

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -375,21 +375,17 @@ class SarvamTranscriber(BaseTranscriber):
                             if self.current_turn_start_time:
                                 total_stream_duration = time.perf_counter() - self.current_turn_start_time
                                 total_stream_duration_ms = round(total_stream_duration * 1000)
-                                
-                                self.meta_info['transcriber_total_stream_duration'] = total_stream_duration
-                                self.meta_info['transcriber_latency'] = total_stream_duration  
 
-                                turn_info = {
-                                    "turn_id": self.current_turn_id,
-                                    "interruption_count": self.meta_info.get('interruption_count'),
-                                    "sequence_id": self.meta_info.get('sequence_id'),
+                                self.meta_info['transcriber_total_stream_duration'] = total_stream_duration
+                                self.meta_info['transcriber_latency'] = total_stream_duration
+
+                                # Include timing data in meta_info for TaskManager to process
+                                self.meta_info['transcriber_turn_metrics'] = {
                                     "first_result_latency_ms": self.turn_first_result_latency,
                                     "total_stream_duration_ms": total_stream_duration_ms,
                                 }
-                                self.turn_latencies.append(turn_info)
-                                self.meta_info["turn_latencies"] = self.turn_latencies
-                                
-                                # Reset turn tracking 
+
+                                # Reset turn tracking
                                 self.current_turn_start_time = None
                                 self.current_turn_id = None
 


### PR DESCRIPTION
## Goal
  Fix turn_id to properly increment on every speaker change and ensure all components track turn_id, interruption_count, and sequence_id in latency data.

  ## Problem
  - turn_id stayed at 1 throughout conversations (should increment: 1→2→3→4...) and we happened to be tracking interruption counts and progating this for llms and syn
  - syn sequence id was not set to sequence id and was mapped to the internal turn ids
  - transcriber is showing sequence id (internal turn id sequence is written that way currently

  ## Changes

  1. **task_manager.py** - Moved user turn tracking before welcome_message_played() check so turn_id increments immediately
  2. **LLM files** (litellm.py, openai_llm.py) - Added turn_id and interruption_count to latency tracking
  3. **Synthesizers** (elevenlabs, sarvam, smallest) - Fixed turn_id tracking in latencies
  4. **Transcribers** (deepgram, google, sarvam, assemblyai) - Use internal turn counter to avoid null values

  ## Field Definitions
  - **turn_id**: Increments on every speaker change (user/agent alternation)
  - **interruption_count**: Only increments when user interrupts agent
  - **sequence_id**: Monotonically increasing message counter

  ## TODO
  Transcriber turn_id is currently using internal counter, not system's authoritative turn_id. Need to implement feedback mechanism from TaskManager to Transcriber to sync properly.

  ## Result
  - turn_id increments properly across all components
  - All latency data includes turn_id, interruption_count, sequence_id
  - No more null values in tracking fields
