### PR TITLE
refactor: use append_assistant for check_user_online history entry

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2880,7 +2880,7 @@ class TaskManager(BaseManager):
                     else:
                         meta_info={'io': self.tools["output"].get_provider(), "request_id": str(uuid.uuid4()), "cached": False, "sequence_id": -1, 'format': 'pcm', "message_category": "is_user_online_message", 'end_of_llm_stream': True}
                         await self._synthesize(create_ws_data_packet(user_online_message, meta_info= meta_info))
-                    self.history.append({'role': 'assistant', 'content': user_online_message, 'exclude_from_llm': True})
+                    self.conversation_history.append_assistant(user_online_message, exclude_from_llm=True)
 
                 # Just in case we need to clear messages sent before
                 await self.tools["output"].handle_interruption()

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -27,8 +27,8 @@ class ConversationHistory:
     def append_user(self, content: str):
         self._messages.append({"role": ChatRole.USER, "content": content})
 
-    def append_assistant(self, content: str, tool_calls: list | None = None):
-        msg = {"role": ChatRole.ASSISTANT, "content": content}
+    def append_assistant(self, content: str, tool_calls: list | None = None, **kwargs):
+        msg = {"role": ChatRole.ASSISTANT, "content": content, **kwargs}
         if tool_calls is not None:
             msg["tool_calls"] = tool_calls
         self._messages.append(msg)


### PR DESCRIPTION
## Summary
- Adds `**kwargs` support to `ConversationHistory.append_assistant()` so extra flags like `exclude_from_llm` can be passed cleanly
- Replaces raw `self.history.append(...)` with `self.conversation_history.append_assistant(...)` for the check_user_online message, consistent with the rest of the codebase