### PR TITLE
fix(security): remove dangerous exec() in legacy function calling path

### DIFF
--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -87,8 +87,6 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
                     for k, v in kwargs.items()
                 }
 
-                code = compile(param % json_kwargs, "<string>", "exec")
-                exec(code, globals(), json_kwargs)
                 request_body = param % json_kwargs
                 api_params = json.loads(request_body)
 


### PR DESCRIPTION
## Summary

- Removes `compile()` + `exec()` calls from the legacy string-template code path in `function_calling_helpers.py`
- The `exec` was unnecessary — `param % json_kwargs` on the following line already produces the correct `request_body`
- The `exec` posed a security risk if the template string or kwargs contained untrusted input (e.g., from LLM output)

## What changed

**Before (lines 90-92):**
```python
code = compile(param % json_kwargs, "<string>", "exec")
exec(code, globals(), json_kwargs)
request_body = param % json_kwargs
```

**After:**
```python
request_body = param % json_kwargs
```

The new `$var` marker substitution system (already in the same function) is the recommended safe path. This just cleans up the legacy fallback.

## Test plan

- [ ] Verify existing function calling tests pass
- [ ] Test legacy `%(field)s` style param templates still produce correct API payloads

Fixes #407