### PR TITLE
fix: force use_mulaw for all telephony providers in multilingual synthesizer pool

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -837,9 +837,15 @@ class TaskManager(BaseManager):
                 multilingual = synth_config["multilingual"]
                 active_label = synth_config.get("active", DEFAULT_LANGUAGE_CODE)
 
-                is_sip = self.task_config["tools_config"]["output"]["provider"] == TelephonyProvider.SIP_TRUNK.value
+                # Telephony providers expect mulaw@8000Hz — force use_mulaw for all synths in the pool
+                output_provider = self.task_config["tools_config"]["output"]["provider"]
+                is_telephony = output_provider in (
+                    TelephonyProvider.PLIVO.value, TelephonyProvider.TWILIO.value,
+                    TelephonyProvider.EXOTEL.value, TelephonyProvider.VOBIZ.value,
+                    TelephonyProvider.SIP_TRUNK.value,
+                )
                 synthesizer_kwargs = self.kwargs.copy()
-                if is_sip:
+                if is_telephony:
                     synthesizer_kwargs['use_mulaw'] = True
 
                 synthesizers = {}


### PR DESCRIPTION
## Summary
- Multilingual synthesizer pool only forced `use_mulaw=True` for SIP trunk, causing ElevenLabs to output mp3@44100Hz instead of mulaw@8000Hz on other telephony providers (Plivo, Twilio, etc.)
- Plivo plays 16000Hz audio at 8000Hz → 2x slow motion + wrong pitch
- Now explicitly checks all telephony providers and forces `use_mulaw=True` for the entire pool