### PR TITLE
feat: add deterministic expression-based routing for graph agents

### DIFF
--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -11,6 +11,8 @@ from bolna.agent_types.base_agent import BaseAgent
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.rag_service_client import RAGServiceClientSingleton
 from bolna.helpers.utils import now_ms, format_messages, update_prompt_with_context, enrich_context_with_time_variables, DictWithMissing
+from bolna.helpers.expression_evaluator import evaluate_edge_expression
+from bolna.enums import EdgeConditionType
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
@@ -28,6 +30,8 @@ except ImportError:
 
 load_dotenv()
 logger = configure_logger(__name__)
+
+_DETERMINISTIC_REASONING_PREFIX = "deterministic:"
 
 class GraphAgent(BaseAgent):
     def __init__(self, config: GraphAgentConfig):
@@ -212,16 +216,15 @@ class GraphAgent(BaseAgent):
             logger.error(f'check_for_voicemail exception: {str(e)}')
             return {'is_voicemail': 'No'}, {}
 
-    def _build_transition_tools(self, node: dict) -> List[dict]:
-        """Build and cache function/tool definitions for node edges."""
-        node_id = node.get('id')
-        if node_id and node_id in self._transition_tools_cache:
-            return self._transition_tools_cache[node_id]
+    @staticmethod
+    def _edge_function_name(edge: dict) -> str:
+        return edge.get('function_name') or f"transition_to_{edge['to_node_id']}"
 
+    def _build_transition_tools_for_edges(self, edges: list) -> list:
+        """Build function/tool definitions for a list of edges."""
         tools = []
-        for edge in node.get('edges', []):
-            to_node_id = edge.get('to_node_id')
-            func_name = edge.get('function_name') or f"transition_to_{to_node_id}"
+        for edge in edges:
+            func_name = self._edge_function_name(edge)
             func_description = edge.get('function_description') or f"Call this function when: {edge.get('condition', '')}"
 
             parameters = {"type": "object", "properties": {}, "required": []}
@@ -230,7 +233,6 @@ class GraphAgent(BaseAgent):
                     parameters["properties"][param_name] = {"type": param_type, "description": f"The {param_name} provided by the user"}
                     parameters["required"].append(param_name)
 
-            # Add reasoning and confidence as required parameters on every transition tool
             parameters["properties"]["reasoning"] = {"type": "string", "description": "Brief explanation of why this routing decision was made"}
             parameters["properties"]["confidence"] = {"type": "number", "description": "Confidence score from 0.0 to 1.0 for this routing decision"}
             parameters["required"].extend(["reasoning", "confidence"])
@@ -242,43 +244,76 @@ class GraphAgent(BaseAgent):
 
         tools.append({
             "type": "function",
-            "function": {"name": "stay_on_current_node", "description": "No transition matches. Need more info or clarification.", "parameters": {"type": "object", "properties": {"reasoning": {"type": "string", "description": "Brief explanation of why this routing decision was made"}, "confidence": {"type": "number", "description": "Confidence score from 0.0 to 1.0 for this routing decision"}}, "required": ["reasoning", "confidence"]}}
+            "function": {
+                "name": "stay_on_current_node",
+                "description": "No transition matches. Need more info or clarification.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "reasoning": {"type": "string", "description": "Brief explanation of why this routing decision was made"},
+                        "confidence": {"type": "number", "description": "Confidence score from 0.0 to 1.0 for this routing decision"},
+                    },
+                    "required": ["reasoning", "confidence"],
+                },
+            },
         })
+        return tools
+
+    def _build_transition_tools(self, node: dict) -> List[dict]:
+        """Build and cache function/tool definitions for all node edges."""
+        node_id = node.get('id')
+        if node_id and node_id in self._transition_tools_cache:
+            return self._transition_tools_cache[node_id]
+
+        tools = self._build_transition_tools_for_edges(node.get('edges', []))
 
         if node_id:
             if len(self._transition_tools_cache) >= self._transition_tools_cache_max_size:
-                # Evict oldest entry
                 oldest_key = next(iter(self._transition_tools_cache))
                 del self._transition_tools_cache[oldest_key]
             self._transition_tools_cache[node_id] = tools
         return tools
 
-    def _get_edge_by_function_name(self, node: dict, function_name: str) -> Optional[dict]:
-        """Find the edge that corresponds to a function name."""
-        for edge in node.get('edges', []):
-            expected_name = edge.get('function_name') or f"transition_to_{edge['to_node_id']}"
-            if expected_name == function_name:
+    def _get_edge_by_function_name_from_edges(self, edges: list, function_name: str) -> Optional[dict]:
+        for edge in edges:
+            if self._edge_function_name(edge) == function_name:
                 return edge
         return None
 
-    async def decide_next_node_with_functions(self, history: List[dict]) -> Tuple[Optional[str], Optional[Dict[str, Any]], float, Optional[List[dict]], Optional[List[dict]], Optional[str], Optional[float]]:
-        """Decide next node using LLM function calling.
+    def _get_edge_by_function_name(self, node: dict, function_name: str) -> Optional[dict]:
+        return self._get_edge_by_function_name_from_edges(node.get('edges', []), function_name)
 
-        Returns (next_node_id, extracted_params, latency_ms, routing_messages, routing_tools, reasoning, confidence).
-        """
-        start_time = time.perf_counter()
+    def _classify_edges(self, edges: list) -> tuple:
+        """Split edges into (deterministic_edges, llm_edges), sorted by priority."""
+        deterministic = []
+        llm = []
+        for edge in edges:
+            if edge.get('condition_type') in (EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL):
+                deterministic.append(edge)
+            else:
+                llm.append(edge)
 
