### PR TITLE
fix: enhance QUEUE_DRAINED handling with jitter buffer

### DIFF
--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -282,11 +282,20 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             logger.debug(f"Asterisk control: {event}")
             return
         if event == "QUEUE_DRAINED" or "QUEUE_DRAINED" in event:
-            # Do not use QUEUE_DRAINED to clear is_audio_being_played or process marks.
-            # Asterisk can send QUEUE_DRAINED when it has accepted the bulk, before the
-            # caller has heard it. Rely only on the output handler's duration-based
-            # fallback so completion/hangup logic does not trigger mid-playback.
-            logger.debug(f"QUEUE_DRAINED for channel {self.channel_id} (playback-done handled by fallback)")
+            # Forward to output handler — QUEUE_DRAINED fires when Asterisk has
+            # consumed all buffered audio for RTP transmission. The output handler
+            # adds a small jitter buffer delay, then clears is_audio_being_played
+            # and processes pending marks (same contract as Plivo/Twilio mark echoes).
+            logger.debug(f"QUEUE_DRAINED for channel {self.channel_id}")
+            if hasattr(self, "output_handler_ref") and self.output_handler_ref:
+                task = asyncio.create_task(self.output_handler_ref.on_queue_drained())
+
+                def _on_queue_drained_done(t):
+                    exc = t.exception()
+                    if exc is not None:
+                        logger.exception("sip-trunk on_queue_drained failed: %s", exc)
+
+                task.add_done_callback(_on_queue_drained_done)
             return
         if event or parsed:
             logger.debug(f"Asterisk control: {text} -> event={event}")

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -282,20 +282,9 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             logger.debug(f"Asterisk control: {event}")
             return
         if event == "QUEUE_DRAINED" or "QUEUE_DRAINED" in event:
-            # Forward to output handler — QUEUE_DRAINED fires when Asterisk has
-            # consumed all buffered audio for RTP transmission. The output handler
-            # adds a small jitter buffer delay, then clears is_audio_being_played
-            # and processes pending marks (same contract as Plivo/Twilio mark echoes).
-            logger.debug(f"QUEUE_DRAINED for channel {self.channel_id}")
-            if hasattr(self, "output_handler_ref") and self.output_handler_ref:
-                task = asyncio.create_task(self.output_handler_ref.on_queue_drained())
-
-                def _on_queue_drained_done(t):
-                    exc = t.exception()
-                    if exc is not None:
-                        logger.exception("sip-trunk on_queue_drained failed: %s", exc)
-
-                task.add_done_callback(_on_queue_drained_done)
+            # At 1x pacing, playback completion is tracked by the output handler's
+            # send-loop drain detection — QUEUE_DRAINED is informational only.
+            logger.debug(f"QUEUE_DRAINED for channel {self.channel_id} (informational)")
             return
         if event or parsed:
             logger.debug(f"Asterisk control: {text} -> event={event}")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -65,6 +65,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         self._response_audio_duration = 0.0
         self._playback_done_task = None
         self._awaiting_queue_drained: bool = False
+        self._report_queue_drained_sent_at: float = 0.0
 
         # Send loop: frames are enqueued as (bytes, generation) tuples and sent at 1x real-time
         self._send_queue: asyncio.Queue = asyncio.Queue()
@@ -163,7 +164,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             if self._send_queue.empty() and self._pending_stop_after_drain and not self._local_audio_queue:
                 self._pending_stop_after_drain = False
                 self._awaiting_queue_drained = True
+                self._report_queue_drained_sent_at = time.time()
                 await self._send_control("REPORT_QUEUE_DRAINED")
