### PR TITLE
refactor: streamline audio handling in SipTrunkOutputHandler 

### DIFF
--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -1,10 +1,14 @@
 """
 Asterisk WebSocket (chan_websocket) output handler for sip-trunk provider.
-Send all media between START_MEDIA_BUFFERING and STOP_MEDIA_BUFFERING; Asterisk re-frames and re-times.
-On MEDIA_XOFF queue locally; on MEDIA_XON drain to Asterisk. FLUSH_MEDIA on interrupt.
+
+Sends ulaw audio at 1x real-time pace (160 bytes / 20ms) via a background send loop.
+START_MEDIA_BUFFERING once at call start; FLUSH_MEDIA on interrupt.
+Generation counter drops stale frames after interruption.
+
 Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 """
 import asyncio
+import os
 import time
 import uuid
 import traceback
@@ -17,21 +21,23 @@ from dotenv import load_dotenv
 logger = configure_logger(__name__)
 load_dotenv()
 
-ASTERISK_ULAW_OPTIMAL_FRAME_SIZE = 160
-# Asterisk max WebSocket message size (docs: sending > 65500 closes the connection)
-MAX_WS_MESSAGE_BYTES = 65500
-# Preferred chunk size when sending binary to Asterisk. res_http_websocket.c allows only 10
-# short-read retries per frame; large frames (e.g. 65KB) can cause "Websocket seems unresponsive,
-# disconnecting" (ws_safe_read). Use smaller frames so Asterisk receives each in one or few reads.
-PREFERRED_WS_SEND_CHUNK_BYTES = 8192
-PLAYBACK_DONE_BUFFER_S = 0.5
+# 160 bytes = 20ms of ulaw at 8kHz (one RTP frame)
+FRAME_SIZE = 160
+FRAME_DURATION_S = 0.02
+
+# Pre-buffer: accumulate this many ms of audio before sending first frame of a response.
+# Absorbs TTS jitter so the first frames don't have micro-gaps.
+DEFAULT_JITTER_BUFFER_MS = int(os.environ.get("SIP_JITTER_BUFFER_MS", "40"))
+
+# Fallback timer buffer after expected playback duration (seconds).
+DEFAULT_FALLBACK_BUFFER_S = float(os.environ.get("SIP_FALLBACK_BUFFER_S", "0.1"))
 
 
 class SipTrunkOutputHandler(TelephonyOutputHandler):
     """
-    Sends ulaw as BINARY between START_MEDIA_BUFFERING and STOP_MEDIA_BUFFERING.
-    When Asterisk sends MEDIA_XOFF (queue full), we queue audio locally; on MEDIA_XON we drain to Asterisk.
-    On user interrupt we send FLUSH_MEDIA and clear the local queue.
+    Sends ulaw audio to Asterisk at 1x real-time pace via a background send loop.
+    START_MEDIA_BUFFERING sent once per call. FLUSH_MEDIA on interrupt.
+    MEDIA_XOFF/XON flow control queues audio locally when Asterisk is full.
     """
 
     def __init__(
@@ -47,18 +53,24 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         super().__init__(io_provider, websocket, mark_event_meta_data, log_dir_name)
         self.asterisk_media_start = asterisk_media_start or {}
         self.agent_config = agent_config or {}
-        self._optimal_frame_size = ASTERISK_ULAW_OPTIMAL_FRAME_SIZE
+        self._optimal_frame_size = FRAME_SIZE
         self.input_handler = input_handler
         self.queue_full = False
         if input_handler:
             input_handler.output_handler_ref = self
 
-        self._buffering_active = False
         self._response_audio_duration = 0.0
         self._playback_done_task = None
-        # Local queue when Asterisk sends MEDIA_XOFF; drained on MEDIA_XON (deque for O(1) popleft)
-        self._local_audio_queue = deque()
-        # If is_final arrived while we had queued audio, send STOP after drain
+
+        # Send loop: frames are enqueued as (bytes, generation) tuples and sent at 1x real-time
+        self._send_queue: asyncio.Queue = asyncio.Queue()
+        self._send_loop_task = None
+        self._flush_generation = 0
+        self._start_buffering_sent = False
+
+        # Local queue when Asterisk sends MEDIA_XOFF; drained on MEDIA_XON
+        self._local_audio_queue: deque = deque()
+        # If is_final arrived while send queue still has frames, defer fallback
         self._pending_stop_after_drain = False
         self._pending_stop_duration = 0.0
         self._pending_stop_category = "agent_response"
@@ -86,17 +98,116 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             pass
         return {}
 
+    # ------------------------------------------------------------------
+    # Send loop — drains _send_queue at 1x real-time (160 bytes / 20ms)
+    # ------------------------------------------------------------------
+
+    def _ensure_send_loop(self):
+        """Start the background send loop if not already running."""
+        if self._send_loop_task is None or self._send_loop_task.done():
+            self._send_loop_task = asyncio.create_task(self._send_loop())
+
+    async def _send_loop(self):
+        """Dequeue frames and send at 1x real-time pace."""
+        jitter_buffer_frames = max(1, DEFAULT_JITTER_BUFFER_MS // 20)
+        next_send = 0.0
+
+        while True:
+            try:
+                frame, generation = await self._send_queue.get()
+            except asyncio.CancelledError:
+                return
+
+            # Discard stale frames from a previous generation (post-interruption)
+            if generation != self._flush_generation:
+                continue
+
+            # Pre-buffer: if this is the first frame after the queue was empty,
+            # wait briefly to accumulate more frames and absorb TTS jitter.
+            if self._send_queue.qsize() < jitter_buffer_frames - 1:
+                try:
+                    await asyncio.sleep(DEFAULT_JITTER_BUFFER_MS / 1000.0)
+                except asyncio.CancelledError:
+                    return
+
+            # Respect XOFF backpressure
+            if self.queue_full:
+                self._local_audio_queue.append(frame)
+                continue
+
+            # Pace: wait until next_send time
+            now = time.monotonic()
+            if next_send > now:
+                try:
+                    await asyncio.sleep(next_send - now)
+                except asyncio.CancelledError:
+                    return
+
+            # Re-check generation after sleep (interruption may have happened)
+            if generation != self._flush_generation:
+                continue
+
+            try:
+                if self._closed:
+                    return
+                await self.websocket.send_bytes(frame)
+            except Exception as e:
+                logger.debug(f"sip-trunk send_bytes stopped: {e}")
+                return
+
+            next_send = time.monotonic() + FRAME_DURATION_S
+
+            # If the send queue just drained and we have a pending fallback, fire it
+            if self._send_queue.empty() and self._pending_stop_after_drain and not self._local_audio_queue:
+                self._pending_stop_after_drain = False
+                await self._send_control("REPORT_QUEUE_DRAINED")
+                duration = self._pending_stop_duration
+                category = self._pending_stop_category
+                if self._playback_done_task:
+                    self._playback_done_task.cancel()
+                self._playback_done_task = asyncio.create_task(
+                    self._playback_done_fallback(duration, category)
+                )
+
+    def _enqueue_audio(self, audio_chunk: bytes):
+        """Split audio_chunk into FRAME_SIZE frames and enqueue with current generation."""
+        gen = self._flush_generation
+        offset = 0
+        n = len(audio_chunk)
+        while offset < n:
+            end = min(offset + FRAME_SIZE, n)
+            frame = audio_chunk[offset:end]
+            # Pad last frame to FRAME_SIZE if short (Asterisk expects uniform frames)
+            if len(frame) < FRAME_SIZE:
+                frame = frame + b"\xff" * (FRAME_SIZE - len(frame))
+            self._send_queue.put_nowait((frame, gen))
+            offset = end
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
     async def handle_interruption(self):
-        """FLUSH_MEDIA, clear local queue and state, mark playback not active."""
+        """FLUSH_MEDIA, clear queues, increment generation to drop stale frames."""
         logger.info("sip-trunk: handling interruption (FLUSH_MEDIA)")
         try:
             if self._playback_done_task:
                 self._playback_done_task.cancel()
                 self._playback_done_task = None
-            self._buffering_active = False
+
+            # Increment generation so send loop discards any in-flight frames
+            self._flush_generation += 1
             self._response_audio_duration = 0.0
-            self._local_audio_queue.clear()
             self._pending_stop_after_drain = False
+
+            # Clear both queues
+            while not self._send_queue.empty():
+                try:
+                    self._send_queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    break
+            self._local_audio_queue.clear()
+
             await self._send_control("FLUSH_MEDIA")
             if self.mark_event_meta_data:
                 self.mark_event_meta_data.clear_data()
@@ -105,18 +216,30 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         except Exception as e:
             logger.error(f"sip-trunk handle_interruption: {e}")
 
+    # ------------------------------------------------------------------
+    # XOFF/XON drain
+    # ------------------------------------------------------------------
+
     async def drain_local_queue(self):
-        """Send any audio queued during MEDIA_XOFF to Asterisk (called when MEDIA_XON is received)."""
+        """Re-enqueue XOFF-queued audio into the send queue (called on MEDIA_XON)."""
+        gen = self._flush_generation
         while self._local_audio_queue and not self.queue_full:
             chunk = self._local_audio_queue.popleft()
             if not chunk:
                 continue
-            await self._send_binary(chunk)
+            # Re-enqueue as individual frames so pacing is maintained
+            offset = 0
+            n = len(chunk)
+            while offset < n:
+                end = min(offset + FRAME_SIZE, n)
+                frame = chunk[offset:end]
+                if len(frame) < FRAME_SIZE:
+                    frame = frame + b"\xff" * (FRAME_SIZE - len(frame))
+                self._send_queue.put_nowait((frame, gen))
+                offset = end
+
         if not self._local_audio_queue and self._pending_stop_after_drain:
             self._pending_stop_after_drain = False
-            if self._buffering_active:
-                await self._send_control("STOP_MEDIA_BUFFERING")
-                self._buffering_active = False
             await self._send_control("REPORT_QUEUE_DRAINED")
             duration = self._pending_stop_duration
             category = self._pending_stop_category
@@ -126,29 +249,21 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 self._playback_done_fallback(duration, category)
             )
 
+    # ------------------------------------------------------------------
+    # Control helpers
+    # ------------------------------------------------------------------
+
     async def _send_control(self, command, params=None):
         """Send one control command as TEXT (plain text, Asterisk-compatible)."""
         try:
+            if self._closed:
+                return
             msg = command if not params else f"{command} {' '.join(str(v) for v in params.values())}"
             await self.websocket.send_text(msg)
             logger.debug(f"sip-trunk sent: {command}")
         except Exception as e:
             logger.error(f"sip-trunk send_control {command}: {e}")
             traceback.print_exc()
-
-    async def _send_binary(self, data: bytes):
-        """Send raw ulaw to Asterisk in small chunks to avoid Asterisk ws_safe_read 'unresponsive' disconnect."""
-        n = len(data)
-        if n <= PREFERRED_WS_SEND_CHUNK_BYTES:
-            await self.websocket.send_bytes(data)
-            return
-        offset = 0
-        while offset < n:
-            chunk_size = min(PREFERRED_WS_SEND_CHUNK_BYTES, n - offset, MAX_WS_MESSAGE_BYTES)
-            chunk = data[offset : offset + chunk_size]
-            if chunk:
-                await self.websocket.send_bytes(chunk)
-            offset += chunk_size
 
     async def flush_media(self):
         await self._send_control("FLUSH_MEDIA")
@@ -165,10 +280,14 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     def _duration_ulaw(self, num_bytes):
         return num_bytes / 8000.0
 
+    # ------------------------------------------------------------------
+    # Main handle — enqueue audio into the paced send loop
+    # ------------------------------------------------------------------
+
     async def handle(self, ws_data_packet):
         """
-        One START_MEDIA_BUFFERING per response, then send all audio (or queue if MEDIA_XOFF), then STOP_MEDIA_BUFFERING.
-        Asterisk re-frames and re-times; we do not pace packets.
+        Enqueue audio into the 1x real-time send loop.
+        START_MEDIA_BUFFERING is sent once per call on first audio.
         """
         try:
             audio_chunk = ws_data_packet.get("data")
@@ -201,16 +320,21 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 if meta_info.get("message_category") == "agent_welcome_message" and not self.welcome_message_sent_ts:
                     self.welcome_message_sent_ts = time.time() * 1000
 
-                # Per Asterisk docs: START_MEDIA_BUFFERING before media so driver can buffer and re-frame
-                if not self._buffering_active and len(audio_chunk) > self._optimal_frame_size:
+                # Send START_MEDIA_BUFFERING once per call on first audio
+                if not self._start_buffering_sent:
                     await self._send_control("START_MEDIA_BUFFERING")
-                    self._buffering_active = True
+                    self._start_buffering_sent = True
+                    logger.info("sip-trunk: START_MEDIA_BUFFERING sent (once per call)")
+
+                # Reset duration tracking at the start of each new response
+                if meta_info.get("is_first_chunk"):
                     self._response_audio_duration = 0.0
 
-                if self.queue_full:
-                    self._local_audio_queue.append(audio_chunk)
-                else:
-                    await self._send_binary(audio_chunk)
+                # Ensure the background send loop is running
+                self._ensure_send_loop()
+
+                # Enqueue frames — the send loop handles pacing, XOFF, and generation
+                self._enqueue_audio(audio_chunk)
 
                 audio_duration = self._duration_ulaw(len(audio_chunk))
                 self._response_audio_duration += audio_duration
@@ -233,21 +357,19 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
                 if is_final:
                     total_duration = self._response_audio_duration
-                    # _response_audio_duration is reset when START_MEDIA_BUFFERING
-                    # is sent for the next response, not here. is_final fires twice
-                    # per response (last audio chunk + null-byte sentinel) and
-                    # resetting here caused the second fire to replace a valid
-                    # fallback timer with a 0-duration one.
+                    # _response_audio_duration is reset on the next new response
+                    # (when _start_buffering_sent logic resets it), not here.
+                    # is_final fires twice per response (last audio chunk +
+                    # null-byte sentinel) and resetting here would replace a
+                    # valid fallback timer with a 0-duration one.
 
-                    if self._local_audio_queue:
+                    if self._send_queue.qsize() > 0 or self._local_audio_queue:
+                        # Audio still being sent/queued — defer fallback
                         self._pending_stop_after_drain = True
                         self._pending_stop_duration = total_duration
                         self._pending_stop_category = message_category
-                        logger.debug("sip-trunk: final chunk queued (XOFF); will send STOP after drain")
+                        logger.debug("sip-trunk: final chunk received, audio still in send queue; deferring fallback")
                     else:
-                        if self._buffering_active:
-                            await self._send_control("STOP_MEDIA_BUFFERING")
-                            self._buffering_active = False
                         await self._send_control("REPORT_QUEUE_DRAINED")
                         if total_duration > 0 or not self._playback_done_task:
                             if self._playback_done_task:
@@ -255,16 +377,16 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                             self._playback_done_task = asyncio.create_task(
                                 self._playback_done_fallback(total_duration, message_category)
                             )
-                        logger.debug(f"sip-trunk: response done, fallback in {total_duration + PLAYBACK_DONE_BUFFER_S:.1f}s")
+                        logger.debug(f"sip-trunk: response done, fallback in {total_duration + DEFAULT_FALLBACK_BUFFER_S:.1f}s")
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
             traceback.print_exc()
 
     async def _playback_done_fallback(self, duration: float, message_category: str):
-        """If QUEUE_DRAINED never arrives, mark playback done after duration + buffer and process marks."""
+        """Mark playback done after expected duration + buffer. Process pending marks."""
         try:
-            await asyncio.sleep(duration + PLAYBACK_DONE_BUFFER_S)
+            await asyncio.sleep(duration + DEFAULT_FALLBACK_BUFFER_S)
         except asyncio.CancelledError:
             return
         self._playback_done_task = None


### PR DESCRIPTION
This pull request refactors the SIP trunk output handler to send ulaw audio at real-time pace using a background send loop, improving audio delivery reliability and jitter handling. The main changes introduce a paced send queue, generation-based frame dropping for interruptions, and improved handling of flow control and buffering. Legacy chunk-based sending logic is replaced with frame-based queuing and pacing.

**Audio sending and pacing improvements:**

* Introduced a background send loop that dequeues and sends ulaw audio frames at 1x real-time (160 bytes every 20ms), replacing the previous chunk-based approach. This loop absorbs TTS jitter with a configurable jitter buffer and ensures consistent pacing. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L3-R11) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L20-R40) [[3]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L50-R73) [[4]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R101-R210)
* Audio is now split into uniform frames and enqueued with a generation counter, allowing the send loop to drop stale frames after interruptions for cleaner recovery. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L50-R73) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R101-R210)

**Flow control and interruption handling:**

* MEDIA_XOFF/XON flow control now queues audio locally and re-enqueues it into the paced send queue when ready, maintaining proper pacing and frame structure.
* On interruption, both the send and local queues are cleared, and the generation counter is incremented to ensure no stale frames are sent.

**Buffering and fallback logic:**

* START_MEDIA_BUFFERING is now sent only once per call, and fallback timers for playback done are based on a configurable buffer duration. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L204-R337) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L236-R389)
* The handler now correctly defers fallback actions if audio is still in the send/local queues at end of response, ensuring accurate playback completion signaling.

**Code cleanup and removal of legacy logic:**

* Removed the old `_send_binary` chunked sending method and related constants, as all audio is now handled by the paced send loop.

These changes collectively improve audio delivery robustness, reduce jitter, and simplify the logic for flow control and interruptions.