### PR TITLE
fix: add tool call message in prompt logs

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1740,7 +1740,7 @@ class TaskManager(BaseManager):
         convert_to_request_log(function_response, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.RESPONSE, is_cached= False, run_id = self.run_id)
 
         messages = self.conversation_history.get_copy()
-        convert_to_request_log(format_messages(messages, True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached= False, run_id = self.run_id)
+        convert_to_request_log(format_messages(messages, use_system_prompt=True, include_tools=True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached= False, run_id = self.run_id)
         self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
 
         if not called_fun.startswith("transfer_call"):
@@ -1785,7 +1785,7 @@ class TaskManager(BaseManager):
         try:
             async for llm_message in self.tools['llm_agent'].generate(messages, synthesize=synthesize, meta_info=meta_info):
                 if isinstance(llm_message, dict) and 'messages' in llm_message: # custom list of messages before the llm call
-                    convert_to_request_log(format_messages(llm_message['messages'], True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached=False, run_id=self.run_id)
+                    convert_to_request_log(format_messages(llm_message['messages'], use_system_prompt=True, include_tools=True), meta_info, self.llm_config['model'], LogComponent.LLM, direction=LogDirection.REQUEST, is_cached=False, run_id=self.run_id)
                     continue
 
                 # Handle graph agent routing info
@@ -1941,7 +1941,7 @@ class TaskManager(BaseManager):
 
         # Request logs converted inside do_llm_generation for knowledgebase agent
         if not self.__is_knowledgebase_agent() and not self.__is_graph_agent():
-            convert_to_request_log(message=format_messages(messages, use_system_prompt=True), meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.REQUEST, model=self.llm_config["model"], run_id= self.run_id)
+            convert_to_request_log(message=format_messages(messages, use_system_prompt=True, include_tools=True), meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.REQUEST, model=self.llm_config["model"], run_id= self.run_id)
 
         await self.__do_llm_generation(messages, meta_info, next_step, should_bypass_synth)
         # TODO : Write a better check for completion prompt

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -274,7 +274,8 @@ def format_messages(messages, use_system_prompt=False, include_tools=False):
                 formatted_string += "user: " + content + "\n"
         elif include_tools and role == 'tool':
             if content:
-                formatted_string += "tool_response: " + content + "\n"
+                tool_call_id = message.get('tool_call_id', '')
+                formatted_string += f"tool_response ({tool_call_id}): " + content + "\n"
 
     return formatted_string
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -275,7 +275,7 @@ def format_messages(messages, use_system_prompt=False, include_tools=False):
         elif include_tools and role == 'tool':
             if content:
                 tool_call_id = message.get('tool_call_id', '')
-                formatted_string += f"tool_response ({tool_call_id}): " + content + "\n"
+                formatted_string += f"tool_response: ({tool_call_id}): " + content + "\n"
 
     return formatted_string
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -251,22 +251,30 @@ def format_messages(messages, use_system_prompt=False, include_tools=False):
     formatted_string = ""
     for message in messages:
         role = message['role']
-        if message['content'] is None:
-            logger.info(f"Continuing the loop as content received is None")
-            continue
-        content = message['content']
+        content = message.get('content')
+        tool_calls = message.get('tool_calls')
 
         if use_system_prompt and role == 'system':
-            try:
-                formatted_string += "system: " + content + "\n"
-            except Exception as e:
-                a = 1
-        if role == 'assistant':
-            formatted_string += "assistant: " + content + "\n"
+            if content:
+                try:
+                    formatted_string += "system: " + content + "\n"
+                except Exception as e:
+                    pass
+        elif role == 'assistant':
+            if content:
+                formatted_string += "assistant: " + content + "\n"
+            if include_tools and tool_calls:
+                for tc in tool_calls:
+                    try:
+                        formatted_string += "assistant_tool_call: " + str(tc) + "\n"
+                    except Exception as e:
+                        logger.warning(f"Error formatting tool call content: {e}")
         elif role == 'user':
-            formatted_string += "user: " + content + "\n"
+            if content:
+                formatted_string += "user: " + content + "\n"
         elif include_tools and role == 'tool':
-            formatted_string += "tool_response: " + content + "\n"
+            if content:
+                formatted_string += "tool_response: " + content + "\n"
 
     return formatted_string
 


### PR DESCRIPTION
Includes tools messages in the logs. This is correct behaviour as the formatted messages must be a true copy of the prompt passed to the LLM, which do include tool call messages.