### PR TITLE
feat: Add GitHub Actions workflow to publish Docker images

### DIFF
--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,0 +1,55 @@
+# This workflow builds and publishes the Docker images to Docker Hub.
+#
+# To use this workflow, you need to create two secrets in your repository:
+#
+#   DOCKERHUB_USERNAME: Your Docker Hub username.
+#   DOCKERHUB_TOKEN: Your Docker Hub access token.
+#
+# The workflow will be triggered automatically when you push a new tag to the repository.
+
+name: Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push bolna-app
+        uses: docker/build-push-action@v4
+        with:
+          context: bolna/local_setup
+          dockerfile: bolna/local_setup/dockerfiles/bolna_server.Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/bolna-app:${{ github.ref_name }}
+
+      - name: Build and push twilio-app
+        uses: docker/build-push-action@v4
+        with:
+          context: bolna/local_setup
+          dockerfile: bolna/local_setup/dockerfiles/twilio_server.Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/twilio-app:${{ github.ref_name }}
+
+      - name: Build and push plivo-app
+        uses: docker/build-push-action@v4
+        with:
+          context: bolna/local_setup
+          dockerfile: bolna/local_setup/dockerfiles/plivo_server.Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/plivo-app:${{ github.ref_name }}


### PR DESCRIPTION
This pull request fixes #196.

**Summary of the issue:**

The issue proposed to Dockerize the `bolna` package along with the quickstart servers. The goal is to publish the Docker images to a container registry like Docker Hub to allow users to easily pull the images and build on top of them.

**Root cause:**

Currently, there is no easy way for users to consume the `bolna` application as a Docker image. They have to manually build the images from the source code.

**Solution:**

This pull request adds a new GitHub Actions workflow that automates the process of building and publishing the Docker images for `bolna-app`, `twilio-app`, and `plivo-app`.

The workflow is triggered when a new tag is pushed to the repository. It builds the Docker images and pushes them to Docker Hub.

To use this workflow, you need to create two secrets in your repository:
*   `DOCKERHUB_USERNAME`: Your Docker Hub username.
*   `DOCKERHUB_TOKEN`: Your Docker Hub access token.

**Tests added/updated:**

This change is to the CI/CD process and does not directly affect the application code. The test for this change is the workflow itself. It will be tested when a new tag is pushed to the repository.