### PR TITLE
fix: plug memory leaks in synthesizer_tasks and deepgram transcriber

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1306,10 +1306,9 @@ class TaskManager(BaseManager):
 
         # self.synthesizer_task.cancel()
         # self.synthesizer_task = asyncio.create_task(self.__listen_synthesizer())
-        #for task in self.synthesizer_tasks:
-        #    task.cancel()
-
-        #self.synthesizer_tasks = []
+        for task in self.synthesizer_tasks:
+            task.cancel()
+        self.synthesizer_tasks = []
 
         logger.info(f"Synth Task cancelled seconds")
         if not self.buffered_output_queue.empty():
@@ -3164,6 +3163,9 @@ class TaskManager(BaseManager):
             if "synthesizer" in self.tools and self.synthesizer_task is not None:
                 tasks_to_cancel.append(process_task_cancellation(self.synthesizer_task, 'synthesizer_task'))
                 tasks_to_cancel.append(process_task_cancellation(self.synthesizer_monitor_task, 'synthesizer_monitor_task'))
+                for task in self.synthesizer_tasks:
+                    tasks_to_cancel.append(process_task_cancellation(task, 'synthesizer_task_item'))
+                self.synthesizer_tasks = []
 
             # Transcriber cleanup
             if "transcriber" in self.tools:

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -321,6 +321,10 @@ class DeepgramTranscriber(BaseTranscriber):
                 self.websocket_connection = None
                 self.connection_authenticated = False
 
+        # Always clear accumulated per-call data to prevent memory leaks
+        self.audio_frame_timestamps = []
+        self.current_turn_interim_details = []
+
     async def _get_http_transcription(self, audio_data):
         if self.session is None or self.session.closed:
             self.session = aiohttp.ClientSession()


### PR DESCRIPTION
## Summary
- Uncomment synthesizer_tasks cancellation in interruption handler (was commented out, causing orphaned tasks)
- Add synthesizer_tasks cleanup in the finally block on call teardown
- Clear `audio_frame_timestamps` and `current_turn_interim_details` in deepgram transcriber cleanup — these lists grow per-call and were never reclaimed