### PR TITLE
fix: replace broken examples.bolna.dev links with local examples/ directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once the docker containers are up, you can now start to create your agents and i
 
 
 ## Example agents to create, use and start making calls
-You may try out different agents from [example.bolna.dev](https://examples.bolna.dev).
+You may try out different agents from the [examples/](examples/) directory (e.g., `simple_assistant.py`, `text_only_assistant.py`).
 
 ## Programmatic usage (minimal example)
 

--- a/local_setup/README.md
+++ b/local_setup/README.md
@@ -54,4 +54,4 @@ Once the docker containers are up, you can now start to create your agents and i
 
 
 ## Example agents to create, use and start making calls
-Go to the [Bolna examples](https://examples.bolna.dev/) to try out sample agents.
+Check out the [examples/](../examples/) directory (e.g., `simple_assistant.py`, `text_only_assistant.py`) to try out sample agents.


### PR DESCRIPTION
## Summary

- Replaces broken `examples.bolna.dev` links in `README.md` and `local_setup/README.md` with relative links to the `examples/` directory in the repo
- Using repo-relative links prevents this from breaking again in the future

## Context

I previously reported this same broken link in #398, which was fixed and closed. The link has since broken again (#553). Rather than fixing the URL, this PR points to the in-repo `examples/` directory so it won't regress.

Fixes #553
Related: #398