### PR TITLE
feat: per-language handoff message for multilingual switch

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1526,6 +1526,8 @@ class TaskManager(BaseManager):
             meta_info['message_category'] = 'filler'
 
         if next_step == "synthesizer" and not should_bypass_synth:
+            if not text_chunk or not text_chunk.strip():
+                return
             self._turn_audio_flushed.clear()
             task = asyncio.create_task(self._synthesize(create_ws_data_packet(text_chunk, meta_info)))
             self.synthesizer_tasks.append(asyncio.ensure_future(task))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -110,6 +110,7 @@ class TaskManager(BaseManager):
         self.hangup_triggered = False
         self.hangup_triggered_at = None
         self.hangup_message_queued = False
+        self.switch_handoff_message = ""
         self._end_of_conversation_in_progress = False
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
@@ -736,6 +737,8 @@ class TaskManager(BaseManager):
         # Entry must exist in tools_params so ToolCallAccumulator.build_api_payload
         # doesn't drop the call, but no pre_call_message — the switch is silent.
         self.kwargs["api_tools"]["tools_params"]["switch_language"] = {}
+
+        self.switch_handoff_message = self.task_config.get("tools_config", {}).get("switch_handoff_message", "")
 
     def __setup_transcriber(self):
         try:
@@ -1658,6 +1661,29 @@ class TaskManager(BaseManager):
         if called_fun == "switch_language":
             language_label = resp.get("language", "")
             await self.wait_for_current_message()
+
+            # Synthesize handoff message with CURRENT voice before switching
+            if self.switch_handoff_message:
+                target_voice = self._get_voice_name_for_label(language_label)
+                handoff_text = self.switch_handoff_message.replace(
+                    "{voice_name}", target_voice
+                ).replace(
+                    "{language}", language_label
+                )
+                meta_info_handoff = {
+                    'io': self.tools["output"].get_provider(),
+                    "request_id": str(uuid.uuid4()),
+                    "cached": False,
+                    "sequence_id": -1,
+                    'format': 'pcm',
+                    'message_category': 'handoff',
+                    'end_of_llm_stream': True,
+                    'text': handoff_text,
+                }
+                self._turn_audio_flushed.clear()
+                await self._synthesize(create_ws_data_packet(handoff_text, meta_info=meta_info_handoff))
+                await self.wait_for_current_message()
+
             try:
                 await self.switch_language(language_label)
                 function_response = f"Switched to {language_label}"
@@ -2363,6 +2389,12 @@ class TaskManager(BaseManager):
     def is_sequence_id_in_current_ids(self, sequence_id):
         """Check if sequence_id is valid. Delegates to InterruptionManager."""
         return self.interruption_manager.is_valid_sequence(sequence_id)
+
+    def _get_voice_name_for_label(self, label):
+        """Get voice name for a language label from synth multilingual config."""
+        synth_multilingual = self.task_config.get("tools_config", {}).get("synthesizer", {}).get("multilingual", {})
+        lang_cfg = synth_multilingual.get(label, {})
+        return lang_cfg.get("provider_config", {}).get("voice", label)
 
     async def switch_language(self, label, components=None):
         """Switch the active language for multilingual pools.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -111,6 +111,7 @@ class TaskManager(BaseManager):
         self.hangup_triggered_at = None
         self.hangup_message_queued = False
         self.switch_handoff_messages = {}
+        self.agent_names = {}
         self._end_of_conversation_in_progress = False
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
@@ -739,6 +740,7 @@ class TaskManager(BaseManager):
         self.kwargs["api_tools"]["tools_params"]["switch_language"] = {}
 
         self.switch_handoff_messages = self.task_config.get("tools_config", {}).get("switch_handoff_messages", {})
+        self.agent_names = self.task_config.get("tools_config", {}).get("agent_names", {})
 
     def __setup_transcriber(self):
         try:
@@ -2392,10 +2394,8 @@ class TaskManager(BaseManager):
         return self.interruption_manager.is_valid_sequence(sequence_id)
 
     def _get_voice_name_for_label(self, label):
-        """Get voice name for a language label from synth multilingual config."""
-        synth_multilingual = self.task_config.get("tools_config", {}).get("synthesizer", {}).get("multilingual", {})
-        lang_cfg = synth_multilingual.get(label, {})
-        return lang_cfg.get("provider_config", {}).get("voice", label)
+        """Get agent name for a language label from configured agent_names."""
+        return self.agent_names.get(label, "")
 
     async def switch_language(self, label, components=None):
         """Switch the active language for multilingual pools.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1662,7 +1662,9 @@ class TaskManager(BaseManager):
 
         if called_fun == "switch_language":
             language_label = resp.get("language", "")
