### PR TITLE
fix: resolve multilingual call hang on user hangup causing missing transcript data

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2459,10 +2459,13 @@ class TaskManager(BaseManager):
                     elif message["data"] == "transcriber_connection_closed":
                         self.transcriber_duration += message.get("meta_info", {}).get("transcriber_duration", 0) if message["meta_info"] is not None else 0
                         # In a pool, a standby transcriber closing is expected (e.g. Deepgram
-                        # inactivity timeout). Only end the call if we're NOT using a pool.
+                        # inactivity timeout). But if the active transcriber closed, the call
+                        # is over (e.g. user hung up via telephony stop event).
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
-                            logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
-                            continue
+                            if self.tools["transcriber"].is_active_transcriber_alive():
+                                logger.info(f"TranscriberPool: standby transcriber closed, continuing")
+                                continue
+                            logger.info(f"TranscriberPool: active transcriber closed, ending call")
                         await self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 
@@ -2471,8 +2474,10 @@ class TaskManager(BaseManager):
                     if message["data"] == "transcriber_connection_closed":
                         self.transcriber_duration += message.get("meta_info", {}).get("transcriber_duration", 0) if message["meta_info"] is not None else 0
                         if isinstance(self.tools.get("transcriber"), TranscriberPool):
-                            logger.info(f"TranscriberPool: a transcriber connection closed (standby drop), continuing")
-                            continue
+                            if self.tools["transcriber"].is_active_transcriber_alive():
+                                logger.info(f"TranscriberPool: standby transcriber closed, continuing")
+                                continue
+                            logger.info(f"TranscriberPool: active transcriber closed, ending call")
                         await self._log_transcriber_connection_error((message.get("meta_info") or {}).get("connection_error"))
                         break
 

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -65,6 +65,12 @@ class TranscriberPool:
     def labels(self):
         return list(self.transcribers.keys())
 
+    def is_active_transcriber_alive(self):
+        """True if the active transcriber's connection task is still running."""
+        active = self.transcribers[self.active_label]
+        task = getattr(active, 'transcription_task', None)
+        return task is not None and not task.done()
+
     # ------------------------------------------------------------------
     # Duck-typed interface
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Problem
Multilingual calls lose transcript, cost, and trace data when user hangs up. Recording and telephony data are saved but everything from `task_output` is missing.

## Root Cause
`_listen_transcriber` always `continue`s on `transcriber_connection_closed` for a `TranscriberPool`, treating every close as a standby drop. When the **active** transcriber closes (user hangup via telephony stop event), the loop hangs forever at `await queue.get()` — `task_manager.run()` never returns.

## Fix
- Add `TranscriberPool.is_active_transcriber_alive()` to check if the active transcriber's task is still running
- In `_listen_transcriber`, only `continue` if the active transcriber is alive (standby drop). If it's done, `break` (call is over)