+                logger.info(f"sip-trunk: send queue drained, REPORT_QUEUE_DRAINED sent (deferred), audio={self._response_audio_duration:.2f}s")
                 if self._playback_done_task:
                     self._playback_done_task.cancel()
                 self._playback_done_task = asyncio.create_task(
@@ -190,7 +193,13 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
     async def handle_interruption(self):
         """FLUSH_MEDIA, clear queues, increment generation to drop stale frames."""
-        logger.info("sip-trunk: handling interruption (FLUSH_MEDIA)")
+        awaiting = self._awaiting_queue_drained
+        elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at and awaiting else 0
+        logger.info(
+            f"sip-trunk: handling interruption (FLUSH_MEDIA), "
+            f"awaiting_queue_drained={awaiting}, audio={self._response_audio_duration:.2f}s"
+            + (f", waited={elapsed:.3f}s" if elapsed else "")
+        )
         try:
             if self._playback_done_task:
                 self._playback_done_task.cancel()
@@ -243,7 +252,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         if not self._local_audio_queue and self._pending_stop_after_drain:
             self._pending_stop_after_drain = False
             self._awaiting_queue_drained = True
+            self._report_queue_drained_sent_at = time.time()
             await self._send_control("REPORT_QUEUE_DRAINED")
+            logger.info(f"sip-trunk: XON drain complete, REPORT_QUEUE_DRAINED sent, audio={self._response_audio_duration:.2f}s")
             if self._playback_done_task:
                 self._playback_done_task.cancel()
             self._playback_done_task = asyncio.create_task(
@@ -370,6 +381,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                         logger.debug("sip-trunk: final chunk received, audio still in send queue; deferring fallback")
                     else:
                         self._awaiting_queue_drained = True
+                        self._report_queue_drained_sent_at = time.time()
                         await self._send_control("REPORT_QUEUE_DRAINED")
                         if total_duration > 0 or not self._playback_done_task:
                             if self._playback_done_task:
@@ -377,7 +389,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                             self._playback_done_task = asyncio.create_task(
                                 self._playback_done_fallback()
                             )
-                        logger.debug(f"sip-trunk: response done ({total_duration:.2f}s audio), safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
+                        logger.info(f"sip-trunk: REPORT_QUEUE_DRAINED sent, response audio={total_duration:.2f}s, safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
@@ -393,11 +405,12 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         """
         if not self.input_handler or not self.input_handler.mark_event_meta_data:
             return
+        total_elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
         remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
-        if remaining:
-            logger.info(
-                f"sip-trunk: playback done ({reason}), processing {len(remaining)} mark(s)"
-            )
+        logger.info(
+            f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s), "
+            f"audio={self._response_audio_duration:.2f}s, elapsed_since_report={total_elapsed:.3f}s"
+        )
         for mid in remaining:
             self.input_handler.process_mark_message({"name": mid})
         # Safety: if process_mark_message didn't clear it (e.g., no final mark
@@ -412,7 +425,13 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         buffer for the remaining RTP jitter.
         """
         if not self._awaiting_queue_drained:
-            return  # Spurious or duplicate QUEUE_DRAINED
+            logger.debug("sip-trunk: ignoring spurious/duplicate QUEUE_DRAINED")
+            return
+        queue_drained_latency = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
+        logger.info(
+            f"sip-trunk: QUEUE_DRAINED received {queue_drained_latency:.3f}s after REPORT_QUEUE_DRAINED, "
+            f"audio={self._response_audio_duration:.2f}s, adding {QUEUE_DRAINED_BUFFER_S}s jitter buffer"
+        )
         self._awaiting_queue_drained = False
 
         if self._playback_done_task:
@@ -439,10 +458,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         if self._closed:
             return
         if self._awaiting_queue_drained:
+            elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
             logger.warning(
-                f"sip-trunk: QUEUE_DRAINED not received within "
-                f"{QUEUE_DRAINED_SAFETY_TIMEOUT_S}s (audio duration {self._response_audio_duration:.2f}s), "
-                f"using safety fallback"
+                f"sip-trunk: QUEUE_DRAINED not received within {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s, "
+                f"audio={self._response_audio_duration:.2f}s, elapsed={elapsed:.3f}s — using safety fallback"
             )
             self._awaiting_queue_drained = False
         self._finish_playback(reason="safety-timeout")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -1,10 +1,11 @@
 """
 Asterisk WebSocket (chan_websocket) output handler for sip-trunk provider.
 
-Sends ulaw audio at 1x real-time pace (160 bytes / 20ms) via a background send loop.
-START_MEDIA_BUFFERING once at call start lets Asterisk retime any micro-jitter.
-FLUSH_MEDIA on interrupt. Generation counter drops stale frames after interruption.
-Playback completion detected when send queue drains after final chunk + settle delay.
+Sends audio to Asterisk in bursts as it arrives from TTS (like Plivo/Twilio).
+START_MEDIA_BUFFERING once per call lets Asterisk reframe and retime for smooth
+RTP delivery. Server-side duration tracking knows when playback ends without
+relying on QUEUE_DRAINED. FLUSH_MEDIA on interrupt. Generation counter drops
+stale audio after interruption.
 
 Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 """
@@ -22,25 +23,16 @@ from dotenv import load_dotenv
 logger = configure_logger(__name__)
 load_dotenv()
 
-# 160 bytes = 20ms of ulaw at 8kHz (one RTP frame)
-FRAME_SIZE = 160
-FRAME_DURATION_S = 0.02
-
-# Pre-buffer: accumulate this many ms of audio before sending first frame of a response.
-# Absorbs TTS jitter so the first frames don't have micro-gaps.
-DEFAULT_JITTER_BUFFER_MS = int(os.environ.get("SIP_JITTER_BUFFER_MS", "40"))
-
-# After audio finishes sending at 1x pace, Asterisk needs a small settle time
-# for its internal retiming buffer before we clear is_audio_being_played.
-# 100ms is sufficient — Asterisk's buffer is at most a few frames deep at 1x pace.
+# Extra buffer after estimated playback end before clearing is_audio_being_played.
+# Accounts for Asterisk's internal retiming and RTP jitter buffer.
 PLAYBACK_SETTLE_S = float(os.environ.get("SIP_PLAYBACK_SETTLE_S", "0.1"))
 
 
 class SipTrunkOutputHandler(TelephonyOutputHandler):
     """
-    Sends ulaw audio to Asterisk at 1x real-time pace via a background send loop.
-    START_MEDIA_BUFFERING sent once per call. FLUSH_MEDIA on interrupt.
-    Playback completion via send-loop drain detection + settle delay.
+    Sends ulaw audio to Asterisk in bursts — Asterisk buffers and retimes.
+    Server-side duration tracking for playback completion.
+    FLUSH_MEDIA on interrupt. XOFF/XON for backpressure safety.
     """
 
     def __init__(
@@ -56,24 +48,25 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         super().__init__(io_provider, websocket, mark_event_meta_data, log_dir_name)
         self.asterisk_media_start = asterisk_media_start or {}
         self.agent_config = agent_config or {}
-        self._optimal_frame_size = FRAME_SIZE
         self.input_handler = input_handler
         self.queue_full = False
         if input_handler:
             input_handler.output_handler_ref = self
 
+        # Playback duration tracking
+        self._response_first_send: float = 0.0   # monotonic time first chunk was sent
+        self._response_audio_duration: float = 0.0  # accumulated seconds of audio
         self._settle_task: asyncio.Task | None = None
+        self._pending_finish: bool = False
 
-        # Send loop: frames are enqueued as (bytes, generation) tuples and sent at 1x real-time
-        self._send_queue: asyncio.Queue = asyncio.Queue()
-        self._send_loop_task = None
-        self._flush_generation = 0
-        self._start_buffering_sent = False
+        # Generation counter — incremented on interruption, stale audio is dropped
+        self._flush_generation: int = 0
 
-        # Local queue when Asterisk sends MEDIA_XOFF; drained on MEDIA_XON
+        # Asterisk buffering state
+        self._start_buffering_sent: bool = False
+
+        # XOFF/XON: local queue when Asterisk signals backpressure
         self._local_audio_queue: deque = deque()
-        # If is_final arrived while send queue still has frames, defer fallback
-        self._pending_finish = False
 
         output_config = self._get_output_config()
         self._output_format = (
@@ -81,13 +74,6 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         ).lower()
         if self._output_format not in ("ulaw", "mulaw"):
             self._output_format = "ulaw"
-
-        opt = self.asterisk_media_start.get("optimal_frame_size")
-        if opt is not None:
-            try:
-                self._optimal_frame_size = int(opt)
-            except (TypeError, ValueError):
-                pass
 
     def _get_output_config(self):
         try:
@@ -99,129 +85,75 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         return {}
 
     # ------------------------------------------------------------------
-    # Send loop — drains _send_queue at 1x real-time (160 bytes / 20ms)
+    # Playback completion — server-side duration tracking
     # ------------------------------------------------------------------
 
-    def _ensure_send_loop(self):
-        """Start the background send loop if not already running."""
-        if self._send_loop_task is None or self._send_loop_task.done():
-            self._send_loop_task = asyncio.create_task(self._send_loop())
+    def _schedule_finish(self, generation: int):
+        """Schedule playback completion based on how much audio was sent and when.
 
-    async def _send_loop(self):
-        """Dequeue frames and send at 1x real-time pace."""
-        jitter_buffer_frames = max(1, DEFAULT_JITTER_BUFFER_MS // 20)
-        next_send = 0.0
-
-        while True:
-            try:
-                frame, generation = await self._send_queue.get()
-            except asyncio.CancelledError:
-                return
-
-            # Discard stale frames from a previous generation (post-interruption)
-            if generation != self._flush_generation:
-                continue
-
-            # Pre-buffer: if this is the first frame after the queue was empty,
-            # wait briefly to accumulate more frames and absorb TTS jitter.
-            if self._send_queue.qsize() < jitter_buffer_frames - 1:
-                try:
-                    await asyncio.sleep(DEFAULT_JITTER_BUFFER_MS / 1000.0)
-                except asyncio.CancelledError:
-                    return
-
-            # Respect XOFF backpressure
-            if self.queue_full:
-                self._local_audio_queue.append(frame)
-                continue
-
-            # Pace: wait until next_send time
-            now = time.monotonic()
-            if next_send > now:
-                try:
-                    await asyncio.sleep(next_send - now)
-                except asyncio.CancelledError:
-                    return
-
-            # Re-check generation after sleep (interruption may have happened)
-            if generation != self._flush_generation:
-                continue
-
-            try:
-                if self._closed:
-                    return
-                await self.websocket.send_bytes(frame)
-            except Exception as e:
-                logger.debug(f"sip-trunk send_bytes stopped: {e}")
-                return
-
-            next_send = time.monotonic() + FRAME_DURATION_S
-
-            # If the send queue just drained and final chunk was received, finish playback
-            if self._send_queue.empty() and self._pending_finish and not self._local_audio_queue:
-                self._pending_finish = False
-                if self._settle_task:
-                    self._settle_task.cancel()
-                self._settle_task = asyncio.create_task(
-                    self._settle_and_finish(self._flush_generation)
-                )
-
-    def _enqueue_audio(self, audio_chunk: bytes):
-        """Split audio_chunk into FRAME_SIZE frames and enqueue with current generation."""
-        gen = self._flush_generation
-        offset = 0
-        n = len(audio_chunk)
-        while offset < n:
-            end = min(offset + FRAME_SIZE, n)
-            frame = audio_chunk[offset:end]
-            # Pad last frame to FRAME_SIZE if short (Asterisk expects uniform frames)
-            if len(frame) < FRAME_SIZE:
-                frame = frame + b"\xff" * (FRAME_SIZE - len(frame))
-            self._send_queue.put_nowait((frame, gen))
-            offset = end
-
-    async def _settle_and_finish(self, generation: int):
-        """Wait for Asterisk's retiming buffer to flush, then clear playback state.
-
-        At 1x pacing the Asterisk buffer is at most a few frames deep, so a
-        short constant delay is sufficient — no need to wait for QUEUE_DRAINED.
-        The generation parameter guards against stale finishes after interruption.
+        Since audio is sent in bursts (faster than real-time), Asterisk buffers
+        it and plays at 1x. Playback ends at approximately:
+            first_send_time + total_audio_duration + settle_buffer
         """
+        if self._settle_task:
+            self._settle_task.cancel()
+
+        elapsed = time.monotonic() - self._response_first_send if self._response_first_send else 0
+        remaining = self._response_audio_duration - elapsed
+        delay = max(remaining, 0) + PLAYBACK_SETTLE_S
+
+        self._settle_task = asyncio.create_task(
+            self._settle_and_finish(generation, delay)
+        )
+        logger.info(
+            f"sip-trunk: playback finish in {delay:.2f}s "
+            f"(audio={self._response_audio_duration:.2f}s, elapsed={elapsed:.2f}s)"
+        )
+
+    async def _settle_and_finish(self, generation: int, delay: float):
+        """Wait for estimated playback to complete, then clear playback state."""
         try:
-            await asyncio.sleep(PLAYBACK_SETTLE_S)
+            await asyncio.sleep(delay)
         except asyncio.CancelledError:
             return
         if self._closed or generation != self._flush_generation:
             return
         self._settle_task = None
-        self._finish_playback(reason="send-complete")
+        self._finish_playback(reason="duration-complete")
+
+    def _finish_playback(self, reason: str = "duration-complete") -> None:
+        """Process all pending marks and clear playback state."""
+        if not self.input_handler or not self.input_handler.mark_event_meta_data:
+            return
+        remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
+        logger.info(f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s)")
+        for mid in remaining:
+            self.input_handler.process_mark_message({"name": mid})
+        if self.input_handler.is_audio_being_played_to_user():
+            self.input_handler.update_is_audio_being_played(False)
 
     # ------------------------------------------------------------------
     # Interruption
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
-        """FLUSH_MEDIA, clear queues, increment generation to drop stale frames."""
+        """FLUSH_MEDIA, clear local queue, increment generation to drop stale audio."""
         logger.info("sip-trunk: handling interruption (FLUSH_MEDIA)")
         try:
-            # Cancel any pending settle task
             if self._settle_task:
                 self._settle_task.cancel()
                 self._settle_task = None
 
-            # Increment generation so send loop discards any in-flight frames
             self._flush_generation += 1
             self._pending_finish = False
-
-            # Clear both queues
-            while not self._send_queue.empty():
-                try:
-                    self._send_queue.get_nowait()
-                except asyncio.QueueEmpty:
-                    break
+            self._response_audio_duration = 0.0
+            self._response_first_send = 0.0
             self._local_audio_queue.clear()
 
             await self._send_control("FLUSH_MEDIA")
+            # FLUSH_MEDIA resets Asterisk's buffering state; re-arm for next response
+            self._start_buffering_sent = False
+
             if self.mark_event_meta_data:
                 self.mark_event_meta_data.clear_data()
             if self.input_handler:
@@ -230,31 +162,32 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             logger.error(f"sip-trunk handle_interruption: {e}")
 
     # ------------------------------------------------------------------
-    # XOFF/XON drain
+    # XOFF/XON — backpressure safety for very long responses
     # ------------------------------------------------------------------
 
     async def drain_local_queue(self):
-        """Re-enqueue XOFF-queued audio into the send queue (called on MEDIA_XON)."""
+        """Send XOFF-queued audio to Asterisk (called on MEDIA_XON)."""
         gen = self._flush_generation
         while self._local_audio_queue and not self.queue_full:
+            # Drop stale audio from before an interruption
+            if gen != self._flush_generation:
+                self._local_audio_queue.clear()
+                self._pending_finish = False
+                return
             chunk = self._local_audio_queue.popleft()
             if not chunk:
                 continue
-            # Re-enqueue as individual frames so pacing is maintained
-            offset = 0
-            n = len(chunk)
-            while offset < n:
-                end = min(offset + FRAME_SIZE, n)
-                frame = chunk[offset:end]
-                if len(frame) < FRAME_SIZE:
-                    frame = frame + b"\xff" * (FRAME_SIZE - len(frame))
-                self._send_queue.put_nowait((frame, gen))
-                offset = end
+            try:
+                if self._closed:
+                    return
+                await self.websocket.send_bytes(chunk)
+            except Exception as e:
+                logger.debug(f"sip-trunk drain send_bytes stopped: {e}")
+                return
 
         if not self._local_audio_queue and self._pending_finish:
-            # _pending_finish stays True — the send loop will fire
-            # _settle_and_finish when the re-enqueued frames finish sending.
-            logger.info("sip-trunk: XON drain complete, frames re-enqueued, awaiting send loop drain")
+            self._pending_finish = False
+            self._schedule_finish(self._flush_generation)
 
     # ------------------------------------------------------------------
     # Control helpers
@@ -284,17 +217,15 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     async def set_stream_sid(self, stream_id):
         self.stream_sid = stream_id
 
-    def _duration_ulaw(self, num_bytes):
-        return num_bytes / 8000.0
-
     # ------------------------------------------------------------------
-    # Main handle — enqueue audio into the paced send loop
+    # Main handle — send audio directly to Asterisk (burst, like Plivo)
     # ------------------------------------------------------------------
 
     async def handle(self, ws_data_packet):
         """
-        Enqueue audio into the 1x real-time send loop.
-        START_MEDIA_BUFFERING is sent once per call on first audio.
+        Send audio directly to Asterisk in bursts. Asterisk's START_MEDIA_BUFFERING
+        reframes and retimes for smooth RTP. Server-side duration tracking knows
+        when playback ends.
         """
         try:
             audio_chunk = ws_data_packet.get("data")
@@ -314,6 +245,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
             audio_format = (meta_info.get("format") or "ulaw").lower()
             audio_duration = 0.0
+            gen = self._flush_generation
 
             if has_audio:
                 if len(audio_chunk) == 1:
@@ -327,20 +259,44 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 if meta_info.get("message_category") == "agent_welcome_message" and not self.welcome_message_sent_ts:
                     self.welcome_message_sent_ts = time.time() * 1000
 
-                # Send START_MEDIA_BUFFERING once per call on first audio
+                # New response — reset duration tracking
+                if meta_info.get("is_first_chunk"):
+                    self._response_first_send = 0.0
+                    self._response_audio_duration = 0.0
+                    self._pending_finish = False
+                    if self._settle_task:
+                        self._settle_task.cancel()
+                        self._settle_task = None
+
+                # Send START_MEDIA_BUFFERING once per call (or after FLUSH_MEDIA reset)
                 if not self._start_buffering_sent:
                     await self._send_control("START_MEDIA_BUFFERING")
                     self._start_buffering_sent = True
-                    logger.info("sip-trunk: START_MEDIA_BUFFERING sent (once per call)")
+                    logger.info("sip-trunk: START_MEDIA_BUFFERING sent")
 
-                # Ensure the background send loop is running
-                self._ensure_send_loop()
+                # Track audio duration
+                audio_duration = len(audio_chunk) / 8000.0
+                self._response_audio_duration += audio_duration
 
-                # Enqueue frames — the send loop handles pacing, XOFF, and generation
-                self._enqueue_audio(audio_chunk)
+                # Drop stale audio from a previous generation
+                if gen != self._flush_generation:
+                    return
 
-                audio_duration = self._duration_ulaw(len(audio_chunk))
+                # Send directly to Asterisk (burst, like Plivo/Twilio)
+                if self.queue_full:
+                    self._local_audio_queue.append(audio_chunk)
+                else:
+                    if self._response_first_send == 0.0:
+                        self._response_first_send = time.monotonic()
+                    try:
+                        if self._closed:
+                            return
+                        await self.websocket.send_bytes(audio_chunk)
+                    except Exception as e:
+                        logger.debug(f"sip-trunk send_bytes stopped: {e}")
+                        return
 
+            # Register mark metadata (same as Plivo/Twilio contract)
             if self.mark_event_meta_data:
                 message_category = meta_info.get("message_category", "agent_response")
                 mark_id = meta_info.get("mark_id") or str(uuid.uuid4())
@@ -358,42 +314,17 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 )
 
                 if is_final:
-                    if self._send_queue.qsize() > 0 or self._local_audio_queue:
-                        # Audio still being sent/queued — defer finish
+                    if self._local_audio_queue:
+                        # XOFF queued audio not yet sent — defer finish
                         self._pending_finish = True
-                        logger.debug("sip-trunk: final chunk, audio still in send queue; deferring finish")
+                        logger.debug("sip-trunk: final chunk, XOFF audio pending; deferring finish")
                     else:
-                        # Send queue already empty — finish directly
                         self._pending_finish = False
-                        if self._settle_task:
-                            self._settle_task.cancel()
-                        self._settle_task = asyncio.create_task(
-                            self._settle_and_finish(self._flush_generation)
-                        )
-                        logger.info("sip-trunk: final chunk, send queue empty, settling")
+                        self._schedule_finish(gen)
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
             traceback.print_exc()
-
-    def _finish_playback(self, reason: str = "send-complete") -> None:
-        """Process all pending marks and clear playback state."""
-        if not self.input_handler or not self.input_handler.mark_event_meta_data:
-            return
-        remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
-        logger.info(f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s)")
-        for mid in remaining:
-            self.input_handler.process_mark_message({"name": mid})
-        if self.input_handler.is_audio_being_played_to_user():
-            self.input_handler.update_is_audio_being_played(False)
-
-    async def on_queue_drained(self) -> None:
-        """No-op — QUEUE_DRAINED is informational only at 1x pacing.
-
-        Kept as a stub so the input handler (which may still forward the event)
-        does not raise AttributeError. Task 2 removes the caller.
-        """
-        logger.debug("sip-trunk: QUEUE_DRAINED received (informational, no action)")
 
     async def send_hangup(self):
         await self._send_control("HANGUP")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -2,8 +2,9 @@
 Asterisk WebSocket (chan_websocket) output handler for sip-trunk provider.
 
 Sends ulaw audio at 1x real-time pace (160 bytes / 20ms) via a background send loop.
-START_MEDIA_BUFFERING once at call start; FLUSH_MEDIA on interrupt.
-Generation counter drops stale frames after interruption.
+START_MEDIA_BUFFERING once at call start lets Asterisk retime any micro-jitter.
+FLUSH_MEDIA on interrupt. Generation counter drops stale frames after interruption.
+Playback completion detected when send queue drains after final chunk + settle delay.
 
 Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 """
@@ -29,18 +30,17 @@ FRAME_DURATION_S = 0.02
 # Absorbs TTS jitter so the first frames don't have micro-gaps.
 DEFAULT_JITTER_BUFFER_MS = int(os.environ.get("SIP_JITTER_BUFFER_MS", "40"))
 
-# Small delay after QUEUE_DRAINED for Asterisk's remaining RTP jitter buffer (seconds).
-QUEUE_DRAINED_BUFFER_S = float(os.environ.get("SIP_QUEUE_DRAINED_BUFFER_S", "0.1"))
-
-# Safety timeout if QUEUE_DRAINED is never received (seconds).
-QUEUE_DRAINED_SAFETY_TIMEOUT_S = float(os.environ.get("SIP_QUEUE_DRAINED_TIMEOUT_S", "2.0"))
+# After audio finishes sending at 1x pace, Asterisk needs a small settle time
+# for its internal retiming buffer before we clear is_audio_being_played.
+# 100ms is sufficient — Asterisk's buffer is at most a few frames deep at 1x pace.
+PLAYBACK_SETTLE_S = float(os.environ.get("SIP_PLAYBACK_SETTLE_S", "0.1"))
 
 
 class SipTrunkOutputHandler(TelephonyOutputHandler):
     """
     Sends ulaw audio to Asterisk at 1x real-time pace via a background send loop.
     START_MEDIA_BUFFERING sent once per call. FLUSH_MEDIA on interrupt.
-    MEDIA_XOFF/XON flow control queues audio locally when Asterisk is full.
+    Playback completion via send-loop drain detection + settle delay.
     """
 
     def __init__(
@@ -62,10 +62,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         if input_handler:
             input_handler.output_handler_ref = self
 
-        self._response_audio_duration = 0.0
-        self._playback_done_task = None
-        self._awaiting_queue_drained: bool = False
-        self._report_queue_drained_sent_at: float = 0.0
+        self._settle_task: asyncio.Task | None = None
 
         # Send loop: frames are enqueued as (bytes, generation) tuples and sent at 1x real-time
         self._send_queue: asyncio.Queue = asyncio.Queue()
@@ -76,7 +73,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         # Local queue when Asterisk sends MEDIA_XOFF; drained on MEDIA_XON
         self._local_audio_queue: deque = deque()
         # If is_final arrived while send queue still has frames, defer fallback
-        self._pending_stop_after_drain = False
+        self._pending_finish = False
 
         output_config = self._get_output_config()
         self._output_format = (
@@ -160,17 +157,13 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
             next_send = time.monotonic() + FRAME_DURATION_S
 
-            # If the send queue just drained and we have a pending fallback, fire it
-            if self._send_queue.empty() and self._pending_stop_after_drain and not self._local_audio_queue:
-                self._pending_stop_after_drain = False
-                self._awaiting_queue_drained = True
-                self._report_queue_drained_sent_at = time.time()
-                await self._send_control("REPORT_QUEUE_DRAINED")
-                logger.info(f"sip-trunk: send queue drained, REPORT_QUEUE_DRAINED sent (deferred), audio={self._response_audio_duration:.2f}s")
-                if self._playback_done_task:
-                    self._playback_done_task.cancel()
-                self._playback_done_task = asyncio.create_task(
-                    self._playback_done_fallback()
+            # If the send queue just drained and final chunk was received, finish playback
+            if self._send_queue.empty() and self._pending_finish and not self._local_audio_queue:
+                self._pending_finish = False
+                if self._settle_task:
+                    self._settle_task.cancel()
+                self._settle_task = asyncio.create_task(
+                    self._settle_and_finish(self._flush_generation)
                 )
 
     def _enqueue_audio(self, audio_chunk: bytes):
@@ -187,29 +180,38 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self._send_queue.put_nowait((frame, gen))
             offset = end
 
+    async def _settle_and_finish(self, generation: int):
+        """Wait for Asterisk's retiming buffer to flush, then clear playback state.
+
+        At 1x pacing the Asterisk buffer is at most a few frames deep, so a
+        short constant delay is sufficient — no need to wait for QUEUE_DRAINED.
+        The generation parameter guards against stale finishes after interruption.
+        """
+        try:
+            await asyncio.sleep(PLAYBACK_SETTLE_S)
+        except asyncio.CancelledError:
+            return
+        if self._closed or generation != self._flush_generation:
+            return
+        self._settle_task = None
+        self._finish_playback(reason="send-complete")
+
     # ------------------------------------------------------------------
     # Interruption
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
         """FLUSH_MEDIA, clear queues, increment generation to drop stale frames."""
-        awaiting = self._awaiting_queue_drained
-        elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at and awaiting else 0
-        logger.info(
-            f"sip-trunk: handling interruption (FLUSH_MEDIA), "
-            f"awaiting_queue_drained={awaiting}, audio={self._response_audio_duration:.2f}s"
-            + (f", waited={elapsed:.3f}s" if elapsed else "")
-        )
+        logger.info("sip-trunk: handling interruption (FLUSH_MEDIA)")
         try:
-            if self._playback_done_task:
-                self._playback_done_task.cancel()
-                self._playback_done_task = None
+            # Cancel any pending settle task
+            if self._settle_task:
+                self._settle_task.cancel()
+                self._settle_task = None
 
             # Increment generation so send loop discards any in-flight frames
             self._flush_generation += 1
-            self._response_audio_duration = 0.0
-            self._pending_stop_after_drain = False
-            self._awaiting_queue_drained = False
+            self._pending_finish = False
 
             # Clear both queues
             while not self._send_queue.empty():
@@ -249,17 +251,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 self._send_queue.put_nowait((frame, gen))
                 offset = end
 
-        if not self._local_audio_queue and self._pending_stop_after_drain:
-            self._pending_stop_after_drain = False
-            self._awaiting_queue_drained = True
-            self._report_queue_drained_sent_at = time.time()
-            await self._send_control("REPORT_QUEUE_DRAINED")
-            logger.info(f"sip-trunk: XON drain complete, REPORT_QUEUE_DRAINED sent, audio={self._response_audio_duration:.2f}s")
-            if self._playback_done_task:
-                self._playback_done_task.cancel()
-            self._playback_done_task = asyncio.create_task(
-                self._playback_done_fallback()
-            )
+        if not self._local_audio_queue and self._pending_finish:
+            # _pending_finish stays True — the send loop will fire
+            # _settle_and_finish when the re-enqueued frames finish sending.
+            logger.info("sip-trunk: XON drain complete, frames re-enqueued, awaiting send loop drain")
 
     # ------------------------------------------------------------------
     # Control helpers
@@ -338,10 +333,6 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     self._start_buffering_sent = True
                     logger.info("sip-trunk: START_MEDIA_BUFFERING sent (once per call)")
 
-                # Reset duration tracking at the start of each new response
-                if meta_info.get("is_first_chunk"):
-                    self._response_audio_duration = 0.0
-
                 # Ensure the background send loop is running
                 self._ensure_send_loop()
 
@@ -349,7 +340,6 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 self._enqueue_audio(audio_chunk)
 
                 audio_duration = self._duration_ulaw(len(audio_chunk))
-                self._response_audio_duration += audio_duration
 
             if self.mark_event_meta_data:
                 message_category = meta_info.get("message_category", "agent_response")
@@ -368,103 +358,42 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 )
 
                 if is_final:
-                    total_duration = self._response_audio_duration
-                    # _response_audio_duration is reset on the next new response
-                    # (when _start_buffering_sent logic resets it), not here.
-                    # is_final fires twice per response (last audio chunk +
-                    # null-byte sentinel) and resetting here would replace a
-                    # valid fallback timer with a 0-duration one.
-
                     if self._send_queue.qsize() > 0 or self._local_audio_queue:
-                        # Audio still being sent/queued — defer fallback
-                        self._pending_stop_after_drain = True
-                        logger.debug("sip-trunk: final chunk received, audio still in send queue; deferring fallback")
+                        # Audio still being sent/queued — defer finish
+                        self._pending_finish = True
+                        logger.debug("sip-trunk: final chunk, audio still in send queue; deferring finish")
                     else:
-                        self._awaiting_queue_drained = True
-                        self._report_queue_drained_sent_at = time.time()
-                        await self._send_control("REPORT_QUEUE_DRAINED")
-                        if total_duration > 0 or not self._playback_done_task:
-                            if self._playback_done_task:
-                                self._playback_done_task.cancel()
-                            self._playback_done_task = asyncio.create_task(
-                                self._playback_done_fallback()
-                            )
-                        logger.info(f"sip-trunk: REPORT_QUEUE_DRAINED sent, response audio={total_duration:.2f}s, safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
+                        # Send queue already empty — finish directly
+                        self._pending_finish = False
+                        if self._settle_task:
+                            self._settle_task.cancel()
+                        self._settle_task = asyncio.create_task(
+                            self._settle_and_finish(self._flush_generation)
+                        )
+                        logger.info("sip-trunk: final chunk, send queue empty, settling")
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
             traceback.print_exc()
 
-    def _finish_playback(self, reason: str = "fallback") -> None:
-        """Process all pending marks and clear playback state.
-
-        Delegates to input_handler.process_mark_message() for each mark so
-        that welcome-message detection, hangup observables, latency tracking,
-        and response_heard_by_user all fire — same contract as Plivo/Twilio
-        mark echoes.
-        """
+    def _finish_playback(self, reason: str = "send-complete") -> None:
+        """Process all pending marks and clear playback state."""
         if not self.input_handler or not self.input_handler.mark_event_meta_data:
             return
-        total_elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
         remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
-        logger.info(
-            f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s), "
-            f"audio={self._response_audio_duration:.2f}s, elapsed_since_report={total_elapsed:.3f}s"
-        )
+        logger.info(f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s)")
         for mid in remaining:
             self.input_handler.process_mark_message({"name": mid})
-        # Safety: if process_mark_message didn't clear it (e.g., no final mark
-        # registered), force-clear so the flag doesn't stay stuck True.
         if self.input_handler.is_audio_being_played_to_user():
             self.input_handler.update_is_audio_being_played(False)
 
     async def on_queue_drained(self) -> None:
-        """Called when Asterisk sends QUEUE_DRAINED — audio consumed for RTP.
+        """No-op — QUEUE_DRAINED is informational only at 1x pacing.
 
-        Cancels the safety fallback and clears playback state after a short
-        buffer for the remaining RTP jitter.
+        Kept as a stub so the input handler (which may still forward the event)
+        does not raise AttributeError. Task 2 removes the caller.
         """
-        if not self._awaiting_queue_drained:
-            logger.debug("sip-trunk: ignoring spurious/duplicate QUEUE_DRAINED")
-            return
-        queue_drained_latency = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
-        logger.info(
-            f"sip-trunk: QUEUE_DRAINED received {queue_drained_latency:.3f}s after REPORT_QUEUE_DRAINED, "
-            f"audio={self._response_audio_duration:.2f}s, adding {QUEUE_DRAINED_BUFFER_S}s jitter buffer"
-        )
-        self._awaiting_queue_drained = False
-
-        if self._playback_done_task:
-            self._playback_done_task.cancel()
-            self._playback_done_task = None
-
-        # Small sleep for Asterisk's RTP jitter buffer, then clear
-        try:
-            await asyncio.sleep(QUEUE_DRAINED_BUFFER_S)
-        except asyncio.CancelledError:
-            return
-
-        if self._closed:
-            return
-        self._finish_playback(reason="QUEUE_DRAINED")
-
-    async def _playback_done_fallback(self):
-        """Safety timeout: clear playback state if QUEUE_DRAINED never arrives."""
-        try:
-            await asyncio.sleep(QUEUE_DRAINED_SAFETY_TIMEOUT_S)
-        except asyncio.CancelledError:
-            return
-        self._playback_done_task = None
-        if self._closed:
-            return
-        if self._awaiting_queue_drained:
-            elapsed = time.time() - self._report_queue_drained_sent_at if self._report_queue_drained_sent_at else 0
-            logger.warning(
-                f"sip-trunk: QUEUE_DRAINED not received within {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s, "
-                f"audio={self._response_audio_duration:.2f}s, elapsed={elapsed:.3f}s — using safety fallback"
-            )
-            self._awaiting_queue_drained = False
-        self._finish_playback(reason="safety-timeout")
+        logger.debug("sip-trunk: QUEUE_DRAINED received (informational, no action)")
 
     async def send_hangup(self):
         await self._send_control("HANGUP")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -32,6 +32,12 @@ DEFAULT_JITTER_BUFFER_MS = int(os.environ.get("SIP_JITTER_BUFFER_MS", "40"))
 # Fallback timer buffer after expected playback duration (seconds).
 DEFAULT_FALLBACK_BUFFER_S = float(os.environ.get("SIP_FALLBACK_BUFFER_S", "0.1"))
 
+# Small delay after QUEUE_DRAINED for Asterisk's remaining RTP jitter buffer (seconds).
+QUEUE_DRAINED_BUFFER_S = float(os.environ.get("SIP_QUEUE_DRAINED_BUFFER_S", "0.1"))
+
+# Safety timeout if QUEUE_DRAINED is never received (seconds).
+QUEUE_DRAINED_SAFETY_TIMEOUT_S = float(os.environ.get("SIP_QUEUE_DRAINED_TIMEOUT_S", "2.0"))
+
 
 class SipTrunkOutputHandler(TelephonyOutputHandler):
     """
@@ -61,6 +67,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
         self._response_audio_duration = 0.0
         self._playback_done_task = None
+        self._awaiting_queue_drained: bool = False
 
         # Send loop: frames are enqueued as (bytes, generation) tuples and sent at 1x real-time
         self._send_queue: asyncio.Queue = asyncio.Queue()
@@ -160,6 +167,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             # If the send queue just drained and we have a pending fallback, fire it
             if self._send_queue.empty() and self._pending_stop_after_drain and not self._local_audio_queue:
                 self._pending_stop_after_drain = False
+                self._awaiting_queue_drained = True
                 await self._send_control("REPORT_QUEUE_DRAINED")
                 duration = self._pending_stop_duration
                 category = self._pending_stop_category
@@ -199,6 +207,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self._flush_generation += 1
             self._response_audio_duration = 0.0
             self._pending_stop_after_drain = False
+            self._awaiting_queue_drained = False
 
             # Clear both queues
             while not self._send_queue.empty():
@@ -240,6 +249,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
         if not self._local_audio_queue and self._pending_stop_after_drain:
             self._pending_stop_after_drain = False
+            self._awaiting_queue_drained = True
             await self._send_control("REPORT_QUEUE_DRAINED")
             duration = self._pending_stop_duration
             category = self._pending_stop_category
@@ -370,6 +380,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                         self._pending_stop_category = message_category
                         logger.debug("sip-trunk: final chunk received, audio still in send queue; deferring fallback")
                     else:
+                        self._awaiting_queue_drained = True
                         await self._send_control("REPORT_QUEUE_DRAINED")
                         if total_duration > 0 or not self._playback_done_task:
                             if self._playback_done_task:
@@ -377,29 +388,70 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                             self._playback_done_task = asyncio.create_task(
                                 self._playback_done_fallback(total_duration, message_category)
                             )
-                        logger.debug(f"sip-trunk: response done, fallback in {total_duration + DEFAULT_FALLBACK_BUFFER_S:.1f}s")
+                        logger.debug(f"sip-trunk: response done, safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
             traceback.print_exc()
 
-    async def _playback_done_fallback(self, duration: float, message_category: str):
-        """Mark playback done after expected duration + buffer. Process pending marks."""
-        try:
-            await asyncio.sleep(duration + DEFAULT_FALLBACK_BUFFER_S)
-        except asyncio.CancelledError:
-            return
-        self._playback_done_task = None
+    def _finish_playback(self, reason: str = "fallback") -> None:
+        """Process all pending marks and clear playback state.
+
+        Delegates to input_handler.process_mark_message() for each mark so
+        that welcome-message detection, hangup observables, latency tracking,
+        and response_heard_by_user all fire — same contract as Plivo/Twilio
+        mark echoes.
+        """
         if not self.input_handler or not self.input_handler.mark_event_meta_data:
             return
         remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
-        if not remaining:
-            return
-        logger.info(f"sip-trunk: playback-done fallback ({duration:.2f}s), processing {len(remaining)} mark(s)")
-        self.input_handler.update_is_audio_being_played(False)
+        if remaining:
+            logger.info(
+                f"sip-trunk: playback done ({reason}), processing {len(remaining)} mark(s)"
+            )
         for mid in remaining:
-            md = self.input_handler.mark_event_meta_data.mark_event_meta_data.get(mid, {})
-            self.input_handler.process_mark_message({"name": mid, "type": md.get("type", message_category)})
+            self.input_handler.process_mark_message({"name": mid})
+        # Safety: if process_mark_message didn't clear it (e.g., no final mark
+        # registered), force-clear so the flag doesn't stay stuck True.
+        if self.input_handler.is_audio_being_played_to_user():
+            self.input_handler.update_is_audio_being_played(False)
+
+    async def on_queue_drained(self) -> None:
+        """Called when Asterisk sends QUEUE_DRAINED — audio consumed for RTP.
+
+        Cancels the safety fallback and clears playback state after a short
+        buffer for the remaining RTP jitter.
+        """
+        if not self._awaiting_queue_drained:
+            return  # Spurious or duplicate QUEUE_DRAINED
+        self._awaiting_queue_drained = False
+
+        if self._playback_done_task:
+            self._playback_done_task.cancel()
+            self._playback_done_task = None
+
+        # Small sleep for Asterisk's RTP jitter buffer, then clear
+        try:
+            await asyncio.sleep(QUEUE_DRAINED_BUFFER_S)
+        except asyncio.CancelledError:
+            return
+
+        self._finish_playback(reason="QUEUE_DRAINED")
+
+    async def _playback_done_fallback(self, duration: float, message_category: str):
+        """Safety timeout: clear playback state if QUEUE_DRAINED never arrives."""
+        try:
+            await asyncio.sleep(QUEUE_DRAINED_SAFETY_TIMEOUT_S)
+        except asyncio.CancelledError:
+            return
+        self._playback_done_task = None
+        if self._awaiting_queue_drained:
+            logger.warning(
+                f"sip-trunk: QUEUE_DRAINED not received within "
+                f"{QUEUE_DRAINED_SAFETY_TIMEOUT_S}s, using safety fallback"
+            )
+            self._awaiting_queue_drained = False
+        self._finish_playback(reason="safety-timeout")
 
     async def send_hangup(self):
         await self._send_control("HANGUP")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -29,9 +29,6 @@ FRAME_DURATION_S = 0.02
 # Absorbs TTS jitter so the first frames don't have micro-gaps.
 DEFAULT_JITTER_BUFFER_MS = int(os.environ.get("SIP_JITTER_BUFFER_MS", "40"))
 
-# Fallback timer buffer after expected playback duration (seconds).
-DEFAULT_FALLBACK_BUFFER_S = float(os.environ.get("SIP_FALLBACK_BUFFER_S", "0.1"))
-
 # Small delay after QUEUE_DRAINED for Asterisk's remaining RTP jitter buffer (seconds).
 QUEUE_DRAINED_BUFFER_S = float(os.environ.get("SIP_QUEUE_DRAINED_BUFFER_S", "0.1"))
 
@@ -79,8 +76,6 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         self._local_audio_queue: deque = deque()
         # If is_final arrived while send queue still has frames, defer fallback
         self._pending_stop_after_drain = False
-        self._pending_stop_duration = 0.0
-        self._pending_stop_category = "agent_response"
 
         output_config = self._get_output_config()
         self._output_format = (
@@ -169,12 +164,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 self._pending_stop_after_drain = False
                 self._awaiting_queue_drained = True
                 await self._send_control("REPORT_QUEUE_DRAINED")
-                duration = self._pending_stop_duration
-                category = self._pending_stop_category
                 if self._playback_done_task:
                     self._playback_done_task.cancel()
                 self._playback_done_task = asyncio.create_task(
-                    self._playback_done_fallback(duration, category)
+                    self._playback_done_fallback()
                 )
 
     def _enqueue_audio(self, audio_chunk: bytes):
@@ -251,12 +244,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self._pending_stop_after_drain = False
             self._awaiting_queue_drained = True
             await self._send_control("REPORT_QUEUE_DRAINED")
-            duration = self._pending_stop_duration
-            category = self._pending_stop_category
             if self._playback_done_task:
                 self._playback_done_task.cancel()
             self._playback_done_task = asyncio.create_task(
-                self._playback_done_fallback(duration, category)
+                self._playback_done_fallback()
             )
 
     # ------------------------------------------------------------------
@@ -376,8 +367,6 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     if self._send_queue.qsize() > 0 or self._local_audio_queue:
                         # Audio still being sent/queued — defer fallback
                         self._pending_stop_after_drain = True
-                        self._pending_stop_duration = total_duration
-                        self._pending_stop_category = message_category
                         logger.debug("sip-trunk: final chunk received, audio still in send queue; deferring fallback")
                     else:
                         self._awaiting_queue_drained = True
@@ -386,9 +375,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                             if self._playback_done_task:
                                 self._playback_done_task.cancel()
                             self._playback_done_task = asyncio.create_task(
-                                self._playback_done_fallback(total_duration, message_category)
+                                self._playback_done_fallback()
                             )
-                        logger.debug(f"sip-trunk: response done, safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
+                        logger.debug(f"sip-trunk: response done ({total_duration:.2f}s audio), safety fallback in {QUEUE_DRAINED_SAFETY_TIMEOUT_S}s")
 
         except Exception as e:
             logger.error(f"sip-trunk output error: {e}")
@@ -436,19 +425,24 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         except asyncio.CancelledError:
             return
 
+        if self._closed:
+            return
         self._finish_playback(reason="QUEUE_DRAINED")
 
-    async def _playback_done_fallback(self, duration: float, message_category: str):
+    async def _playback_done_fallback(self):
         """Safety timeout: clear playback state if QUEUE_DRAINED never arrives."""
         try:
             await asyncio.sleep(QUEUE_DRAINED_SAFETY_TIMEOUT_S)
         except asyncio.CancelledError:
             return
         self._playback_done_task = None
+        if self._closed:
+            return
         if self._awaiting_queue_drained:
             logger.warning(
                 f"sip-trunk: QUEUE_DRAINED not received within "
-                f"{QUEUE_DRAINED_SAFETY_TIMEOUT_S}s, using safety fallback"
+                f"{QUEUE_DRAINED_SAFETY_TIMEOUT_S}s (audio duration {self._response_audio_duration:.2f}s), "
+                f"using safety fallback"
             )
             self._awaiting_queue_drained = False
         self._finish_playback(reason="safety-timeout")


### PR DESCRIPTION
This pull request improves the reliability and correctness of playback completion handling for the SIP trunk telephony provider, especially around the detection and processing of the `QUEUE_DRAINED` event from Asterisk. The changes ensure that playback state is only cleared after all audio has been sent and consumed, matching the contract of other providers and reducing the risk of premature hangup or missed events.

Key changes include:

**Playback Completion Handling Improvements:**

* Introduced a new method `on_queue_drained` in `SipTrunkOutputHandler` to process the `QUEUE_DRAINED` event from Asterisk, adding a configurable buffer to account for RTP jitter before clearing playback state and processing any pending marks. This ensures playback is only considered complete after all audio has been consumed by the network.
* Updated the input handler (`_on_drain_done`) to forward `QUEUE_DRAINED` events to the output handler, which now manages the timing and state transitions for playback completion.

**Safety and Robustness Enhancements:**

* Added a safety timeout (`QUEUE_DRAINED_SAFETY_TIMEOUT_S`) to ensure playback state is eventually cleared if the `QUEUE_DRAINED` event is never received, preventing the system from getting stuck in a playback state. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R35-R40) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R383-R454)
* The fallback mechanism for playback completion now uses the safety timeout instead of relying on the expected audio duration, making the behavior more robust to network or signaling issues.

**State Management and Code Organization:**

* Introduced the `_awaiting_queue_drained` flag to track whether the system is waiting for a `QUEUE_DRAINED` event, preventing duplicate or spurious processing. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R70) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R170) [[3]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R252) [[4]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R210) [[5]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R383-R454)
* Refactored mark processing and playback state clearing into a dedicated `_finish_playback` method, ensuring consistent handling whether playback completes normally or via the safety fallback.

**Configuration and Defaults:**

* Added environment-configurable constants for the RTP jitter buffer delay (`SIP_QUEUE_DRAINED_BUFFER_S`) and the safety timeout (`SIP_QUEUE_DRAINED_TIMEOUT_S`), allowing tuning without code changes.