-        current_node = self.get_node_by_id(self.current_node_id)
-        if not current_node:
-            logger.error(f"Current node '{self.current_node_id}' not found")
-            return None, None, 0, None, None, None, None
+        deterministic.sort(key=lambda e: e.get('priority', 0))
+        llm.sort(key=lambda e: e.get('priority', 100))
+        return deterministic, llm
 
-        edges = current_node.get('edges', [])
-        if not edges:
-            logger.debug(f"Node '{self.current_node_id}' has no edges, staying on current node")
-            return None, None, 0, None, None, None, None
+    def _evaluate_deterministic_edges(self, edges: list) -> Optional[dict]:
+        """Return first matching deterministic edge, or None."""
+        for edge in edges:
+            if evaluate_edge_expression(edge, self.context_data):
+                return edge
+        return None
 
-        tools = self._build_transition_tools(current_node)
+    def _compute_turn_counts(self, history: list) -> tuple:
+        """Count (node_turns, total_turns) from history."""
+        total_turns = sum(1 for msg in history if msg.get('role') == 'user')
+        node_history = history[self.current_node_entry_index:] if self.current_node_entry_index < len(history) else history
+        node_turns = sum(1 for msg in node_history if msg.get('role') == 'user')
+        return node_turns, total_turns
+
+    async def _decide_next_node_llm(self, node: dict, llm_edges: list, history: List[dict], start_time: float) -> Tuple[Optional[str], Optional[Dict[str, Any]], float, Optional[List[dict]], Optional[List[dict]], Optional[str], Optional[float]]:
+        """LLM-based routing. Only called when no deterministic edge matched."""
+        tools = self._build_transition_tools_for_edges(llm_edges)
 
         # Build compact context for routing
         context_section = ""
@@ -300,8 +335,8 @@ class GraphAgent(BaseAgent):
             except Exception as e:
                 logger.debug(f"Variable substitution in routing_instructions failed: {e}")
 
-        node_objective = current_node.get('prompt', '')
-        system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {current_node['id']}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""
+        node_objective = node.get('prompt', '')
+        system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {node['id']}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""
 
         logger.debug(f"Routing system prompt:\n{system_prompt}")
         messages = [{"role": "system", "content": system_prompt}]
@@ -363,13 +398,13 @@ class GraphAgent(BaseAgent):
                 reasoning = function_args.pop('reasoning', None)
                 confidence = function_args.pop('confidence', None)
 
-                logger.info(f"Routing decision: {function_name} | confidence: {confidence} | reasoning: {reasoning} (latency: {latency_ms:.1f}ms)")
+                logger.info(f"Routing decision (LLM): {function_name} | confidence: {confidence} | reasoning: {reasoning} (latency: {latency_ms:.1f}ms)")
 
                 if function_name == "stay_on_current_node":
                     return None, None, latency_ms, messages, tools, reasoning, confidence
 
                 # Find the edge for this function
-                edge = self._get_edge_by_function_name(current_node, function_name)
+                edge = self._get_edge_by_function_name_from_edges(llm_edges, function_name)
                 if edge:
                     return edge['to_node_id'], function_args, latency_ms, messages, tools, reasoning, confidence
                 else:
@@ -383,6 +418,47 @@ class GraphAgent(BaseAgent):
             latency_ms = (time.perf_counter() - start_time) * 1000
             logger.error(f"Routing error: {e} (latency: {latency_ms:.1f}ms)")
             return None, None, latency_ms, messages, tools, None, None
+
+    async def decide_next_node_with_functions(self, history: List[dict]) -> Tuple[Optional[str], Optional[Dict[str, Any]], float, Optional[List[dict]], Optional[List[dict]], Optional[str], Optional[float]]:
+        """Two-phase routing: deterministic expressions first, then LLM fallback."""
+        start_time = time.perf_counter()
+
+        current_node = self.get_node_by_id(self.current_node_id)
+        if not current_node:
+            logger.error(f"Current node '{self.current_node_id}' not found")
+            return None, None, 0, None, None, None, None
+
+        edges = current_node.get('edges', [])
+        if not edges:
+            logger.debug(f"Node '{self.current_node_id}' has no edges, staying on current node")
+            return None, None, 0, None, None, None, None
+
+        # Inject time variables and turn counts for expression evaluation
+        timezone_str = self.context_data.get('recipient_data', {}).get('timezone') if isinstance(self.context_data.get('recipient_data'), dict) else None
+        if timezone_str:
+            enrich_context_with_time_variables(self.context_data, timezone_str)
+
+        node_turns, total_turns = self._compute_turn_counts(history)
+        self.context_data['_node_turns'] = node_turns
+        self.context_data['_total_turns'] = total_turns
+
+        deterministic_edges, llm_edges = self._classify_edges(edges)
+
+        # Phase 1: deterministic (0ms)
+        if deterministic_edges:
+            matched_edge = self._evaluate_deterministic_edges(deterministic_edges)
+            if matched_edge:
+                latency_ms = (time.perf_counter() - start_time) * 1000
+                ct = matched_edge.get('condition_type', EdgeConditionType.EXPRESSION)
+                reasoning = f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{matched_edge.get('condition', ct)}"
+                logger.info(f"Routing decision (deterministic): -> {matched_edge['to_node_id']} | {reasoning} (latency: {latency_ms:.1f}ms)")
+                return matched_edge['to_node_id'], None, latency_ms, None, None, reasoning, 1.0
+
+        # Phase 2: LLM
+        if llm_edges:
+            return await self._decide_next_node_llm(current_node, llm_edges, history, start_time)
+
+        return None, None, 0, None, None, None, None
 
     def get_node_by_id(self, node_id: str) -> Optional[dict]:
         return next((node for node in self.config.get('nodes', []) if node['id'] == node_id), None)
