### PR TITLE
fix: remove system prompt leak from hangup request logs

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1864,7 +1864,7 @@ class TaskManager(BaseManager):
 
                 prompt = [
                     {'role': 'system', 'content': self.check_for_completion_prompt},
-                    {'role': 'user', 'content': format_messages(self.history, use_system_prompt=True)}
+                    {'role': 'user', 'content': format_messages(self.history)}
                 ]
                 logger.info(f"##### Answer from the LLM {completion_res}")
                 convert_to_request_log(message=format_messages(prompt, use_system_prompt=True), meta_info=meta_info, component="llm_hangup", direction="request", model=self.check_for_completion_llm, run_id=self.run_id)


### PR DESCRIPTION
## Summary
- Hangup check logging used `format_messages(self.history, use_system_prompt=True)`, leaking the conversation system prompt into logged data
- The actual LLM call correctly uses `use_system_prompt=False` — so the log didn't match reality
- Since billing counts tokens from logged data, hangup costs were inflated ~6x (e.g. 20K tokens logged vs ~3.5K actual)
- Fix: removed `use_system_prompt=True` so the log matches the actual API call