### PR TITLE
feat: sarvam v3 models

### DIFF
--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -90,3 +90,8 @@ LLM_DEFAULT_CONFIGS = {
         "provider": "openai"
     }
 }
+
+SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
+    "bulbul:v2": 22050,
+    "bulbul:v3": 22050 # NOTE: Documentation claims 24000, but WAV header shows 22050
+}

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timezone
 PREPROCESS_DIR = 'agent_data'
+PCM16_SCALE = 32768.0
 
 HIGH_LEVEL_ASSISTANT_ANALYTICS_DATA = {
         "extraction_details":{}, 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -378,17 +378,73 @@ def convert_audio_to_wav(audio_bytes, source_format = 'flac'):
     return buffer.getvalue()
 
 
-def resample(audio_bytes, target_sample_rate, format = "mp3"):
+import io
+import torch
+import torchaudio
+import numpy as np
+
+def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, original_sample_rate=None):
+    """
+    Resample audio bytes
+    
+    Args:
+        audio_bytes: Audio data as bytes
+        target_sample_rate: Target sample rate
+        format: Audio format ('wav', 'mp3', 'pcm', etc.)
+        original_sample_rate: Required if format='pcm'
+        pcm_channels: Number of channels for PCM (default: 1 mono)
+    """
+    
+    # Handle PCM separately
+    if format == "pcm":
+        if original_sample_rate is None:
+            raise ValueError("original_sample_rate must be provided for PCM format")
+        
+        audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
+        
+        waveform = torch.from_numpy(audio_array).float() / 32768.0
+        
+        if pcm_channels == 1:
+            waveform = waveform.unsqueeze(0)  # (1, samples)
+        else:
+            # For multi-channel, interleaved PCM
+            waveform = waveform.reshape(pcm_channels, -1)
+        
+        if original_sample_rate == target_sample_rate:
+            return audio_bytes
+        
+        # Resample
+        resampler = torchaudio.transforms.Resample(original_sample_rate, target_sample_rate)
+        audio_waveform = resampler(waveform)
+        
+        audio_int16 = (audio_waveform * 32768.0).to(torch.int16)
+        return audio_int16.numpy().tobytes()
+    
+    # Handle other formats (wav, mp3, etc.)
     audio_buffer = io.BytesIO(audio_bytes)
-    waveform, orig_sample_rate = torchaudio.load(audio_buffer, format = format)
-    if orig_sample_rate == target_sample_rate:
+    waveform, original_sample_rate = torchaudio.load(audio_buffer, format=format)
+    
+    if original_sample_rate == target_sample_rate:
         return audio_bytes
-    resampler = torchaudio.transforms.Resample(orig_sample_rate, target_sample_rate)
+    
+    resampler = torchaudio.transforms.Resample(original_sample_rate, target_sample_rate)
     audio_waveform = resampler(waveform)
+    
     audio_buffer = io.BytesIO()
-    logger.info(f"Resampling from {orig_sample_rate} to {target_sample_rate}")
+    logger.info(f"Resampling from {original_sample_rate} to {target_sample_rate}")
     torchaudio.save(audio_buffer, audio_waveform, target_sample_rate, format="wav")
+    
     return audio_buffer.getvalue()
+
+
+def get_synth_audio_format(audio_bytes):
+    # input to this can be WAV or PCM
+    try:
+        audio_buffer = io.BytesIO(audio_bytes)
+        with wave.open(audio_buffer, 'rb') as wav_file:
+            return "wav"
+    except wave.Error:
+        return "pcm"
 
 
 def merge_wav_bytes(wav_files_bytes):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -22,7 +22,7 @@ from contextlib import AsyncExitStack
 from dotenv import load_dotenv
 from pydantic import create_model
 from .logger_config import configure_logger
-from bolna.constants import PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, DEFAULT_LANGUAGE_CODE, TRANSFERING_CALL_FILLER
+from bolna.constants import PCM16_SCALE, PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, DEFAULT_LANGUAGE_CODE, TRANSFERING_CALL_FILLER
 from bolna.prompts import DATE_PROMPT
 from pydub import AudioSegment
 import audioop
@@ -397,7 +397,7 @@ def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, orig
         
         audio_array = np.frombuffer(audio_bytes, dtype=np.int16)
         
-        waveform = torch.from_numpy(audio_array).float() / 32768.0
+        waveform = torch.from_numpy(audio_array).float() / PCM16_SCALE
         
         if pcm_channels == 1:
             waveform = waveform.unsqueeze(0)  # (1, samples)

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -412,7 +412,7 @@ def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, orig
         resampler = torchaudio.transforms.Resample(original_sample_rate, target_sample_rate)
         audio_waveform = resampler(waveform)
         
