### PR TITLE
Refactor: use enums for providers

### DIFF
--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -1,0 +1,90 @@
+from enum import Enum
+
+
+class TelephonyProvider(str, Enum):
+    """Enum for telephony/IO providers (input/output handlers)."""
+    TWILIO = "twilio"
+    EXOTEL = "exotel"
+    PLIVO = "plivo"
+    VOBIZ = "vobiz"
+    SIP_TRUNK = "sip-trunk"
+    DEFAULT = "default"
+    DATABASE = "database"
+
+    @classmethod
+    def telephony_providers(cls):
+        """Return only telephony providers (excluding default and database)."""
+        return [cls.TWILIO, cls.EXOTEL, cls.PLIVO, cls.VOBIZ, cls.SIP_TRUNK]
+
+    @classmethod
+    def all_values(cls):
+        """Return all provider values as a list of strings."""
+        return [provider.value for provider in cls]
+
+    @classmethod
+    def telephony_values(cls):
+        """Return telephony provider values as a list of strings."""
+        return [provider.value for provider in cls.telephony_providers()]
+
+
+class SynthesizerProvider(str, Enum):
+    """Enum for synthesizer (TTS) providers."""
+    POLLY = "polly"
+    ELEVENLABS = "elevenlabs"
+    OPENAI = "openai"
+    DEEPGRAM = "deepgram"
+    AZURETTS = "azuretts"
+    CARTESIA = "cartesia"
+    SMALLEST = "smallest"
+    SARVAM = "sarvam"
+    RIME = "rime"
+    PIXA = "pixa"
+
+    @classmethod
+    def all_values(cls):
+        """Return all provider values as a list of strings."""
+        return [provider.value for provider in cls]
+
+
+class TranscriberProvider(str, Enum):
+    """Enum for transcriber (STT) providers."""
+    DEEPGRAM = "deepgram"
+    AZURE = "azure"
+    SARVAM = "sarvam"
+    ASSEMBLY = "assembly"
+    GOOGLE = "google"
+    PIXA = "pixa"
+    GLADIA = "gladia"
+    ELEVENLABS = "elevenlabs"
+    SMALLEST = "smallest"
+
+    @classmethod
+    def all_values(cls):
+        """Return all provider values as a list of strings."""
+        return [provider.value for provider in cls]
+
+
+class LLMProvider(str, Enum):
+    """Enum for LLM providers."""
+    OPENAI = "openai"
+    COHERE = "cohere"
+    OLLAMA = "ollama"
+    DEEPINFRA = "deepinfra"
+    TOGETHER = "together"
+    FIREWORKS = "fireworks"
+    AZURE_OPENAI = "azure-openai"
+    PERPLEXITY = "perplexity"
+    VLLM = "vllm"
+    ANYSCALE = "anyscale"
+    CUSTOM = "custom"
+    OLA = "ola"
+    GROQ = "groq"
+    ANTHROPIC = "anthropic"
+    DEEPSEEK = "deepseek"
+    OPENROUTER = "openrouter"
+    AZURE = "azure"
+
+    @classmethod
+    def all_values(cls):
+        """Return all provider values as a list of strings."""
+        return [provider.value for provider in cls]

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Union, Dict, Callable
 from pydantic import BaseModel, Field, field_validator, ValidationError, Json, model_validator
 from pydantic_core import PydanticCustomError
 from .providers import *
+from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider
 
 AGENT_WELCOME_MESSAGE = "This call is being recorded for quality assurance and training. Please speak now."
 
@@ -101,7 +102,7 @@ class Transcriber(BaseModel):
 
     @field_validator("provider")
     def validate_model(cls, value):
-        return validate_attribute(value, list(SUPPORTED_TRANSCRIBER_PROVIDERS.keys()))
+        return validate_attribute(value, TranscriberProvider.all_values())
 
 
 class Synthesizer(BaseModel):