-            await self.wait_for_current_message()
+            # Only wait if audio is currently playing
+            if not self._turn_audio_flushed.is_set():
+                await self.wait_for_current_message()
 
             # Synthesize handoff message with CURRENT voice before switching
             handoff_template = self.switch_handoff_messages.get(self.language, "")
@@ -1684,6 +1686,8 @@ class TaskManager(BaseManager):
                     'end_of_llm_stream': True,
                     'text': handoff_text,
                 }
+                # Flush stale synthesis requests to give handoff a clean pipeline
+                await self.tools["synthesizer"].handle_interruption()
                 self._turn_audio_flushed.clear()
                 await self._synthesize(create_ws_data_packet(handoff_text, meta_info=meta_info_handoff))
                 await self.wait_for_current_message()

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -110,7 +110,7 @@ class TaskManager(BaseManager):
         self.hangup_triggered = False
         self.hangup_triggered_at = None
         self.hangup_message_queued = False
-        self.switch_handoff_message = ""
+        self.switch_handoff_messages = {}
         self._end_of_conversation_in_progress = False
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
@@ -738,7 +738,7 @@ class TaskManager(BaseManager):
         # doesn't drop the call, but no pre_call_message — the switch is silent.
         self.kwargs["api_tools"]["tools_params"]["switch_language"] = {}
 
-        self.switch_handoff_message = self.task_config.get("tools_config", {}).get("switch_handoff_message", "")
+        self.switch_handoff_messages = self.task_config.get("tools_config", {}).get("switch_handoff_messages", {})
 
     def __setup_transcriber(self):
         try:
@@ -1663,9 +1663,10 @@ class TaskManager(BaseManager):
             await self.wait_for_current_message()
 
             # Synthesize handoff message with CURRENT voice before switching
-            if self.switch_handoff_message:
+            handoff_template = self.switch_handoff_messages.get(self.language, "")
+            if handoff_template:
                 target_voice = self._get_voice_name_for_label(language_label)
-                handoff_text = self.switch_handoff_message.replace(
+                handoff_text = handoff_template.replace(
                     "{voice_name}", target_voice
                 ).replace(
                     "{language}", language_label

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1668,10 +1668,11 @@ class TaskManager(BaseManager):
             handoff_template = self.switch_handoff_messages.get(self.language, "")
             if handoff_template:
                 target_voice = self._get_voice_name_for_label(language_label)
+                language_display = LANGUAGE_NAMES.get(language_label, language_label)
                 handoff_text = handoff_template.replace(
                     "{voice_name}", target_voice
                 ).replace(
-                    "{language}", language_label
+                    "{language}", language_display
                 )
                 meta_info_handoff = {
                     'io': self.tools["output"].get_provider(),

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -431,6 +431,9 @@ class ToolsConfig(BaseModel):
     input: Optional[IOModel] = None
     output: Optional[IOModel] = None
     api_tools: Optional[ToolModel] = None
+    switch_tool_description: Optional[str] = None
+    switch_handoff_messages: Optional[Dict[str, str]] = None
+    agent_names: Optional[Dict[str, str]] = None
 
 class ToolsChainModel(BaseModel):
     execution: str = Field(..., pattern="^(parallel|sequential)$")


### PR DESCRIPTION
## Summary
Synthesizes a configurable handoff message with the current voice before switching languages. Each language can have its own handoff message template with `{voice_name}` and `{language}` placeholders.

## Changes
- Per-language `switch_handoff_messages` dict and `agent_names` dict read from `tools_config`
- `switch_language` block in `__execute_function_call`: resolves placeholders, synthesizes with current voice using `sequence_id: -1`, waits for playback, then switches pools
- `{language}` resolves to display name ("Hindi") via `LANGUAGE_NAMES` mapping, not code ("hi")
- `_get_voice_name_for_label()` helper looks up agent name for target language
- Skip synthesis for empty text in `_handle_llm_output` — eliminates 3s delay from empty pre-function-call push on tool calls
- Skip `wait_for_current_message` when no audio is pending, flush stale synth requests before handoff
- No-op when handoff message is empty — no regression for existing agents