### PR TITLE
feat: add end_call as LLM function tool

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -17,7 +17,8 @@ import aiohttp
 
 from bolna.constants import (ACCIDENTAL_INTERRUPTION_PHRASES, DEFAULT_USER_ONLINE_MESSAGE,
     DEFAULT_USER_ONLINE_MESSAGE_TRIGGER_DURATION, FILLER_DICT, DEFAULT_LANGUAGE_CODE,
-    DEFAULT_TIMEZONE, LANGUAGE_NAMES, LLM_DEFAULT_CONFIGS, SWITCH_LANGUAGE_TOOL_DEFINITION)
+    DEFAULT_TIMEZONE, LANGUAGE_NAMES, LLM_DEFAULT_CONFIGS, SWITCH_LANGUAGE_TOOL_DEFINITION,
+    END_CALL_FUNCTION_PREFIX, END_CALL_TOOL_DEFINITION)
 from bolna.helpers.function_calling_helpers import trigger_api, computed_api_response, prepare_api_request
 from bolna.helpers.conversation_history import ConversationHistory
 from .base_manager import BaseManager
@@ -1731,6 +1732,33 @@ class TaskManager(BaseManager):
                 f"'{resp['execution_id']}' -> '{self.run_id}'"
             )
             resp["execution_id"] = self.run_id
+
+        if called_fun.startswith(END_CALL_FUNCTION_PREFIX):
+            reason = resp.get("reason", "")
+            logger.info(f"end_call tool invoked, reason: {reason}")
+            convert_to_request_log(
+                json.dumps({"called_fun": called_fun, "reason": reason}),
+                meta_info, None, "function_call", direction="request", run_id=self.run_id
+            )
+
+            # Tool-result flow: feed result back to LLM so it generates a clean goodbye
+            textual_response = resp.get("textual_response", None)
+            tool_result = json.dumps({"status": "success", "message": "Call is ending now. Say a brief goodbye to the user."})
+            self.conversation_history.append_assistant(textual_response, tool_calls=resp["model_response"])
+            self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), tool_result)
+            convert_to_request_log(tool_result, meta_info, None, "function_call", direction="response", run_id=self.run_id)
+
+            messages = self.conversation_history.get_copy()
+            convert_to_request_log(format_messages(messages, True), meta_info, self.llm_config['model'], "llm", direction="request", run_id=self.run_id)
+
+            # Generate goodbye with should_trigger_function_call=False to prevent recursion
+            await self.__do_llm_generation(messages, meta_info, next_step, should_trigger_function_call=False)
+            await self.wait_for_current_message()
+
+            self.hangup_detail = "end_call_tool"
+            self.call_hangup_message_config = None
+            await self.process_call_hangup()
+            return
 
         if called_fun.startswith("transfer_call"):
             await asyncio.sleep(2)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -300,6 +300,8 @@ class TaskManager(BaseManager):
             provider_config = self.task_config["tools_config"]["synthesizer"].get("provider_config")
             self.synthesizer_voice = provider_config["voice"]
             self.hangup_detail = None
+            self.shadow_end_call_enabled = False
+            self.shadow_end_call_events = []
 
             self.handle_accumulated_message_task = None
             # self.initial_silence_task = None
@@ -367,6 +369,32 @@ class TaskManager(BaseManager):
                     else:
                         self.call_hangup_message_config = update_prompt_with_context(self.call_hangup_message_config, self.context_data)
                 self.check_for_completion_llm = os.getenv("CHECK_FOR_COMPLETION_LLM")