@@ -154,7 +155,7 @@ class Synthesizer(BaseModel):
 
     @field_validator("provider")
     def validate_model(cls, value):
-        return validate_attribute(value, ["polly", "elevenlabs", "azuretts", "openai", "deepgram", "cartesia", "smallest", "sarvam", "rime", "pixa"])
+        return validate_attribute(value, SynthesizerProvider.all_values())
 
 
 
@@ -164,7 +165,7 @@ class IOModel(BaseModel):
 
     @field_validator("provider")
     def validate_provider(cls, value):
-        return validate_attribute(value, ["twilio", "default", "database", "exotel", "plivo", "vobiz"])
+        return validate_attribute(value, TelephonyProvider.all_values())
 
 
 # Can be used to route across multiple prompts as well

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -3,30 +3,31 @@ from .transcriber import DeepgramTranscriber, AzureTranscriber, SarvamTranscribe
 from .input_handlers import DefaultInputHandler, TwilioInputHandler, ExotelInputHandler, PlivoInputHandler, VobizInputHandler, SipTrunkInputHandler
 from .output_handlers import DefaultOutputHandler, TwilioOutputHandler, ExotelOutputHandler, PlivoOutputHandler, VobizOutputHandler, SipTrunkOutputHandler
 from .llms import OpenAiLLM, LiteLLM, AzureLLM
