### PR TITLE
fix: forward use_responses_api to graph agent LLM

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -812,6 +812,8 @@ class TaskManager(BaseManager):
                 injected_cfg['routing_reasoning_effort'] = self.kwargs['routing_reasoning_effort']
             if 'routing_max_tokens' in self.kwargs:
                 injected_cfg['routing_max_tokens'] = self.kwargs['routing_max_tokens']
+            if self.llm_config.get('use_responses_api'):
+                injected_cfg['use_responses_api'] = True
             injected_cfg['buffer_size'] = self.task_config["tools_config"]["synthesizer"].get('buffer_size')
             injected_cfg['language'] = self.language
 

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -94,7 +94,7 @@ class GraphAgent(BaseAgent):
                 'provider': provider,
             }
 
-            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier']:
+            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api']:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]
 


### PR DESCRIPTION
## Summary
- `use_responses_api` was never forwarded from task_manager to graph agent's LLM instance, so graph agents couldn't use the Responses API even when configured
- Inject the flag into graph agent config in `task_manager.py` and add it to the key forwarding list in `graph_agent._initialize_llm()`

## Changes
- `task_manager.py`: forward `use_responses_api` from `llm_config` into `injected_cfg`
- `graph_agent.py`: add `use_responses_api` to the key list passed to the LLM constructor