### PR TITLE
Revert "fix:  Only disable keyterms for multilingual mode"

### DIFF
--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -119,10 +119,8 @@ class DeepgramTranscriber(BaseTranscriber):
         if self.keywords and len(self.keywords.split(",")) > 0:
             if self.model.startswith('nova-3'):
                 dg_params['keyterm'] = "&keyterm=".join(self.keywords.split(","))
-                # Only disable keyterms for multilingual mode (not monolingual languages)
-                if self.language in ['multi', 'detect']:
+                if self.language != 'en':
                     dg_params.pop('keyterm', None)
-                    logger.info(f"Keyterms disabled for multilingual transcription (language={self.language})")
             else:
                 dg_params['keywords'] = "&keywords=".join(self.keywords.split(","))
 


### PR DESCRIPTION
This reverts commit 9f2a9cf2b57521cfd991f249a99b93633746d509.