### PR TITLE
fix: clear stale end_of_llm_stream to prevent speech truncation after language switch

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1816,6 +1816,10 @@ class TaskManager(BaseManager):
             logger.info(f"__do_llm_generation: Skipping — hangup_triggered={self.hangup_triggered}, conversation_ended={self.conversation_ended}")
             return
 
+        # Clear stale end_of_llm_stream from previous generation so only
+        # the final chunk of THIS generation carries the flag.
+        meta_info.pop("end_of_llm_stream", None)
+
         # Reset response tracking for new turn
         if self.generate_precise_transcript:
             self.tools["input"].reset_response_heard_by_user()


### PR DESCRIPTION
## Summary
- After a language switch, `__do_llm_generation` was called with `meta_info` that still had `end_of_llm_stream: True` from the previous LLM turn
- This caused every text chunk sent to the synthesizer (Cartesia/ElevenLabs/Deepgram/etc.) to carry `end_of_llm_stream=True`, sending premature end-of-stream signals after each chunk
- The synthesizer would close the context after the first chunk, causing subsequent chunks to be dropped — agent stops speaking midway
- Fix: `meta_info.pop("end_of_llm_stream", None)` at the start of `__do_llm_generation` ensures each generation starts clean