### PR TITLE
fix: remove concurrent synthesizer cleanup to prevent aclose race

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3233,7 +3233,6 @@ class TaskManager(BaseManager):
             # Construct output
             tasks_to_cancel = []
             if "synthesizer" in self.tools and self.synthesizer_task is not None:
-                tasks_to_cancel.append(self.tools["synthesizer"].cleanup())
                 tasks_to_cancel.append(process_task_cancellation(self.synthesizer_task, 'synthesizer_task'))
                 tasks_to_cancel.append(process_task_cancellation(self.synthesizer_monitor_task, 'synthesizer_monitor_task'))
 


### PR DESCRIPTION
## Summary
- Removes `synthesizer.cleanup()` from `run()`'s finally block where it ran concurrently with `process_task_cancellation(synthesizer_task)` via `asyncio.gather()`
- `cleanup()` closes the websocket → wakes `generate()`'s async generator → generator starts handling it → meanwhile task cancellation calls `aclose()` on the same generator → `RuntimeError: aclose(): asynchronous generator is already running`
- `__listen_synthesizer`'s own finally block already calls `cleanup()` after the async for loop exits, so the call in `run()`'s finally was redundant

## What changed
1 line removed in `task_manager.py`