### PR TITLE
fix: prevent duplicates in precise transcript

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2607,6 +2607,9 @@ class TaskManager(BaseManager):
                     detected_lang = self.language_detector.dominant_language
                     user_online_message = select_message_by_language(self.check_user_online_message_config, detected_lang)
 
+                    if self.generate_precise_transcript:
+                        self.tools["input"].reset_response_heard_by_user()
+
                     if self.should_record:
                         meta_info={'io': 'default', "request_id": str(uuid.uuid4()), "cached": False, "sequence_id": -1, 'format': 'wav', "message_category": "is_user_online_message", 'end_of_llm_stream': True}
                         await self._synthesize(create_ws_data_packet(user_online_message, meta_info= meta_info))


### PR DESCRIPTION
**Issue**: When the user_online_message is sent, often the previous LLM message gets duplicated in the transcript, replacing the user_online_message.

**Steps to reproduce**:
- Enable user_online_check
- Have 1 or more turns of conversation
- Wait for user_online_message
- End the call

**Cause**: The `reponse_heard_by_user` is not reset before synthesizing the user_online message. This is incorrectly checked in `update_transcript_for_interruption` against the last message in the `conversation_history`. 

**Fix**: reset the `response_heard_by_user` just before synthesizing the user_online message.