### PR TITLE
feat: add typed error attribution for call-breaking errors

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -23,7 +23,7 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
-from bolna.enums import TelephonyProvider, LogComponent, LogDirection
+from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
@@ -1970,7 +1970,7 @@ class TaskManager(BaseManager):
                 if self.hangup_triggered or self.conversation_ended:
                     logger.info(f"Hangup already triggered or conversation ended, skipping duplicate hangup request")
                     return
-                self.hangup_detail = "llm_prompted_hangup"
+                self.hangup_detail = HangupReason.LLM_PROMPTED_HANGUP
                 await self.process_call_hangup()
                 return
 
@@ -2036,7 +2036,7 @@ class TaskManager(BaseManager):
         except BolnaComponentError as e:
             logger.error(f"Component error in llm: {e}", exc_info=True)
             self.response_in_pipeline = False
-            await self._end_call_on_component_error(e, "llm_error")
+            await self._end_call_on_component_error(e, HangupReason.LLM_ERROR)
             raise
         except Exception as e:
             traceback.print_exc()
@@ -2044,7 +2044,7 @@ class TaskManager(BaseManager):
             self.response_in_pipeline = False
             await self._end_call_on_component_error(
                 LLMError(str(e), provider=self.llm_config.get("provider", "unknown"), model=self.llm_config.get("model")),
-                "llm_error"
+                HangupReason.LLM_ERROR
             )
 
 
@@ -2209,7 +2209,7 @@ class TaskManager(BaseManager):
                 if is_voicemail:
                     logger.info(f"Voicemail detected in background task! Message: {transcriber_message}")
                     self.voicemail_detected = True
-                    self.hangup_detail = "voicemail_detected"
+                    self.hangup_detail = HangupReason.VOICEMAIL_DETECTED
 
                     # Trigger voicemail handling and call hangup
                     await self._handle_voicemail_detected()
@@ -2324,7 +2324,7 @@ class TaskManager(BaseManager):
             provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
             await self._end_call_on_component_error(
                 TranscriberError(connection_error, provider=provider),
-                "transcriber_connection_error"
+                HangupReason.TRANSCRIBER_CONNECTION_ERROR
             )
 
     async def _listen_transcriber(self):
@@ -2487,7 +2487,7 @@ class TaskManager(BaseManager):
             provider = self.task_config["tools_config"]["transcriber"].get("provider")
             await self._end_call_on_component_error(
                 TranscriberError(str(e), provider=provider),
-                "transcriber_error"
+                HangupReason.TRANSCRIBER_ERROR
             )
             raise TranscriberError(
                 str(e),
@@ -2628,7 +2628,7 @@ class TaskManager(BaseManager):
                     self._turn_audio_flushed.set()
                     await self._end_call_on_component_error(
                         SynthesizerError(str(e), provider=self.synthesizer_provider),
-                        "synthesizer_error"
+                        HangupReason.SYNTHESIZER_ERROR
                     )
                     break
 
@@ -2641,7 +2641,7 @@ class TaskManager(BaseManager):
             logger.error(f"Unexpected error in __listen_synthesizer: {e}", exc_info=True)
             await self._end_call_on_component_error(
                 SynthesizerError(str(e), provider=self.synthesizer_provider),
-                "synthesizer_error"
+                HangupReason.SYNTHESIZER_ERROR
             )
             raise SynthesizerError(
                 str(e), provider=self.synthesizer_provider
@@ -2891,7 +2891,7 @@ class TaskManager(BaseManager):
                     self.task_config["task_config"]["call_terminate"]):
                 logger.info("Hanging up for web call as max time of call has been reached")
                 await self.__process_end_of_conversation(web_call_timeout=True)
-                self.hangup_detail = "web_call_max_duration_reached"
+                self.hangup_detail = HangupReason.WEB_CALL_MAX_DURATION_REACHED
                 break
 
             if self.last_transmitted_timestamp == 0:
@@ -2924,7 +2924,7 @@ class TaskManager(BaseManager):
 
             if self.hang_conversation_after > 0 and time_since_last_spoken_ai_word > self.hang_conversation_after and time_since_user_last_spoke > self.hang_conversation_after:
                 logger.info(f"{time_since_last_spoken_ai_word} seconds since AI last spoke and {time_since_user_last_spoke} seconds since user last spoke, both exceed {self.hang_conversation_after}s timeout - hanging up")
-                self.hangup_detail = "inactivity_timeout"
+                self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
                 await self.process_call_hangup()
                 break
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2042,6 +2042,10 @@ class TaskManager(BaseManager):
             traceback.print_exc()
             logger.error(f"Something went wrong in llm: {e}")
             self.response_in_pipeline = False
+            await self._end_call_on_component_error(
+                LLMError(str(e), provider=self.llm_config.get("provider", "unknown"), model=self.llm_config.get("model")),
+                "llm_error"
+            )
 
 
     #################################################################

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -23,13 +23,15 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
-from bolna.enums import TelephonyProvider
+from bolna.enums import TelephonyProvider, LogComponent, LogDirection
+from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
 from bolna.transcriber.transcriber_pool import TranscriberPool
 from bolna.synthesizer.synthesizer_pool import SynthesizerPool
 from bolna.helpers.utils import structure_system_prompt, compute_function_pre_call_message, select_message_by_language, get_date_time_from_timezone, calculate_audio_duration, create_ws_data_packet, get_file_names_in_directory, get_raw_audio_bytes, is_valid_md5, \
-    get_required_input_types, format_messages, get_prompt_responses, resample, save_audio_file_to_s3, update_prompt_with_context, get_md5_hash, clean_json_string, wav_bytes_to_pcm, convert_to_request_log, yield_chunks_from_memory, process_task_cancellation, pcm_to_ulaw
+    get_required_input_types, format_messages, get_prompt_responses, resample, save_audio_file_to_s3, update_prompt_with_context, get_md5_hash, clean_json_string, wav_bytes_to_pcm, convert_to_request_log, yield_chunks_from_memory, process_task_cancellation, pcm_to_ulaw, \
+    format_error_message
 from bolna.helpers.logger_config import configure_logger
 from ..helpers.mark_event_meta_data import MarkEventMetaData
 from ..helpers.observable_variable import ObservableVariable
@@ -173,6 +175,8 @@ class TaskManager(BaseManager):
         self.execute_function_call_task = None
         self.synthesizer_tasks = []
         self.synthesizer_task = None
+        self._component_error = None
+        self._error_logged = False
         self.synthesizer_monitor_task = None
         self.dtmf_task = None
 
@@ -695,7 +699,7 @@ class TaskManager(BaseManager):
                         self.tools["input"].is_welcome_message_played = True
                     else:
                         self.tools["input"].update_is_audio_being_played(True)
-                        convert_to_request_log(message=text, meta_info=meta_info, component="synthesizer", direction="response", model=self.synthesizer_provider, is_cached=meta_info.get("is_cached", False), engine=self.tools['synthesizer'].get_engine(), run_id=self.run_id)
+                        convert_to_request_log(message=text, meta_info=meta_info, component=LogComponent.SYNTHESIZER, direction=LogDirection.RESPONSE, model=self.synthesizer_provider, is_cached=meta_info.get("is_cached", False), engine=self.tools['synthesizer'].get_engine(), run_id=self.run_id)
                         await self.tools["output"].handle(message)
                         try:
                             data = message.get("data")
@@ -1358,7 +1362,16 @@ class TaskManager(BaseManager):
             })
 
             start_time = time.time()
-            json_data = await self.tools["llm_agent"].generate(self.history)
+            try:
+                json_data = await self.tools["llm_agent"].generate(self.history)
+            except BolnaComponentError:
+                raise
+            except Exception as e:
+                raise LLMError(
+                    str(e),
+                    provider=self.llm_config.get("provider"),
+                    model=self.llm_config.get("model")
+                ) from e
             latency_ms = (time.time() - start_time) * 1000
             
             if self.task_config["task_type"] == "summarization":
@@ -1554,7 +1567,7 @@ class TaskManager(BaseManager):
             messages.append({'role': 'user', 'content': message['data']})
             logger.info(f"Starting LLM Agent {messages}")
             #Expose get current classification_response method from the agent class and use it for the response log
-            convert_to_request_log(message=format_messages(messages, use_system_prompt= True), meta_info= meta_info, component="llm", direction="request", model=self.llm_agent_config["model"], is_cached= True, run_id= self.run_id)
+            convert_to_request_log(message=format_messages(messages, use_system_prompt= True), meta_info= meta_info, component=LogComponent.LLM, direction=LogDirection.REQUEST, model=self.llm_agent_config["model"], is_cached= True, run_id= self.run_id)
             async for next_state in self.tools['llm_agent'].generate(messages, label_flow=self.label_flow):
                 if next_state == "<end_of_conversation>":
                     meta_info["end_of_conversation"] = True
@@ -1636,8 +1649,8 @@ class TaskManager(BaseManager):
 
             if self.tools['input'].io_provider == 'default':
                 mock_response = f"This is a mocked response demonstrating a successful transfer of call to {call_transfer_number}"
-                convert_to_request_log(str(payload), meta_info, None, "function_call", direction="request", run_id=self.run_id)
-                convert_to_request_log(mock_response, meta_info, None, "function_call", direction="response", run_id=self.run_id)
+                convert_to_request_log(str(payload), meta_info, None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, run_id=self.run_id)
+                convert_to_request_log(mock_response, meta_info, None, LogComponent.FUNCTION_CALL, direction=LogDirection.RESPONSE, run_id=self.run_id)
 
                 bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
                 await self.tools["output"].handle(bos_packet)
@@ -1650,12 +1663,12 @@ class TaskManager(BaseManager):
                 logger.info(f"Sending the payload to stop the conversation {payload} url {url}")
                 while self.tools["input"].is_audio_being_played_to_user():
                     await asyncio.sleep(1)
-                convert_to_request_log(str(payload), meta_info, None, "function_call", direction="request", is_cached=False,
+                convert_to_request_log(str(payload), meta_info, None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, is_cached=False,
                                        run_id=self.run_id)
                 async with session.post(url, json = payload) as response:
                     response_text = await response.text()
                     logger.info(f"Response from the server after call transfer: {response_text}")
-                    convert_to_request_log(str(response_text), meta_info, None, "function_call", direction="response", is_cached=False, run_id=self.run_id)
+                    convert_to_request_log(str(response_text), meta_info, None, LogComponent.FUNCTION_CALL, direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
                     return
 
         if called_fun == "switch_language":
@@ -1715,10 +1728,10 @@ class TaskManager(BaseManager):
         self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), function_response)
 
         logger.info(f"Logging function call parameters ")
-        convert_to_request_log(function_response, meta_info , None, "function_call", direction = "response", is_cached= False, run_id = self.run_id)
+        convert_to_request_log(function_response, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.RESPONSE, is_cached= False, run_id = self.run_id)
 
         messages = self.conversation_history.get_copy()