@@ -495,11 +571,14 @@ class GraphAgent(BaseAgent):
             if next_node_id and (not self.node_history or self.node_history[-1] != self.current_node_id):
                 self.node_history.append(self.current_node_id)
 
+            routing_type = "deterministic" if (reasoning and reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)) else "llm"
+
             yield {
                 'routing_info': {
                     'previous_node': previous_node,
                     'current_node': self.current_node_id,
                     'transitioned': next_node_id is not None,
+                    'routing_type': routing_type,
                     'routing_model': self.routing_model,
                     'routing_provider': getattr(self, 'routing_provider', None),
                     'routing_latency_ms': round(routing_latency_ms, 1),

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -293,8 +293,8 @@ class GraphAgent(BaseAgent):
             else:
                 llm.append(edge)
 
-        deterministic.sort(key=lambda e: e.get('priority', 0))
-        llm.sort(key=lambda e: e.get('priority', 100))
+        deterministic.sort(key=lambda e: e['priority'] if e.get('priority') is not None else 0)
+        llm.sort(key=lambda e: e['priority'] if e.get('priority') is not None else 100)
         return deterministic, llm
 
     def _evaluate_deterministic_edges(self, edges: list) -> Optional[dict]:

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -212,3 +212,28 @@ class LogDirection(str, Enum):
     @classmethod
     def all_values(cls):
         return [d.value for d in cls]
+
+
+class ExpressionOperator(str, Enum):
+    EQ = "eq"
+    NEQ = "neq"
+    GT = "gt"
+    GTE = "gte"
+    LT = "lt"
+    LTE = "lte"
+    IN = "in"
+    NOT_IN = "not_in"
+    CONTAINS = "contains"
+    EXISTS = "exists"
+    NOT_EXISTS = "not_exists"
+
+
+class ExpressionLogic(str, Enum):
+    AND = "and"
+    OR = "or"
+
+
+class EdgeConditionType(str, Enum):
+    LLM = "llm"
+    EXPRESSION = "expression"
+    UNCONDITIONAL = "unconditional"

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -1,0 +1,110 @@
+"""Deterministic expression evaluator for graph agent routing.
+
+No eval(), no side effects. Evaluates expression conditions against
+context_data for instant routing decisions.
+"""
+
+import operator as op
+from typing import Any
+
+from bolna.enums import ExpressionOperator, ExpressionLogic, EdgeConditionType
+
+_MISSING = object()
+
+_COMPARISON_OPS = {
+    ExpressionOperator.EQ: op.eq,
+    ExpressionOperator.NEQ: op.ne,
+    ExpressionOperator.GT: op.gt,
+    ExpressionOperator.GTE: op.ge,
+    ExpressionOperator.LT: op.lt,
+    ExpressionOperator.LTE: op.le,
+}
+
+
+def resolve_variable(context_data: dict, path: str) -> Any:
+    """Dot-notation lookup. Returns _MISSING if not found."""
+    current = context_data
+    for segment in path.split("."):
+        if isinstance(current, dict) and segment in current:
+            current = current[segment]
+        else:
+            return _MISSING
+    return current
+
+
+def _coerce_for_comparison(actual: Any, expected: Any):
+    """Coerce actual/expected to comparable types (e.g. string "3" vs int 3)."""
+    if type(actual) == type(expected):
+        return actual, expected
+    if isinstance(actual, (str, int, float)) and isinstance(expected, (str, int, float)):
+        try:
+            return float(actual), float(expected)
+        except (ValueError, TypeError):
+            pass
+    return actual, expected
+
+
+def evaluate_condition(condition: dict, context_data: dict) -> bool:
+    """Evaluate a single ExpressionCondition dict against context_data."""
+    variable = condition.get("variable", "")
+    operator = condition.get("operator", "")
+    expected = condition.get("value")
+
+    actual = resolve_variable(context_data, variable)
+
+    if operator == ExpressionOperator.EXISTS:
+        return actual is not _MISSING
+    if operator == ExpressionOperator.NOT_EXISTS:
+        return actual is _MISSING
+    if actual is _MISSING:
+        return False
+
+    cmp_fn = _COMPARISON_OPS.get(operator)
+    if cmp_fn:
+        try:
+            coerced_actual, coerced_expected = _coerce_for_comparison(actual, expected)
+            return cmp_fn(coerced_actual, coerced_expected)
+        except TypeError:
+            return False
+
+    if operator == ExpressionOperator.IN:
+        return actual in expected if isinstance(expected, list) else False
+    if operator == ExpressionOperator.NOT_IN:
+        return actual not in expected if isinstance(expected, list) else True
+    if operator == ExpressionOperator.CONTAINS:
+        if isinstance(actual, str) and isinstance(expected, str):
+            return expected in actual
+        if isinstance(actual, (list, tuple)):
+            return expected in actual
+        return False
+
+    return False
+
+
+def evaluate_expression_group(group: dict, context_data: dict) -> bool:
+    """Evaluate an AND/OR group of conditions."""
+    logic = group.get("logic", ExpressionLogic.AND)
+    conditions = group.get("conditions", [])
+
+    if not conditions:
+        return False
+
+    if logic == ExpressionLogic.OR:
+        return any(evaluate_condition(c, context_data) for c in conditions)
+    return all(evaluate_condition(c, context_data) for c in conditions)
+
+
+def evaluate_edge_expression(edge: dict, context_data: dict) -> bool:
+    """Evaluate an edge's expression. Returns True if it matches."""
+    condition_type = edge.get("condition_type")
+
+    if condition_type == EdgeConditionType.UNCONDITIONAL:
+        return True
+    if condition_type != EdgeConditionType.EXPRESSION:
+        return False
+
+    expression = edge.get("expression")
+    if not expression:
+        return False
+
+    return evaluate_expression_group(expression, context_data)

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -281,19 +281,26 @@ def format_messages(messages, use_system_prompt=False, include_tools=False):
 
 
 def enrich_context_with_time_variables(context_data, timezone):
-    """Inject current_date, current_time, timezone into context_data['recipient_data']
-    so users can reference {current_date}, {current_time}, {timezone} in prompts."""
+    """Inject time variables into context_data['recipient_data']
+    so users can reference {current_date}, {current_time}, etc. in prompts
+    and use current_hour, current_weekday, etc. in expression routing."""
     if context_data is None:
         return
     if isinstance(timezone, str):
         import pytz
         timezone = pytz.timezone(timezone)
-    current_date, current_time = get_date_time_from_timezone(timezone)
+    now = datetime.now(timezone)
     recipient_data = context_data.setdefault('recipient_data', {})
     if isinstance(recipient_data, dict):
-        recipient_data['current_date'] = current_date
-        recipient_data['current_time'] = current_time
+        recipient_data['current_date'] = now.strftime("%A, %B %d, %Y")
+        recipient_data['current_time'] = now.strftime("%I:%M:%S %p")
         recipient_data['timezone'] = str(timezone)
+        recipient_data['current_hour'] = now.hour
+        recipient_data['current_minute'] = now.minute
+        recipient_data['current_weekday'] = now.strftime('%A').lower()
+        recipient_data['current_day'] = now.day
+        recipient_data['current_month'] = now.month
+        recipient_data['current_year'] = now.year
 
 
 def update_prompt_with_context(prompt, context_data):
@@ -694,9 +701,9 @@ async def process_task_cancellation(asyncio_task, task_name):
 
 
 def get_date_time_from_timezone(timezone):
-    dt = datetime.now(timezone).strftime("%A, %B %d, %Y")
-    ts = datetime.now(timezone).strftime("%I:%M:%S %p")
-
+    now = datetime.now(timezone)
+    dt = now.strftime("%A, %B %d, %Y")
+    ts = now.strftime("%I:%M:%S %p")
     return dt, ts
 
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -1,9 +1,9 @@
 import json
-from typing import Literal, Optional, List, Union, Dict, Callable
+from typing import Any, Literal, Optional, List, Union, Dict, Callable
 from pydantic import BaseModel, Field, field_validator, ValidationError, Json, model_validator
 from pydantic_core import PydanticCustomError
 from .providers import *
-from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, ReasoningEffort, Verbosity
+from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, ReasoningEffort, Verbosity, ExpressionOperator, ExpressionLogic, EdgeConditionType
 from .constants import MODEL_REASONING_EFFORT_MAP
 
 AGENT_WELCOME_MESSAGE = "This call is being recorded for quality assurance and training. Please speak now."
@@ -283,6 +283,15 @@ class LlmAgentGraph(BaseModel):
     nodes: List[Node]
     edges: List[Edge]
 
+class ExpressionCondition(BaseModel):
+    variable: str  # dot-notation key, e.g. "detected_language" or "recipient_data.timezone"
+    operator: ExpressionOperator
+    value: Optional[Any] = None
+
+class ExpressionGroup(BaseModel):
+    logic: ExpressionLogic = ExpressionLogic.AND
+    conditions: List[ExpressionCondition] = Field(default_factory=list)
+
 class GraphEdge(BaseModel):
     """Edge definition for graph-based conversation flow.
 
@@ -290,12 +299,15 @@ class GraphEdge(BaseModel):
     The LLM will call the transition function when the condition is met.
     """
     to_node_id: str
-    condition: str  # Human-readable description of when to transition
+    condition: str = ""  # Human-readable description of when to transition
+    condition_type: Optional[EdgeConditionType] = None  # None → "llm" (backward compat)
+    expression: Optional[ExpressionGroup] = None  # required when condition_type == "expression"
     # Function definition for LLM to call (auto-generated if not provided)
     function_name: Optional[str] = None  # e.g., "go_to_city_question"
     function_description: Optional[str] = None  # Detailed description for LLM
     # Optional parameters to collect during transition
     parameters: Optional[Dict[str, str]] = None  # e.g., {"city": "string"}
+    priority: Optional[int] = None         # lower = evaluated first. Defaults: expression/unconditional=0, llm=100
 
 class GraphNodeRAGConfig(BaseModel):
     """RAG configuration for Graph Agent nodes."""

--- a/tests/tests/test_expression_routing.py
+++ b/tests/tests/test_expression_routing.py
@@ -1,0 +1,620 @@
+"""Tests for expression-based routing in GraphAgent.
+
+Covers: _classify_edges, deterministic match skips LLM, no-match falls through
+to LLM, backward compatibility, unconditional edges, priority ordering, mixed edges.
+"""
+
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_types.graph_agent import GraphAgent, _DETERMINISTIC_REASONING_PREFIX
+
+
+# ---------------------------------------------------------------------------
+# Helpers (reused from test_routing_reasoning_confidence.py)
+# ---------------------------------------------------------------------------
+
+def _make_config(**overrides):
+    defaults = {
+        'agent_information': 'Test agent',
+        'model': 'gpt-4o-mini',
+        'provider': 'openai',
+        'temperature': 0.7,
+        'max_tokens': 150,
+        'current_node_id': 'greeting',
+        'nodes': [
+            {
+                'id': 'greeting',
+                'prompt': 'Greet the user.',
+                'edges': [
+                    {
+                        'to_node_id': 'booking',
+                        'condition': 'user wants to book',
+                        'function_name': 'go_to_booking',
+                        'parameters': {'appointment_type': 'string'},
+                    },
+                ],
+            },
+            {
+                'id': 'booking',
+                'prompt': 'Book the appointment.',
+                'edges': [],
+            },
+            {
+                'id': 'hindi_agent',
+                'prompt': 'Respond in Hindi.',
+                'edges': [],
+            },
+            {
+                'id': 'escalation',
+                'prompt': 'Escalate.',
+                'edges': [],
+            },
+            {
+                'id': 'fallback',
+                'prompt': 'Fallback.',
+                'edges': [],
+            },
+        ],
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_agent(config_overrides=None):
+    cfg = _make_config(**(config_overrides or {}))
+    mock_llm = MagicMock()
+    mock_llm.generate_stream = AsyncMock(return_value=_async_iter([]))
+    mock_llm.trigger_function_call = False
+    mock_openai_client = MagicMock()
+    mock_openai_llm_cls = MagicMock(return_value=mock_llm)
+
+    with patch('bolna.agent_types.graph_agent.OpenAI', return_value=mock_openai_client), \
+         patch('bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS', {'openai': mock_openai_llm_cls}), \
+         patch('bolna.agent_types.graph_agent.OpenAiLLM', return_value=MagicMock()):
+        agent = GraphAgent(cfg)
+
+    agent._mock_llm = mock_llm
+    return agent
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+def _mock_routing_response(function_name, function_args_dict):
+    mock_tool_call = MagicMock()
+    mock_tool_call.function.name = function_name
+    mock_tool_call.function.arguments = json.dumps(function_args_dict)
+    mock_message = MagicMock()
+    mock_message.tool_calls = [mock_tool_call]
+    mock_choice = MagicMock()
+    mock_choice.message = mock_message
+    mock_response = MagicMock()
+    mock_response.choices = [mock_choice]
+    return mock_response
+
+
+# ---------------------------------------------------------------------------
+# _edge_function_name
+# ---------------------------------------------------------------------------
+
+class TestEdgeFunctionName:
+    def test_explicit_name(self):
+        assert GraphAgent._edge_function_name({"function_name": "go_to_booking", "to_node_id": "booking"}) == "go_to_booking"
+
+    def test_auto_generated_name(self):
+        assert GraphAgent._edge_function_name({"to_node_id": "booking"}) == "transition_to_booking"
+
+
+# ---------------------------------------------------------------------------
+# _classify_edges
+# ---------------------------------------------------------------------------
+
+class TestClassifyEdges:
+    def test_all_llm_edges(self):
+        agent = _make_agent()
+        edges = [
+            {"to_node_id": "a", "condition": "wants a"},
+            {"to_node_id": "b", "condition": "wants b", "condition_type": "llm"},
+        ]
+        det, llm = agent._classify_edges(edges)
+        assert len(det) == 0
+        assert len(llm) == 2
+
+    def test_all_expression_edges(self):
+        agent = _make_agent()
+        edges = [
+            {"to_node_id": "a", "condition_type": "expression", "expression": {"logic": "and", "conditions": []}},
+            {"to_node_id": "b", "condition_type": "unconditional"},
+        ]
+        det, llm = agent._classify_edges(edges)
+        assert len(det) == 2
+        assert len(llm) == 0
+
+    def test_mixed_edges(self):
+        agent = _make_agent()
+        edges = [
+            {"to_node_id": "a", "condition_type": "expression", "expression": {}},
+            {"to_node_id": "b", "condition": "user intent"},
+            {"to_node_id": "c", "condition_type": "unconditional"},
+        ]
+        det, llm = agent._classify_edges(edges)
+        assert len(det) == 2
+        assert len(llm) == 1
+
+    def test_priority_sorting(self):
+        agent = _make_agent()
+        edges = [
+            {"to_node_id": "b", "condition_type": "expression", "priority": 10, "expression": {}},
+            {"to_node_id": "a", "condition_type": "expression", "priority": 1, "expression": {}},
+            {"to_node_id": "c", "condition_type": "unconditional", "priority": 999},
+        ]
+        det, llm = agent._classify_edges(edges)
+        assert [e["to_node_id"] for e in det] == ["a", "b", "c"]
+
+    def test_none_condition_type_is_llm(self):
+        """Backward compat: edges with no condition_type are treated as LLM."""
+        agent = _make_agent()
+        edges = [{"to_node_id": "x", "condition": "something", "condition_type": None}]
+        det, llm = agent._classify_edges(edges)
+        assert len(det) == 0
+        assert len(llm) == 1
+
+    def test_none_priority_does_not_crash(self):
+        """priority: None (from JSON null) should not crash sorting."""
+        agent = _make_agent()
+        edges = [
+            {"to_node_id": "a", "condition_type": "expression", "priority": None, "expression": {}},
+            {"to_node_id": "b", "condition_type": "expression", "priority": None, "expression": {}},
+            {"to_node_id": "c", "condition": "fallback", "priority": None},
+        ]
+        det, llm = agent._classify_edges(edges)
+        assert len(det) == 2
+        assert len(llm) == 1
+
+
+# ---------------------------------------------------------------------------
+# Expression match skips LLM
+# ---------------------------------------------------------------------------
+
+class TestExpressionMatchSkipsLLM:
+    @pytest.mark.asyncio
+    async def test_expression_match_returns_instantly(self):
+        """When an expression edge matches, LLM should NOT be called."""
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'hindi_agent',
+                            'condition': 'Hindi speaker',
+                            'condition_type': 'expression',
+                            'expression': {'logic': 'or', 'conditions': [
+                                {'variable': 'detected_language', 'operator': 'eq', 'value': 'hindi'},
+                                {'variable': 'detected_language', 'operator': 'eq', 'value': 'hi'},
+                            ]},
+                        },
+                        {
+                            'to_node_id': 'booking',
+                            'condition': 'user wants to book',
+                            'function_name': 'go_to_booking',
+                        },
+                    ],
+                },
+                {'id': 'hindi_agent', 'prompt': 'Hindi.', 'edges': []},
+                {'id': 'booking', 'prompt': 'Book.', 'edges': []},
+            ],
+        })
+
+        agent.context_data = {'detected_language': 'hindi'}
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock) as mock_thread:
+            result = await agent.decide_next_node_with_functions(
+                [{'role': 'user', 'content': 'namaste'}]
+            )
+            # LLM should NOT have been called
+            mock_thread.assert_not_called()
+
+        next_node, params, latency_ms, msgs, tools, reasoning, confidence = result
+        assert next_node == 'hindi_agent'
+        assert confidence == 1.0
+        assert reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)
+        assert latency_ms < 50  # should be near-instant
+
+    @pytest.mark.asyncio
+    async def test_unconditional_match_returns_instantly(self):
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {'to_node_id': 'fallback', 'condition': 'Default', 'condition_type': 'unconditional'},
+                    ],
+                },
+                {'id': 'fallback', 'prompt': 'Fallback.', 'edges': []},
+            ],
+        })
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock) as mock_thread:
+            result = await agent.decide_next_node_with_functions(
+                [{'role': 'user', 'content': 'hello'}]
+            )
+            mock_thread.assert_not_called()
+
+        assert result[0] == 'fallback'
+        assert result[6] == 1.0  # confidence
+
+
+# ---------------------------------------------------------------------------
+# No expression match → falls through to LLM
+# ---------------------------------------------------------------------------
+
+class TestFallThroughToLLM:
+    @pytest.mark.asyncio
+    async def test_expression_no_match_falls_to_llm(self):
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'hindi_agent',
+                            'condition': 'Hindi speaker',
+                            'condition_type': 'expression',
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': 'detected_language', 'operator': 'eq', 'value': 'hindi'},
+                            ]},
+                        },
+                        {
+                            'to_node_id': 'booking',
+                            'condition': 'user wants to book',
+                            'function_name': 'go_to_booking',
+                        },
+                    ],
+                },
+                {'id': 'hindi_agent', 'prompt': 'Hindi.', 'edges': []},
+                {'id': 'booking', 'prompt': 'Book.', 'edges': []},
+            ],
+        })
+
+        agent.context_data = {'detected_language': 'en'}
+
+        mock_resp = _mock_routing_response('go_to_booking', {
+            'reasoning': 'User wants to book',
+            'confidence': 0.9,
+        })
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=mock_resp):
+            result = await agent.decide_next_node_with_functions(
+                [{'role': 'user', 'content': 'I want to book'}]
+            )
+
+        next_node, params, latency_ms, msgs, tools, reasoning, confidence = result
+        assert next_node == 'booking'
+        assert confidence == 0.9
+        assert not reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)
+
+    @pytest.mark.asyncio
+    async def test_llm_tools_exclude_expression_edges(self):
+        """When falling through to LLM, tools should only contain LLM edges."""
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'hindi_agent',
+                            'condition_type': 'expression',
+                            'condition': 'Hindi',
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': 'detected_language', 'operator': 'eq', 'value': 'hindi'},
+                            ]},
+                        },
+                        {
+                            'to_node_id': 'booking',
+                            'condition': 'user wants to book',
+                            'function_name': 'go_to_booking',
+                        },
+                    ],
+                },
+                {'id': 'hindi_agent', 'prompt': 'Hindi.', 'edges': []},
+                {'id': 'booking', 'prompt': 'Book.', 'edges': []},
+            ],
+        })
+
+        agent.context_data = {'detected_language': 'en'}
+
+        mock_resp = _mock_routing_response('stay_on_current_node', {
+            'reasoning': 'No match',
+            'confidence': 0.5,
+        })
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=mock_resp):
+            result = await agent.decide_next_node_with_functions(
+                [{'role': 'user', 'content': 'hi'}]
+            )
+
+        # Check that tools (result[4]) only has go_to_booking + stay_on_current_node
+        tools = result[4]
+        tool_names = [t['function']['name'] for t in tools]
+        assert 'go_to_booking' in tool_names
+        assert 'stay_on_current_node' in tool_names
+        # Expression edge should NOT appear as an LLM tool
+        assert 'transition_to_hindi_agent' not in tool_names
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompatibility:
+    @pytest.mark.asyncio
+    async def test_existing_config_no_condition_type(self):
+        """Edges without condition_type still work as LLM edges."""
+        agent = _make_agent()  # default config has no condition_type
+        agent.context_data = {}
+
+        mock_resp = _mock_routing_response('go_to_booking', {
+            'appointment_type': 'oil_change',
+            'reasoning': 'User wants oil change',
+            'confidence': 0.95,
+        })
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=mock_resp):
+            result = await agent.decide_next_node_with_functions(
+                [{'role': 'user', 'content': 'I want an oil change'}]
+            )
+
+        assert result[0] == 'booking'
+        assert result[6] == 0.95
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering
+# ---------------------------------------------------------------------------
+
+class TestPriorityOrdering:
+    @pytest.mark.asyncio
+    async def test_lower_priority_evaluated_first(self):
+        """Edge with lower priority number should be evaluated first."""
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'fallback',
+                            'condition_type': 'unconditional',
+                            'condition': 'Default',
+                            'priority': 999,
+                        },
+                        {
+                            'to_node_id': 'escalation',
+                            'condition_type': 'expression',
+                            'condition': 'Turn limit',
+                            'priority': 1,
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': '_node_turns', 'operator': 'gte', 'value': 3},
+                            ]},
+                        },
+                    ],
+                },
+                {'id': 'escalation', 'prompt': 'Escalate.', 'edges': []},
+                {'id': 'fallback', 'prompt': 'Fallback.', 'edges': []},
+            ],
+        })
+
+        # With enough turns, expression edge (priority 1) should match first
+        history = [{'role': 'user', 'content': f'msg {i}'} for i in range(5)]
+        agent.context_data = {}
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock) as mock_thread:
+            result = await agent.decide_next_node_with_functions(history)
+            mock_thread.assert_not_called()
+
+        assert result[0] == 'escalation'
+
+    @pytest.mark.asyncio
+    async def test_unconditional_with_high_priority_is_fallback(self):
+        """Unconditional edge with high priority should only match if expression doesn't."""
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'escalation',
+                            'condition_type': 'expression',
+                            'condition': 'Turn limit',
+                            'priority': 1,
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': '_node_turns', 'operator': 'gte', 'value': 10},
+                            ]},
+                        },
+                        {
+                            'to_node_id': 'fallback',
+                            'condition_type': 'unconditional',
+                            'condition': 'Default',
+                            'priority': 999,
+                        },
+                    ],
+                },
+                {'id': 'escalation', 'prompt': 'Escalate.', 'edges': []},
+                {'id': 'fallback', 'prompt': 'Fallback.', 'edges': []},
+            ],
+        })
+
+        # Only 2 turns — expression won't match, unconditional will
+        history = [{'role': 'user', 'content': 'hi'}, {'role': 'user', 'content': 'hello'}]
+        agent.context_data = {}
+
+        result = await agent.decide_next_node_with_functions(history)
+        assert result[0] == 'fallback'
+
+
+# ---------------------------------------------------------------------------
+# Turn count injection
+# ---------------------------------------------------------------------------
+
+class TestTurnCounts:
+    @pytest.mark.asyncio
+    async def test_node_turns_computed(self):
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'escalation',
+                            'condition_type': 'expression',
+                            'condition': 'Too many turns',
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': '_node_turns', 'operator': 'gte', 'value': 3},
+                            ]},
+                        },
+                    ],
+                },
+                {'id': 'escalation', 'prompt': 'Escalate.', 'edges': []},
+            ],
+        })
+        agent.context_data = {}
+        agent.current_node_entry_index = 0
+
+        history = [
+            {'role': 'user', 'content': 'msg1'},
+            {'role': 'assistant', 'content': 'reply1'},
+            {'role': 'user', 'content': 'msg2'},
+            {'role': 'assistant', 'content': 'reply2'},
+            {'role': 'user', 'content': 'msg3'},
+        ]
+
+        result = await agent.decide_next_node_with_functions(history)
+        assert result[0] == 'escalation'
+        assert agent.context_data['_node_turns'] == 3
+        assert agent.context_data['_total_turns'] == 3
+
+    @pytest.mark.asyncio
+    async def test_total_turns_with_node_entry_offset(self):
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'escalation',
+                            'condition_type': 'expression',
+                            'condition': 'Total turns high',
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': '_total_turns', 'operator': 'gte', 'value': 4},
+                            ]},
+                        },
+                    ],
+                },
+                {'id': 'escalation', 'prompt': 'Escalate.', 'edges': []},
+            ],
+        })
+        agent.context_data = {}
+        agent.current_node_entry_index = 4  # entered at message index 4
+
+        history = [
+            {'role': 'user', 'content': 'msg1'},
+            {'role': 'assistant', 'content': 'reply1'},
+            {'role': 'user', 'content': 'msg2'},
+            {'role': 'assistant', 'content': 'reply2'},
+            # node entry here
+            {'role': 'user', 'content': 'msg3'},
+            {'role': 'assistant', 'content': 'reply3'},
+            {'role': 'user', 'content': 'msg4'},
+        ]
+
+        result = await agent.decide_next_node_with_functions(history)
+        assert result[0] == 'escalation'
+        assert agent.context_data['_total_turns'] == 4
+        assert agent.context_data['_node_turns'] == 2
+
+
+# ---------------------------------------------------------------------------
+# routing_info includes routing_type
+# ---------------------------------------------------------------------------
+
+class TestRoutingInfoType:
+    @pytest.mark.asyncio
+    async def test_deterministic_routing_type(self):
+        agent = _make_agent({
+            'nodes': [
+                {
+                    'id': 'greeting',
+                    'prompt': 'Greet.',
+                    'edges': [
+                        {
+                            'to_node_id': 'hindi_agent',
+                            'condition_type': 'expression',
+                            'condition': 'Hindi',
+                            'expression': {'logic': 'and', 'conditions': [
+                                {'variable': 'detected_language', 'operator': 'eq', 'value': 'hindi'},
+                            ]},
+                        },
+                    ],
+                },
+                {'id': 'hindi_agent', 'prompt': 'Hindi.', 'edges': []},
+            ],
+        })
+
+        async def fake_stream(*args, **kwargs):
+            return
+            yield
+
+        agent._mock_llm.generate_stream = fake_stream
+        agent.context_data = {'detected_language': 'hindi'}
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock):
+            chunks = []
+            async for chunk in agent.generate(
+                [{'role': 'user', 'content': 'namaste'}],
+                meta_info={'detected_language': 'hindi'},
+            ):
+                chunks.append(chunk)
+
+        routing_info = chunks[0].get('routing_info')
+        assert routing_info['routing_type'] == 'deterministic'
+        assert routing_info['confidence'] == 1.0
+
+    @pytest.mark.asyncio
+    async def test_llm_routing_type(self):
+        agent = _make_agent()
+
+        async def fake_stream(*args, **kwargs):
+            return
+            yield
+
+        agent._mock_llm.generate_stream = fake_stream
+        agent.context_data = {}
+
+        mock_resp = _mock_routing_response('go_to_booking', {
+            'appointment_type': 'oil_change',
+            'reasoning': 'User wants to book',
+            'confidence': 0.9,
+        })
+
+        with patch('asyncio.to_thread', new_callable=AsyncMock, return_value=mock_resp):
+            chunks = []
+            async for chunk in agent.generate(
+                [{'role': 'user', 'content': 'book me'}],
+                meta_info={},
+            ):
+                chunks.append(chunk)
+
+        routing_info = chunks[0].get('routing_info')
+        assert routing_info['routing_type'] == 'llm'


