### PR TITLE
fix: prevent websocket send after close by tracking closed state

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1301,6 +1301,10 @@ class TaskManager(BaseManager):
         self.conversation_ended = True
         self.ended_by_assistant = True
 
+        # Close output handler to prevent sends after websocket close
+        if "output" in self.tools and self.tools["output"] is not None:
+            self.tools["output"].close()
+
         await self.tools["input"].stop_handler()
         logger.info("Stopped input handler")
         if "transcriber" in self.tools and not self.turn_based_conversation:

--- a/bolna/output_handlers/telephony.py
+++ b/bolna/output_handlers/telephony.py
@@ -34,6 +34,8 @@ class TelephonyOutputHandler(DefaultOutputHandler):
         self.stream_sid = stream_id
 
     async def handle(self, ws_data_packet):
+        if self._closed:
+            return
         try:
             audio_chunk = ws_data_packet.get('data')
             meta_info = ws_data_packet.get('meta_info')


### PR DESCRIPTION
## Summary
Fixes #460

When a conversation ends, the websocket is closed but async tasks (LLM, transcriber, synthesizer) may still try to send data, causing "Unexpected ASGI message 'websocket.send', after sending 'websocket.close'" errors.

**Root cause timeline:**
1. Conversation ends → `__process_end_of_conversation()` called
2. `input.stop_handler()` closes the websocket
3. Async tasks still running try to call `output.handle()` → `websocket.send_text()`
4. WebSocket already closed → error logged to Sentry

## Fix
1. Added `_closed` flag to `DefaultOutputHandler` and `TelephonyOutputHandler`
2. Added early return check in `handle()` and `handle_interruption()` if closed
3. Call `output.close()` before `input.stop_handler()` in `__process_end_of_conversation()`

This ensures all send attempts after conversation end are silently skipped.

**Sentry issues addressed:**
- https://bolna-voice-ai.sentry.io/issues/6804920470/ (1,865 events/7d)
- https://bolna-voice-ai.sentry.io/issues/6805047312/ (677 events/7d)

**Combined impact:** ~2,542 events in 7 days