### PR TITLE
Add configurable Deepgram websocket protocol via DEEPGRAM_HOST_PROTOCOL

### DIFF
--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -18,6 +18,8 @@ from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 logger = configure_logger(__name__)
 load_dotenv()
 
+DEEPGRAM_HOST_PROTOCOL = os.getenv('DEEPGRAM_HOST_PROTOCOL', 'wss')
+
 
 class DeepgramTranscriber(BaseTranscriber):
     def __init__(self, telephony_provider, input_queue=None, model='nova-2', stream=True, language="en", endpointing="400",
@@ -123,7 +125,7 @@ class DeepgramTranscriber(BaseTranscriber):
             else:
                 dg_params['keywords'] = "&keywords=".join(self.keywords.split(","))
 
-        websocket_api = 'wss://{}/v1/listen?'.format(self.deepgram_host)
+        websocket_api = '{}://{}/v1/listen?'.format(DEEPGRAM_HOST_PROTOCOL, self.deepgram_host)
         websocket_url = websocket_api + urlencode(dg_params)
         return websocket_url
 


### PR DESCRIPTION
Introduces DEEPGRAM_HOST_PROTOCOL env var (default "wss") and uses it when composing the Deepgram websocket listen URL.

Motivation: allow switching between "ws" and "wss" for environments behind proxies or special setups.