### PR TITLE
fix: deduplicate sentry error logging across voice pipeline

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2101,13 +2101,10 @@ class TaskManager(BaseManager):
                 logger.error("unsupported task type: {}".format(self.task_config["task_type"]))
             self.llm_task = None
         except BolnaComponentError as e:
-            logger.error(f"Component error in llm: {e}", exc_info=True)
             self.response_in_pipeline = False
             await self._end_call_on_component_error(e, HangupReason.LLM_ERROR)
             raise
         except Exception as e:
-            traceback.print_exc()
-            logger.error(f"Something went wrong in llm: {e}")
             self.response_in_pipeline = False
             await self._end_call_on_component_error(
                 LLMError(str(e), provider=self.llm_config.get("provider", "unknown"), model=self.llm_config.get("model")),
@@ -2227,7 +2224,6 @@ class TaskManager(BaseManager):
 
         # Trigger graceful shutdown
         if not self.conversation_ended and not self._end_of_conversation_in_progress:
-            logger.error(f"Critical component failure, ending call: {hangup_detail} - {error}")
             self.hangup_detail = hangup_detail
             await self.__process_end_of_conversation()
 
@@ -2399,8 +2395,6 @@ class TaskManager(BaseManager):
             # Normal WebSocket closure (code 1000)
             pass
         except Exception as e:
-            traceback.print_exc()
-            logger.error(f"Error in transcriber {e}")
             provider = self.task_config["tools_config"]["transcriber"].get("provider")
             await self._end_call_on_component_error(
                 TranscriberError(str(e), provider=provider),
@@ -2557,7 +2551,6 @@ class TaskManager(BaseManager):
                     self._turn_audio_flushed.set()
                     break
                 except Exception as e:
-                    logger.error(f"Error in synthesizer: {e}", exc_info=True)
                     self._turn_audio_flushed.set()
                     await self._end_call_on_component_error(
                         SynthesizerError(str(e), provider=self.synthesizer_provider),
@@ -2571,7 +2564,6 @@ class TaskManager(BaseManager):
             logger.info("Synthesizer task cancelled outside loop.")
             #await self.handle_cancellation("Synthesizer task was cancelled outside loop.")
         except Exception as e:
-            logger.error(f"Unexpected error in __listen_synthesizer: {e}", exc_info=True)
             await self._end_call_on_component_error(
                 SynthesizerError(str(e), provider=self.synthesizer_provider),
                 HangupReason.SYNTHESIZER_ERROR
@@ -3067,12 +3059,11 @@ class TaskManager(BaseManager):
                         self.ambient_noise_task = asyncio.create_task(self.__start_transmitting_ambient_noise())
                 try:
                     await asyncio.gather(*tasks)
-                except asyncio.CancelledError as e:
-                    logger.error(f'task got cancelled {e}')
-                    traceback.print_exc()
+                except asyncio.CancelledError:
+                    pass
                 except Exception as e:
-                    traceback.print_exc()
-                    logger.error(f"Error: {e}")
+                    if not isinstance(e, BolnaComponentError):
+                        logger.error(f"Error: {e}")
                     if self.run_id and not self._error_logged:
                         if isinstance(e, BolnaComponentError):
                             error_msg = format_error_message(e.component, e.provider or e.model or "-", str(e))
@@ -3122,7 +3113,6 @@ class TaskManager(BaseManager):
                 except BolnaComponentError:
                     raise
                 except Exception as e:
-                    logger.error(f"Could not do llm call: {e}")
                     raise
 
         except asyncio.CancelledError as e:
@@ -3134,8 +3124,8 @@ class TaskManager(BaseManager):
         except Exception as e:
             # Cancel all tasks on error
             error_message = str(e)
-            logger.error(f"Exception in task manager run: {error_message}")
-            traceback.print_exc()
+            if not isinstance(e, BolnaComponentError):
+                logger.error(f"Exception in task manager run: {error_message}")
 
             # Log call-breaking exception to CSV trace with component attribution (skip if already logged)
             if self.run_id and not self._error_logged:

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -697,7 +697,7 @@ async def process_task_cancellation(asyncio_task, task_name):
         except asyncio.CancelledError:
             logger.info(f"{task_name} has been successfully cancelled.")
         except Exception as e:
-            logger.error(f"Error cancelling {task_name}: {e}")
+            logger.warning(f"Error cancelling {task_name}: {e}")
 
 
 def get_date_time_from_timezone(timezone):

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -464,7 +464,7 @@ class DeepgramSynthesizer(BaseSynthesizer):
             except asyncio.CancelledError:
                 logger.info("Deepgram sender task was successfully cancelled during cleanup.")
             except Exception as e:
-                logger.error(f"Error cancelling sender task: {e}")
+                logger.warning(f"Error cancelling sender task: {e}")
 
         if self.websocket_holder["websocket"]:
             try:

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -396,7 +396,7 @@ class PixaSynthesizer(BaseSynthesizer):
             except asyncio.CancelledError:
                 logger.info("Sender task was successfully cancelled during WebSocket cleanup.")
             except Exception as e:
-                logger.error(f"Error cancelling sender task: {e}")
+                logger.warning(f"Error cancelling sender task: {e}")
 
         try:
             if self.websocket_holder["websocket"]:

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -168,7 +168,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"AssemblyAI {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling AssemblyAI {task_name}: {e}")
+                    logger.warning(f"Error cancelling AssemblyAI {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -365,7 +365,7 @@ class AzureTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Azure {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Azure {task_name}: {e}")
+                    logger.warning(f"Error cancelling Azure {task_name}: {e}")
 
         # Run sync cleanup in executor to not block event loop
         loop = asyncio.get_event_loop()

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -308,7 +308,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Deepgram {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Deepgram {task_name}: {e}")
+                    logger.warning(f"Error cancelling Deepgram {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -267,7 +267,7 @@ class ElevenLabsTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"ElevenLabs {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling ElevenLabs {task_name}: {e}")
+                    logger.warning(f"Error cancelling ElevenLabs {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -448,7 +448,7 @@ class GladiaTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Gladia {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Gladia {task_name}: {e}")
+                    logger.warning(f"Error cancelling Gladia {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -477,7 +477,7 @@ class GoogleTranscriber(BaseTranscriber):
             except asyncio.CancelledError:
                 logger.info("Google transcription_task cancelled")
             except Exception as e:
-                logger.error(f"Error cancelling Google transcription_task: {e}")
+                logger.warning(f"Error cancelling Google transcription_task: {e}")
 
         # Run sync cleanup in executor to not block event loop
         loop = asyncio.get_event_loop()

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -471,7 +471,7 @@ class PixaTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Pixa {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Pixa {task_name}: {e}")
+                    logger.warning(f"Error cancelling Pixa {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -516,7 +516,7 @@ class SarvamTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Sarvam {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Sarvam {task_name}: {e}")
+                    logger.warning(f"Error cancelling Sarvam {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -367,7 +367,7 @@ class SmallestTranscriber(BaseTranscriber):
                 except asyncio.CancelledError:
                     logger.info(f"Smallest {task_name} cancelled")
                 except Exception as e:
-                    logger.error(f"Error cancelling Smallest {task_name}: {e}")
+                    logger.warning(f"Error cancelling Smallest {task_name}: {e}")
 
         # Close websocket
         if self.websocket_connection is not None:


### PR DESCRIPTION
## Summary
- Single errors were creating 3-5 separate Sentry issues due to cascading `logger.error()` at every layer (provider → component handler → `_end_call_on_component_error` → top-level `run()`)
- Applied "log or raise, never both" — removed wrapper-level logs, kept provider-level `logger.error()` as the single source of truth
- Added safety-net `logger.error()` at top-level catches for unexpected non-`BolnaComponentError` exceptions only