+from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider
 
 SUPPORTED_SYNTHESIZER_MODELS = {
-    'polly': PollySynthesizer,
-    'elevenlabs': ElevenlabsSynthesizer,
-    'openai': OPENAISynthesizer,
-    'deepgram': DeepgramSynthesizer,
-    'azuretts': AzureSynthesizer,
-    'cartesia': CartesiaSynthesizer,
-    'smallest': SmallestSynthesizer,
-    'sarvam': SarvamSynthesizer,
-    'rime': RimeSynthesizer,
-    'pixa': PixaSynthesizer
+    SynthesizerProvider.POLLY.value: PollySynthesizer,
+    SynthesizerProvider.ELEVENLABS.value: ElevenlabsSynthesizer,
+    SynthesizerProvider.OPENAI.value: OPENAISynthesizer,
+    SynthesizerProvider.DEEPGRAM.value: DeepgramSynthesizer,
+    SynthesizerProvider.AZURETTS.value: AzureSynthesizer,
+    SynthesizerProvider.CARTESIA.value: CartesiaSynthesizer,
+    SynthesizerProvider.SMALLEST.value: SmallestSynthesizer,
+    SynthesizerProvider.SARVAM.value: SarvamSynthesizer,
+    SynthesizerProvider.RIME.value: RimeSynthesizer,
+    SynthesizerProvider.PIXA.value: PixaSynthesizer
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {
-    'deepgram': DeepgramTranscriber,
-    'azure': AzureTranscriber,
-    'sarvam': SarvamTranscriber,
-    'assembly': AssemblyAITranscriber,
-    'google': GoogleTranscriber,
-    'pixa': PixaTranscriber,
-    'gladia': GladiaTranscriber,
-    'elevenlabs': ElevenLabsTranscriber,
-    'smallest': SmallestTranscriber
+    TranscriberProvider.DEEPGRAM.value: DeepgramTranscriber,
+    TranscriberProvider.AZURE.value: AzureTranscriber,
+    TranscriberProvider.SARVAM.value: SarvamTranscriber,
+    TranscriberProvider.ASSEMBLY.value: AssemblyAITranscriber,
+    TranscriberProvider.GOOGLE.value: GoogleTranscriber,
+    TranscriberProvider.PIXA.value: PixaTranscriber,
+    TranscriberProvider.GLADIA.value: GladiaTranscriber,
+    TranscriberProvider.ELEVENLABS.value: ElevenLabsTranscriber,
+    TranscriberProvider.SMALLEST.value: SmallestTranscriber
 }
 
 #Backwards compatibility
@@ -35,51 +36,51 @@ SUPPORTED_TRANSCRIBER_MODELS = {
 }
 
 SUPPORTED_LLM_PROVIDERS = {
-    'openai': OpenAiLLM,
-    'cohere': LiteLLM,
-    'ollama': LiteLLM,
-    'deepinfra': LiteLLM,
-    'together': LiteLLM,
-    'fireworks': LiteLLM,
-    'azure-openai': AzureLLM,
-    'perplexity': LiteLLM,
-    'vllm': LiteLLM,
-    'anyscale': LiteLLM,
-    'custom': OpenAiLLM,
-    'ola': OpenAiLLM,
-    'groq': LiteLLM,
-    'anthropic': LiteLLM,
-    'deepseek': LiteLLM,
-    'openrouter': LiteLLM,
-    'azure': AzureLLM
+    LLMProvider.OPENAI.value: OpenAiLLM,
+    LLMProvider.COHERE.value: LiteLLM,
+    LLMProvider.OLLAMA.value: LiteLLM,
+    LLMProvider.DEEPINFRA.value: LiteLLM,
+    LLMProvider.TOGETHER.value: LiteLLM,
+    LLMProvider.FIREWORKS.value: LiteLLM,
+    LLMProvider.AZURE_OPENAI.value: AzureLLM,
+    LLMProvider.PERPLEXITY.value: LiteLLM,
+    LLMProvider.VLLM.value: LiteLLM,
+    LLMProvider.ANYSCALE.value: LiteLLM,
+    LLMProvider.CUSTOM.value: OpenAiLLM,
+    LLMProvider.OLA.value: OpenAiLLM,
+    LLMProvider.GROQ.value: LiteLLM,
+    LLMProvider.ANTHROPIC.value: LiteLLM,
+    LLMProvider.DEEPSEEK.value: LiteLLM,
+    LLMProvider.OPENROUTER.value: LiteLLM,
+    LLMProvider.AZURE.value: AzureLLM
 }
 SUPPORTED_INPUT_HANDLERS = {
-    'default': DefaultInputHandler,
-    'twilio': TwilioInputHandler,
-    'exotel': ExotelInputHandler,
-    'plivo': PlivoInputHandler,
-    'vobiz': VobizInputHandler,
-    'sip-trunk': SipTrunkInputHandler
+    TelephonyProvider.DEFAULT.value: DefaultInputHandler,
+    TelephonyProvider.TWILIO.value: TwilioInputHandler,
+    TelephonyProvider.EXOTEL.value: ExotelInputHandler,
+    TelephonyProvider.PLIVO.value: PlivoInputHandler,
+    TelephonyProvider.VOBIZ.value: VobizInputHandler,
+    TelephonyProvider.SIP_TRUNK.value: SipTrunkInputHandler
 }
 SUPPORTED_INPUT_TELEPHONY_HANDLERS = {
-    'twilio': TwilioInputHandler,
-    'exotel': ExotelInputHandler,
-    'plivo': PlivoInputHandler,
-    'vobiz': VobizInputHandler,
-    'sip-trunk': SipTrunkInputHandler
+    TelephonyProvider.TWILIO.value: TwilioInputHandler,
+    TelephonyProvider.EXOTEL.value: ExotelInputHandler,
+    TelephonyProvider.PLIVO.value: PlivoInputHandler,
+    TelephonyProvider.VOBIZ.value: VobizInputHandler,
+    TelephonyProvider.SIP_TRUNK.value: SipTrunkInputHandler
 }
 SUPPORTED_OUTPUT_HANDLERS = {
-    'default': DefaultOutputHandler,
-    'twilio': TwilioOutputHandler,
-    'exotel': ExotelOutputHandler,
-    'plivo': PlivoOutputHandler,
-    'vobiz': VobizOutputHandler,
-    'sip-trunk': SipTrunkOutputHandler
+    TelephonyProvider.DEFAULT.value: DefaultOutputHandler,
+    TelephonyProvider.TWILIO.value: TwilioOutputHandler,
+    TelephonyProvider.EXOTEL.value: ExotelOutputHandler,
+    TelephonyProvider.PLIVO.value: PlivoOutputHandler,
+    TelephonyProvider.VOBIZ.value: VobizOutputHandler,
+    TelephonyProvider.SIP_TRUNK.value: SipTrunkOutputHandler
 }
 SUPPORTED_OUTPUT_TELEPHONY_HANDLERS = {
-    'twilio': TwilioOutputHandler,
-    'exotel': ExotelOutputHandler,
-    'plivo': PlivoOutputHandler,
-    'vobiz': VobizOutputHandler,
-    'sip-trunk': SipTrunkOutputHandler
+    TelephonyProvider.TWILIO.value: TwilioOutputHandler,
+    TelephonyProvider.EXOTEL.value: ExotelOutputHandler,
+    TelephonyProvider.PLIVO.value: PlivoOutputHandler,
+    TelephonyProvider.VOBIZ.value: VobizOutputHandler,
+    TelephonyProvider.SIP_TRUNK.value: SipTrunkOutputHandler
 }

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
+from bolna.enums import TelephonyProvider
 
 
 logger = configure_logger(__name__)
@@ -86,10 +87,10 @@ class DeepgramTranscriber(BaseTranscriber):
 
         self.audio_frame_duration = 0.5  # We're sending 8k samples with a sample rate of 16k
 
-        if self.provider in ('twilio', 'exotel', 'plivo', 'vobiz', 'sip-trunk'):
+        if self.provider in TelephonyProvider.telephony_values():
             # For sip-trunk (Asterisk), encoding and sampling_rate are already set in task_manager
             # Don't override them - use what was passed from task_config
-            if self.provider != 'sip-trunk':
+            if self.provider != TelephonyProvider.SIP_TRUNK.value:
                 self.encoding = 'mulaw' if self.provider in ("twilio") else "linear16"
                 self.sampling_rate = 8000
             # For sip-trunk, encoding and sampling_rate come from task_config (set in task_manager)
@@ -99,8 +100,8 @@ class DeepgramTranscriber(BaseTranscriber):
             dg_params['encoding'] = self.encoding
             dg_params['sample_rate'] = self.sampling_rate
             dg_params['channels'] = "1"
-            
-            if self.provider == 'sip-trunk':
+
+            if self.provider == TelephonyProvider.SIP_TRUNK.value:
                 logger.info(f"[SIP-TRUNK] Deepgram transcriber configured with encoding={self.encoding}, sample_rate={self.sampling_rate}")
 
         elif self.provider == "web_based_call":


### PR DESCRIPTION
Summary of Changes
1. Created new file: enums.py Contains four enum classes:

TelephonyProvider - includes SIP_TRUNK = "sip-trunk" along with twilio, exotel, plivo, vobiz, default, and database SynthesizerProvider - all TTS providers (polly, elevenlabs, openai, etc.) TranscriberProvider - all STT providers (deepgram, azure, sarvam, etc.) LLMProvider - all LLM providers (openai, anthropic, groq, etc.) Each enum has helper methods like all_values() and for TelephonyProvider, also telephony_values().

2. Updated models.py Added enum imports
IOModel validator now uses TelephonyProvider.all_values() - this fixes the missing sip-trunk validation issue Synthesizer validator uses SynthesizerProvider.all_values() Transcriber validator uses TranscriberProvider.all_values()
3. Updated providers.py All provider dictionaries now use enum values as keys (e.g., TelephonyProvider.SIP_TRUNK.value: SipTrunkInputHandler)
4. Updated task_manager.py All "sip-trunk" string comparisons replaced with TelephonyProvider.SIP_TRUNK.value
5. Updated deepgram_transcriber.py Uses TelephonyProvider.telephony_values() for provider list checks Uses TelephonyProvider.SIP_TRUNK.value for sip-trunk comparisons