+
+                # Shadow end_call tool: inject alongside hangup_after_LLMCall for comparison testing
+                self.shadow_end_call_enabled = False
+                self.shadow_end_call_events = []
+                if os.getenv("SHADOW_END_CALL_TOOL", "").lower() == "true" and self.use_llm_to_determine_hangup:
+                    self.shadow_end_call_enabled = True
+                    api_tools = self.kwargs.get('api_tools')
+                    if api_tools is None:
+                        api_tools = {"tools": [], "tools_params": {}}
+                        self.kwargs['api_tools'] = api_tools
+                    if END_CALL_FUNCTION_PREFIX not in api_tools.get("tools_params", {}):
+                        tool_def = copy.deepcopy(END_CALL_TOOL_DEFINITION)
+                        # Use the agent's hangup criteria so the comparison is apples-to-apples
+                        cancellation_criteria = self.conversation_config.get("call_cancellation_prompt", "")
+                        if cancellation_criteria:
+                            tool_def["function"]["description"] = (
+                                f"End the current call. Always say your goodbye message before calling this function.\n"
+                                f"Criteria for when to end: {cancellation_criteria}"
+                            )
+                        tools_list = api_tools.get("tools", [])
+                        if isinstance(tools_list, str):
+                            tools_list = json.loads(tools_list)
+                        tools_list.append(tool_def)
+                        api_tools["tools"] = tools_list
+                        api_tools["tools_params"][END_CALL_FUNCTION_PREFIX] = {"pre_call_message": None}
+                    logger.info("Shadow end_call tool injected for hangup comparison")
 
                 # Voicemail detection (time-based)
                 output_tool_available = (
@@ -1735,6 +1763,16 @@ class TaskManager(BaseManager):
 
         if called_fun.startswith(END_CALL_FUNCTION_PREFIX):
             reason = resp.get("reason", "")
+
+            if self.shadow_end_call_enabled:
+                logger.info(f"Shadow end_call invoked: reason={reason}, seq={meta_info.get('sequence_id')}")
+                self.shadow_end_call_events.append({
+                    "seq": meta_info.get("sequence_id"),
+                    "reason": reason,
+                    "timestamp": time.time(),
+                })
+                return
+
             logger.info(f"end_call tool invoked, reason: {reason}")
             convert_to_request_log(
                 json.dumps({"called_fun": called_fun, "reason": reason}),
@@ -2267,6 +2305,12 @@ class TaskManager(BaseManager):
             logger.info(f"##### Answer from the LLM {completion_res}")
             convert_to_request_log(message=format_messages(prompt, use_system_prompt=True), meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.REQUEST, model=self.check_for_completion_llm, run_id=self.run_id)
             convert_to_request_log(message=completion_res, meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.RESPONSE, model=self.check_for_completion_llm, run_id=self.run_id, input_tokens=metadata.get('input_tokens'), output_tokens=metadata.get('output_tokens'), reasoning_tokens=metadata.get('reasoning_tokens'), cached_tokens=metadata.get('cached_tokens'))
+
+            if self.shadow_end_call_enabled and (should_hangup or self.shadow_end_call_events):
+                logger.info(
+                    f"hangup_after_LLMCall result: hangup={should_hangup}, seq={meta_info.get('sequence_id')}, "
+                    f"shadow_end_call_events={json.dumps(self.shadow_end_call_events)}"
+                )
 
             if should_hangup:
                 if self.hangup_triggered or self.conversation_ended:
@@ -3456,6 +3500,17 @@ class TaskManager(BaseManager):
                     },
                     "hangup_detail": self.hangup_detail
                 }
+
+                if self.shadow_end_call_enabled:
+                    end_call_seq = self.shadow_end_call_events[0]["seq"] if self.shadow_end_call_events else None
+                    hangup_detail_str = str(self.hangup_detail) if self.hangup_detail else None
+                    logger.info(
+                        f"Shadow end_call summary: "
+                        f"end_call_count={len(self.shadow_end_call_events)}, "
+                        f"first_end_call_seq={end_call_seq}, "
+                        f"actual_hangup_reason={hangup_detail_str}, "
+                        f"events={json.dumps(self.shadow_end_call_events)}"
+                    )
 
                 try:
                     if welcome_message_sent_ts:

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -118,6 +118,28 @@ SWITCH_LANGUAGE_TOOL_DEFINITION = {
     }
 }
 
