### PR TITLE
fix: add null check for message data in duration calculation

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -698,11 +698,12 @@ class TaskManager(BaseManager):
                     convert_to_request_log(message=text, meta_info=meta_info, component="synthesizer", direction="response", model=self.synthesizer_provider, is_cached=meta_info.get("is_cached", False), engine=self.tools['synthesizer'].get_engine(), run_id=self.run_id)
                     await self.tools["output"].handle(message)
                     try:
-                        if message["data"] is not None:
-                            duration = calculate_audio_duration(len(message["data"]), self.sampling_rate,
+                        data = message.get("data")
+                        if data is not None:
+                            duration = calculate_audio_duration(len(data), self.sampling_rate,
                                                                 format=message['meta_info']['format'])
                             self.conversation_recording['output'].append(
-                                {'data': message['data'], "start_time": time.time(), "duration": duration})
+                                {'data': data, "start_time": time.time(), "duration": duration})
                     except Exception as e:
                         duration = 0.256
                         logger.error("Exception in __forced_first_message for duration calculation: {}".format(str(e)))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -698,10 +698,11 @@ class TaskManager(BaseManager):
                     convert_to_request_log(message=text, meta_info=meta_info, component="synthesizer", direction="response", model=self.synthesizer_provider, is_cached=meta_info.get("is_cached", False), engine=self.tools['synthesizer'].get_engine(), run_id=self.run_id)
                     await self.tools["output"].handle(message)
                     try:
-                        duration = calculate_audio_duration(len(message["data"]), self.sampling_rate,
-                                                            format=message['meta_info']['format'])
-                        self.conversation_recording['output'].append(
-                            {'data': message['data'], "start_time": time.time(), "duration": duration})
+                        if message["data"] is not None:
+                            duration = calculate_audio_duration(len(message["data"]), self.sampling_rate,
+                                                                format=message['meta_info']['format'])
+                            self.conversation_recording['output'].append(
+                                {'data': message['data'], "start_time": time.time(), "duration": duration})
                     except Exception as e:
                         duration = 0.256
                         logger.error("Exception in __forced_first_message for duration calculation: {}".format(str(e)))


### PR DESCRIPTION
## Summary
Fixes #465

When `__forced_first_message` is called with empty text, `audio_chunk` is set to `None`. This results in `message["data"]` being `None`, and `len(None)` fails.

**Root cause flow:**
1. `meta_info['text'] == ''` → `audio_chunk = None` (line 680-681)
2. `create_ws_data_packet(None, meta_info)` → `message["data"] = None`
3. `len(message["data"])` → `TypeError: object of type 'NoneType' has no len()`

## Fix
Add null check before calling `len()`. When `message["data"]` is None, skip duration calculation and recording (no audio data to record).

**Sentry:** https://bolna-voice-ai.sentry.io/issues/6804869977/
**Events:** 5,428 total, 122 in last 24h