### PR TITLE
fix: use minimal reasoning_effort default and send verbosity to Responses API

### DIFF
--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -42,7 +42,7 @@ class AzureLLM(OpenAICompatibleLLM):
         self.model_args = {}
         if self.model.startswith(GPT5_MODEL_PREFIX):
             max_tokens_key = "max_completion_tokens"
-            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or ReasoningEffort.LOW.value
+            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or ReasoningEffort.MINIMAL.value
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -129,6 +129,9 @@ class OpenAICompatibleLLM(BaseLLM):
             reasoning_effort = self.model_args.get("reasoning_effort")
             if reasoning_effort:
                 create_kwargs["reasoning"] = {"effort": reasoning_effort}
+            verbosity = self.model_args.get("verbosity")
+            if verbosity:
+                create_kwargs["verbosity"] = verbosity
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id
@@ -322,6 +325,9 @@ class OpenAICompatibleLLM(BaseLLM):
             reasoning_effort = self.model_args.get("reasoning_effort")
             if reasoning_effort:
                 create_kwargs["reasoning"] = {"effort": reasoning_effort}
+            verbosity = self.model_args.get("verbosity")
+            if verbosity:
+                create_kwargs["verbosity"] = verbosity
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -42,7 +42,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.model_args = {}
         if model.startswith(GPT5_MODEL_PREFIX):
             max_tokens_key = "max_completion_tokens"
-            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or ReasoningEffort.LOW.value
+            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or ReasoningEffort.MINIMAL.value
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})


### PR DESCRIPTION
## Summary

- Changed default `reasoning_effort` for GPT-5 models from `low` to `minimal` (fewest reasoning tokens, fastest response)
- Fixed `verbosity` param not being sent to the Responses API — it was stored in `model_args` but never passed to the `create()` call
- Both fixes apply to OpenAI and Azure LLM providers

## What changed

**`openai_llm.py` + `azure_llm.py`**: Default `reasoning_effort` changed from `ReasoningEffort.LOW` to `ReasoningEffort.MINIMAL`

**`openai_base.py`**: Added `verbosity` to the Responses API `create_kwargs` for GPT-5 models (both streaming and non-streaming paths). Previously it was only stored but never sent.

## Why

GPT-5 reasoning models spend extra tokens "thinking" before responding. Using `minimal` instead of `low` reduces this overhead, directly improving TTFT for voice calls. The missing `verbosity` param means the API was ignoring our verbosity setting entirely.