+END_CALL_FUNCTION_PREFIX = "end_call"
+
+END_CALL_TOOL_DEFINITION = {
+    "type": "function",
+    "function": {
+        "name": "end_call",
+        "description": "End the current call. Use this when the conversation is naturally complete, the user has explicitly said goodbye, or you've fulfilled the purpose of the call. Always say your goodbye message before calling this function.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "reason": {
+                    "type": "string",
+                    "description": "Brief reason for ending the call (e.g. 'conversation_complete', 'user_goodbye', 'task_fulfilled')"
+                }
+            },
+            "required": ["reason"],
+            "additionalProperties": False
+        },
+        "strict": True
+    }
+}
+
 SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
     "bulbul:v2": 22050,
     "bulbul:v3": 22050 # NOTE: Documentation claims 24000, but WAV header shows 22050

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -22,7 +22,7 @@ from enum import Enum
 from dotenv import load_dotenv
 from pydantic import create_model
 from .logger_config import configure_logger
-from bolna.constants import PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, TRANSFERING_CALL_FILLER
+from bolna.constants import PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, TRANSFERING_CALL_FILLER, END_CALL_FUNCTION_PREFIX
 from bolna.enums import LogComponent, LogDirection, UsageSource
 from bolna.prompts import DATE_PROMPT
 from pydub import AudioSegment
@@ -784,6 +784,10 @@ def compute_function_pre_call_message(language, function_name, api_tool_pre_call
     # Built-in tools that should switch silently — no audible filler.
     if function_name and function_name == "switch_language":
         return ""
+
+    # No filler for end_call — LLM's textual response is the goodbye
+    if function_name and function_name.startswith(END_CALL_FUNCTION_PREFIX):
+        return None
 
     if function_name and function_name.startswith("transfer_call"):
         default_message = TRANSFERING_CALL_FILLER

--- a/bolna/llms/tool_call_accumulator.py
+++ b/bolna/llms/tool_call_accumulator.py
@@ -1,4 +1,5 @@
 import json
+from bolna.constants import END_CALL_FUNCTION_PREFIX
 from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message
 from bolna.helpers.logger_config import configure_logger
 from .types import FunctionCallPayload
@@ -50,6 +51,8 @@ class ToolCallAccumulator:
         ``None`` on subsequent calls.
         """
         if self._gave_pre_call_msg or self.received_textual or not self.called_fun:
+            return None
+        if self.called_fun.startswith(END_CALL_FUNCTION_PREFIX):
             return None
         self._gave_pre_call_msg = True
         api_tool_pre_call_message = self.api_params.get(self.called_fun, {}).get('pre_call_message', None)


### PR DESCRIPTION
Adds `end_call` as a special-cased LLM function tool (similar to `transfer_call`) so the primary conversation LLM can signal when to hang up, replacing the extra `hangup_after_LLMCall` inference.

When the LLM calls `end_call`, the tool result is fed back and the LLM generates a clean goodbye message before disconnect (tool-result flow).

**Shadow test mode** (gated by `SHADOW_END_CALL_TOOL=true` env var): injects `end_call` alongside `hangup_after_LLMCall` for A/B comparison. The tool is available to the LLM but invocations are only logged, not acted on. `hangup_after_LLMCall` remains the active hangup mechanism. Per-turn and per-call comparison data is logged for analysis via Loki.

**Changes**
- `constants.py`: `END_CALL_FUNCTION_PREFIX` and `END_CALL_TOOL_DEFINITION`
- `helpers/utils.py`: skip filler message for end_call
- `llms/tool_call_accumulator.py`: skip pre-call message for end_call
- `agent_manager/task_manager.py`: handle end_call in `__execute_function_call` with tool-result flow + shadow mode injection and logging