-        convert_to_request_log(format_messages(messages, True), meta_info, self.llm_config['model'], "llm", direction = "request", is_cached= False, run_id = self.run_id)
+        convert_to_request_log(format_messages(messages, True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached= False, run_id = self.run_id)
         self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
 
         if not called_fun.startswith("transfer_call"):
@@ -1729,7 +1742,7 @@ class TaskManager(BaseManager):
 
     def __store_into_history(self, meta_info, messages, llm_response, should_trigger_function_call = False):
         self.llm_response_generated = True
-        convert_to_request_log(message=llm_response, meta_info= meta_info, component="llm", direction="response", model=self.llm_config["model"], run_id= self.run_id)
+        convert_to_request_log(message=llm_response, meta_info= meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id= self.run_id)
         if should_trigger_function_call:
             logger.info(f"There was a function call and need to make that work")
             self.conversation_history.append_assistant(llm_response)
@@ -1760,125 +1773,135 @@ class TaskManager(BaseManager):
         if detected_lang:
             meta_info['detected_language'] = detected_lang
 
-        async for llm_message in self.tools['llm_agent'].generate(messages, synthesize=synthesize, meta_info=meta_info):
-            if isinstance(llm_message, dict) and 'messages' in llm_message: # custom list of messages before the llm call
-                convert_to_request_log(format_messages(llm_message['messages'], True), meta_info, self.llm_config['model'], "llm", direction="request", is_cached=False, run_id=self.run_id)
-                continue
+        try:
+            async for llm_message in self.tools['llm_agent'].generate(messages, synthesize=synthesize, meta_info=meta_info):
+                if isinstance(llm_message, dict) and 'messages' in llm_message: # custom list of messages before the llm call
+                    convert_to_request_log(format_messages(llm_message['messages'], True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached=False, run_id=self.run_id)
+                    continue
 
-            # Handle graph agent routing info
-            if isinstance(llm_message, dict) and 'routing_info' in llm_message:
-                routing_info = llm_message['routing_info']
+                # Handle graph agent routing info
+                if isinstance(llm_message, dict) and 'routing_info' in llm_message:
+                    routing_info = llm_message['routing_info']
 
-                # Log routing request with tools
-                routing_messages = routing_info.get('routing_messages')
-                routing_tools = routing_info.get('routing_tools', [])
-                if routing_messages:
-                    # Format tools for logging (show full descriptions with conditions)
-                    tools_summary = ""
-                    if routing_tools:
-                        tool_lines = []
-                        for t in routing_tools:
-                            if 'function' in t:
-                                name = t['function']['name']
-                                desc = t['function'].get('description', '')
-                                tool_lines.append(f"  - {name}: {desc}")
-                        if tool_lines:
-                            tools_summary = "\n\nAvailable transitions:\n" + "\n".join(tool_lines)
+                    # Log routing request with tools
+                    routing_messages = routing_info.get('routing_messages')
+                    routing_tools = routing_info.get('routing_tools', [])
+                    if routing_messages:
+                        # Format tools for logging (show full descriptions with conditions)
+                        tools_summary = ""
+                        if routing_tools:
+                            tool_lines = []
+                            for t in routing_tools:
+                                if 'function' in t:
+                                    name = t['function']['name']
+                                    desc = t['function'].get('description', '')
+                                    tool_lines.append(f"  - {name}: {desc}")
+                            if tool_lines:
+                                tools_summary = "\n\nAvailable transitions:\n" + "\n".join(tool_lines)
 
+                        convert_to_request_log(
+                            message=format_messages(routing_messages, use_system_prompt=True) + tools_summary,
+                            meta_info=meta_info,
+                            model=routing_info.get('routing_model', ''),
+                            component=LogComponent.GRAPH_ROUTING,
+                            direction=LogDirection.REQUEST,
+                            run_id=self.run_id
+                        )
+
+                    # Build routing response data
+                    if routing_info.get('transitioned'):
+                        routing_data = f"Node: {routing_info.get('previous_node', '?')} → {routing_info['current_node']}"
+                    else:
+                        routing_data = f"Node: {routing_info['current_node']} (no transition)"
+                    if routing_info.get('extracted_params'):
+                        routing_data += f" | Params: {json.dumps(routing_info['extracted_params'])}"
+                    if routing_info.get('confidence') is not None:
+                        routing_data += f" | Confidence: {routing_info['confidence']}"
+                    if routing_info.get('reasoning'):
+                        routing_data += f" | Reasoning: {routing_info['reasoning']}"
+                    if routing_info.get('node_history'):
+                        routing_data += f" | Flow: {' → '.join(routing_info['node_history'])}"
+
+                    meta_info['llm_metadata'] = meta_info.get('llm_metadata') or {}
+                    meta_info['llm_metadata']['graph_routing_info'] = routing_info
+
+                    if routing_info.get('routing_latency_ms') is not None:
+                        self.routing_latencies['turn_latencies'].append({
+                            'latency_ms': routing_info['routing_latency_ms'],
+                            'routing_model': routing_info.get('routing_model'),
+                            'routing_provider': routing_info.get('routing_provider'),
+                            'previous_node': routing_info.get('previous_node'),
+                            'current_node': routing_info.get('current_node'),
+                            'transitioned': routing_info.get('transitioned', False),
+                            'sequence_id': meta_info.get('sequence_id'),
+                            'reasoning': routing_info.get('reasoning'),
+                            'confidence': routing_info.get('confidence'),
+                        })
+
+                    if routing_info.get('node_history'):
+                        self.routing_latencies['node_flow'] = list(routing_info['node_history'])
+
+                    # Log routing response
                     convert_to_request_log(
-                        message=format_messages(routing_messages, use_system_prompt=True) + tools_summary,
+                        message=routing_data,
                         meta_info=meta_info,
                         model=routing_info.get('routing_model', ''),
-                        component="graph_routing",
-                        direction="request",
+                        component=LogComponent.GRAPH_ROUTING,
+                        direction=LogDirection.RESPONSE,
                         run_id=self.run_id
                     )
+                    continue
 
-                # Build routing response data
-                if routing_info.get('transitioned'):
-                    routing_data = f"Node: {routing_info.get('previous_node', '?')} → {routing_info['current_node']}"
-                else:
-                    routing_data = f"Node: {routing_info['current_node']} (no transition)"
-                if routing_info.get('extracted_params'):
-                    routing_data += f" | Params: {json.dumps(routing_info['extracted_params'])}"
-                if routing_info.get('confidence') is not None:
-                    routing_data += f" | Confidence: {routing_info['confidence']}"
-                if routing_info.get('reasoning'):
-                    routing_data += f" | Reasoning: {routing_info['reasoning']}"
-                if routing_info.get('node_history'):
-                    routing_data += f" | Flow: {' → '.join(routing_info['node_history'])}"
+                data = llm_message.data
+                end_of_llm_stream = llm_message.end_of_stream
+                latency = llm_message.latency
+                trigger_function_call = llm_message.is_function_call
+                function_tool = llm_message.function_name
+                function_tool_message = llm_message.function_message
 
-                meta_info['llm_metadata'] = meta_info.get('llm_metadata') or {}
-                meta_info['llm_metadata']['graph_routing_info'] = routing_info
+                if trigger_function_call:
+                    logger.info(f"Triggering function call for {data}")
+                    await self.__execute_function_call(next_step = next_step, **data.model_dump())
+                    return
 
-                if routing_info.get('routing_latency_ms') is not None:
-                    self.routing_latencies['turn_latencies'].append({
-                        'latency_ms': routing_info['routing_latency_ms'],
-                        'routing_model': routing_info.get('routing_model'),
-                        'routing_provider': routing_info.get('routing_provider'),
-                        'previous_node': routing_info.get('previous_node'),
-                        'current_node': routing_info.get('current_node'),
-                        'transitioned': routing_info.get('transitioned', False),
-                        'sequence_id': meta_info.get('sequence_id'),
-                        'reasoning': routing_info.get('reasoning'),
-                        'confidence': routing_info.get('confidence'),
-                    })
+                if latency:
+                    latency_dict = latency.model_dump()
+                    previous_latency_item = self.llm_latencies['turn_latencies'][-1] if self.llm_latencies['turn_latencies'] else None
+                    if previous_latency_item and previous_latency_item.get('sequence_id') == latency_dict.get('sequence_id'):
+                        self.llm_latencies['turn_latencies'][-1] = latency_dict
+                    else:
+                        self.llm_latencies['turn_latencies'].append(latency_dict)
 
-                if routing_info.get('node_history'):
-                    self.routing_latencies['node_flow'] = list(routing_info['node_history'])
+                llm_response += " " + data
 
-                # Log routing response
-                convert_to_request_log(
-                    message=routing_data,
-                    meta_info=meta_info,
-                    model=routing_info.get('routing_model', ''),
-                    component="graph_routing",
-                    direction="response",
-                    run_id=self.run_id
-                )
-                continue
+                logger.info(f"Got a response from LLM {llm_response}")
+                if end_of_llm_stream:
+                    meta_info["end_of_llm_stream"] = True
 
-            data = llm_message.data
-            end_of_llm_stream = llm_message.end_of_stream
-            latency = llm_message.latency
-            trigger_function_call = llm_message.is_function_call
-            function_tool = llm_message.function_name
-            function_tool_message = llm_message.function_message
+                if self.stream:
+                    text_chunk = self.__process_stop_words(data, meta_info)
 
-            if trigger_function_call:
-                logger.info(f"Triggering function call for {data}")
-                await self.__execute_function_call(next_step = next_step, **data.model_dump())
-                return
+                    # A hack as during the 'await' part control passes to llm streaming function parameters
+                    # So we have to make sure we've commited the filler message
+                    detected_lang = self.language_detector.dominant_language or self.language
+                    filler_message = compute_function_pre_call_message(detected_lang, function_tool, function_tool_message)
+                    #filler_message = PRE_FUNCTION_CALL_MESSAGE.get(self.language, PRE_FUNCTION_CALL_MESSAGE[DEFAULT_LANGUAGE_CODE])
+                    if text_chunk == filler_message:
+                        logger.info("Got a pre function call message")
+                        messages.append({'role':'assistant', 'content': filler_message})
+                        self.conversation_history.append_assistant(filler_message)
+                        self.conversation_history.sync_interim(messages)
 
-            if latency:
-                latency_dict = latency.model_dump()
-                previous_latency_item = self.llm_latencies['turn_latencies'][-1] if self.llm_latencies['turn_latencies'] else None
-                if previous_latency_item and previous_latency_item.get('sequence_id') == latency_dict.get('sequence_id'):
-                    self.llm_latencies['turn_latencies'][-1] = latency_dict
-                else:
-                    self.llm_latencies['turn_latencies'].append(latency_dict)
-
-            llm_response += " " + data
-
-            logger.info(f"Got a response from LLM {llm_response}")
-            if end_of_llm_stream:
-                meta_info["end_of_llm_stream"] = True
-
-            if self.stream:
-                text_chunk = self.__process_stop_words(data, meta_info)
-
-                # A hack as during the 'await' part control passes to llm streaming function parameters
-                # So we have to make sure we've commited the filler message
-                detected_lang = self.language_detector.dominant_language or self.language
-                filler_message = compute_function_pre_call_message(detected_lang, function_tool, function_tool_message)
-                #filler_message = PRE_FUNCTION_CALL_MESSAGE.get(self.language, PRE_FUNCTION_CALL_MESSAGE[DEFAULT_LANGUAGE_CODE])
-                if text_chunk == filler_message:
-                    logger.info("Got a pre function call message")
-                    messages.append({'role':'assistant', 'content': filler_message})
-                    self.conversation_history.append_assistant(filler_message)
-                    self.conversation_history.sync_interim(messages)
-
-                await self._handle_llm_output(next_step, text_chunk, should_bypass_synth, meta_info)
+                    await self._handle_llm_output(next_step, text_chunk, should_bypass_synth, meta_info)
+        except BolnaComponentError:
+            raise
+        except Exception as e:
+            # CSV error logging is handled by the top-level handler in run()
+            raise LLMError(
+                str(e),
+                provider=self.llm_config.get("provider"),
+                model=self.llm_config.get("model")
+            ) from e
 
         detected_lang = self.language_detector.dominant_language or self.language
         filler_message = compute_function_pre_call_message(detected_lang, function_tool, function_tool_message)
@@ -1889,7 +1912,7 @@ class TaskManager(BaseManager):
             if self.turn_based_conversation:
                 self.conversation_history.append_assistant(llm_response)
             await self._handle_llm_output(next_step, llm_response, should_bypass_synth, meta_info, is_function_call=should_trigger_function_call)
-            convert_to_request_log(message=llm_response, meta_info=meta_info, component="llm", direction="response", model=self.llm_config["model"], run_id=self.run_id)
+            convert_to_request_log(message=llm_response, meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id=self.run_id)
 
         # Collect RAG latency if present (from KnowledgeBaseAgent)
         if meta_info.get('rag_latency'):
@@ -1909,7 +1932,7 @@ class TaskManager(BaseManager):
 
         # Request logs converted inside do_llm_generation for knowledgebase agent
         if not self.__is_knowledgebase_agent() and not self.__is_graph_agent():
-            convert_to_request_log(message=format_messages(messages, use_system_prompt=True), meta_info=meta_info, component="llm", direction="request", model=self.llm_config["model"], run_id= self.run_id)
+            convert_to_request_log(message=format_messages(messages, use_system_prompt=True), meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.REQUEST, model=self.llm_config["model"], run_id= self.run_id)
 
         await self.__do_llm_generation(messages, meta_info, next_step, should_bypass_synth)
         # TODO : Write a better check for completion prompt
@@ -1940,8 +1963,8 @@ class TaskManager(BaseManager):
                 {'role': 'user', 'content': format_messages(self.history)}
             ]
             logger.info(f"##### Answer from the LLM {completion_res}")
-            convert_to_request_log(message=format_messages(prompt, use_system_prompt=True), meta_info=meta_info, component="llm_hangup", direction="request", model=self.check_for_completion_llm, run_id=self.run_id)
-            convert_to_request_log(message=completion_res, meta_info=meta_info, component="llm_hangup", direction="response", model=self.check_for_completion_llm, run_id=self.run_id)
+            convert_to_request_log(message=format_messages(prompt, use_system_prompt=True), meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.REQUEST, model=self.check_for_completion_llm, run_id=self.run_id)
+            convert_to_request_log(message=completion_res, meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.RESPONSE, model=self.check_for_completion_llm, run_id=self.run_id)
 
             if should_hangup:
                 if self.hangup_triggered or self.conversation_ended:
@@ -2010,6 +2033,12 @@ class TaskManager(BaseManager):
             else:
                 logger.error("unsupported task type: {}".format(self.task_config["task_type"]))
             self.llm_task = None
+        except BolnaComponentError as e:
+            logger.error(f"Component error in llm: {e}", exc_info=True)
+            self.response_in_pipeline = False
+            if self._component_error is None:
+                self._component_error = e
+            raise
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Something went wrong in llm: {e}")
@@ -2137,8 +2166,8 @@ class TaskManager(BaseManager):
                 convert_to_request_log(
                     message=format_messages(prompt, use_system_prompt=True),
                     meta_info=meta_info,
-                    component="llm_voicemail",
-                    direction="request",
+                    component=LogComponent.LLM_VOICEMAIL,
+                    direction=LogDirection.REQUEST,
                     model=self.voicemail_llm,
                     run_id=self.run_id
                 )
@@ -2168,8 +2197,8 @@ class TaskManager(BaseManager):
                 convert_to_request_log(
                     message=voicemail_result,
                     meta_info=meta_info,
-                    component="llm_voicemail",
-                    direction="response",
+                    component=LogComponent.LLM_VOICEMAIL,
+                    direction=LogDirection.RESPONSE,
                     model=self.voicemail_llm,
                     run_id=self.run_id
                 )
@@ -2227,7 +2256,7 @@ class TaskManager(BaseManager):
 
         self.conversation_history.append_user(transcriber_message)
 
-        convert_to_request_log(message=transcriber_message, meta_info=meta_info, model=self.task_config["tools_config"]["transcriber"]["provider"], run_id= self.run_id)
+        convert_to_request_log(message=transcriber_message, meta_info=meta_info, model=self.task_config["tools_config"]["transcriber"]["provider"], run_id=self.run_id)
         if next_task == "llm":
             logger.info(f"Running llm Tasks")
             meta_info["origin"] = "transcriber"
@@ -2253,6 +2282,23 @@ class TaskManager(BaseManager):
         else:
             logger.info(f"Need to separate out output task")
 
+    def _log_transcriber_connection_error(self, connection_error):
+        if connection_error and self.run_id:
+            provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
+            error_msg = format_error_message("transcriber", provider, connection_error)
+            convert_to_request_log(
+                error_msg,
+                {"request_id": self.task_id, "sequence_id": None},
+                model=provider,
+                component=LogComponent.ERROR,
+                direction=LogDirection.ERROR,
+                is_cached=False,
+                run_id=self.run_id,
+            )
+            self._error_logged = True
+            if self._component_error is None:
+                self._component_error = TranscriberError(connection_error, provider=provider)
+
     async def _listen_transcriber(self):
         temp_transcriber_message = ""
         try:
@@ -2264,6 +2310,7 @@ class TaskManager(BaseManager):
                     if message["data"] == "transcriber_connection_closed":
                         logger.info(f"Transcriber connection has been closed")
                         self.transcriber_duration += message.get("meta_info", {}).get("transcriber_duration", 0) if message['meta_info'] is not None else 0
+                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
                     continue
 
@@ -2388,7 +2435,7 @@ class TaskManager(BaseManager):
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
                             logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
                             continue
-                        logger.info(f"Transcriber connection has been closed")
+                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 
                 else:
@@ -2398,7 +2445,7 @@ class TaskManager(BaseManager):
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
                             logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
                             continue
-                        logger.info(f"Transcriber connection has been closed")
+                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 
                     await self.__process_http_transcription(message)
@@ -2409,6 +2456,10 @@ class TaskManager(BaseManager):
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Error in transcriber {e}")
+            raise TranscriberError(
+                str(e),
+                provider=self.task_config["tools_config"]["transcriber"].get("provider")
+            ) from e
 
     async def __process_http_transcription(self, message):
         meta_info = self.__get_updated_meta_info(message["meta_info"])
@@ -2520,8 +2571,8 @@ class TaskManager(BaseManager):
                                 convert_to_request_log(
                                     message=current_text,
                                     meta_info=meta_info,
-                                    component="synthesizer",
-                                    direction="response",
+                                    component=LogComponent.SYNTHESIZER,
+                                    direction=LogDirection.RESPONSE,
                                     model=self.synthesizer_provider,
                                     is_cached=meta_info.get("is_cached", False),
                                     engine=self.tools['synthesizer'].get_engine(),
@@ -2542,6 +2593,20 @@ class TaskManager(BaseManager):
                 except Exception as e:
                     logger.error(f"Error in synthesizer: {e}", exc_info=True)
                     self._turn_audio_flushed.set()
+                    if self.run_id and not self._error_logged:
+                        error_msg = format_error_message("synthesizer", self.synthesizer_provider, str(e))
+                        convert_to_request_log(
+                            error_msg,
+                            {"request_id": self.task_id, "sequence_id": None},
+                            model=self.synthesizer_provider,
+                            component=LogComponent.ERROR,
+                            direction=LogDirection.ERROR,
+                            is_cached=False,
+                            run_id=self.run_id
+                        )
+                        self._error_logged = True
+                    if self._component_error is None:
+                        self._component_error = SynthesizerError(str(e), provider=self.synthesizer_provider)
                     break
 
             logger.info("Exiting __listen_synthesizer gracefully.")
@@ -2551,6 +2616,21 @@ class TaskManager(BaseManager):
             #await self.handle_cancellation("Synthesizer task was cancelled outside loop.")
         except Exception as e:
             logger.error(f"Unexpected error in __listen_synthesizer: {e}", exc_info=True)
+            if self.run_id and not self._error_logged:
+                error_msg = format_error_message("synthesizer", self.synthesizer_provider, str(e))
+                convert_to_request_log(
+                    error_msg,
+                    {"request_id": self.task_id, "sequence_id": None},
+                    model=self.synthesizer_provider,
+                    component=LogComponent.ERROR,
+                    direction=LogDirection.ERROR,
+                    is_cached=False,
+                    run_id=self.run_id
+                )
+                self._error_logged = True
+            raise SynthesizerError(
+                str(e), provider=self.synthesizer_provider
+            ) from e
         finally:
             await self.tools["synthesizer"].cleanup()
 
@@ -2628,10 +2708,10 @@ class TaskManager(BaseManager):
                     await self.__send_preprocessed_audio(meta_info, text)
 
                 elif self.synthesizer_provider in SUPPORTED_SYNTHESIZER_MODELS.keys():
-                    convert_to_request_log(message = text, meta_info= meta_info, component="synthesizer", direction="request", model = self.synthesizer_provider, engine=self.tools['synthesizer'].get_engine(), run_id= self.run_id)
+                    convert_to_request_log(message = text, meta_info= meta_info, component=LogComponent.SYNTHESIZER, direction=LogDirection.REQUEST, model = self.synthesizer_provider, engine=self.tools['synthesizer'].get_engine(), run_id= self.run_id)
                     if 'cached' in message['meta_info'] and meta_info['cached'] is True:
                         logger.info(f"Cached response and hence sending preprocessed text")
-                        convert_to_request_log(message = text, meta_info= meta_info, component="synthesizer", direction="response", model = self.synthesizer_provider, is_cached= True, engine=self.tools['synthesizer'].get_engine(), run_id= self.run_id)
+                        convert_to_request_log(message = text, meta_info= meta_info, component=LogComponent.SYNTHESIZER, direction=LogDirection.RESPONSE, model = self.synthesizer_provider, is_cached= True, engine=self.tools['synthesizer'].get_engine(), run_id= self.run_id)
                         await self.__send_preprocessed_audio(meta_info, get_md5_hash(text))
                     else:
                         self.synthesizer_characters += len(text)
@@ -2997,6 +3077,8 @@ class TaskManager(BaseManager):
             logger.error(f"Error occurred in handling init event - {e}")
 
     async def run(self):
+        self._component_error = None  # Reset for each run
+        self._error_logged = False
         try:
             if self._is_conversation_task():
                 logger.info("started running")
@@ -3043,6 +3125,36 @@ class TaskManager(BaseManager):
                 except Exception as e:
                     traceback.print_exc()
                     logger.error(f"Error: {e}")
+                    self._error_logged = True
+                    if self.run_id:
+                        if isinstance(e, BolnaComponentError):
+                            error_msg = format_error_message(e.component, e.provider or e.model or "-", str(e))
+                            model = e.model or "-"
+                        else:
+                            error_msg = format_error_message("unknown", "-", str(e))
+                            model = "-"
+                        convert_to_request_log(
+                            error_msg,
+                            {"request_id": self.task_id, "sequence_id": None},
+                            model=model,
+                            component=LogComponent.ERROR,
+                            direction=LogDirection.ERROR,
+                            is_cached=False,
+                            run_id=self.run_id
+                        )
+
+                # Surface component errors from fire-and-forget tasks or stored errors
+                if self._component_error is not None:
+                    raise self._component_error
+                for attr, cls, provider in [
+                    ('synthesizer_task', SynthesizerError, getattr(self, 'synthesizer_provider', None)),
+                    ('transcriber_task', TranscriberError, self.task_config.get("tools_config", {}).get("transcriber", {}).get("provider")),
+                ]:
+                    task = getattr(self, attr, None)
+                    if task and task.done() and not task.cancelled():
+                        exc = task.exception()
+                        if exc is not None:
+                            raise exc if isinstance(exc, BolnaComponentError) else cls(str(exc), provider=provider)
 
                 if self.generate_precise_transcript:
                     has_pending_marks = len(self.mark_event_meta_data.mark_event_meta_data) > 0
@@ -3059,9 +3171,11 @@ class TaskManager(BaseManager):
                         await self._process_followup_task()
                     else:
                         await self._run_llm_task(self.input_parameters)
+                except BolnaComponentError:
+                    raise
                 except Exception as e:
                     logger.error(f"Could not do llm call: {e}")
-                    raise Exception(e)
+                    raise
 
         except asyncio.CancelledError as e:
             # Cancel all tasks on cancel
@@ -3075,24 +3189,30 @@ class TaskManager(BaseManager):
             logger.error(f"Exception in task manager run: {error_message}")
             traceback.print_exc()
 
-            # Log call-breaking exception to CSV trace
-            if self.run_id:
+            # Log call-breaking exception to CSV trace with component attribution (skip if already logged)
+            if self.run_id and not self._error_logged:
                 meta_info = {
                     'request_id': self.task_id,
                     'sequence_id': None
                 }
+                if isinstance(e, BolnaComponentError):
+                    error_msg = format_error_message(e.component, e.provider or e.model or "-", error_message)
+                    model = e.model or "-"
+                else:
+                    error_msg = format_error_message("unknown", "-", error_message)
+                    model = "-"
                 convert_to_request_log(
-                    f"Call Breaking Error: {error_message}",
+                    error_msg,
                     meta_info,
-                    model="-",
-                    component="error",
-                    direction="error",
+                    model=model,
+                    component=LogComponent.ERROR,
+                    direction=LogDirection.ERROR,
                     is_cached=False,
                     run_id=self.run_id
                 )
 
             await self.handle_cancellation(f"Exception occurred {e}")
-            raise Exception(e)
+            raise
 
         finally:
             # Construct output

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3140,8 +3140,7 @@ class TaskManager(BaseManager):
                 except Exception as e:
                     traceback.print_exc()
                     logger.error(f"Error: {e}")
-                    self._error_logged = True
-                    if self.run_id:
+                    if self.run_id and not self._error_logged:
                         if isinstance(e, BolnaComponentError):
                             error_msg = format_error_message(e.component, e.provider or e.model or "-", str(e))
                             model = e.model or "-"
@@ -3157,6 +3156,7 @@ class TaskManager(BaseManager):
                             is_cached=False,
                             run_id=self.run_id
                         )
+                    self._error_logged = True
 
                 # Surface component errors from fire-and-forget tasks or stored errors
                 if self._component_error is not None:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2480,9 +2480,14 @@ class TaskManager(BaseManager):
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Error in transcriber {e}")
+            provider = self.task_config["tools_config"]["transcriber"].get("provider")
+            await self._end_call_on_component_error(
+                TranscriberError(str(e), provider=provider),
+                "transcriber_error"
+            )
             raise TranscriberError(
                 str(e),
-                provider=self.task_config["tools_config"]["transcriber"].get("provider")
+                provider=provider
             ) from e
 
     async def __process_http_transcription(self, message):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2036,8 +2036,7 @@ class TaskManager(BaseManager):
         except BolnaComponentError as e:
             logger.error(f"Component error in llm: {e}", exc_info=True)
             self.response_in_pipeline = False
-            if self._component_error is None:
-                self._component_error = e
+            await self._end_call_on_component_error(e, "llm_error")
             raise
         except Exception as e:
             traceback.print_exc()
@@ -2282,22 +2281,47 @@ class TaskManager(BaseManager):
         else:
             logger.info(f"Need to separate out output task")
 
-    def _log_transcriber_connection_error(self, connection_error):
-        if connection_error and self.run_id:
-            provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
-            error_msg = format_error_message("transcriber", provider, connection_error)
+    async def _end_call_on_component_error(self, error, hangup_detail):
+        """End the call gracefully when a critical pipeline component fails.
+
+        Handles: CSV error logging, _component_error tracking, and triggering
+        __process_end_of_conversation for immediate graceful shutdown.
+        """
+        if self._component_error is None:
+            self._component_error = error
+
+        # Log to CSV if not already done
+        if self.run_id and not self._error_logged:
+            if isinstance(error, BolnaComponentError):
+                error_msg = format_error_message(error.component, error.provider or error.model or "-", str(error))
+                model = error.model or error.provider or "-"
+            else:
+                error_msg = format_error_message("unknown", "-", str(error))
+                model = "-"
             convert_to_request_log(
                 error_msg,
                 {"request_id": self.task_id, "sequence_id": None},
-                model=provider,
+                model=model,
                 component=LogComponent.ERROR,
                 direction=LogDirection.ERROR,
                 is_cached=False,
                 run_id=self.run_id,
             )
             self._error_logged = True
-            if self._component_error is None:
-                self._component_error = TranscriberError(connection_error, provider=provider)
+
+        # Trigger graceful shutdown
+        if not self.conversation_ended and not self._end_of_conversation_in_progress:
+            logger.error(f"Critical component failure, ending call: {hangup_detail} - {error}")
+            self.hangup_detail = hangup_detail
+            await self.__process_end_of_conversation()
+
+    async def _log_transcriber_connection_error(self, connection_error):
+        if connection_error:
+            provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
+            await self._end_call_on_component_error(
+                TranscriberError(connection_error, provider=provider),
+                "transcriber_connection_error"
+            )
 
     async def _listen_transcriber(self):
         temp_transcriber_message = ""
@@ -2310,7 +2334,7 @@ class TaskManager(BaseManager):
                     if message["data"] == "transcriber_connection_closed":
                         logger.info(f"Transcriber connection has been closed")
                         self.transcriber_duration += message.get("meta_info", {}).get("transcriber_duration", 0) if message['meta_info'] is not None else 0
-                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
+                        await self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
                     continue
 
@@ -2435,7 +2459,7 @@ class TaskManager(BaseManager):
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
                             logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
                             continue
-                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
+                        await self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 
                 else:
@@ -2445,7 +2469,7 @@ class TaskManager(BaseManager):
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
                             logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
                             continue
-                        self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
+                        await self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 
                     await self.__process_http_transcription(message)
@@ -2593,20 +2617,10 @@ class TaskManager(BaseManager):
                 except Exception as e:
                     logger.error(f"Error in synthesizer: {e}", exc_info=True)
                     self._turn_audio_flushed.set()
-                    if self.run_id and not self._error_logged:
-                        error_msg = format_error_message("synthesizer", self.synthesizer_provider, str(e))
-                        convert_to_request_log(
-                            error_msg,
-                            {"request_id": self.task_id, "sequence_id": None},
-                            model=self.synthesizer_provider,
-                            component=LogComponent.ERROR,
-                            direction=LogDirection.ERROR,
-                            is_cached=False,
-                            run_id=self.run_id
-                        )
-                        self._error_logged = True
-                    if self._component_error is None:
-                        self._component_error = SynthesizerError(str(e), provider=self.synthesizer_provider)
+                    await self._end_call_on_component_error(
+                        SynthesizerError(str(e), provider=self.synthesizer_provider),
+                        "synthesizer_error"
+                    )
                     break
 
             logger.info("Exiting __listen_synthesizer gracefully.")
@@ -2616,18 +2630,10 @@ class TaskManager(BaseManager):
             #await self.handle_cancellation("Synthesizer task was cancelled outside loop.")
         except Exception as e:
             logger.error(f"Unexpected error in __listen_synthesizer: {e}", exc_info=True)
-            if self.run_id and not self._error_logged:
-                error_msg = format_error_message("synthesizer", self.synthesizer_provider, str(e))
-                convert_to_request_log(
-                    error_msg,
-                    {"request_id": self.task_id, "sequence_id": None},
-                    model=self.synthesizer_provider,
-                    component=LogComponent.ERROR,
-                    direction=LogDirection.ERROR,
-                    is_cached=False,
-                    run_id=self.run_id
-                )
-                self._error_logged = True
+            await self._end_call_on_component_error(
+                SynthesizerError(str(e), provider=self.synthesizer_provider),
+                "synthesizer_error"
+            )
             raise SynthesizerError(
                 str(e), provider=self.synthesizer_provider
             ) from e

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -150,3 +150,33 @@ class ResponseItemType(str, Enum):
     @classmethod
     def all_values(cls):
         return [e.value for e in cls]
+
+
+class LogComponent(str, Enum):
+    """Enum for CSV trace log component types."""
+    ERROR = "error"
+    FUNCTION_CALL = "function_call"
+    GRAPH_ROUTING = "graph_routing"
+    LLM = "llm"
+    LLM_HANGUP = "llm_hangup"
+    LLM_LANGUAGE_DETECTION = "llm_language_detection"
+    LLM_VOICEMAIL = "llm_voicemail"
+    SYNTHESIZER = "synthesizer"
+    TRANSCRIBER = "transcriber"
+    WARNING = "warning"
+
+    @classmethod
+    def all_values(cls):
+        return [c.value for c in cls]
+
+
+class LogDirection(str, Enum):
+    """Enum for CSV trace log direction types."""
+    ERROR = "error"
+    REQUEST = "request"
+    RESPONSE = "response"
+    WARNING = "warning"
+
+    @classmethod
+    def all_values(cls):
+        return [d.value for d in cls]

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -165,9 +165,25 @@ class LogComponent(str, Enum):
     TRANSCRIBER = "transcriber"
     WARNING = "warning"
 
+    @property
+    def display_name(self):
+        return _DISPLAY_NAMES.get(self, self.value)
+
     @classmethod
     def all_values(cls):
         return [c.value for c in cls]
+
+
+_DISPLAY_NAMES = {
+    LogComponent.TRANSCRIBER: "Speech recognition",
+    LogComponent.SYNTHESIZER: "Text-to-speech",
+    LogComponent.LLM: "LLM",
+    LogComponent.LLM_HANGUP: "LLM hangup check",
+    LogComponent.LLM_VOICEMAIL: "LLM voicemail check",
+    LogComponent.LLM_LANGUAGE_DETECTION: "LLM language detection",
+    LogComponent.FUNCTION_CALL: "Function call",
+    LogComponent.GRAPH_ROUTING: "Graph routing",
+}
 
 
 class LogDirection(str, Enum):

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -152,6 +152,22 @@ class ResponseItemType(str, Enum):
         return [e.value for e in cls]
 
 
+class HangupReason(str, Enum):
+    """Enum for hangup_detail values — why the call ended."""
+    LLM_PROMPTED_HANGUP = "llm_prompted_hangup"
+    VOICEMAIL_DETECTED = "voicemail_detected"
+    WEB_CALL_MAX_DURATION_REACHED = "web_call_max_duration_reached"
+    INACTIVITY_TIMEOUT = "inactivity_timeout"
+    TRANSCRIBER_ERROR = "transcriber_error"
+    TRANSCRIBER_CONNECTION_ERROR = "transcriber_connection_error"
+    SYNTHESIZER_ERROR = "synthesizer_error"
+    LLM_ERROR = "llm_error"
+
+    @classmethod
+    def all_values(cls):
+        return [r.value for r in cls]
+
+
 class LogComponent(str, Enum):
     """Enum for CSV trace log component types."""
     ERROR = "error"

--- a/bolna/exceptions.py
+++ b/bolna/exceptions.py
@@ -1,0 +1,23 @@
+class BolnaComponentError(Exception):
+    """Base exception that carries component context for error attribution."""
+
+    def __init__(self, message, component, provider=None, model=None):
+        self.component = component
+        self.provider = provider
+        self.model = model
+        super().__init__(message)
+
+
+class LLMError(BolnaComponentError):
+    def __init__(self, message, provider=None, model=None):
+        super().__init__(message, component="llm", provider=provider, model=model)
+
+
+class SynthesizerError(BolnaComponentError):
+    def __init__(self, message, provider=None, model=None):
+        super().__init__(message, component="synthesizer", provider=provider, model=model)
+
+
+class TranscriberError(BolnaComponentError):
+    def __init__(self, message, provider=None, model=None):
+        super().__init__(message, component="transcriber", provider=provider, model=model)

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -3,7 +3,8 @@ import json
 
 import aiohttp
 from bolna.helpers.logger_config import configure_logger
-from bolna.helpers.utils import convert_to_request_log
+from bolna.enums import LogComponent, LogDirection
+from bolna.helpers.utils import convert_to_request_log, format_error_message
 
 logger = configure_logger(__name__)
 
@@ -102,7 +103,7 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
 
         if headers.get('Content-Type').lower().startswith('application/x-www-form-urlencoded'):
             content_type = 'form'
-        convert_to_request_log(request_body, meta_info , None, "function_call", direction="request", is_cached=False, run_id=run_id)
+        convert_to_request_log(request_body, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, is_cached=False, run_id=run_id)
 
         async with aiohttp.ClientSession() as session:
             if method.lower() == "get":
@@ -123,6 +124,16 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
     except Exception as e:
         message = f"ERROR CALLING API: Please check your API: {e}"
         logger.error(message)
+        if run_id:
+            convert_to_request_log(
+                format_error_message("function_call", url, str(e)),
+                meta_info,
+                model=None,
+                component=LogComponent.WARNING,
+                direction=LogDirection.WARNING,
+                is_cached=False,
+                run_id=run_id
+            )
         return message
 
 

--- a/bolna/helpers/language_detector.py
+++ b/bolna/helpers/language_detector.py
@@ -5,6 +5,7 @@ import asyncio
 import uuid
 from bolna.llms import OpenAiLLM
 from bolna.prompts import LANGUAGE_DETECTION_PROMPT
+from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log
 from bolna.helpers.logger_config import configure_logger
 
@@ -91,11 +92,11 @@ class LanguageDetector:
         model = self._llm.model if self._llm else 'unknown'
         convert_to_request_log(
             message={'transcripts': self._transcripts},
-            meta_info=meta_info, component="llm_language_detection",
-            direction="request", model=model, run_id=self.run_id
+            meta_info=meta_info, component=LogComponent.LLM_LANGUAGE_DETECTION,
+            direction=LogDirection.REQUEST, model=model, run_id=self.run_id
         )
         convert_to_request_log(
             message=result, meta_info=meta_info,
-            component="llm_language_detection", direction="response",
+            component=LogComponent.LLM_LANGUAGE_DETECTION, direction=LogDirection.RESPONSE,
             model=model, run_id=self.run_id
         )

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -646,7 +646,7 @@ def convert_to_request_log(message, meta_info, model, component=LogComponent.TRA
             log['latency'] = meta_info.get('transcriber_latency', None) if direction == LogDirection.RESPONSE else None
             if 'is_final' in meta_info and meta_info['is_final']:
                 log['is_final'] = True
-        case LogComponent.FUNCTION_CALL | LogComponent.WARNING:
+        case LogComponent.FUNCTION_CALL | LogComponent.WARNING | LogComponent.ERROR:
             log['latency'] = None
         case LogComponent.GRAPH_ROUTING:
             log['latency'] = None

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -18,10 +18,12 @@ from scipy.io import wavfile
 from botocore.exceptions import BotoCoreError, ClientError
 from aiobotocore.session import AioSession
 from contextlib import AsyncExitStack
+from enum import Enum
 from dotenv import load_dotenv
 from pydantic import create_model
 from .logger_config import configure_logger
 from bolna.constants import PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, TRANSFERING_CALL_FILLER
+from bolna.enums import LogComponent, LogDirection
 from bolna.prompts import DATE_PROMPT
 from pydub import AudioSegment
 import audioop
@@ -478,27 +480,30 @@ async def write_request_logs(message, run_id):
 
     row = [message['time'], message["component"], message["direction"], message["leg_id"], message['sequence_id'], message['model']]
     metadata = {}
-    if message["component"] in ("llm", "llm_hangup", "llm_voicemail"):
+    if message["component"] in (LogComponent.LLM, LogComponent.LLM_HANGUP, LogComponent.LLM_VOICEMAIL, LogComponent.LLM_LANGUAGE_DETECTION):
         # Convert dict to string if necessary
         if isinstance(message_data, dict):
             message_data = json.dumps(message_data)
         component_details = [message_data, message.get('input_tokens', 0), message.get('output_tokens', 0), None, message.get('latency', None), message['cached'], None, None]
         metadata = message.get('llm_metadata', {})
-    elif message["component"] == "transcriber":
+    elif message["component"] == LogComponent.TRANSCRIBER:
         component_details = [message_data, None, None, None, message.get('latency', None), False, message.get('is_final', False), None]
         metadata = message.get('transcriber_metadata', {})
-    elif message["component"] == "synthesizer":
+    elif message["component"] == LogComponent.SYNTHESIZER:
         component_details = [message_data, None, None, len(message_data), message.get('latency', None), message['cached'], None, message['engine']]
         metadata = message.get('synthesizer_metadata', {})
-    elif message["component"] == "function_call":
+    elif message["component"] == LogComponent.FUNCTION_CALL:
         component_details = [message_data, None, None, None, message.get('latency', None), None, None, None]
         metadata = message.get('function_call_metadata', {})
-    elif message["component"] == "graph_routing":
+    elif message["component"] == LogComponent.GRAPH_ROUTING:
         component_details = [message_data, None, None, None, message.get('latency', None), False, None, None]
         metadata = message.get('graph_routing_metadata', {})
-    elif message["component"] == "error":
+    elif message["component"] == LogComponent.ERROR:
         component_details = [message_data, None, None, None, message.get('latency', None), False, None, None]
         metadata = message.get('error_metadata', {})
+    elif message["component"] == LogComponent.WARNING:
+        component_details = [message_data, None, None, None, message.get('latency', None), False, None, None]
+        metadata = message.get('warning_metadata', {})
 
     metadata_str = None
     if metadata:
@@ -589,34 +594,75 @@ def get_file_names_in_directory(directory):
     return os.listdir(directory)
 
 
-def convert_to_request_log(message, meta_info, model, component="transcriber", direction='response', is_cached=False, engine=None, run_id=None):
+COMPONENT_DISPLAY_NAMES = {
+    "transcriber": "Speech recognition",
+    "synthesizer": "Text-to-speech",
+    "llm": "LLM",
+    "llm_hangup": "LLM hangup check",
+    "llm_voicemail": "LLM voicemail check",
+    "llm_language_detection": "LLM language detection",
+    "function_call": "Function call",
+    "graph_routing": "Graph routing",
+}
+
+
+def format_error_message(component, provider, error_str):
+    """Map technical error strings to customer-friendly messages for CSV trace data."""
+    display = COMPONENT_DISPLAY_NAMES.get(component, component)
+    provider_str = f" ({provider})" if provider and provider != "-" else ""
+    err_lower = error_str.lower() if error_str else ""
+
+    if "content policy" in err_lower or "content_policy" in err_lower:
+        return "Content policy violation - response blocked by safety filter"
+    if "timeout" in err_lower:
+        return f"{display} service{provider_str} connection timed out"
+    if "auth" in err_lower or "401" in err_lower or "invalid api key" in err_lower or "incorrect api key" in err_lower or "invalid_api_key" in err_lower:
+        return f"{display} service{provider_str} authentication failed - please check API key"
+    if "rate limit" in err_lower or "429" in err_lower or "too many requests" in err_lower:
+        return f"{display} service{provider_str} rate limit exceeded - too many requests"
+    if "permission" in err_lower or "403" in err_lower:
+        return f"{display} service{provider_str} permission denied"
+    if "not found" in err_lower or "404" in err_lower:
+        return f"{display} service{provider_str} resource not found"
+    if "connection closed" in err_lower or "connection reset" in err_lower or "connectionclosed" in err_lower:
+        return f"{display} service{provider_str} disconnected unexpectedly"
+    if "connection" in err_lower:
+        return f"{display} service{provider_str} connection error"
+
+    # Truncate long error messages for readability
+    truncated = error_str[:200] if len(error_str) > 200 else error_str
+    return f"{display} service{provider_str} error: {truncated}"
+
+
+def convert_to_request_log(message, meta_info, model, component=LogComponent.TRANSCRIBER, direction=LogDirection.RESPONSE, is_cached=False, engine=None, run_id=None):
     log = dict()
-    log['direction'] = direction
+    log['direction'] = direction.value if isinstance(direction, Enum) else direction
     log['data'] = message
     log['leg_id'] = meta_info['request_id'] if "request_id" in meta_info else "-"
     log['time'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
-    log['component'] = component
+    log['component'] = component.value if isinstance(component, Enum) else component
     log['sequence_id'] = meta_info.get('sequence_id', None)
     log['model'] = model
     log['cached'] = is_cached
-    if component == "llm":
-        log['latency'] = meta_info.get('llm_latency', None) if direction == "response" else None
+    log['is_final'] = False
+    if component == LogComponent.LLM:
+        log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
         log['llm_metadata'] = meta_info.get('llm_metadata', None)
-    if component == "synthesizer":
-        log['latency'] = meta_info.get('synthesizer_latency', None) if direction == "response" else None
-    if component == "transcriber":
-        log['latency'] = meta_info.get('transcriber_latency', None) if direction == "response" else None
+    elif component == LogComponent.SYNTHESIZER:
+        log['latency'] = meta_info.get('synthesizer_latency', None) if direction == LogDirection.RESPONSE else None
+    elif component == LogComponent.TRANSCRIBER:
+        log['latency'] = meta_info.get('transcriber_latency', None) if direction == LogDirection.RESPONSE else None
         if 'is_final' in meta_info and meta_info['is_final']:
             log['is_final'] = True
-    if component == "function_call":
+    elif component == LogComponent.FUNCTION_CALL:
         log['latency'] = None
-    if component == "graph_routing":
+    elif component == LogComponent.GRAPH_ROUTING:
         log['latency'] = None
         log['graph_routing_metadata'] = meta_info.get('llm_metadata', {})
-    if component == "llm-hangup":
-        log['latency'] = meta_info.get('llm_latency', None) if direction == "response" else None
-    else:
-        log['is_final'] = False #This is logged only for users to know final transcript from the transcriber
+    elif component == LogComponent.WARNING:
+        log['latency'] = None
+    elif component in (LogComponent.LLM_HANGUP, LogComponent.LLM_VOICEMAIL, LogComponent.LLM_LANGUAGE_DETECTION):
+        log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
     log['engine'] = engine
     asyncio.create_task(write_request_logs(log, run_id))
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -594,21 +594,12 @@ def get_file_names_in_directory(directory):
     return os.listdir(directory)
 
 
-COMPONENT_DISPLAY_NAMES = {
-    "transcriber": "Speech recognition",
-    "synthesizer": "Text-to-speech",
-    "llm": "LLM",
-    "llm_hangup": "LLM hangup check",
-    "llm_voicemail": "LLM voicemail check",
-    "llm_language_detection": "LLM language detection",
-    "function_call": "Function call",
-    "graph_routing": "Graph routing",
-}
-
-
 def format_error_message(component, provider, error_str):
     """Map technical error strings to customer-friendly messages for CSV trace data."""
-    display = COMPONENT_DISPLAY_NAMES.get(component, component)
+    try:
+        display = LogComponent(component).display_name
+    except ValueError:
+        display = component
     provider_str = f" ({provider})" if provider and provider != "-" else ""
     err_lower = error_str.lower() if error_str else ""
 
@@ -645,24 +636,23 @@ def convert_to_request_log(message, meta_info, model, component=LogComponent.TRA
     log['model'] = model
     log['cached'] = is_cached
     log['is_final'] = False
-    if component == LogComponent.LLM:
-        log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
-        log['llm_metadata'] = meta_info.get('llm_metadata', None)
-    elif component == LogComponent.SYNTHESIZER:
-        log['latency'] = meta_info.get('synthesizer_latency', None) if direction == LogDirection.RESPONSE else None
-    elif component == LogComponent.TRANSCRIBER:
-        log['latency'] = meta_info.get('transcriber_latency', None) if direction == LogDirection.RESPONSE else None
-        if 'is_final' in meta_info and meta_info['is_final']:
-            log['is_final'] = True
-    elif component == LogComponent.FUNCTION_CALL:
-        log['latency'] = None
-    elif component == LogComponent.GRAPH_ROUTING:
-        log['latency'] = None
-        log['graph_routing_metadata'] = meta_info.get('llm_metadata', {})
-    elif component == LogComponent.WARNING:
-        log['latency'] = None
-    elif component in (LogComponent.LLM_HANGUP, LogComponent.LLM_VOICEMAIL, LogComponent.LLM_LANGUAGE_DETECTION):
-        log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
+    match component:
+        case LogComponent.LLM:
+            log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
+            log['llm_metadata'] = meta_info.get('llm_metadata', None)
+        case LogComponent.SYNTHESIZER:
+            log['latency'] = meta_info.get('synthesizer_latency', None) if direction == LogDirection.RESPONSE else None
+        case LogComponent.TRANSCRIBER:
+            log['latency'] = meta_info.get('transcriber_latency', None) if direction == LogDirection.RESPONSE else None
+            if 'is_final' in meta_info and meta_info['is_final']:
+                log['is_final'] = True
+        case LogComponent.FUNCTION_CALL | LogComponent.WARNING:
+            log['latency'] = None
+        case LogComponent.GRAPH_ROUTING:
+            log['latency'] = None
+            log['graph_routing_metadata'] = meta_info.get('llm_metadata', {})
+        case LogComponent.LLM_HANGUP | LogComponent.LLM_VOICEMAIL | LogComponent.LLM_LANGUAGE_DETECTION:
+            log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
     log['engine'] = engine
     asyncio.create_task(write_request_logs(log, run_id))
 

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -7,6 +7,7 @@ from litellm.exceptions import AuthenticationError, RateLimitError, APIError, AP
 from dotenv import load_dotenv
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE
+from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
 from .llm import BaseLLM
 from .tool_call_accumulator import ToolCallAccumulator
@@ -90,11 +91,17 @@ class LiteLLM(BaseLLM):
         except ContentPolicyViolationError as e:
             error_message = str(e)
             logger.error(f'Content policy violation in stream: {error_message}')
+
+            # Log to CSV trace as warning (non-call-breaking)
             if meta_info and self.run_id:
                 convert_to_request_log(
                     f"Content Policy Violation: {error_message}",
-                    meta_info, self.model, component="llm",
-                    direction="error", is_cached=False, run_id=self.run_id
+                    meta_info,
+                    self.model,
+                    component=LogComponent.WARNING,
+                    direction=LogDirection.WARNING,
+                    is_cached=False,
+                    run_id=self.run_id
                 )
             return
         except AuthenticationError as e:
@@ -181,14 +188,14 @@ class LiteLLM(BaseLLM):
             error_message = str(e)
             logger.error(f'Content policy violation: {error_message}')
 
-            # Log to CSV trace
+            # Log to CSV trace as warning (non-call-breaking)
             if meta_info and self.run_id:
                 convert_to_request_log(
                     f"Content Policy Violation: {error_message}",
                     meta_info,
                     self.model,
-                    component="llm",
-                    direction="error",
+                    component=LogComponent.WARNING,
+                    direction=LogDirection.WARNING,
                     is_cached=False,
                     run_id=self.run_id
                 )

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -3,7 +3,7 @@ import json
 from openai import BadRequestError, APIError
 
 from bolna.constants import GPT5_MODEL_PREFIX
-from bolna.enums import ChatRole, ResponseStreamEvent, ResponseItemType
+from bolna.enums import ChatRole, ResponseStreamEvent, ResponseItemType, LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
 from .llm import BaseLLM
 from .message_models import MessageFormatAdapter
@@ -281,8 +281,8 @@ class OpenAICompatibleLLM(BaseLLM):
                         parsed_args = json.loads(arguments_str)
                         required_keys = tool_spec.get("parameters", {}).get("required", [])
                         if tool_spec.get("parameters") is not None and all(k in parsed_args for k in required_keys):
-                            convert_to_request_log(arguments_str, meta_info, self.model, "llm",
-                                                   direction="response", is_cached=False, run_id=self.run_id)
+                            convert_to_request_log(arguments_str, meta_info, self.model, LogComponent.LLM,
+                                                   direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
                             for k, v in parsed_args.items():
                                 setattr(api_call_payload, k, v)
                         else:

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -53,6 +53,7 @@ class CartesiaSynthesizer(BaseSynthesizer):
         self.sequence_id = 0
         self.context_ids_to_ignore = set()
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
 
@@ -125,6 +126,7 @@ class CartesiaSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(input_message))
                 except Exception as e:
                     logger.error(f"Error sending chunk context_id={self.context_id} request_id={self.ws_request_id}: {e}")
+                    self.connection_error = str(e)
                     return
 
             # If end_of_llm_stream is True, mark the last chunk and send an empty message
@@ -138,6 +140,7 @@ class CartesiaSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(input_message))
                 except Exception as e:
                     logger.error(f"Error sending end-of-stream signal context_id={self.context_id} request_id={self.ws_request_id}: {e}")
+                    self.connection_error = str(e)
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")
         except Exception as e:
@@ -150,6 +153,8 @@ class CartesiaSynthesizer(BaseSynthesizer):
                     return
 
                 if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED:
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.1)
                     continue
@@ -225,6 +230,8 @@ class CartesiaSynthesizer(BaseSynthesizer):
     async def generate(self):
         try:
             async for message in self.receiver():
+                if self.connection_error:
+                    raise Exception(self.connection_error)
                 if len(self.text_queue) > 0:
                     self.meta_info = self.text_queue.popleft()
                     # Compute first-result latency on first audio chunk
@@ -275,10 +282,13 @@ class CartesiaSynthesizer(BaseSynthesizer):
                         pass
 
                 yield create_ws_data_packet(audio, self.meta_info)
+            if self.connection_error:
+                raise Exception(self.connection_error)
 
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Error in cartesia generate {e}")
+            raise
 
     async def establish_connection(self):
         try:
@@ -303,10 +313,13 @@ class CartesiaSynthesizer(BaseSynthesizer):
             error_msg = str(e)
             if '401' in error_msg or '403' in error_msg:
                 logger.error(f"Cartesia authentication failed: Invalid or expired API key - {e}")
+                self.connection_error = str(e)
             elif '404' in error_msg:
                 logger.error(f"Cartesia endpoint not found: {e}")
+                self.connection_error = str(e)
             else:
                 logger.error(f"Cartesia handshake failed: {e}")
+                self.connection_error = str(e)
             return None
         except Exception as e:
             logger.error(f"Failed to connect to Cartesia: {e}")
@@ -326,6 +339,7 @@ class CartesiaSynthesizer(BaseSynthesizer):
                     logger.warning(f"Cartesia connection failed (attempt {consecutive_failures}/{max_failures})")
                     if consecutive_failures >= max_failures:
                         logger.error("Max connection failures reached for Cartesia - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
                         break
                 else:
                     self.websocket_holder["websocket"] = result

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -57,6 +57,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
         self.last_text_sent = False
         self.sender_task = None
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_text = ""
@@ -162,6 +163,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(speak_message))
                 except Exception as e:
                     logger.error(f"Error sending chunk to Deepgram: {e}")
+                    self.connection_error = str(e)
                     return
 
             # If end_of_llm_stream is True, flush the buffer and mark stream as complete
@@ -174,6 +176,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
                     logger.info("Sent Flush message to Deepgram TTS WebSocket")
                 except Exception as e:
                     logger.error(f"Error sending Flush to Deepgram: {e}")
+                    self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Deepgram sender task was cancelled.")
@@ -190,6 +193,8 @@ class DeepgramSynthesizer(BaseSynthesizer):
 
                 if (self.websocket_holder["websocket"] is None or
                         self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED):
+                    if self.connection_error:
+                        return
                     logger.info("Deepgram WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.10)
                     continue
@@ -251,6 +256,8 @@ class DeepgramSynthesizer(BaseSynthesizer):
             if self.stream:
                 # WebSocket streaming mode
                 async for message in self.receiver():
+                    if self.connection_error:
+                        raise Exception(self.connection_error)
                     if len(self.text_queue) > 0:
                         self.meta_info = self.text_queue.popleft()
                         # Compute TTFB on first audio chunk only
@@ -301,6 +308,8 @@ class DeepgramSynthesizer(BaseSynthesizer):
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     yield create_ws_data_packet(audio, self.meta_info)
+                if self.connection_error:
+                    raise Exception(self.connection_error)
             else:
                 # HTTP non-streaming mode
                 while True:
@@ -364,6 +373,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Error in Deepgram generate: {e}")
+            raise
 
     async def establish_connection(self):
         """Establish WebSocket connection to Deepgram TTS"""
@@ -390,6 +400,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
                 logger.error(f"Deepgram authentication failed: Access forbidden")
             else:
                 logger.error(f"Deepgram WebSocket connection failed with status {e.status_code}: {e}")
+            self.connection_error = str(e)
             return None
         except Exception as e:
             logger.error(f"Failed to connect to Deepgram TTS WebSocket: {e}")
@@ -409,6 +420,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
                     logger.warning(f"Deepgram TTS connection failed (attempt {consecutive_failures}/{max_failures})")
                     if consecutive_failures >= max_failures:
                         logger.error("Max connection failures reached for Deepgram TTS - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
                         break
                 else:
                     self.websocket_holder["websocket"] = result

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -414,11 +414,24 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
             return None
 
     async def monitor_connection(self):
-        # Periodically check if the connection is still alive
-        while True:
+        """Periodically check if the connection is still alive and reconnect if needed"""
+        consecutive_failures = 0
+        max_failures = 3
+
+        while consecutive_failures < max_failures:
             if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED:
                 logger.info("Re-establishing elevenlabs connection...")
-                self.websocket_holder["websocket"] = await self.establish_connection()
+                result = await self.establish_connection()
+                if result is None:
+                    consecutive_failures += 1
+                    logger.warning(f"ElevenLabs connection failed (attempt {consecutive_failures}/{max_failures})")
+                    if consecutive_failures >= max_failures:
+                        logger.error("Max connection failures reached for ElevenLabs - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
+                        break
+                else:
+                    self.websocket_holder["websocket"] = result
+                    consecutive_failures = 0
             await asyncio.sleep(1)
 
     async def get_sender_task(self):

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -49,6 +49,7 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
         self.websocket_holder = {"websocket": None}
         self.sender_task = None
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_text = ""
@@ -116,6 +117,7 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
                         await self.websocket_holder["websocket"].send(json.dumps({"text": text_chunk}))
                     except Exception as e:
                         logger.info(f"Error sending chunk: {e}")
+                        self.connection_error = str(e)
                         return
 
             # If end_of_llm_stream is True, mark the last chunk and send an empty message
@@ -128,6 +130,7 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
                 await self.websocket_holder["websocket"].send(json.dumps({"text": "", "flush": True}))
             except Exception as e:
                 logger.info(f"Error sending end-of-stream signal: {e}")
+                self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")
@@ -144,6 +147,8 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
 
                 if (self.websocket_holder["websocket"] is None or
                         self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED):
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.10)
                     continue
@@ -255,6 +260,8 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
         try:
             if self.stream:
                 async for message, text_synthesized in self.receiver():
+                    if self.connection_error:
+                        raise Exception(self.connection_error)
                     gen_loop_start = time.perf_counter()
                     if last_yield_time:
                         loop_gap = (gen_loop_start - last_yield_time) * 1000
@@ -324,6 +331,8 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     last_yield_time = time.perf_counter()
                     yield create_ws_data_packet(audio, self.meta_info)
+                if self.connection_error:
+                    raise Exception(self.connection_error)
             else:
                 while True:
                     message = await self.internal_queue.get()
@@ -368,6 +377,7 @@ class ElevenlabsSynthesizer(BaseSynthesizer):
         except Exception as e:
             traceback.print_exc()
             logger.info(f"Error in eleven labs generate {e}")
+            raise
 
     def supports_websocket(self):
         return True

--- a/bolna/synthesizer/openai_synthesizer.py
+++ b/bolna/synthesizer/openai_synthesizer.py
@@ -99,6 +99,7 @@ class OPENAISynthesizer(BaseSynthesizer):
 
         except Exception as e:
                 logger.error(f"Error in openai generate {e}")
+                raise
 
     async def open_connection(self):
         pass

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -49,6 +49,7 @@ class PixaSynthesizer(BaseSynthesizer):
         self.sender_task = None
         self.context_ids_to_ignore = set()
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_text = ""
@@ -129,6 +130,7 @@ class PixaSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(input_message))
                 except Exception as e:
                     logger.error(f"Error sending chunk: {e}")
+                    self.connection_error = str(e)
                     return
 
             if end_of_llm_stream:
@@ -138,6 +140,7 @@ class PixaSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(input_message))
                 except Exception as e:
                     logger.error(f"Error sending end-of-stream signal: {e}")
+                    self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")
@@ -151,6 +154,8 @@ class PixaSynthesizer(BaseSynthesizer):
                     return
 
                 if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state != websockets.protocol.State.OPEN:
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.1)
                     continue
@@ -234,6 +239,8 @@ class PixaSynthesizer(BaseSynthesizer):
     async def generate(self):
         try:
             async for message in self.receiver():
+                if self.connection_error:
+                    raise Exception(self.connection_error)
                 if len(self.text_queue) > 0:
                     self.meta_info = self.text_queue.popleft()
                     try:
@@ -280,10 +287,13 @@ class PixaSynthesizer(BaseSynthesizer):
                         pass
 
                 yield create_ws_data_packet(audio, self.meta_info)
+            if self.connection_error:
+                raise Exception(self.connection_error)
 
         except Exception as e:
             traceback.print_exc()
             logger.error(f"Error in pixa generate: {e}")
+            raise
 
     async def establish_connection(self):
         try:
@@ -324,6 +334,7 @@ class PixaSynthesizer(BaseSynthesizer):
                 logger.error(f"Pixa endpoint not found: {e}")
             else:
                 logger.error(f"Pixa handshake failed: {e}")
+            self.connection_error = str(e)
             return None
         except Exception as e:
             logger.error(f"Failed to connect to Pixa: {e}")
@@ -342,6 +353,7 @@ class PixaSynthesizer(BaseSynthesizer):
                     logger.warning(f"Pixa connection failed (attempt {consecutive_failures}/{max_failures})")
                     if consecutive_failures >= max_failures:
                         logger.error("Max connection failures reached for Pixa - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
                         break
                 else:
                     self.websocket_holder["websocket"] = result

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -319,11 +319,24 @@ class RimeSynthesizer(BaseSynthesizer):
             return None
 
     async def monitor_connection(self):
-        # Periodically check if the connection is still alive
-        while True:
+        """Periodically check if the connection is still alive and reconnect if needed"""
+        consecutive_failures = 0
+        max_failures = 3
+
+        while consecutive_failures < max_failures:
             if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED:
                 logger.info("Re-establishing rime connection...")
-                self.websocket_holder["websocket"] = await self.establish_connection()
+                result = await self.establish_connection()
+                if result is None:
+                    consecutive_failures += 1
+                    logger.warning(f"Rime connection failed (attempt {consecutive_failures}/{max_failures})")
+                    if consecutive_failures >= max_failures:
+                        logger.error("Max connection failures reached for Rime - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
+                        break
+                else:
+                    self.websocket_holder["websocket"] = result
+                    consecutive_failures = 0
             await asyncio.sleep(1)
 
     async def get_sender_task(self):

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -46,6 +46,7 @@ class RimeSynthesizer(BaseSynthesizer):
         self.sender_task = None
         self.last_text_sent = False
         self.conversation_ended = False
+        self.connection_error = None
         self.current_text = ""
         self.context_id = None
         self.text_queue = deque()
@@ -148,6 +149,7 @@ class RimeSynthesizer(BaseSynthesizer):
                         await self.websocket_holder["websocket"].send(json.dumps({"text": text_chunk, "contextId": self.context_id}))
                     except Exception as e:
                         logger.info(f"Error sending chunk: {e}")
+                        self.connection_error = str(e)
                         return
 
             # If end_of_llm_stream is True, mark the last chunk and send an empty message
@@ -160,6 +162,7 @@ class RimeSynthesizer(BaseSynthesizer):
                 await self.websocket_holder["websocket"].send(json.dumps({"operation": "flush"}))
             except Exception as e:
                 logger.info(f"Error sending end-of-stream signal: {e}")
+                self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")
@@ -174,6 +177,8 @@ class RimeSynthesizer(BaseSynthesizer):
 
                 if (self.websocket_holder["websocket"] is None or
                         self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED):
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.1)
                     continue
@@ -203,6 +208,8 @@ class RimeSynthesizer(BaseSynthesizer):
         try:
             if self.stream:
                 async for message in self.receiver():
+                    if self.connection_error:
+                        raise Exception(self.connection_error)
                     logger.info(f"Received message from server")
 
                     if len(self.text_queue) > 0:
@@ -247,6 +254,8 @@ class RimeSynthesizer(BaseSynthesizer):
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     yield create_ws_data_packet(audio, self.meta_info)
+                if self.connection_error:
+                    raise Exception(self.connection_error)
             else:
                 while True:
                     message = await self.internal_queue.get()
@@ -289,7 +298,8 @@ class RimeSynthesizer(BaseSynthesizer):
 
         except Exception as e:
             traceback.print_exc()
-            logger.info(f"Error in eleven labs generate {e}")
+            logger.info(f"Error in rime generate {e}")
+            raise
 
     async def establish_connection(self):
         try:

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -48,6 +48,7 @@ class SarvamSynthesizer(BaseSynthesizer):
         self.websocket_holder = {"websocket": None}
         self.sender_task = None
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.text_queue = deque()
@@ -123,6 +124,7 @@ class SarvamSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps({"type": "text", "data": {"text": text}}))
                 except Exception as e:
                     logger.error(f"Error sending chunk: {e}")
+                    self.connection_error = str(e)
                     return
 
             # If end_of_llm_stream is True, mark the last chunk and send an empty message
@@ -133,6 +135,7 @@ class SarvamSynthesizer(BaseSynthesizer):
                 await self.websocket_holder["websocket"].send(json.dumps({"type": "flush"}))
             except Exception as e:
                 logger.info(f"Error sending end-of-stream signal: {e}")
+                self.connection_error = str(e)
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")
         except Exception as e:
@@ -164,6 +167,8 @@ class SarvamSynthesizer(BaseSynthesizer):
 
                 if (self.websocket_holder["websocket"] is None or
                         self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED):
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.1)
                     continue
