### PR TITLE
fix: override LLM-generated execution_id with authoritative run_id

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1606,6 +1606,13 @@ class TaskManager(BaseManager):
     async def __execute_function_call(self, url, method, param, api_token, headers, model_args, meta_info, next_step, called_fun, **resp):
         self.check_if_user_online = False
 
+        if "execution_id" in resp and resp["execution_id"] != self.run_id:
+            logger.warning(
+                f"Correcting LLM-generated execution_id: "
+                f"'{resp['execution_id']}' -> '{self.run_id}'"
+            )
+            resp["execution_id"] = self.run_id
+
         if called_fun.startswith("transfer_call"):
             await asyncio.sleep(2)
             try:


### PR DESCRIPTION
## Summary

- LLMs hallucinate UUID characters when generating `execution_id` in function call args (e.g. `bc8a` → `bc8e`). This overrides `execution_id` in kwargs with `self.run_id` before calling `trigger_api`, matching the pattern `transfer_call` already uses.