### PR TITLE
fix: log pre function call message correctly

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1700,7 +1700,10 @@ class TaskManager(BaseManager):
                 function_response = f"Failed to switch language: {e}"
 
             textual_response = resp.get("textual_response", None)
-            self.conversation_history.append_assistant(textual_response, tool_calls=resp["model_response"])
+            if not textual_response:
+                self.conversation_history.append_assistant(textual_response, tool_calls=resp["model_response"])
+            else:
+                self.conversation_history.attach_tool_calls_to_last_response(resp["model_response"])
             self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), function_response)
             convert_to_request_log(function_response, meta_info, None, "function_call", direction="response", run_id=self.run_id)
 
@@ -1744,7 +1747,10 @@ class TaskManager(BaseManager):
             set_response_prompt = function_response
 
         textual_response = resp.get("textual_response", None)
-        self.conversation_history.append_assistant(textual_response, tool_calls=resp["model_response"])
+        if not textual_response:
+            self.conversation_history.append_assistant(textual_response, tool_calls=resp["model_response"])
+        else:
+            self.conversation_history.attach_tool_calls_to_last_response(resp["model_response"])
         self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), function_response)
 
         logger.info(f"Logging function call parameters ")
@@ -1881,6 +1887,9 @@ class TaskManager(BaseManager):
 
                 if trigger_function_call:
                     logger.info(f"Triggering function call for {data}")
+                    textual_response = data.textual_response if hasattr(data, 'textual_response') else None
+                    if textual_response: #intentionally omitting tool_calls, which will be filled later if the tool_call flow completed (requirement from OpenAI)
+                        self.__store_into_history(meta_info, messages, textual_response, should_trigger_function_call=should_trigger_function_call)
                     await self.__execute_function_call(next_step = next_step, **data.model_dump())
                     return
 

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -40,6 +40,9 @@ class ConversationHistory:
             "content": content,
         })
 
+    def attach_tool_calls_to_last_response(self, tool_calls: list):
+        self._messages[-1]["tool_calls"] = tool_calls
+
     def update_system_prompt(self, content: str):
         if self._messages and self._messages[0].get("role") == ChatRole.SYSTEM:
             self._messages[0]["content"] = content

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -41,7 +41,11 @@ class ConversationHistory:
         })
 
     def attach_tool_calls_to_last_response(self, tool_calls: list):
-        self._messages[-1]["tool_calls"] = tool_calls
+        if self._messages and self._messages[-1].get("role") == ChatRole.ASSISTANT:
+            self._messages[-1]["tool_calls"] = tool_calls
+        else:
+            logger.warning("attach_tool_calls_to_last_response: last message is not assistant, appending new")
+            self.append_assistant(None, tool_calls=tool_calls)
 
     def update_system_prompt(self, content: str):
         if self._messages and self._messages[0].get("role") == ChatRole.SYSTEM:


### PR DESCRIPTION
Issue:
1) Any message before the function call in the same stream is not logged to trace data
2) The same response if spoken is not visible in the transcript if the user interrupts while the function call is running. This also means that the next LLM call gets incomplete context.

Fix:
Log this message both to trace data and conversation history early. If the tool call succeeds, edit this message to contain the tool call as well. 