### PR TITLE
fix: reset is_transcript_sent_for_processing on SpeechStarted to prevent audio deadlock

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2849,7 +2849,7 @@ class TaskManager(BaseManager):
                         logger.info(f"Waiting for hangup mark event ({time_since_hangup:.1f}s / {self.hangup_mark_event_timeout}s)")
                 continue
 
-            if self.tools["input"].is_audio_being_played_to_user():
+            if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
                 continue
 
             time_since_last_spoken_ai_word = (time.time() - self.last_transmitted_timestamp)

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -60,7 +60,6 @@ class AssemblyAITranscriber(BaseTranscriber):
         # Message states for turn management
         self.session_id = None
         self.current_transcript = ""
-        self.is_transcript_sent_for_processing = False
         self.websocket_connection = None
         self.connection_authenticated = False
         self.current_turn_start_time = None

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -22,6 +22,7 @@ class BaseTranscriber:
         self.connection_time = None
         self.turn_latencies = []
         self.connection_error = None
+        self.is_transcript_sent_for_processing = False
 
     def update_meta_info(self):
         self.meta_info['request_id'] = self.current_request_id if self.current_request_id else None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -69,7 +69,6 @@ class DeepgramTranscriber(BaseTranscriber):
         self.curr_message = ''
         self.finalized_transcript = ""
         self.final_transcript = ""
-        self.is_transcript_sent_for_processing = False
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.websocket_connection = None
@@ -450,6 +449,7 @@ class DeepgramTranscriber(BaseTranscriber):
                     self.current_turn_id = self.turn_counter
                     self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
+                    self.is_transcript_sent_for_processing = False
 
                     logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                     yield create_ws_data_packet("speech_started", self.meta_info)

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -67,7 +67,6 @@ class ElevenLabsTranscriber(BaseTranscriber):
         self.curr_message = ''
         self.finalized_transcript = ""
         self.final_transcript = ""
-        self.is_transcript_sent_for_processing = False
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.websocket_connection = None

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -106,7 +106,6 @@ class GladiaTranscriber(BaseTranscriber):
         # Transcript state management
         self.current_transcript = ""
         self.final_transcript = ""
-        self.is_transcript_sent_for_processing = False
         self.interruption_signalled = False
 
         # Turn tracking

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -88,7 +88,6 @@ class PixaTranscriber(BaseTranscriber):
         self.turn_first_result_latency = None
 
         # Since Pixa has no VAD, use is_final-based turn detection
-        self.is_transcript_sent_for_processing = False
         self.last_interim_time = None
         self.interim_timeout = kwargs.get("interim_timeout", 5.0)  # Default 5 seconds
 

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -86,7 +86,6 @@ class SarvamTranscriber(BaseTranscriber):
         self.turn_counter = 0
         self.turn_first_result_latency = None
         
-        self.is_transcript_sent_for_processing = False
         self.curr_message = ''
         self.finalized_transcript = ""
         self.interruption_signalled = False

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -95,7 +95,6 @@ class SmallestTranscriber(BaseTranscriber):
 
         # Transcript state management
         self.final_transcript = ""
-        self.is_transcript_sent_for_processing = False
         self.interruption_signalled = False
 
         # Turn tracking


### PR DESCRIPTION
## Problem

Agent stops producing audio output mid-call (audio deadlock). Root cause traced across few production calls:

1. **Phantom SpeechStarted turns**: Deepgram fires `SpeechStarted` for noise/echo but never sends `speech_final`/`UtteranceEnd`. The `is_transcript_sent_for_processing` flag stays stale `True` from the previous turn, preventing `monitor_utterance_timeout` from force-finalizing the stuck turn. This leaves `callee_speaking=True` forever → audio WAIT loop never resolves.

2. **check_user_online fires during pending LLM**: `__check_for_completion` only checked `is_audio_being_played_to_user()`, not whether an LLM response was still being generated/synthesized.

## Changes

- **deepgram_transcriber.py**: Reset `is_transcript_sent_for_processing = False` in `SpeechStarted` handler. This allows the existing `monitor_utterance_timeout` (5s safety net) to catch phantom turns and force-finalize them.

- **task_manager.py**: Add `response_in_pipeline` check in `__check_for_completion` to prevent "Hey, can you hear me?" while LLM is still generating.