### PR TITLE
fix: reset is_audio_being_played when final audio chunk is discarded

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2450,6 +2450,11 @@ class TaskManager(BaseManager):
                     elif status == "BLOCK":
                         # Audio blocked (user speaking or invalid sequence) - discard
                         logger.info(f'Audio blocked: discarding message (sequence_id={sequence_id})')
+                        # If discarding the final chunk of the response, reset is_audio_being_played
+                        # to prevent state deadlock where mark event never arrives from telephony
+                        if message['meta_info'].get('is_final_chunk_of_entire_response', False):
+                            self.tools["input"].update_is_audio_being_played(False)
+                            logger.info(f'Final chunk discarded, resetting is_audio_being_played to prevent deadlock')
                         should_continue_outer_loop = True
                         break  # Exit inner loop, skip to next message
 


### PR DESCRIPTION
## Summary
- Agent goes silent after first response when user speaks briefly during audio playback
- Root cause: when audio chunks are discarded (BLOCK path), the final chunk's mark event never reaches telephony provider, so `is_audio_being_played` stays `True` forever
- Fix: reset `is_audio_being_played` to `False` when the final chunk of a response is discarded