### PR TITLE
fix: replace hardcoded sleep with mark-event wait before tool API call

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1493,6 +1493,7 @@ class TaskManager(BaseManager):
                     convert_to_request_log(str(response_text), meta_info, None, "function_call", direction="response", is_cached=False, run_id=self.run_id)
                     return
 
+        await self.wait_for_current_message()
         response = await trigger_api(url=url, method=method.lower(), param=param, api_token=api_token, headers_data=headers, meta_info=meta_info, run_id=self.run_id, **resp)
         function_response = str(response)
         get_res_keys, get_res_values = await computed_api_response(function_response)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1273,7 +1273,12 @@ class TaskManager(BaseManager):
             if first_item.get('text_synthesized') and first_item.get('is_final_chunk') is True:
                 break
 
-            await asyncio.sleep(0.5)
+            remaining = self.hangup_mark_event_timeout - elapsed
+            self.mark_event_meta_data.mark_changed.clear()
+            try:
+                await asyncio.wait_for(self.mark_event_meta_data.mark_changed.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                pass  # re-enters loop, hits timeout check at top
         return
 
     async def inject_digits_to_conversation(self) -> None:

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -104,8 +104,6 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
             content_type = 'form'
         convert_to_request_log(request_body, meta_info , None, "function_call", direction="request", is_cached=False, run_id=run_id)
 
-        await asyncio.sleep(0.7)
-
         async with aiohttp.ClientSession() as session:
             if method.lower() == "get":
                 logger.info(f"Sending request {request_body}, {url}, {headers}")

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 
 from bolna.helpers.logger_config import configure_logger
@@ -10,6 +11,7 @@ class MarkEventMetaData:
         self.mark_event_meta_data = {}
         self.previous_mark_event_meta_data = {}
         self.counter = 0
+        self.mark_changed = asyncio.Event()
 
     def update_data(self, mark_id, value):
         value['counter'] = self.counter
@@ -17,13 +19,17 @@ class MarkEventMetaData:
         self.mark_event_meta_data[mark_id] = value
 
     def fetch_data(self, mark_id):
-        return self.mark_event_meta_data.pop(mark_id, {})
+        result = self.mark_event_meta_data.pop(mark_id, {})
+        if result:
+            self.mark_changed.set()
+        return result
 
     def clear_data(self):
         logger.info(f"Clearing mark meta data dict")
         self.counter = 0
         self.previous_mark_event_meta_data = copy.deepcopy(self.mark_event_meta_data)
         self.mark_event_meta_data = {}
+        self.mark_changed.set()
 
     def fetch_cleared_mark_event_data(self):
         return self.previous_mark_event_meta_data


### PR DESCRIPTION
## Problem

Two sources of unnecessary latency on every tool call path:

1. `trigger_api` had a hardcoded `asyncio.sleep(0.7)` — a blind 700ms delay before every API call
2. `wait_for_current_message()` polled `mark_event_meta_data` every 500ms via `asyncio.sleep(0.5)` to check if telephony mark ACKs arrived — adding up to 500ms of dead time after marks clear

Together these added ~1.2s of wasted latency to every tool call, hangup, and end-of-conversation path.

## Fix

- Remove the hardcoded `sleep(0.7)` from `trigger_api`
- Call `wait_for_current_message()` before `trigger_api` in `__execute_function_call` so audio is properly flushed before the API fires (replacing the blind sleep with the real signal)
- Add `asyncio.Event` (`mark_changed`) to `MarkEventMetaData` — set on `fetch_data` (mark popped) and `clear_data` (interruption), not on `update_data`
- Replace `asyncio.sleep(0.5)` in `wait_for_current_message` with `asyncio.wait_for(mark_changed.wait(), ...)` so the waiter wakes immediately when marks are removed

All exit conditions in the wait loop are unchanged — only the sleep mechanism between checks is replaced.

## Files changed

- `bolna/helpers/function_calling_helpers.py` — remove `sleep(0.7)` from `trigger_api`
- `bolna/agent_manager/task_manager.py` — add `wait_for_current_message()` before tool API call, replace polling sleep with event wait
- `bolna/helpers/mark_event_meta_data.py` — add `mark_changed` event, signal on fetch/clear