### PR TITLE
fix: wait for synth tasks to finish before hangup

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1225,6 +1225,35 @@ class TaskManager(BaseManager):
             await self.__process_end_of_conversation()
 
     async def wait_for_current_message(self):
+        """
+        Wait for the current message to be processed. Checks if there are any outputs being generated, sent to telephony, or yet to be marked as played.
+        """
+
+        # Phase 1: Wait for synthesizer pipeline to drain (bounded)
+        # Covers: text pushed to synthesizer but audio not yet generated,
+        # and audio generated but not yet sent to telephony.
+
+        synth_timeout = 2  # seconds: don't wait indefinitely for synthesizer
+        synth_start = time.time()
+        while not self.conversation_ended:
+            elapsed = time.time() - synth_start
+            if elapsed > synth_timeout:
+                logger.warning(f"wait_for_current_message: synthesizer wait timed out after {synth_timeout}s")
+                break
+
+            has_pending_synth = self.tools["synthesizer"].has_pending_work()
+            has_pending_output = not self.buffered_output_queue.empty()
+
+            if has_pending_synth or has_pending_output:
+                logger.info(f"wait_for_current_message: waiting for synth pipeline "
+                            f"(synth={has_pending_synth}, output_q={has_pending_output})")
+                await asyncio.sleep(0.3)
+                continue
+
+            # Synthesizer pipeline is drained
+            break
+
+        # Phase 2: Wait for mark events (fresh timer)
         start_time = time.time()
         while not self.conversation_ended:
             elapsed = time.time() - start_time

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -80,5 +80,17 @@ class BaseSynthesizer:
     def supports_websocket(self):
         return True
     
+    def has_pending_work(self):
+        """Check if the synthesizer has pending work (text pushed but audio not yet fully generated).
+        
+        Covers both WS-streaming synthesizers (which use current_turn_start_time)
+        and HTTP-based synthesizers (which use internal_queue).
+        """
+        if getattr(self, 'current_turn_start_time', None) is not None:
+            return True
+        if not self.internal_queue.empty():
+            return True
+        return False
+
     def get_sleep_time(self):
         return 0.2


### PR DESCRIPTION
Issue: The last message before hangup sometimes gets skipped
Cause: The wait_for_current_message function only checked for pending mark events from telephony, however did not check if there is text waiting to synthesized, or waiting to be sent to telephony