### PR TITLE
perf: share httpx client pool across LLM instances

### DIFF
--- a/bolna/helpers/httpx_client_pool.py
+++ b/bolna/helpers/httpx_client_pool.py
@@ -1,0 +1,84 @@
+"""Shared httpx.AsyncClient pool — one client per (origin, key) to reuse TCP+TLS connections."""
+
+import atexit
+import asyncio
+from typing import Dict, Tuple, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from bolna.helpers.logger_config import configure_logger
+
+logger = configure_logger(__name__)
+
+
+def _normalize_origin(url: Optional[str]) -> str:
+    if not url:
+        return "_default"
+    parsed = urlparse(url)
+    return parsed.hostname or parsed.netloc or url
+
+
+class HttpxClientPool:
+    """Singleton pool of httpx.AsyncClient instances keyed by (origin, key).
+
+    Any service that makes repeated HTTP calls to the same host can use this
+    to avoid redundant TCP+TLS handshakes and leverage HTTP/2 multiplexing.
+    """
+
+    _clients: Dict[Tuple[str, str, bool], httpx.AsyncClient] = {}
+
+    @classmethod
+    def get_client(
+        cls,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        http2: bool = True,
+    ) -> httpx.AsyncClient:
+        """Return a cached or new httpx.AsyncClient for the given origin+key+protocol."""
+        origin = _normalize_origin(base_url)
+        key = (origin, api_key or "", http2)
+
+        client = cls._clients.get(key)
+        if client is not None:
+            return client
+
+        limits = httpx.Limits(
+            max_connections=100,
+            max_keepalive_connections=100,
+            keepalive_expiry=120,
+        )
+        client = httpx.AsyncClient(
+            limits=limits,
+            timeout=httpx.Timeout(600.0, connect=10.0),
+            http2=http2,
+        )
+        cls._clients[key] = client
+        proto = "h2" if http2 else "h1.1"
+        logger.info(f"HttpxClientPool: new {proto} client for {origin} (pool size: {len(cls._clients)})")
+        return client
+
+    @classmethod
+    async def close_all(cls) -> None:
+        """Close every pooled client."""
+        for _, client in list(cls._clients.items()):
+            try:
+                await client.aclose()
+            except Exception:
+                pass
+        cls._clients.clear()
+        logger.info("HttpxClientPool: all clients closed")
+
+
+def _atexit_cleanup() -> None:
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            loop.create_task(HttpxClientPool.close_all())
+        else:
+            loop.run_until_complete(HttpxClientPool.close_all())
+    except Exception:
+        pass
+
+
+atexit.register(_atexit_cleanup)

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -1,6 +1,5 @@
 import os
 import json
-import httpx
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 from openai import AsyncAzureOpenAI, AsyncOpenAI, AuthenticationError, PermissionDeniedError, NotFoundError, RateLimitError, APIError, APIConnectionError, BadRequestError
@@ -11,6 +10,7 @@ from bolna.helpers.utils import convert_to_request_log, compute_function_pre_cal
 from .openai_base import OpenAICompatibleLLM
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import LLMStreamChunk, LatencyData
+from bolna.helpers.httpx_client_pool import HttpxClientPool
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -52,12 +52,7 @@ class AzureLLM(OpenAICompatibleLLM):
         api_key = kwargs.get('llm_key', os.getenv('AZURE_OPENAI_API_KEY'))
         api_version = kwargs.get("api_version", os.getenv('AZURE_OPENAI_API_VERSION', '2024-12-01-preview'))
 