### PR DESCRIPTION
## Summary

Adds a deterministic expression evaluation layer to graph agent routing that runs **before** LLM routing. Expression-based and unconditional edges resolve instantly (0ms, no API call), falling back to LLM function-calling only when no deterministic edge matches.

**Routing flow:**
```
BEFORE:  User message → LLM routing (every time, ~200ms+) → transition

AFTER:   User message → Expression/Unconditional edges (0ms, deterministic)
                            ↓ no match
                         LLM edges (only when needed)
```

## What changed

### `bolna/enums.py`
- Added `ExpressionOperator` (eq, neq, gt, gte, lt, lte, in, not_in, contains, exists, not_exists)
- Added `ExpressionLogic` (and, or)
- Added `EdgeConditionType` (llm, expression, unconditional)

### `bolna/models.py`
- Added `ExpressionCondition` and `ExpressionGroup` Pydantic models
- Extended `GraphEdge` with `condition_type`, `expression`, and `priority` fields
- All new fields are `Optional` with defaults — **zero breaking changes** for existing configs

### `bolna/helpers/expression_evaluator.py` (new)
- Pure-function evaluator — no `eval()`, no side effects
- Dot-notation variable resolution (`recipient_data.timezone`, `detected_language`)
- Type coercion for cross-type comparisons (string "3" vs int 3)
- Operator dispatch via `operator` module (no string comparisons in hot path)

