### PR TITLE
fix: bump pydantic to ==2.9.0 required by google-genai>=1.68.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ numpy==1.26.1
 onnxruntime>=1.16.3
 openai>=1.10.0
 plivo==4.47.0
-pydantic==2.5.3
+pydantic==2.9.0
 pydub==0.25.1
 python-dateutil==2.8.2
 python-dotenv==1.0.0


### PR DESCRIPTION
Updating pydantic to ==2.9.0