### PR TITLE
fix(task-manager): cancel background tasks during shutdown

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3129,6 +3129,19 @@ class TaskManager(BaseManager):
                 self.transcriber_latencies.connection_latency_ms = self.tools["transcriber"].connection_time
                 self.synthesizer_latencies.connection_latency_ms = self.tools["synthesizer"].connection_time
 
+                # Ensure fire-and-forget/background tasks spawned during the call
+                # are cancelled and awaited to avoid pending-task warnings at shutdown.
+                background_tasks = [
+                    ("first_message_task_new", getattr(self, "first_message_task_new", None)),
+                    ("llm_queue_task", getattr(self, "llm_queue_task", None)),
+                    ("execute_function_call_task", getattr(self, "execute_function_call_task", None)),
+                ]
+                for task_name, task in background_tasks:
+                    tasks_to_cancel.append(process_task_cancellation(task, task_name))
+
+                for index, task in enumerate(getattr(self, "synthesizer_tasks", [])):
+                    tasks_to_cancel.append(process_task_cancellation(task, f"synthesizer_tasks[{index}]"))
+
                 self.transcriber_latencies.turn_latencies = self.tools["transcriber"].turn_latencies
                 self.synthesizer_latencies.turn_latencies = self.tools["synthesizer"].turn_latencies
 


### PR DESCRIPTION
## Bug
https://github.com/bolna-ai/bolna/issues/462 reports recurring `Task was destroyed but it is pending!` errors, especially when conversation context closes while background coroutines are still active.

## Fix
In `TaskManager.run()` final cleanup, added explicit cancellation/awaiting for background tasks that were not previously included in the shutdown list:

- `first_message_task_new`
- `llm_queue_task`
- `execute_function_call_task`
- all tasks in `synthesizer_tasks`

These are now passed through `process_task_cancellation(...)` in the same cleanup phase as the existing transcriber/synthesizer/output tasks, so they are awaited before shutdown completes.

## Why this helps
The pending-task warning is typically raised when long-lived background tasks survive beyond loop teardown. By explicitly cancelling and awaiting these call-scoped tasks, shutdown becomes deterministic and avoids orphaned pending tasks.

## Testing
- `python3 -m py_compile bolna/agent_manager/task_manager.py` (passes)

Happy to iterate if you want this extracted into a shared managed-task helper.

Greetings, saschabuehrle
