### PR TITLE
fix: prevent back-to-back bot responses

### DIFF
--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -144,6 +144,12 @@ class InterruptionManager:
         self.sequence_ids = {-1}
         logger.info("Pending responses invalidated")
 
+    def revalidate_sequence_id(self, sequence_id: int) -> None:
+        """Re-adds a sequence ID after invalidation when a new response's
+        sequence_id was already allocated by __get_updated_meta_info."""
+        self.sequence_ids.add(sequence_id)
+        logger.info(f"Re-validated sequence_id={sequence_id}")
+
     def get_next_sequence_id(self) -> int:
         """Generates and registers a new sequence ID."""
         self.curr_sequence_id += 1


### PR DESCRIPTION
## Summary
- Add `response_in_pipeline` flag to bridge the gap between LLM task creation and first audio chunk reaching telephony, so interruption detection works during that window
- Cancel existing LLM task before creating a new one on rapid `speech_final` events to prevent orphaned concurrent responses
- Add `revalidate_sequence_id()` to InterruptionManager to preserve the new response's sequence after invalidation

## Files changed
- `bolna/agent_manager/task_manager.py`
- `bolna/agent_manager/interruption_manager.py`