### PR TITLE
fix: prevent duplicate function call chains from orphaned async task

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -418,6 +418,7 @@ class TaskManager(BaseManager):
 
                 # Discard pre-welcome utterance
                 self.discard_pre_welcome_utterance = self.conversation_config.get("discard_pre_welcome_utterance", False)
+                self._speech_started_before_welcome = False
 
                 # Ambient noise
                 self.ambient_noise = self.conversation_config.get("ambient_noise", False)
@@ -2176,6 +2177,11 @@ class TaskManager(BaseManager):
             logger.info(f"Welcome message is playing while spoken: {transcriber_message}")
             return
 
+        if self._speech_started_before_welcome:
+            logger.info(f"Discarding transcript from speech that started before welcome finished: {transcriber_message}")
+            self._speech_started_before_welcome = False
+            return
+
         if self.conversation_history.is_duplicate_user(transcriber_message):
             logger.info(f"Skipping duplicate transcript (same content): {transcriber_message}")
             return
@@ -2248,7 +2254,10 @@ class TaskManager(BaseManager):
 
                     # Handling of transcriber events
                     if message["data"] == "speech_started":
+                        if not self.tools["input"].welcome_message_played() and self.discard_pre_welcome_utterance:
+                            self._speech_started_before_welcome = True
                         if self.tools["input"].welcome_message_played():
+                            self._speech_started_before_welcome = False
                             logger.info(f"User has started speaking")
                             # self.callee_silent = False
 
@@ -2262,6 +2271,8 @@ class TaskManager(BaseManager):
                         temp_transcriber_message = message["data"].get("content")
 
                         if not self.tools["input"].welcome_message_played():
+                            if self.discard_pre_welcome_utterance:
+                                self._speech_started_before_welcome = True
                             continue
 
                         interim_transcript_len += len(message["data"].get("content").strip().split(" "))
@@ -2325,6 +2336,7 @@ class TaskManager(BaseManager):
                         ):
                             logger.info(f"Continuing the loop and ignoring the transcript received ({transcript_content}) in speech final as it is false interruption")
                             self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
+                            self._speech_started_before_welcome = False
                             continue
 
                         self.interruption_manager.on_user_speech_ended()
@@ -2344,6 +2356,7 @@ class TaskManager(BaseManager):
                     elif isinstance(message.get("data"), dict) and message["data"].get("type", "") == "speech_ended":
                         logger.info(f"Received speech_ended notification, resetting callee_speaking state")
                         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
+                        self._speech_started_before_welcome = False
                         temp_transcriber_message = ""
 
                     elif message["data"] == "transcriber_connection_closed":

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -416,6 +416,9 @@ class TaskManager(BaseManager):
                     self.first_message_task = None
                     self.transcriber_message = ''
 
+                # Discard pre-welcome utterance
+                self.discard_pre_welcome_utterance = self.conversation_config.get("discard_pre_welcome_utterance", False)
+
                 # Ambient noise
                 self.ambient_noise = self.conversation_config.get("ambient_noise", False)
                 self.ambient_noise_task = None
@@ -2169,7 +2172,7 @@ class TaskManager(BaseManager):
         await self.process_call_hangup()
 
     async def _handle_transcriber_output(self, next_task, transcriber_message, meta_info):
-        if not self.tools["input"].welcome_message_played() and len(self.conversation_history) > 2:
+        if not self.tools["input"].welcome_message_played() and (self.discard_pre_welcome_utterance or len(self.conversation_history) > 2):
             logger.info(f"Welcome message is playing while spoken: {transcriber_message}")
             return
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1477,6 +1477,13 @@ class TaskManager(BaseManager):
         self.conversation_ended = True
         self.ended_by_assistant = True
 
+        # Cancel any running LLM / function-call tasks so they don't add
+        # phantom responses to the transcript after the call has ended.
+        if self.llm_task is not None and not self.llm_task.done():
+            logger.info("__process_end_of_conversation: Cancelling LLM task")
+            self.llm_task.cancel()
+            self.llm_task = None
+
         # Close output handler to prevent sends after websocket close
         if "output" in self.tools and self.tools["output"] is not None:
             self.tools["output"].close()
@@ -1664,6 +1671,11 @@ class TaskManager(BaseManager):
             return
 
         await self.wait_for_current_message()
+
+        if self.hangup_triggered or self.conversation_ended:
+            logger.info(f"__execute_function_call: Aborting before API call — hangup_triggered={self.hangup_triggered}, conversation_ended={self.conversation_ended}")
+            return
+
         response = await trigger_api(url=url, method=method.lower(), param=param, api_token=api_token, headers_data=headers, meta_info=meta_info, run_id=self.run_id, **resp)
         function_response = str(response)
         get_res_keys, get_res_values = await computed_api_response(function_response)
@@ -1721,6 +1733,10 @@ class TaskManager(BaseManager):
             self.conversation_history.sync_interim(messages)
 
     async def __do_llm_generation(self, messages, meta_info, next_step, should_bypass_synth=False, should_trigger_function_call=False):
+        if self.hangup_triggered or self.conversation_ended:
+            logger.info(f"__do_llm_generation: Skipping — hangup_triggered={self.hangup_triggered}, conversation_ended={self.conversation_ended}")
+            return
+
         # Reset response tracking for new turn
         if self.generate_precise_transcript:
             self.tools["input"].reset_response_heard_by_user()
@@ -1825,7 +1841,7 @@ class TaskManager(BaseManager):
 
             if trigger_function_call:
                 logger.info(f"Triggering function call for {data}")
-                self.llm_task = asyncio.create_task(self.__execute_function_call(next_step = next_step, **data.model_dump()))
+                await self.__execute_function_call(next_step = next_step, **data.model_dump())
                 return
 
             if latency:


### PR DESCRIPTION
## Problem

When a user speaks while a function call is executing (e.g. creating a support ticket), a second parallel LLM chain gets spawned, resulting in duplicate function calls, duplicate API side effects (e.g. duplicate tickets), and phantom transcript entries that were never spoken.

## Root Cause

`__execute_function_call` was launched as a detached `asyncio.create_task()`. After `_run_llm_task` finished, it set `self.llm_task = None`, orphaning the function call task. When user speech arrives during the function call, `_handle_transcriber_output` sees `self.llm_task is None`, thinks nothing is running, and spawns a second parallel LLM chain — creating duplicate function calls.

## Fix

- **Inline await** `__execute_function_call` instead of `create_task` — keeps it in the `self.llm_task` chain so interruption handling works correctly
- **Cancel `self.llm_task`** in `__process_end_of_conversation` — covers the `agent_hangup_observer` path where `__cleanup_downstream_tasks` was never called
- **Guard at `__do_llm_generation` entry** — defense-in-depth for the window between `conversation_ended=True` and `CancelledError` delivery
- **Guard before `trigger_api`** — prevents unnecessary API side effects after hangup