### PR TITLE
fix: wait for in-flight audio before switching language pools

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1681,6 +1681,7 @@ class TaskManager(BaseManager):
 
         if called_fun == "switch_language":
             language_label = resp.get("language", "")
+            await self.wait_for_current_message()
             try:
                 await self.switch_language(language_label)
                 function_response = f"Switched to {language_label}"


### PR DESCRIPTION
## Problem
When the LLM generates a handoff message (e.g. "Let me connect you with Monika") alongside a switch_language tool call, the pool switch executes immediately — cancelling the in-flight audio before it finishes playing.

## Fix
Add `wait_for_current_message()` before `switch_language()` so the handoff message plays fully before the pool switch happens.