### PR TITLE
fix: pass null byte through handle() in BLOCK path to prevent is_audio_being_played deadlock

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2576,23 +2576,12 @@ class TaskManager(BaseManager):
                     elif status == "BLOCK":
                         # Audio blocked (user speaking or invalid sequence) - discard
                         logger.info(f'Audio blocked: discarding message (sequence_id={sequence_id})')
-                        # If discarding the final chunk of the response, ensure is_audio_being_played
-                        # will eventually reset to prevent state deadlock.
-                        is_final_message = (
-                            message['meta_info'].get('is_final_chunk_of_entire_response', False) or
-                            (message['meta_info'].get('end_of_llm_stream', False) and
-                             message['meta_info'].get('end_of_synthesizer_stream', False))
-                        )
-                        if is_final_message:
-                            # Update the last pending post-mark to have is_final_chunk=True.
-                            # When Plivo finishes playing the last sent chunk and echoes it back,
-                            # process_mark_message will see is_final_chunk=True and reset
-                            # is_audio_being_played to False.
-                            updated = self.mark_event_meta_data.update_last_post_mark_as_final()
-                            if not updated:
-                                # No pending marks (all chunks already played or none sent)
-                                self.tools["input"].update_is_audio_being_played(False)
-                            logger.info(f'Final chunk discarded, {"updated last mark" if updated else "reset is_audio_being_played"} to prevent deadlock')
+                        # Null byte (b'\x00') is the end-of-stream control signal, not audio.
+                        # Always send it through handle() so the is_final_chunk post-mark is
+                        # created and sent to Plivo. Without this, is_audio_being_played stays
+                        # True forever because no final mark echo ever arrives.
+                        if message['data'] == b'\x00':
+                            await self.tools["output"].handle(message)
                         should_continue_outer_loop = True
                         break  # Exit inner loop, skip to next message
 

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -25,21 +25,6 @@ class MarkEventMetaData:
         self.previous_mark_event_meta_data = copy.deepcopy(self.mark_event_meta_data)
         self.mark_event_meta_data = {}
 
-    def update_last_post_mark_as_final(self):
-        """Update the last stored post-mark to have is_final_chunk=True.
-        Returns True if a post-mark was found and updated, False otherwise."""
-        last_mark_id = None
-        last_counter = -1
-        for mark_id, value in self.mark_event_meta_data.items():
-            if value.get("type") != "pre_mark_message" and value.get("counter", -1) > last_counter:
-                last_counter = value["counter"]
-                last_mark_id = mark_id
-        if last_mark_id is not None:
-            self.mark_event_meta_data[last_mark_id]["is_final_chunk"] = True
-            logger.info(f"Updated last post-mark {last_mark_id} (counter={last_counter}) to is_final_chunk=True")
-            return True
-        return False
-
     def fetch_cleared_mark_event_data(self):
         return self.previous_mark_event_meta_data
 


### PR DESCRIPTION
## Summary
- Null byte (`b'\x00'`) is the end-of-stream control signal from the synthesizer, not audio data
- When the BLOCK path discards it, the `is_final_chunk` post-mark is never created, so `is_audio_being_played` stays `True` forever
- Fix: in the BLOCK path, detect null bytes and send them through `handle()` — this creates the final post-mark (zero audio sent) so Plivo echoes it back and the state resets

## Root cause
During a false interruption (user says <threshold words while audio plays), `callee_speaking=True` causes remaining chunks to be BLOCKED. The null byte — which is the **only** mechanism that creates the `is_final_chunk=True` post-mark — was also blocked. Without that mark echo from Plivo, `is_audio_being_played` never resets, causing a ~73s deadlock until hangup timeout.

## Changes
- `task_manager.py`: 2-line null byte check in BLOCK path
- `mark_event_meta_data.py`: removed unused `update_last_post_mark_as_final()` method