### PR TITLE
feat: add GPT-5.4 series to reasoning effort map

### DIFF
--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -134,4 +134,7 @@ MODEL_REASONING_EFFORT_MAP = {
     "gpt-5.1-codex-max":  [RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.1-codex-mini": [RE.LOW, RE.MEDIUM, RE.HIGH],
     "gpt-5.2":            [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-5.4":            [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-5.4-mini":       [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gpt-5.4-nano":       [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
 }


### PR DESCRIPTION
## Summary
- Add gpt-5.4, gpt-5.4-mini, gpt-5.4-nano to MODEL_REASONING_EFFORT_MAP