### PR TITLE
fix: handle websocket send after close in output handlers

### DIFF
--- a/bolna/output_handlers/telephony.py
+++ b/bolna/output_handlers/telephony.py
@@ -86,8 +86,9 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                 else:
                     logger.info("Not sending")
             except Exception as e:
-                traceback.print_exc()
-                logger.info(f'something went wrong while sending message to twilio {e}')
+                self._closed = True  # Prevent further send attempts
+                logger.debug(f'WebSocket send failed (client disconnected): {e}')
 
         except Exception as e:
-            logger.info(f'something went wrong while handling twilio {e}')
+            self._closed = True
+            logger.debug(f'WebSocket handling failed (client disconnected): {e}')

--- a/bolna/output_handlers/telephony_providers/exotel.py
+++ b/bolna/output_handlers/telephony_providers/exotel.py
@@ -17,13 +17,19 @@ class ExotelOutputHandler(TelephonyOutputHandler):
         self.is_chunking_supported = True
 
     async def handle_interruption(self):
-        logger.info("interrupting because user spoke in between")
-        message_clear = {
-            "event": "clear",
-            "stream_sid": self.stream_sid,
-        }
-        await self.websocket.send_text(json.dumps(message_clear))
-        self.mark_event_meta_data.clear_data()
+        if self._closed:
+            return
+        try:
+            logger.info("interrupting because user spoke in between")
+            message_clear = {
+                "event": "clear",
+                "stream_sid": self.stream_sid,
+            }
+            await self.websocket.send_text(json.dumps(message_clear))
+            self.mark_event_meta_data.clear_data()
+        except Exception as e:
+            logger.info(f"WebSocket closed during interruption: {e}")
+            self._closed = True
 
     async def form_media_message(self, audio_data, audio_format):
         # Exotel expects PCM format (16-bit linear)

--- a/bolna/output_handlers/telephony_providers/twilio.py
+++ b/bolna/output_handlers/telephony_providers/twilio.py
@@ -18,13 +18,19 @@ class TwilioOutputHandler(TelephonyOutputHandler):
         self.is_chunking_supported = True
 
     async def handle_interruption(self):
-        logger.info("interrupting because user spoke in between")
-        message_clear = {
-            "event": "clear",
-            "streamSid": self.stream_sid,
-        }
-        await self.websocket.send_text(json.dumps(message_clear))
-        self.mark_event_meta_data.clear_data()
+        if self._closed:
+            return
+        try:
+            logger.info("interrupting because user spoke in between")
+            message_clear = {
+                "event": "clear",
+                "streamSid": self.stream_sid,
+            }
+            await self.websocket.send_text(json.dumps(message_clear))
+            self.mark_event_meta_data.clear_data()
+        except Exception as e:
+            logger.info(f"WebSocket closed during interruption: {e}")
+            self._closed = True
 
     async def form_media_message(self, audio_data, audio_format="wav"):
         if audio_format != "mulaw":

--- a/bolna/output_handlers/telephony_providers/vobiz.py
+++ b/bolna/output_handlers/telephony_providers/vobiz.py
@@ -16,13 +16,19 @@ class VobizOutputHandler(TelephonyOutputHandler):
         self.is_chunking_supported = True
 
     async def handle_interruption(self):
-        logger.info("interrupting because user spoke in between")
-        message_clear = {
-            "event": "clearAudio",
-            "streamId": self.stream_sid,
-        }
-        await self.websocket.send_text(json.dumps(message_clear))
-        self.mark_event_meta_data.clear_data()
+        if self._closed:
+            return
+        try:
+            logger.info("interrupting because user spoke in between")
+            message_clear = {
+                "event": "clearAudio",
+                "streamId": self.stream_sid,
+            }
+            await self.websocket.send_text(json.dumps(message_clear))
+            self.mark_event_meta_data.clear_data()
+        except Exception as e:
+            logger.info(f"WebSocket closed during interruption: {e}")
+            self._closed = True
 
     async def form_media_message(self, audio_data, audio_format='audio/x-mulaw'):
         base64_audio = base64.b64encode(audio_data).decode("utf-8")


### PR DESCRIPTION
## Summary
- Add try-except around websocket sends in output handlers
- Set `_closed` flag on exception to prevent subsequent send attempts
- Fixes RuntimeError when client disconnects mid-call

## Sentry Issues
- https://bolna-ai.sentry.io/issues/6804920470 (11,953 events)
- https://bolna-ai.sentry.io/issues/6805047312 (6,200 events)
- https://bolna-ai.sentry.io/issues/6804813963 (5,356 events)
- https://bolna-ai.sentry.io/issues/6804962427 (5,386 events)

Closes #460