### PR TITLE
fix: handle large WebSocket frames in SipTrunkOutputHandler 

### DIFF
--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -62,6 +62,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         self._response_audio_duration: float = 0.0  # accumulated seconds of audio
         self._settle_task: asyncio.Task | None = None
         self._pending_finish: bool = False
+        self._current_sequence_id: int | None = None  # track sequence to detect new responses
 
         # Generation counter — incremented on interruption, stale audio is dropped
         self._flush_generation: int = 0
@@ -152,6 +153,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self._pending_finish = False
             self._response_audio_duration = 0.0
             self._response_first_send = 0.0
+            self._current_sequence_id = None
             self._local_audio_queue.clear()
 
             await self._send_control("FLUSH_MEDIA")
@@ -271,8 +273,14 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 if meta_info.get("message_category") == "agent_welcome_message" and not self.welcome_message_sent_ts:
                     self.welcome_message_sent_ts = time.time() * 1000
 
-                # New response — reset duration tracking
-                if meta_info.get("is_first_chunk"):
+                # New response — reset duration tracking only when sequence_id
+                # actually changes.  ElevenLabs may spuriously set is_first_chunk
+                # on every chunk after the LLM stream ends, which would repeatedly
+                # reset the audio-duration accumulator and make the server think
+                # playback finishes far earlier than it actually does.
+                seq_id = meta_info.get("sequence_id")
+                if seq_id is not None and seq_id != self._current_sequence_id:
+                    self._current_sequence_id = seq_id
                     self._response_first_send = 0.0
                     self._response_audio_duration = 0.0
                     self._pending_finish = False

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -188,6 +188,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     return
                 offset = 0
                 while offset < len(chunk):
+                    if gen != self._flush_generation:
+                        self._local_audio_queue.clear()
+                        self._pending_finish = False
+                        return
                     if self.queue_full:
                         # XOFF arrived mid-drain — put remainder back and stop
                         self._local_audio_queue.appendleft(chunk[offset:])
@@ -304,7 +308,8 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
                 # Send to Asterisk in chunks ≤ MAX_WS_FRAME_BYTES (Asterisk limit: 65,500).
                 # If XOFF arrives mid-send, queue the remainder locally.
-                if self.queue_full:
+                # Also queue if drain is still in-flight to preserve ordering.
+                if self.queue_full or self._local_audio_queue:
                     self._local_audio_queue.append(audio_chunk)
                 else:
                     if self._response_first_send == 0.0:

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -198,6 +198,8 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                         return
                     end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
                     await self.websocket.send_bytes(chunk[offset:end])
+                    if self._response_first_send == 0.0:
+                        self._response_first_send = time.monotonic()
                     offset = end
             except Exception as e:
                 logger.debug(f"sip-trunk drain send_bytes stopped: {e}")

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -23,6 +23,10 @@ from dotenv import load_dotenv
 logger = configure_logger(__name__)
 load_dotenv()
 
+# Asterisk's max WebSocket frame size is 65,500 bytes. Chunks larger than this
+# cause "Cannot fit huge websocket frame" and kill the connection.
+MAX_WS_FRAME_BYTES = 60000  # leave headroom below 65,500
+
 # Extra buffer after estimated playback end before clearing is_audio_being_played.
 # Accounts for Asterisk's internal retiming and RTP jitter buffer.
 PLAYBACK_SETTLE_S = float(os.environ.get("SIP_PLAYBACK_SETTLE_S", "0.1"))
@@ -180,7 +184,15 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             try:
                 if self._closed:
                     return
-                await self.websocket.send_bytes(chunk)
+                offset = 0
+                while offset < len(chunk):
+                    if self.queue_full:
+                        # XOFF arrived mid-drain — put remainder back and stop
+                        self._local_audio_queue.appendleft(chunk[offset:])
+                        return
+                    end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
+                    await self.websocket.send_bytes(chunk[offset:end])
+                    offset = end
             except Exception as e:
                 logger.debug(f"sip-trunk drain send_bytes stopped: {e}")
                 return
@@ -282,7 +294,8 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 if gen != self._flush_generation:
                     return
 
-                # Send directly to Asterisk (burst, like Plivo/Twilio)
+                # Send to Asterisk in chunks ≤ MAX_WS_FRAME_BYTES (Asterisk limit: 65,500).
+                # If XOFF arrives mid-send, queue the remainder locally.
                 if self.queue_full:
                     self._local_audio_queue.append(audio_chunk)
                 else:
@@ -291,7 +304,15 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     try:
                         if self._closed:
                             return
-                        await self.websocket.send_bytes(audio_chunk)
+                        offset = 0
+                        while offset < len(audio_chunk):
+                            if self.queue_full:
+                                # XOFF arrived mid-send — queue remainder at front
+                                self._local_audio_queue.appendleft(audio_chunk[offset:])
+                                break
+                            end = min(offset + MAX_WS_FRAME_BYTES, len(audio_chunk))
+                            await self.websocket.send_bytes(audio_chunk[offset:end])
+                            offset = end
                     except Exception as e:
                         logger.debug(f"sip-trunk send_bytes stopped: {e}")
                         return


### PR DESCRIPTION
This pull request addresses a critical issue with sending large audio frames over WebSocket to Asterisk by introducing chunking to respect Asterisk's maximum frame size. It also improves the reliability of response tracking by using a sequence ID to avoid incorrect resets in audio duration tracking, and enhances queue management for audio data. The most important changes are:

**WebSocket Frame Size Handling:**
* Introduced `MAX_WS_FRAME_BYTES` (set to 60,000 bytes) to ensure that audio data sent over WebSocket does not exceed Asterisk's maximum frame size, preventing connection-killing errors. Sending logic in both `drain_local_queue` and direct send paths now splits audio into appropriately sized chunks. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R26-R29) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L183-R201) [[3]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L285-R328)

**Audio Queue Management:**
* Updated audio sending logic to handle partial sends: if the queue becomes full or an XOFF is received mid-send, the remainder of the audio chunk is queued for later, ensuring no data is lost and playback order is preserved. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L183-R201) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L285-R328)

**Response Tracking Improvements:**
* Now uses `sequence_id` from metadata to detect new responses, rather than relying solely on `is_first_chunk`. This prevents incorrect resets of audio duration tracking due to spurious `is_first_chunk` flags, especially with ElevenLabs. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R65) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L262-R287)
* Resets `_current_sequence_id` on interruption to ensure correct state after a flush.