-        limits = httpx.Limits(
-            max_connections=50,
-            max_keepalive_connections=50,
-            keepalive_expiry=30
-        )
-        http_client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0))
+        http_client = HttpxClientPool.get_client(base_url=azure_endpoint, api_key=api_key, http2=False)
 
         self.async_client = AsyncAzureOpenAI(
             azure_endpoint=azure_endpoint,

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -1,5 +1,4 @@
 import os
-import httpx
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 from openai import AsyncOpenAI, OpenAI, AuthenticationError, PermissionDeniedError, NotFoundError, RateLimitError, APIError, APIConnectionError
@@ -11,6 +10,7 @@ from bolna.helpers.utils import now_ms
 from .openai_base import OpenAICompatibleLLM
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import LLMStreamChunk, LatencyData
+from bolna.helpers.httpx_client_pool import HttpxClientPool
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -49,24 +49,15 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")
 
-        limits = httpx.Limits(
-            max_connections=50,
-            max_keepalive_connections=50,
-            keepalive_expiry=30
-        )
-        http_client = httpx.AsyncClient(
-            limits=limits,
-            timeout=httpx.Timeout(600.0, connect=10.0),
-            http2=True
-        )
-
         if kwargs.get("provider", "openai") == "custom":
             base_url = kwargs.get("base_url")
             api_key = kwargs.get('llm_key', None)
+            http_client = HttpxClientPool.get_client(base_url=base_url, api_key=api_key)
             self.async_client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
         else:
             llm_key = kwargs.get('llm_key', os.getenv('OPENAI_API_KEY'))
             base_url = kwargs.get('base_url')
+            http_client = HttpxClientPool.get_client(base_url=base_url, api_key=llm_key)
             if base_url:
                 self.async_client = AsyncOpenAI(base_url=base_url, api_key=llm_key, http_client=http_client)
             else:


### PR DESCRIPTION
## Problem

Every `OpenAiLLM` / `AzureLLM` instance creates its own `httpx.AsyncClient`. A single voice call spins up 3-5 LLM instances (main + completion detection + voicemail + routing), each doing a fresh TCP+TLS handshake to the same endpoint (~100-300ms wasted per instance).

## Solution

New `HttpxClientPool` singleton in `bolna/helpers/httpx_client_pool.py` — caches one `httpx.AsyncClient` per `(origin, api_key)` so all LLM instances on the same call reuse the same connection pool. No redundant handshakes.

- **OpenAI**: uses `http2=True` (HTTP/2 multiplexing works well)
- **Azure**: uses `http2=False` (HTTP/1.1 with parallel connections — tested faster than H2 on Azure at all concurrency levels)
- Pool is generic, not LLM-specific — any service can use it
- Connection pool bumped to 100 max connections, keepalive to 120s

## Load Test Results (live API, `gpt-4.1-mini`)

### OpenAI (HTTP/2 shared pool)

| Concurrency | TTFT avg | TTFT p95 | Total avg |
|:-:|:-:|:-:|:-:|
| 1 | **-18.4%** | **-18.4%** | **-18.0%** |
| 5 | **-10.1%** | **-8.3%** | -2.4% |
| 10 | -2.0% | +7.2% | +1.9% |
| 50 | **-16.2%** | **-15.7%** | **-13.4%** |
| 100 | **-6.6%** | +5.3% | **-4.8%** |
| 200 | **-13.9%** | **-5.5%** | **-13.2%** |

### Azure (HTTP/1.1 shared pool)

Tested three modes: per-instance (old), shared+H2, shared+H1. HTTP/1.1 shared pool won at every level:

| Concurrency | shared(H1) vs old | shared(H2) vs old |
|:-:|:-:|:-:|
| 1 | **-12.6%** | +10.6% |
| 5 | **-16.9%** | +3.7% |
| 10 | **-5.6%** | -4.1% |
| 25 | **-9.3%** | +14.9% |

Azure's HTTP/2 implementation bottlenecks on single-connection multiplexing at higher concurrency, so HTTP/1.1 with parallel connections is the better fit.

## Files Changed

| File | Change |
|------|--------|
| `bolna/helpers/httpx_client_pool.py` | **New** — singleton client pool |
| `bolna/llms/openai_llm.py` | Use pool instead of per-instance client |
| `bolna/llms/azure_llm.py` | Use pool instead of per-instance client |
| `tests/load_test_http_pool.py` | **New** — load test script |

## How to run the load test

```bash
python tests/load_test_http_pool.py --provider openai --concurrency 1,5,10,25
python tests/load_test_http_pool.py --provider azure --concurrency 1,5,10,25 --azure-endpoint <endpoint>
```