### PR TITLE
Fix/deepgram keyword prompting

### DIFF
--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -45,8 +45,13 @@ class DeepgramTranscriber(BaseTranscriber):
             self.api_url = f"https://{self.deepgram_host}/v1/listen?model={self.model}&filler_words=true&language={self.language}"
             self.session = aiohttp.ClientSession()
             if self.keywords is not None:
-                keyword_string = "&keywords=" + "&keywords=".join(self.keywords.split(","))
-                self.api_url = f"{self.api_url}{keyword_string}"
+                keyword_list = [kw.strip() for kw in self.keywords.split(",") if kw.strip()]
+                if keyword_list:
+                    if self.model.startswith('nova-3'):
+                        keyword_string = "&keyterm=" + "&keyterm=".join(keyword_list)
+                    else:
+                        keyword_string = "&keywords=" + "&keywords=".join(keyword_list)
+                    self.api_url = f"{self.api_url}{keyword_string}"
         self.audio_submitted = False
         self.audio_submission_time = None
         self.num_frames = 0
@@ -124,16 +129,17 @@ class DeepgramTranscriber(BaseTranscriber):
         if "en" not in self.language:
             dg_params['language'] = self.language
 
-        if self.keywords and len(self.keywords.split(",")) > 0:
-            if self.model.startswith('nova-3'):
-                dg_params['keyterm'] = "&keyterm=".join(self.keywords.split(","))
-                if self.language != 'en':
-                    dg_params.pop('keyterm', None)
-            else:
-                dg_params['keywords'] = "&keywords=".join(self.keywords.split(","))
-
         websocket_api = '{}://{}/v1/listen?'.format(os.getenv('DEEPGRAM_HOST_PROTOCOL', 'wss'), self.deepgram_host)
         websocket_url = websocket_api + urlencode(dg_params)
+
+        if self.keywords:
+            keyword_list = [kw.strip() for kw in self.keywords.split(",") if kw.strip()]
+            if keyword_list:
+                if self.model.startswith('nova-3'):
+                    websocket_url += "&keyterm=" + "&keyterm=".join(keyword_list)
+                else:
+                    websocket_url += "&keywords=" + "&keywords=".join(keyword_list)
+
         return websocket_url
 
     async def send_heartbeat(self, ws: ClientConnection):

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -4,7 +4,7 @@ import os
 import json
 import aiohttp
 import time
-from urllib.parse import urlencode
+from urllib.parse import urlencode, quote
 from dotenv import load_dotenv
 import websockets
 from websockets.asyncio.client import ClientConnection
@@ -45,7 +45,7 @@ class DeepgramTranscriber(BaseTranscriber):
             self.api_url = f"https://{self.deepgram_host}/v1/listen?model={self.model}&filler_words=true&language={self.language}"
             self.session = aiohttp.ClientSession()
             if self.keywords is not None:
-                keyword_list = [kw.strip() for kw in self.keywords.split(",") if kw.strip()]
+                keyword_list = [quote(kw.strip()) for kw in self.keywords.split(",") if kw.strip()]
                 if keyword_list:
                     if self.model.startswith('nova-3'):
                         keyword_string = "&keyterm=" + "&keyterm=".join(keyword_list)
@@ -133,7 +133,7 @@ class DeepgramTranscriber(BaseTranscriber):
         websocket_url = websocket_api + urlencode(dg_params)
 
         if self.keywords:
-            keyword_list = [kw.strip() for kw in self.keywords.split(",") if kw.strip()]
+            keyword_list = [quote(kw.strip()) for kw in self.keywords.split(",") if kw.strip()]
             if keyword_list:
                 if self.model.startswith('nova-3'):
                     websocket_url += "&keyterm=" + "&keyterm=".join(keyword_list)


### PR DESCRIPTION
### Summary                                                                                                                                                                                                             
                                                                                                                                                                                                                      
  - Fix double-encoding of keyword/keyterm query params in the WebSocket URL path — keywords were being passed through urlencode(), causing Deepgram to receive one malformed value instead of separate repeated
  params
  - Add nova-3 keyterm support to the non-streaming (HTTP) path, which was missing
  - Strip whitespace and filter empty segments from comma-separated keyword input
  - Remove incorrect language restriction that dropped keyterms for non-English languages on nova-3 (multilingual keyterm prompting is supported) https://deepgram.com/learn/deepgram-expands-nova-3-with-10-new-languages-and-multilingual-keyterm-prompting for now it doesnot throw error for even mono languages liek `hi` , `ta`...
    - URL-encode keyword/keyterm values to safely handle multi-word terms (e.g. order number, क्रेडिट कार्ड) and intensifiers (e.g. bolna:2)                                                                                                                                                                                                     


