### PR TITLE
fix: remove response_in_pipeline from interruption check

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2100,7 +2100,7 @@ class TaskManager(BaseManager):
                         if self.interruption_manager.should_trigger_interruption(
                             word_count=interim_transcript_len,
                             transcript=transcript_content,
-                            is_audio_playing=self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline,
+                            is_audio_playing=self.tools["input"].is_audio_being_played_to_user(),
                             welcome_played=self.tools["input"].welcome_message_played()
                         ):
                             logger.info(f"Condition for interruption hit")


### PR DESCRIPTION
## Summary
- `should_trigger_interruption` was using `response_in_pipeline` as part of `is_audio_playing`, causing false interruptions while LLM was generating but no audio was actually playing
- This led to LLM cancellation → duplicate transcript drop → dead silence on calls (especially Hindi backchannel phrases like "हां जी बताइए")
- Fix: only use `is_audio_being_played_to_user()` for the interruption check, not `response_in_pipeline`