### PR TITLE
fix: remove handle_interruption before handoff to prevent stale isFinal

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1688,8 +1688,6 @@ class TaskManager(BaseManager):
                     'end_of_llm_stream': True,
                     'text': handoff_text,
                 }
-                # Flush stale synthesis requests to give handoff a clean pipeline
-                await self.tools["synthesizer"].handle_interruption()
                 self._turn_audio_flushed.clear()
                 await self._synthesize(create_ws_data_packet(handoff_text, meta_info=meta_info_handoff))
                 await self.wait_for_current_message()


### PR DESCRIPTION
## Summary
Fixes handoff message not being spoken during multilingual language switch.

## Problem
`handle_interruption()` sends `close_context` to ElevenLabs before the handoff text is pushed. EL responds with a stale `isFinal: True` (in 3-16ms) that gets consumed by the receiver before the real handoff audio arrives — so the handoff is treated as complete with zero audio (`text_synthesized: ''`, `duration: 0.00025`).

## Fix
Remove `handle_interruption()` before handoff synthesis. The pipeline is already clean at this point because:
- Prior interruptions are handled by `__cleanup_downstream_tasks` which calls `handle_interruption()` at interruption time
- `wait_for_current_message()` ensures any pending audio is done
- EL `push()` starts a fresh turn automatically