### PR TITLE
fix: use correct default sequence index in http transcription path

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2408,7 +2408,7 @@ class TaskManager(BaseManager):
     async def __process_http_transcription(self, message):
         meta_info = self.__get_updated_meta_info(message["meta_info"])
 
-        sequence = message["meta_info"].get('sequence', meta_info['sequence_id'])
+        sequence = message["meta_info"].get('sequence', 0)
         next_task = self._get_next_step(sequence, "transcriber")
         self.transcriber_duration += message["meta_info"]["transcriber_duration"] if "transcriber_duration" in message["meta_info"] else 0
 


### PR DESCRIPTION
## Summary
- `__process_http_transcription` was falling back to `meta_info['sequence_id']` (monotonically increasing counter) instead of `0` when `sequence` key is absent
- Transcribers never set `sequence` in meta_info, so for `/chat` agents this always used `sequence_id` (1, 2, 3...) as the pipeline index
- `self.pipelines` typically has only one entry (index 0), causing `list index out of range` on every message
- The streaming path (`__listen_transcriber`) already correctly defaults to `0`