### PR TITLE
fix: forward use_responses_api to knowledgebase agent LLM

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -853,6 +853,8 @@ class TaskManager(BaseManager):
                 injected_cfg['reasoning_effort'] = self.kwargs['reasoning_effort']
             if 'service_tier' in self.kwargs:
                 injected_cfg['service_tier'] = self.kwargs['service_tier']
+            if self.llm_config.get('use_responses_api'):
+                injected_cfg['use_responses_api'] = True
             injected_cfg['buffer_size'] = self.task_config["tools_config"]["synthesizer"].get('buffer_size')
             injected_cfg['language'] = self.language
 

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -62,7 +62,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 'provider': provider,
             }
 
-            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier']:
+            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api']:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]
 


### PR DESCRIPTION
## Summary
- `use_responses_api` was never forwarded to knowledgebase agent's LLM instance — same gap as #523 but for knowledgebase agents
- Inject the flag into knowledgebase agent config in `task_manager.py` and add it to the key forwarding list in `knowledgebase_agent._initialize_llm()`