### `bolna/agent_types/graph_agent.py`
- Two-phase routing in `decide_next_node_with_functions`:
  1. **Phase 1**: Evaluate deterministic edges (expression + unconditional), return immediately on match
  2. **Phase 2**: Fall back to LLM function-calling for remaining edges
- Injects `_node_turns` and `_total_turns` into context_data for turn-based routing
- Extracted `_edge_function_name()` static method (eliminates prior duplication)
- Existing methods preserved as thin wrappers for backward compatibility

## Backward compatibility

- `condition_type: None` is treated as `"llm"` — existing configs work unchanged
- All new fields are Optional with sensible defaults
- No dashboard-backend changes required

## Example edge configs

**Language routing (instant):**
```json
{
  "to_node_id": "hindi_agent",
  "condition_type": "expression",
  "expression": {
    "logic": "or",
    "conditions": [
      {"variable": "detected_language", "operator": "eq", "value": "hindi"},
      {"variable": "detected_language", "operator": "eq", "value": "hi"}
    ]
  }
}
```

**Turn limit (auto-escalate):**
```json
{
  "to_node_id": "escalation",
  "condition_type": "expression",
  "expression": {
    "logic": "and",
    "conditions": [
      {"variable": "_node_turns", "operator": "gte", "value": 5}
    ]
  }
}
```

**Unconditional fallback:**
```json
{"to_node_id": "fallback", "condition_type": "unconditional", "priority": 999}
```