### PR TITLE
fix: add null check in transcriber _close to prevent NoneType error

### DIFF
--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -54,6 +54,7 @@ class BaseTranscriber:
 
     async def _close(self, ws, data):
         if ws is None:
+            # TEMP LOG
             logger.warning("Transcriber websocket already closed, skipping close message")
             return
         try:

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -54,6 +54,7 @@ class BaseTranscriber:
 
     async def _close(self, ws, data):
         if ws is None:
+            logger.warning("Transcriber websocket already closed, skipping close message")
             return
         try:
             await ws.send(json.dumps(data))

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -53,6 +53,8 @@ class BaseTranscriber:
                 f"No confidence for the last vocal timeframe. Over transcription time {transcription_completion_time - self.transcription_start_time}")
 
     async def _close(self, ws, data):
+        if ws is None:
+            return
         try:
             await ws.send(json.dumps(data))
         except Exception as e:


### PR DESCRIPTION
## Summary
- Adds null check for websocket in `_close()` method before attempting to send

## Problem
In HTTP/non-streaming mode, `_close()` was being called with `ws=None`, causing `'NoneType' object has no attribute 'send'` errors.

**Sentry Issue:** [DASHBOARD-BACKEND-D](https://bolna-voice-ai.sentry.io/issues/6804720192/) - ~13,400 events

Fixes #459

## Changes
- `bolna/transcriber/base_transcriber.py`: Added early return if `ws is None`

## Testing
- Verified `_close(None, data)` no longer raises AttributeError
- Verified `_close(valid_ws, data)` still works correctly