-        audio_int16 = (audio_waveform * 32768.0).to(torch.int16)
+        audio_int16 = (audio_waveform * PCM16_SCALE).to(torch.int16)
         return audio_int16.numpy().tobytes()
     
     # Handle other formats (wav, mp3, etc.)

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -378,11 +378,6 @@ def convert_audio_to_wav(audio_bytes, source_format = 'flac'):
     return buffer.getvalue()
 
 
-import io
-import torch
-import torchaudio
-import numpy as np
-
 def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, original_sample_rate=None):
     """
     Resample audio bytes

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -314,12 +314,12 @@ class SarvamSynthesizer(BaseSynthesizer):
                         except Exception:
                             pass
                     else:
-                        processed_audio = await self._process_audio_data(audio)
-                        if processed_audio is None:
+                        audio = await self._process_audio_data(audio)
+                        if audio is None:
                             continue
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
-                    yield create_ws_data_packet(processed_audio, self.meta_info)
+                    yield create_ws_data_packet(audio, self.meta_info)
 
         except Exception as e:
             traceback.print_exc()

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -93,6 +93,11 @@ class SarvamSynthesizer(BaseSynthesizer):
             "enable_preprocessing": self.enable_preprocessing,
             "model": self.model
         }
+
+        if self.model == "bulbul:v3":
+            payload.pop("pitch")
+            payload.pop("loudness")
+
         response = await self.__send_payload(payload)
         return response
 
@@ -142,6 +147,10 @@ class SarvamSynthesizer(BaseSynthesizer):
             "enable_preprocessing": self.enable_preprocessing,
             "model": self.model
         }
+
+        if self.model == "bulbul:v3":
+            payload.pop("pitch")
+            payload.pop("loudness")
 
         return payload
 

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -59,7 +59,7 @@ class SarvamTranscriber(BaseTranscriber):
         self.api_host = os.getenv("SARVAM_HOST", "api.sarvam.ai")
 
         # saaras models use translate endpoint, saarika models use transcription endpoint
-        if model.startswith("saaras"):
+        if model.startswith("saaras") and model != "saaras:v3":
             self.api_url = f"https://{self.api_host}/speech-to-text-translate"
             self.ws_url = f"wss://{self.api_host}/speech-to-text-translate/ws"
         else:

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -127,10 +127,10 @@ class SarvamTranscriber(BaseTranscriber):
             self.api_url = f"https://{self.api_host}/speech-to-text-translate"
             ws_url = f"wss://{self.api_host}/speech-to-text-translate/ws"
 
-            params["language-code"] = self.language
         else:
             self.api_url = f"https://{self.api_host}/speech-to-text"
             ws_url = f"wss://{self.api_host}/speech-to-text/ws"
+            params["language-code"] = self.language
 
         if self.model == "saaras:v3":
             params["mode"] = "transcribe"   # saaras:v3 supports direct transcription

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -58,7 +58,8 @@ class SarvamTranscriber(BaseTranscriber):
         self.api_key = kwargs.get("transcriber_key", os.getenv("SARVAM_API_KEY"))
         self.api_host = os.getenv("SARVAM_HOST", "api.sarvam.ai")
 
-        # saaras models use translate endpoint, saarika models use transcription endpoint
+        # old saaras models use translate endpoint, saarika models use transcription endpoint
+        # saaras:v3 supports direct transcription
         if model.startswith("saaras") and model != "saaras:v3":
             self.api_url = f"https://{self.api_host}/speech-to-text-translate"
             self.ws_url = f"wss://{self.api_host}/speech-to-text-translate/ws"
@@ -124,8 +125,11 @@ class SarvamTranscriber(BaseTranscriber):
         params = {"model": self.model}
 
         # saaras auto-detects language, saarika requires language-code
-        if not self.model.startswith("saaras"):
+        if not self.model.startswith("saaras") or self.model == "saaras:v3":
             params["language-code"] = self.language
+
+        if self.model == "saaras:v3":
+            params["mode"] = "transcribe"   # saaras:v3 supports direct transcription
 
         if self.high_vad_sensitivity:
             params["high_vad_sensitivity"] = "true"


### PR DESCRIPTION
Added support for saaras:v3 and bulbul:v3.

Notes:
- Using speech to text for saaras:v3 with `mode` parameter as transcribe. Currently hardcoded as this is our only use case. In the future can consider using translate
- bulbul:v3 sends WAV header and then PCM chunks, unlike older versions which send full WAV files in each chunk
- Sampling rate as per docs for bulbul:v3 is 24000, but this is not observed in WAV header, so currently set to 22050
- The resample function now accepts PCM as well