@@ -225,6 +230,7 @@ class SarvamSynthesizer(BaseSynthesizer):
                 logger.error(f"Sarvam TTS endpoint not found: {e}")
             else:
                 logger.error(f"Sarvam TTS handshake failed: {e}")
+            self.connection_error = str(e)
             return None
         except Exception as e:
             logger.error(f"Failed to connect to Sarvam TTS: {e}")
@@ -244,6 +250,7 @@ class SarvamSynthesizer(BaseSynthesizer):
                     logger.warning(f"Sarvam TTS connection failed (attempt {consecutive_failures}/{max_failures})")
                     if consecutive_failures >= max_failures:
                         logger.error("Max connection failures reached for Sarvam TTS - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
                         break
                 else:
                     self.websocket_holder["websocket"] = result
@@ -269,6 +276,8 @@ class SarvamSynthesizer(BaseSynthesizer):
         try:
             if self.stream:
                 async for message in self.receiver():
+                    if self.connection_error:
+                        raise Exception(self.connection_error)
                     logger.info(f"Received message from server")
 
                     if len(self.text_queue) > 0:
@@ -320,10 +329,13 @@ class SarvamSynthesizer(BaseSynthesizer):
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     yield create_ws_data_packet(audio, self.meta_info)
+                if self.connection_error:
+                    raise Exception(self.connection_error)
 
         except Exception as e:
             traceback.print_exc()
             logger.info(f"Error in sarvam generate {e}")
+            raise
 
     async def _process_audio_data(self, audio):
         format = get_synth_audio_format(audio)

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -37,6 +37,7 @@ class SmallestSynthesizer(BaseSynthesizer):
         self.websocket_holder = {"websocket": None}
         self.sender_task = None
         self.conversation_ended = False
+        self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.text_queue = deque()
@@ -87,6 +88,8 @@ class SmallestSynthesizer(BaseSynthesizer):
         try:
             if self.stream:
                 async for message in self.receiver():
+                    if self.connection_error:
+                        raise Exception(self.connection_error)
                     logger.info(f"Received message from server")
 
                     if len(self.text_queue) > 0:
@@ -139,6 +142,8 @@ class SmallestSynthesizer(BaseSynthesizer):
 
                     self.meta_info["mark_id"] = str(uuid.uuid4())
                     yield create_ws_data_packet(audio, self.meta_info)
+                if self.connection_error:
+                    raise Exception(self.connection_error)
             else:
                 while True:
                     message = await self.internal_queue.get()
@@ -173,6 +178,7 @@ class SmallestSynthesizer(BaseSynthesizer):
         except Exception as e:
             traceback.print_exc()
             logger.info(f"Error in smallest generate {e}")
+            raise
 
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
@@ -195,6 +201,7 @@ class SmallestSynthesizer(BaseSynthesizer):
                     await self.websocket_holder["websocket"].send(json.dumps(input_message))
                 except Exception as e:
                     logger.error(f"Error sending chunk: {e}")
+                    self.connection_error = str(e)
                     return
 
             # If end_of_llm_stream is True, mark the last chunk and send an empty message
@@ -224,6 +231,8 @@ class SmallestSynthesizer(BaseSynthesizer):
 
                 if (self.websocket_holder["websocket"] is None or
                         self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED):
+                    if self.connection_error:
+                        return
                     logger.info("WebSocket is not connected, skipping receive.")
                     await asyncio.sleep(0.1)
                     continue

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -270,11 +270,24 @@ class SmallestSynthesizer(BaseSynthesizer):
             return None
 
     async def monitor_connection(self):
-        # Periodically check if the connection is still alive
-        while True:
+        """Periodically check if the connection is still alive and reconnect if needed"""
+        consecutive_failures = 0
+        max_failures = 3
+
+        while consecutive_failures < max_failures:
             if self.websocket_holder["websocket"] is None or self.websocket_holder["websocket"].state is websockets.protocol.State.CLOSED:
                 logger.info("Re-establishing smallest connection...")
-                self.websocket_holder["websocket"] = await self.establish_connection()
+                result = await self.establish_connection()
+                if result is None:
+                    consecutive_failures += 1
+                    logger.warning(f"Smallest connection failed (attempt {consecutive_failures}/{max_failures})")
+                    if consecutive_failures >= max_failures:
+                        logger.error("Max connection failures reached for Smallest - stopping reconnection attempts")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
+                        break
+                else:
+                    self.websocket_holder["websocket"] = result
+                    consecutive_failures = 0
             await asyncio.sleep(1)
 
     async def get_sender_task(self):

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -64,9 +64,20 @@ class AzureTranscriber(BaseTranscriber):
     async def run(self):
         try:
             await self.initialize_connection()
+            if self.connection_error:
+                meta = dict(self.meta_info or {})
+                meta['connection_error'] = self.connection_error
+                await self.transcriber_output_queue.put(
+                    create_ws_data_packet("transcriber_connection_closed", meta))
+                return
             self.send_audio_to_transcriber_task = asyncio.create_task(self.send_audio_to_transcriber())
         except Exception as e:
             logger.error(f"Error received in run method - {e}")
+            self.connection_error = self.connection_error or str(e)
+            meta = dict(self.meta_info or {})
+            meta['connection_error'] = self.connection_error
+            await self.transcriber_output_queue.put(
+                create_ws_data_packet("transcriber_connection_closed", meta))
 
     def _check_and_process_end_of_stream(self, ws_data_packet):
         if 'eos' in ws_data_packet['meta_info'] and ws_data_packet['meta_info']['eos'] is True:
@@ -293,7 +304,8 @@ class AzureTranscriber(BaseTranscriber):
     async def session_stopped_handler(self, evt):
         logger.info(f"Session stop event received: {evt} | run_id - {self.run_id}")
         self.end_time = time.time()
-        self.meta_info["transcriber_duration"] = self.end_time - self.start_time
+        if self.meta_info is not None and self.start_time is not None:
+            self.meta_info["transcriber_duration"] = self.end_time - self.start_time
         meta = dict(self.meta_info or {})
         if self.connection_error:
             meta['connection_error'] = self.connection_error

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -21,6 +21,7 @@ class BaseTranscriber:
         self.current_request_id = None
         self.connection_time = None
         self.turn_latencies = []
+        self.connection_error = None
 
     def update_meta_info(self):
         self.meta_info['request_id'] = self.current_request_id if self.current_request_id else None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -679,6 +679,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 deepgram_ws = await self.deepgram_connect()
             except (ValueError, ConnectionError) as e:
                 logger.error(f"Failed to establish Deepgram connection: {e}")
+                self.connection_error = str(e)
                 await self.toggle_connection()
                 return
 
@@ -742,7 +743,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 self.utterance_timeout_task.cancel()
 
             # Use Deepgram's actual audio duration for billing
-            if "deepgram_duration" in self.meta_info:
+            if self.meta_info is not None and "deepgram_duration" in self.meta_info:
                 self.meta_info["transcriber_duration"] = self.meta_info["deepgram_duration"]
 
             meta = dict(getattr(self, 'meta_info', None) or {})

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -83,6 +83,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.last_interim_time = None
         self.interim_timeout = kwargs.get("interim_timeout", 5.0)  # Default 5 seconds
         self.utterance_timeout_task = None
+        self.connection_error = None
 
     def get_deepgram_ws_url(self):
         dg_params = {
@@ -705,8 +706,10 @@ class DeepgramTranscriber(BaseTranscriber):
                             break
                 except ConnectionClosedError as e:
                     logger.error(f"Deepgram websocket connection closed during streaming: {e}")
+                    self.connection_error = str(e)
                 except Exception as e:
                     logger.error(f"Error during streaming: {e}")
+                    self.connection_error = str(e)
                     raise
             else:
                 async for message in self.sender():
@@ -714,9 +717,11 @@ class DeepgramTranscriber(BaseTranscriber):
 
         except (ValueError, ConnectionError) as e:
             logger.error(f"Connection error in transcribe: {e}")
+            self.connection_error = str(e)
             await self.toggle_connection()
         except Exception as e:
             logger.error(f"Unexpected error in transcribe: {e}")
+            self.connection_error = str(e)
             await self.toggle_connection()
         finally:
             if deepgram_ws is not None:
@@ -740,6 +745,9 @@ class DeepgramTranscriber(BaseTranscriber):
             if "deepgram_duration" in self.meta_info:
                 self.meta_info["transcriber_duration"] = self.meta_info["deepgram_duration"]
 
+            meta = dict(getattr(self, 'meta_info', None) or {})
+            if self.connection_error:
+                meta['connection_error'] = self.connection_error
             await self.push_to_transcriber_queue(
-                create_ws_data_packet("transcriber_connection_closed", getattr(self, 'meta_info', {}))
+                create_ws_data_packet("transcriber_connection_closed", meta)
             )

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -154,7 +154,13 @@ class GoogleTranscriber(BaseTranscriber):
             
         except Exception as e:
             logger.exception(f"Error starting GoogleTranscriber: {e}")
+            self.connection_error = str(e)
             await self.toggle_connection()
+            meta = (self.meta_info or {}).copy()
+            meta['connection_error'] = self.connection_error
+            await self.transcriber_output_queue.put(
+                create_ws_data_packet("transcriber_connection_closed", meta)
+            )
     
     async def _transcribe_wrapper(self):
         """Wrapper to make gRPC streaming fit async pattern better"""

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -555,6 +555,12 @@ class SarvamTranscriber(BaseTranscriber):
             except (ValueError, ConnectionError) as e:
                 self.connection_error = str(e)
                 await self.toggle_connection()
+                try:
+                    meta = dict(self.meta_info or {})
+                    meta['connection_error'] = self.connection_error
+                    await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
+                except Exception:
+                    traceback.print_exc()
                 return
 
             if not self.connection_time:


### PR DESCRIPTION
## Summary
- Replaces stringly-typed component/direction params with `LogComponent` and `LogDirection` enums across all CSV logging call sites
- Adds `BolnaComponentError` exception hierarchy (`LLMError`, `SynthesizerError`, `TranscriberError`) carrying component/provider/model context
- Call-breaking errors now log user-friendly attributed messages instead of raw exception strings
- Bad API keys (user-provided) now surface as call-breaking errors and terminate the call
- Propagates transcriber `connection_error` across all transcriber providers

## Test plan
- [ ] Verify CSV error messages show attributed friendly text for bad API keys (LLM, synthesizer, transcriber)
- [ ] Verify call terminates on bad API key
- [ ] Verify dashboard-backend still parses CSV correctly