### PR TITLE
feat: static nodes, silence repeat, and event injection for graph agents

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.13"
+__version__ = "0.10.14"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1796,20 +1796,22 @@ class TaskManager(BaseManager):
                     continue
 
                 # Process through graph agent
-                result = self.tools['llm_agent'].process_event(event)
+                result = self.tools["llm_agent"].process_event(event)
 
-                if result.get('matched'):
+                if result.get("matched"):
                     # Set node entry index so _node_turns counts from this point
-                    self.tools['llm_agent'].current_node_entry_index = len(self.conversation_history.get_copy())
+                    self.tools["llm_agent"].current_node_entry_index = len(self.conversation_history.get_copy())
 
                     if self.interruption_manager and self.interruption_manager.is_user_speaking():
                         # User is mid-speech — skip proactive generation.
                         # The node already transitioned, so the user's in-progress
                         # utterance will be routed + answered on the new node.
-                        target_node = result.get('target_node')
+                        target_node = result.get("target_node")
                         if target_node:
-                            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
-                        logger.info(f"Event '{event.get('event')}' transitioned node but user is speaking — deferring to conversation flow")
+                            self.repeat_after_silence_seconds = target_node.get("repeat_after_silence_seconds")
+                        logger.info(
+                            f"Event '{event.get('event')}' transitioned node but user is speaking — deferring to conversation flow"
+                        )
                     else:
                         await self._proactive_generate_for_event(event, result)
                 else:
@@ -1837,26 +1839,26 @@ class TaskManager(BaseManager):
 
     async def _proactive_generate_for_event(self, event: dict, result: dict):
         """Trigger proactive speech generation after an event-driven transition."""
-        node_type = result.get('node_type', NodeType.LLM)
-        target_node = result.get('target_node')
+        node_type = result.get("node_type", NodeType.LLM)
+        target_node = result.get("target_node")
 
         # Update repeat_after_silence for the new node
         if target_node:
-            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
+            self.repeat_after_silence_seconds = target_node.get("repeat_after_silence_seconds")
 
         if node_type == NodeType.STATIC:
             # Static node: play cached audio directly, no LLM cost
-            static_text = target_node.get('static_message', '') if target_node else ''
+            static_text = target_node.get("static_message", "") if target_node else ""
             if static_text:
                 if self.context_data:
                     static_text = update_prompt_with_context(static_text, self.context_data)
                 self.conversation_history.append_assistant(static_text)
                 meta_info = {
-                    'io': self.tools["output"].get_provider(),
+                    "io": self.tools["output"].get_provider(),
                     "request_id": str(uuid.uuid4()),
                     "cached": True,
                     "sequence_id": -1,
-                    'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+                    "format": self.task_config["tools_config"]["output"].get("format", "pcm"),
                     "end_of_llm_stream": True,
                     "text": static_text,
                     "message_category": "event_proactive",
@@ -1865,18 +1867,20 @@ class TaskManager(BaseManager):
                 await self._synthesize(ws_packet)
         else:
             # LLM node: set flag and trigger generation without adding a user message
-            self.tools['llm_agent']._event_triggered_generation = True
-            self.tools['llm_agent'].context_data['_event_previous_node'] = result.get('previous_node', '')
+            self.tools["llm_agent"]._event_triggered_generation = True
+            self.tools["llm_agent"].context_data["_event_previous_node"] = result.get("previous_node", "")
             await self._generate_proactive()
 
     async def _generate_proactive(self):
-        meta_info = self.__get_updated_meta_info({
-            'io': self.tools["output"].get_provider(),
-            "request_id": str(uuid.uuid4()),
-            "cached": False,
-            'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
-            "message_category": "event_proactive",
-        })
+        meta_info = self.__get_updated_meta_info(
+            {
+                "io": self.tools["output"].get_provider(),
+                "request_id": str(uuid.uuid4()),
+                "cached": False,
+                "format": self.task_config["tools_config"]["output"].get("format", "pcm"),
+                "message_category": "event_proactive",
+            }
+        )
         self.response_in_pipeline = True
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet("", meta_info)))
         self.llm_task = task
@@ -2609,27 +2613,31 @@ class TaskManager(BaseManager):
                         cached_tokens=routing_usage.get("cached_tokens"),
                     )
 
-                    is_silence_trigger = routing_info.get('is_silence_trigger', False)
+                    is_silence_trigger = routing_info.get("is_silence_trigger", False)
 
-                    current_node = self.tools['llm_agent'].get_node_by_id(routing_info['current_node'])
+                    current_node = self.tools["llm_agent"].get_node_by_id(routing_info["current_node"])
                     if current_node:
-                        self.repeat_after_silence_seconds = current_node.get('repeat_after_silence_seconds')
+                        self.repeat_after_silence_seconds = current_node.get("repeat_after_silence_seconds")
 
                     continue
 
-                if isinstance(llm_message, dict) and 'static_message' in llm_message:
-                    static_text = llm_message['static_message']
-                    static_hash = llm_message['static_audio_hash']
+                if isinstance(llm_message, dict) and "static_message" in llm_message:
+                    static_text = llm_message["static_message"]
+                    static_hash = llm_message["static_audio_hash"]
 
                     if not is_silence_trigger:
                         self.conversation_history.append_assistant(static_text)
-                        messages.append({'role': 'assistant', 'content': static_text})
+                        messages.append({"role": "assistant", "content": static_text})
                         self.conversation_history.sync_interim(messages)
 
                     convert_to_request_log(
-                        message=static_text, meta_info=meta_info,
-                        component=LogComponent.LLM, direction=LogDirection.RESPONSE,
-                        model="static_node", is_cached=True, run_id=self.run_id
+                        message=static_text,
+                        meta_info=meta_info,
+                        component=LogComponent.LLM,
+                        direction=LogDirection.RESPONSE,
+                        model="static_node",
+                        is_cached=True,
+                        run_id=self.run_id,
                     )
 
                     meta_info["end_of_llm_stream"] = True
@@ -3731,12 +3739,14 @@ class TaskManager(BaseManager):
 
     async def _inject_and_run_llm(self, injected_message: str):
         self.conversation_history.append_user(injected_message)
-        meta_info = self.__get_updated_meta_info({
-            'io': self.tools["output"].get_provider(),
-            "request_id": str(uuid.uuid4()),
-            "cached": False,
-            'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
-        })
+        meta_info = self.__get_updated_meta_info(
+            {
+                "io": self.tools["output"].get_provider(),
+                "request_id": str(uuid.uuid4()),
+                "cached": False,
+                "format": self.task_config["tools_config"]["output"].get("format", "pcm"),
+            }
+        )
         self.response_in_pipeline = True
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet(injected_message, meta_info)))
         self.llm_task = task

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -469,6 +469,8 @@ class TaskManager(BaseManager):
 
                 self.time_since_last_spoken_human_word = 0
 
+                self.repeat_after_silence_seconds = None
+
                 # Handling accidental interruption
                 self.number_of_words_for_interruption = self.conversation_config.get(
                     "number_of_words_for_interruption", 3
@@ -2493,7 +2495,36 @@ class TaskManager(BaseManager):
                         reasoning_tokens=routing_usage.get("reasoning_tokens"),
                         cached_tokens=routing_usage.get("cached_tokens"),
                     )
+
+                    is_silence_trigger = routing_info.get('is_silence_trigger', False)
+
+                    current_node = self.tools['llm_agent'].get_node_by_id(routing_info['current_node'])
+                    if current_node:
+                        self.repeat_after_silence_seconds = current_node.get('repeat_after_silence_seconds')
+
                     continue
+
+                if isinstance(llm_message, dict) and 'static_message' in llm_message:
+                    static_text = llm_message['static_message']
+                    static_hash = llm_message['static_audio_hash']
+
+                    if not is_silence_trigger:
+                        self.conversation_history.append_assistant(static_text)
+                        messages.append({'role': 'assistant', 'content': static_text})
+                        self.conversation_history.sync_interim(messages)
+
+                    convert_to_request_log(
+                        message=static_text, meta_info=meta_info,
+                        component=LogComponent.LLM, direction=LogDirection.RESPONSE,
+                        model="static_node", is_cached=True, run_id=self.run_id
+                    )
+
+                    meta_info["end_of_llm_stream"] = True
+                    meta_info["text"] = static_text
+                    meta_info["cached"] = True
+                    ws_packet = create_ws_data_packet(static_hash, meta_info=meta_info, is_md5_hash=True)
+                    await self._synthesize(ws_packet)
+                    return
 
                 data = llm_message.data
                 end_of_llm_stream = llm_message.end_of_stream
@@ -3585,6 +3616,23 @@ class TaskManager(BaseManager):
             traceback.print_exc()
             logger.error(f"Error in processing message output: {str(e)}")
 
+    async def _inject_and_run_llm(self, injected_message: str):
+        self.conversation_history.append_user(injected_message)
+        meta_info = self.__get_updated_meta_info({
+            'io': self.tools["output"].get_provider(),
+            "request_id": str(uuid.uuid4()),
+            "cached": False,
+            'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+        })
+        bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
+        await self.tools["output"].handle(bos_packet)
+        self.response_in_pipeline = True
+        task = asyncio.create_task(self._run_llm_task(create_ws_data_packet(injected_message, meta_info)))
+        self.llm_task = task
+        await task
+        eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
+        await self.tools["output"].handle(eos_packet)
+
     async def __check_for_completion(self):
         logger.info(f"Starting task to check for completion")
         while True:
@@ -3633,6 +3681,17 @@ class TaskManager(BaseManager):
                 if self.time_since_last_spoken_human_word > 0
                 else float("inf")
             )
+
+            if (
+                self.repeat_after_silence_seconds
+                and time_since_last_spoken_ai_word > self.repeat_after_silence_seconds
+                and time_since_user_last_spoke > self.repeat_after_silence_seconds
+                and not self.response_in_pipeline
+            ):
+                await self._inject_and_run_llm(
+                    f"[silence] User was silent for {self.repeat_after_silence_seconds} seconds"
+                )
+                continue
 
             if (
                 self.hang_conversation_after > 0

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -34,7 +34,7 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
-from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason
+from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason, NodeType
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
@@ -140,8 +140,10 @@ class TaskManager(BaseManager):
         self.synthesizer_queue = asyncio.Queue()
         self.transcriber_output_queue = asyncio.Queue()
         self.dtmf_queue = asyncio.Queue()
+        self.event_queue = kwargs.get("event_queue") or asyncio.Queue()
         self.queues = {
             "dtmf": self.dtmf_queue,
+            "events": self.event_queue,
             "transcriber": self.audio_queue,
             "llm": self.llm_queue,
             "synthesizer": self.synthesizer_queue,
@@ -236,6 +238,7 @@ class TaskManager(BaseManager):
         self._error_logged = False
         self.synthesizer_monitor_task = None
         self.dtmf_task = None
+        self.event_listener_task = None
 
         # state of conversation
         self.current_request_id = None
@@ -1772,6 +1775,116 @@ class TaskManager(BaseManager):
                 logger.info(f"DTMF LLM processing triggered with sequence_id={meta_info['sequence_id']}")
             except Exception as e:
                 logger.info(f"DTMF LLM processing triggered with exception {e}")
+
+    async def _listen_events(self):
+        """Listen for external events and process them through the graph agent.
+        Events trigger node transitions and proactive speech without user input."""
+        logger.info("Event listener started for graph agent")
+        while True:
+            try:
+                event = await self.event_queue.get()
+                if self.conversation_ended:
+                    logger.info(f"Event '{event.get('event')}' ignored — conversation ended")
+                    continue
+
+                logger.info(f"Processing external event: {event.get('event')}")
+
+                # Wait for a safe point (no audio playing, no response in pipeline)
+                await self._wait_for_safe_point()
+
+                if self.conversation_ended:
+                    continue
+
+                # Process through graph agent
+                result = self.tools['llm_agent'].process_event(event)
+
+                if result.get('matched'):
+                    # Set node entry index so _node_turns counts from this point
+                    self.tools['llm_agent'].current_node_entry_index = len(self.conversation_history.get_copy())
+
+                    if self.interruption_manager and self.interruption_manager.is_user_speaking():
+                        # User is mid-speech — skip proactive generation.
+                        # The node already transitioned, so the user's in-progress
+                        # utterance will be routed + answered on the new node.
+                        target_node = result.get('target_node')
+                        if target_node:
+                            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
+                        logger.info(f"Event '{event.get('event')}' transitioned node but user is speaking — deferring to conversation flow")
+                    else:
+                        await self._proactive_generate_for_event(event, result)
+                else:
+                    logger.info(f"Event '{event.get('event')}' — no matching edge, context updated silently")
+
+            except asyncio.CancelledError:
+                logger.info("Event listener cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Error in event listener: {e}")
+                traceback.print_exc()
+
+    async def _wait_for_safe_point(self, timeout=30.0):
+        """Wait until the pipeline is idle: no audio playing, no response in pipeline, no active LLM task."""
+        start = time.time()
+        while time.time() - start < timeout:
+            if self.conversation_ended:
+                return
+            audio_playing = self.tools["input"].is_audio_being_played_to_user() if "input" in self.tools else False
+            llm_busy = self.llm_task is not None and not self.llm_task.done() if self.llm_task else False
+            if not audio_playing and not self.response_in_pipeline and not llm_busy:
+                return
+            await asyncio.sleep(0.1)
+        logger.warning(f"_wait_for_safe_point timed out after {timeout}s")
+
+    async def _proactive_generate_for_event(self, event: dict, result: dict):
+        """Trigger proactive speech generation after an event-driven transition."""
+        node_type = result.get('node_type', NodeType.LLM)
+        target_node = result.get('target_node')
+
+        # Update repeat_after_silence for the new node
+        if target_node:
+            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
+
+        if node_type == NodeType.STATIC:
+            # Static node: play cached audio directly, no LLM cost
+            static_text = target_node.get('static_message', '') if target_node else ''
+            if static_text:
+                if self.context_data:
+                    static_text = update_prompt_with_context(static_text, self.context_data)
+                self.conversation_history.append_assistant(static_text)
+                meta_info = {
+                    'io': self.tools["output"].get_provider(),
+                    "request_id": str(uuid.uuid4()),
+                    "cached": True,
+                    "sequence_id": -1,
+                    'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+                    "end_of_llm_stream": True,
+                    "text": static_text,
+                    "message_category": "event_proactive",
+                }
+                ws_packet = create_ws_data_packet(get_md5_hash(static_text), meta_info=meta_info, is_md5_hash=True)
+                await self._synthesize(ws_packet)
+        else:
+            # LLM node: set flag and trigger generation without adding a user message
+            self.tools['llm_agent']._event_triggered_generation = True
+            self.tools['llm_agent'].context_data['_event_previous_node'] = result.get('previous_node', '')
+            await self._generate_proactive()
+
+    async def _generate_proactive(self):
+        meta_info = self.__get_updated_meta_info({
+            'io': self.tools["output"].get_provider(),
+            "request_id": str(uuid.uuid4()),
+            "cached": False,
+            'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+            "message_category": "event_proactive",
+        })
+        self.response_in_pipeline = True
+        task = asyncio.create_task(self._run_llm_task(create_ws_data_packet("", meta_info)))
+        self.llm_task = task
+        try:
+            await task
+        except asyncio.CancelledError:
+            logger.info("Proactive generation cancelled by interruption")
+            return
 
     async def __process_end_of_conversation(self, web_call_timeout=False):
         if self._end_of_conversation_in_progress or self.conversation_ended:
@@ -3935,6 +4048,9 @@ class TaskManager(BaseManager):
                     if self.should_backchannel:
                         self.backchanneling_task = asyncio.create_task(self.__check_for_backchanneling())
 
+                    if self.__is_graph_agent():
+                        self.event_listener_task = asyncio.create_task(self._listen_events())
+
                 try:
                     await asyncio.gather(*tasks)
                 except asyncio.CancelledError:
@@ -4149,6 +4265,7 @@ class TaskManager(BaseManager):
                 # tasks_to_cancel.append(process_task_cancellation(self.initial_silence_task, 'initial_silence_task'))
                 tasks_to_cancel.append(process_task_cancellation(self.first_message_task, "first_message_task"))
                 tasks_to_cancel.append(process_task_cancellation(self.dtmf_task, "dtmf_task"))
+                tasks_to_cancel.append(process_task_cancellation(self.event_listener_task, "event_listener_task"))
                 tasks_to_cancel.append(
                     process_task_cancellation(self.voicemail_handler.check_task, "voicemail_check_task")
                 )

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3737,14 +3737,14 @@ class TaskManager(BaseManager):
             "cached": False,
             'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
         })
-        bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
-        await self.tools["output"].handle(bos_packet)
         self.response_in_pipeline = True
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet(injected_message, meta_info)))
         self.llm_task = task
-        await task
-        eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
-        await self.tools["output"].handle(eos_packet)
+        try:
+            await task
+        except asyncio.CancelledError:
+            logger.info("Silence repeat generation cancelled by interruption")
+            return
 
     async def __check_for_completion(self):
         logger.info(f"Starting task to check for completion")

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -16,9 +16,10 @@ from bolna.helpers.utils import (
     update_prompt_with_context,
     enrich_context_with_time_variables,
     DictWithMissing,
+    get_md5_hash,
 )
 from bolna.helpers.expression_evaluator import evaluate_edge_expression
-from bolna.enums import EdgeConditionType
+from bolna.enums import EdgeConditionType, NodeType
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
@@ -62,7 +63,8 @@ class GraphAgent(BaseAgent):
             self.openai = OpenAI(api_key=self.llm_key)
 
         self.node_history = [self.current_node_id]
-        self.current_node_entry_index = 0  # Track message index when we entered current node
+        self.current_node_entry_index = 0
+        self._silence_repeats = 0
         self.rag_configs = self.initialize_rag_configs()
         self.rag_server_url = os.getenv("RAG_SERVER_URL", "http://localhost:8000")
 
@@ -556,6 +558,7 @@ class GraphAgent(BaseAgent):
         node_turns, total_turns = self._compute_turn_counts(history)
         self.context_data["_node_turns"] = node_turns
         self.context_data["_total_turns"] = total_turns
+        self.context_data["_silence_repeats"] = self._silence_repeats
 
         deterministic_edges, llm_edges = self._classify_edges(edges)
 
@@ -675,6 +678,10 @@ class GraphAgent(BaseAgent):
             self.context_data["detected_language"] = detected_language
 
         try:
+            is_silence_trigger = bool(message and message[-1].get('content', '').startswith('[silence]'))
+            if is_silence_trigger:
+                self._silence_repeats += 1
+
             previous_node = self.current_node_id
             (
                 next_node_id,
@@ -691,6 +698,7 @@ class GraphAgent(BaseAgent):
                 logger.info(f"Transitioning: {self.current_node_id} -> {next_node_id} (params: {extracted_params})")
                 self.current_node_id = next_node_id
                 self.current_node_entry_index = len(message)
+                self._silence_repeats = 0
                 if extracted_params:
                     self.context_data.update(extracted_params)
 
@@ -700,6 +708,9 @@ class GraphAgent(BaseAgent):
             routing_type = (
                 "deterministic" if (reasoning and reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)) else "llm"
             )
+
+            current_node = self.get_node_by_id(self.current_node_id)
+            node_type = current_node.get('node_type', NodeType.LLM) if current_node else NodeType.LLM
 
             yield {
                 "routing_info": {
@@ -717,8 +728,19 @@ class GraphAgent(BaseAgent):
                     "reasoning": reasoning,
                     "confidence": confidence,
                     "routing_usage": routing_usage,
+                    "node_type": node_type,
+                    "is_silence_trigger": is_silence_trigger,
                 }
             }
+
+            if node_type == NodeType.STATIC:
+                static_text = current_node.get('static_message', '') if current_node else ''
+                if static_text:
+                    yield {
+                        'static_message': static_text,
+                        'static_audio_hash': get_md5_hash(static_text),
+                    }
+                return
 
             messages = await self._build_messages(message)
             yield {"messages": messages}

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -65,6 +65,7 @@ class GraphAgent(BaseAgent):
         self.node_history = [self.current_node_id]
         self.current_node_entry_index = 0
         self._silence_repeats = 0
+        self._event_triggered_generation = False
         self.rag_configs = self.initialize_rag_configs()
         self.rag_server_url = os.getenv("RAG_SERVER_URL", "http://localhost:8000")
 
@@ -342,11 +343,15 @@ class GraphAgent(BaseAgent):
         return self._get_edge_by_function_name_from_edges(node.get("edges", []), function_name)
 
     def _classify_edges(self, edges: list) -> tuple:
-        """Split edges into (deterministic_edges, llm_edges), sorted by priority."""
+        """Split edges into (deterministic_edges, llm_edges), sorted by priority.
+        Event edges are excluded — they only fire via process_event()."""
         deterministic = []
         llm = []
         for edge in edges:
-            if edge.get("condition_type") in (EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL):
+            ct = edge.get("condition_type")
+            if ct == EdgeConditionType.EVENT:
+                continue  # event edges only fire via process_event()
+            elif ct in (EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL):
                 deterministic.append(edge)
             else:
                 llm.append(edge)
@@ -361,6 +366,59 @@ class GraphAgent(BaseAgent):
             if evaluate_edge_expression(edge, self.context_data):
                 return edge
         return None
+
+    def process_event(self, event: dict) -> dict:
+        """Process an external event. Merges properties into context_data
+        and checks current node's event edges for a matching transition.
+
+        Returns dict with: matched, event, new_node_id, node_type, etc.
+        """
+        parsed = CallEvent(**event) if not isinstance(event, CallEvent) else event
+        event_name = parsed.event
+        properties = parsed.properties or {}
+
+        # Always merge properties into context_data
+        if properties:
+            self.context_data.update(properties)
+        self.context_data["_last_event"] = event_name
+
+        current_node = self.get_node_by_id(self.current_node_id)
+        if not current_node:
+            logger.warning(f"process_event: current node '{self.current_node_id}' not found")
+            return {"matched": False, "event": event_name}
+
+        # Collect event edges, sorted by priority
+        event_edges = [
+            e for e in current_node.get('edges', [])
+            if e.get('condition_type') == EdgeConditionType.EVENT
+        ]
+        event_edges.sort(key=lambda e: e.get('priority') or 0)
+
+        for edge in event_edges:
+            if edge.get('event_name') == event_name:
+                previous_node = self.current_node_id
+                self.current_node_id = edge['to_node_id']
+                self.current_node_entry_index = 0  # caller should set to len(history)
+                self._silence_repeats = 0
+
+                if self.current_node_id not in self.node_history or self.node_history[-1] != self.current_node_id:
+                    self.node_history.append(self.current_node_id)
+
+                target_node = self.get_node_by_id(edge['to_node_id'])
+                node_type = target_node.get('node_type', NodeType.LLM) if target_node else NodeType.LLM
+
+                logger.info(f"Event '{event_name}' matched edge: {previous_node} -> {self.current_node_id}")
+                return {
+                    "matched": True,
+                    "event": event_name,
+                    "previous_node": previous_node,
+                    "new_node_id": edge['to_node_id'],
+                    "node_type": node_type,
+                    "target_node": target_node,
+                }
+
+        logger.info(f"Event '{event_name}' did not match any event edge on node '{self.current_node_id}' — context updated silently")
+        return {"matched": False, "event": event_name}
 
     def _compute_turn_counts(self, history: list) -> tuple:
         """Count (node_turns, total_turns) from history."""
@@ -678,6 +736,55 @@ class GraphAgent(BaseAgent):
             self.context_data["detected_language"] = detected_language
 
         try:
+            # Event-triggered generation: process_event() already handled routing
+            is_event = self._event_triggered_generation
+            if is_event:
+                self._event_triggered_generation = False
+                current_node = self.get_node_by_id(self.current_node_id)
+                node_type = current_node.get('node_type', NodeType.LLM) if current_node else NodeType.LLM
+
+                yield {
+                    'routing_info': {
+                        'previous_node': self.context_data.get('_event_previous_node', self.current_node_id),
+                        'current_node': self.current_node_id,
+                        'transitioned': True,
+                        'routing_type': 'event',
+                        'routing_model': None,
+                        'routing_provider': None,
+                        'routing_latency_ms': 0,
+                        'extracted_params': {},
+                        'node_history': list(self.node_history),
+                        'routing_messages': None,
+                        'routing_tools': None,
+                        'reasoning': f"event:{self.context_data.get('_last_event', '')}",
+                        'confidence': 1.0,
+                        'node_type': node_type,
+                        'is_silence_trigger': False,
+                        'event_triggered': True,
+                    }
+                }
+
+                if node_type == NodeType.STATIC:
+                    static_text = current_node.get('static_message', '') if current_node else ''
+                    if static_text:
+                        if self.context_data:
+                            static_text = update_prompt_with_context(static_text, self.context_data)
+                        yield {
+                            'static_message': static_text,
+                            'static_audio_hash': get_md5_hash(static_text),
+                        }
+                    return
+
+                messages = await self._build_messages(message)
+                # Inject ephemeral event hint (NOT persisted in conversation_history)
+                event_name = self.context_data.get('_last_event', '')
+                messages.append({"role": "system", "content": f"[Event: {event_name}. Respond proactively — speak first, do not wait for the user.]"})
+                yield {'messages': messages}
+                tool_choice = self._get_tool_choice_for_node()
+                async for chunk in self.llm.generate_stream(messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice):
+                    yield chunk
+                return
+
             is_silence_trigger = bool(message and message[-1].get('content', '').startswith('[silence]'))
             if is_silence_trigger:
                 self._silence_repeats += 1

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -843,6 +843,8 @@ class GraphAgent(BaseAgent):
             if node_type == NodeType.STATIC:
                 static_text = current_node.get('static_message', '') if current_node else ''
                 if static_text:
+                    if self.context_data:
+                        static_text = update_prompt_with_context(static_text, self.context_data)
                     yield {
                         'static_message': static_text,
                         'static_audio_hash': get_md5_hash(static_text),

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -388,36 +388,35 @@ class GraphAgent(BaseAgent):
             return {"matched": False, "event": event_name}
 
         # Collect event edges, sorted by priority
-        event_edges = [
-            e for e in current_node.get('edges', [])
-            if e.get('condition_type') == EdgeConditionType.EVENT
-        ]
-        event_edges.sort(key=lambda e: e.get('priority') or 0)
+        event_edges = [e for e in current_node.get("edges", []) if e.get("condition_type") == EdgeConditionType.EVENT]
+        event_edges.sort(key=lambda e: e.get("priority") or 0)
 
         for edge in event_edges:
-            if edge.get('event_name') == event_name:
+            if edge.get("event_name") == event_name:
                 previous_node = self.current_node_id
-                self.current_node_id = edge['to_node_id']
+                self.current_node_id = edge["to_node_id"]
                 self.current_node_entry_index = 0  # caller should set to len(history)
                 self._silence_repeats = 0
 
                 if self.current_node_id not in self.node_history or self.node_history[-1] != self.current_node_id:
                     self.node_history.append(self.current_node_id)
 
-                target_node = self.get_node_by_id(edge['to_node_id'])
-                node_type = target_node.get('node_type', NodeType.LLM) if target_node else NodeType.LLM
+                target_node = self.get_node_by_id(edge["to_node_id"])
+                node_type = target_node.get("node_type", NodeType.LLM) if target_node else NodeType.LLM
 
                 logger.info(f"Event '{event_name}' matched edge: {previous_node} -> {self.current_node_id}")
                 return {
                     "matched": True,
                     "event": event_name,
                     "previous_node": previous_node,
-                    "new_node_id": edge['to_node_id'],
+                    "new_node_id": edge["to_node_id"],
                     "node_type": node_type,
                     "target_node": target_node,
                 }
 
-        logger.info(f"Event '{event_name}' did not match any event edge on node '{self.current_node_id}' — context updated silently")
+        logger.info(
+            f"Event '{event_name}' did not match any event edge on node '{self.current_node_id}' — context updated silently"
+        )
         return {"matched": False, "event": event_name}
 
     def _compute_turn_counts(self, history: list) -> tuple:
@@ -741,51 +740,58 @@ class GraphAgent(BaseAgent):
             if is_event:
                 self._event_triggered_generation = False
                 current_node = self.get_node_by_id(self.current_node_id)
-                node_type = current_node.get('node_type', NodeType.LLM) if current_node else NodeType.LLM
+                node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
 
                 yield {
-                    'routing_info': {
-                        'previous_node': self.context_data.get('_event_previous_node', self.current_node_id),
-                        'current_node': self.current_node_id,
-                        'transitioned': True,
-                        'routing_type': 'event',
-                        'routing_model': None,
-                        'routing_provider': None,
-                        'routing_latency_ms': 0,
-                        'extracted_params': {},
-                        'node_history': list(self.node_history),
-                        'routing_messages': None,
-                        'routing_tools': None,
-                        'reasoning': f"event:{self.context_data.get('_last_event', '')}",
-                        'confidence': 1.0,
-                        'node_type': node_type,
-                        'is_silence_trigger': False,
-                        'event_triggered': True,
+                    "routing_info": {
+                        "previous_node": self.context_data.get("_event_previous_node", self.current_node_id),
+                        "current_node": self.current_node_id,
+                        "transitioned": True,
+                        "routing_type": "event",
+                        "routing_model": None,
+                        "routing_provider": None,
+                        "routing_latency_ms": 0,
+                        "extracted_params": {},
+                        "node_history": list(self.node_history),
+                        "routing_messages": None,
+                        "routing_tools": None,
+                        "reasoning": f"event:{self.context_data.get('_last_event', '')}",
+                        "confidence": 1.0,
+                        "node_type": node_type,
+                        "is_silence_trigger": False,
+                        "event_triggered": True,
                     }
                 }
 
                 if node_type == NodeType.STATIC:
-                    static_text = current_node.get('static_message', '') if current_node else ''
+                    static_text = current_node.get("static_message", "") if current_node else ""
                     if static_text:
                         if self.context_data:
                             static_text = update_prompt_with_context(static_text, self.context_data)
                         yield {
-                            'static_message': static_text,
-                            'static_audio_hash': get_md5_hash(static_text),
+                            "static_message": static_text,
+                            "static_audio_hash": get_md5_hash(static_text),
                         }
                     return
 
                 messages = await self._build_messages(message)
                 # Inject ephemeral event hint (NOT persisted in conversation_history)
-                event_name = self.context_data.get('_last_event', '')
-                messages.append({"role": "system", "content": f"[Event: {event_name}. Respond proactively — speak first, do not wait for the user.]"})
-                yield {'messages': messages}
+                event_name = self.context_data.get("_last_event", "")
+                messages.append(
+                    {
+                        "role": "system",
+                        "content": f"[Event: {event_name}. Respond proactively — speak first, do not wait for the user.]",
+                    }
+                )
+                yield {"messages": messages}
                 tool_choice = self._get_tool_choice_for_node()
-                async for chunk in self.llm.generate_stream(messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice):
+                async for chunk in self.llm.generate_stream(
+                    messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
+                ):
                     yield chunk
                 return
 
-            is_silence_trigger = bool(message and message[-1].get('content', '').startswith('[silence]'))
+            is_silence_trigger = bool(message and message[-1].get("content", "").startswith("[silence]"))
             if is_silence_trigger:
                 self._silence_repeats += 1
 
@@ -817,7 +823,7 @@ class GraphAgent(BaseAgent):
             )
 
             current_node = self.get_node_by_id(self.current_node_id)
-            node_type = current_node.get('node_type', NodeType.LLM) if current_node else NodeType.LLM
+            node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
 
             yield {
                 "routing_info": {
@@ -841,13 +847,13 @@ class GraphAgent(BaseAgent):
             }
 
             if node_type == NodeType.STATIC:
-                static_text = current_node.get('static_message', '') if current_node else ''
+                static_text = current_node.get("static_message", "") if current_node else ""
                 if static_text:
                     if self.context_data:
                         static_text = update_prompt_with_context(static_text, self.context_data)
                     yield {
-                        'static_message': static_text,
-                        'static_audio_hash': get_md5_hash(static_text),
+                        "static_message": static_text,
+                        "static_audio_hash": get_md5_hash(static_text),
                     }
                 return
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -261,6 +261,7 @@ class EdgeConditionType(str, Enum):
     LLM = "llm"
     EXPRESSION = "expression"
     UNCONDITIONAL = "unconditional"
+    EVENT = "event"
 
 
 class NodeType(str, Enum):

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -263,6 +263,11 @@ class EdgeConditionType(str, Enum):
     UNCONDITIONAL = "unconditional"
 
 
+class NodeType(str, Enum):
+    LLM = "llm"
+    STATIC = "static"
+
+
 class UsageSource(str, Enum):
     """Indicates whether token counts came from the API or text estimation."""
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -12,6 +12,7 @@ from .enums import (
     ExpressionOperator,
     ExpressionLogic,
     EdgeConditionType,
+    NodeType,
 )
 from .constants import MODEL_REASONING_EFFORT_MAP
 
@@ -346,7 +347,10 @@ class GraphNodeRAGConfig(BaseModel):
 class GraphNode(BaseModel):
     id: str
     description: Optional[str] = None
-    prompt: str
+    node_type: NodeType = NodeType.LLM
+    prompt: str = ""
+    static_message: Optional[str] = None
+    repeat_after_silence_seconds: Optional[float] = None
     examples: Optional[Dict[str, str]] = None
     edges: List[GraphEdge] = Field(default_factory=list)
     function_call: Optional[str] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -315,11 +315,14 @@ class ExpressionGroup(BaseModel):
     logic: ExpressionLogic = ExpressionLogic.AND
     conditions: List[ExpressionCondition] = Field(default_factory=list)
 
+
 class CallEvent(BaseModel):
     """Incoming external event payload."""
+
     event: str
     properties: Optional[Dict[str, Any]] = None
     timestamp: Optional[float] = None
+
 
 class GraphEdge(BaseModel):
     """Edge definition for graph-based conversation flow.

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -315,6 +315,11 @@ class ExpressionGroup(BaseModel):
     logic: ExpressionLogic = ExpressionLogic.AND
     conditions: List[ExpressionCondition] = Field(default_factory=list)
 
+class CallEvent(BaseModel):
+    """Incoming external event payload."""
+    event: str
+    properties: Optional[Dict[str, Any]] = None
+    timestamp: Optional[float] = None
 
 class GraphEdge(BaseModel):
     """Edge definition for graph-based conversation flow.
@@ -327,6 +332,7 @@ class GraphEdge(BaseModel):
     condition: str = ""  # Human-readable description of when to transition
     condition_type: Optional[EdgeConditionType] = None  # None → "llm" (backward compat)
     expression: Optional[ExpressionGroup] = None  # required when condition_type == "expression"
+    event_name: Optional[str] = None  # Matches CallEvent.event when condition_type="event"
     # Function definition for LLM to call (auto-generated if not provided)
     function_name: Optional[str] = None  # e.g., "go_to_city_question"
     function_description: Optional[str] = None  # Detailed description for LLM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.13"
+version = "0.10.14"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_event_injection_e2e.py
+++ b/tests/tests/test_event_injection_e2e.py
@@ -1,0 +1,945 @@
+"""End-to-end integration tests for real-time event injection.
+
+Tests the full pipeline: event_queue → _listen_events → process_event →
+_wait_for_safe_point → _proactive_generate_for_event → synthesize/LLM.
+
+Uses a real GraphAgent with mocked I/O components (output handler, synthesizer,
+interruption manager) — the same pattern as test_graceful_shutdown_on_component_error.py
+and test_turn_audio_flushed.py.
+"""
+
+import asyncio
+import time
+import uuid
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.utils import create_ws_data_packet, get_md5_hash, update_prompt_with_context
+from bolna.enums import EdgeConditionType, NodeType
+
+
+# ---------------------------------------------------------------------------
+# Graph agent factory (real agent, mocked LLM clients)
+# ---------------------------------------------------------------------------
+
+BFSI_NODES = [
+    {
+        "id": "waiting_for_link",
+        "prompt": "You sent a payment link. Wait for the user to open it.",
+        "repeat_after_silence_seconds": 15,
+        "edges": [
+            {"to_node_id": "verify_details", "condition_type": "event", "event_name": "link_opened"},
+            {
+                "to_node_id": "resend_link",
+                "condition_type": "expression",
+                "expression": {
+                    "logic": "and",
+                    "conditions": [{"variable": "_silence_repeats", "operator": "gte", "value": 3}],
+                },
+            },
+            {"to_node_id": "help", "condition": "user needs help", "function_name": "go_to_help"},
+        ],
+    },
+    {
+        "id": "verify_details",
+        "prompt": "User opened the link at step {step}. Guide them to verify details.",
+        "edges": [
+            {"to_node_id": "select_payment", "condition_type": "event", "event_name": "details_verified"},
+        ],
+    },
+    {
+        "id": "select_payment",
+        "node_type": "static",
+        "prompt": "",
+        "static_message": "Please select your payment method.",
+        "edges": [
+            {"to_node_id": "awaiting_payment", "condition_type": "event", "event_name": "payment_initiated"},
+        ],
+    },
+    {
+        "id": "awaiting_payment",
+        "prompt": "Payment initiated via {method}. Reassure the user.",
+        "repeat_after_silence_seconds": 20,
+        "edges": [
+            {"to_node_id": "confirmation", "condition_type": "event", "event_name": "payment_completed"},
+            {"to_node_id": "payment_failed", "condition_type": "event", "event_name": "payment_failed"},
+        ],
+    },
+    {
+        "id": "confirmation",
+        "node_type": "static",
+        "prompt": "",
+        "static_message": "Payment confirmed! Thank you!",
+        "edges": [],
+    },
+    {
+        "id": "payment_failed",
+        "prompt": "Payment failed. Suggest they retry.",
+        "edges": [
+            {"to_node_id": "select_payment", "condition_type": "event", "event_name": "retry_payment"},
+        ],
+    },
+    {
+        "id": "resend_link",
+        "node_type": "static",
+        "prompt": "",
+        "static_message": "Let me resend the link to your phone.",
+        "edges": [],
+    },
+    {
+        "id": "help",
+        "prompt": "Help the user find the SMS.",
+        "edges": [],
+    },
+]
+
+AGENT_CONFIG = {
+    "agent_information": "You are a payment assistant from SecureBank.",
+    "model": "gpt-4o-mini",
+    "provider": "openai",
+    "temperature": 0.7,
+    "max_tokens": 150,
+    "current_node_id": "waiting_for_link",
+    "context_data": {"customer_name": "Rahul"},
+    "nodes": BFSI_NODES,
+}
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+def _make_graph_agent(config_overrides=None):
+    """Create a real GraphAgent with mocked LLM clients."""
+    cfg = {**AGENT_CONFIG, **(config_overrides or {})}
+    mock_llm = MagicMock()
+    mock_llm.generate_stream = AsyncMock(return_value=_async_iter([]))
+    mock_llm.trigger_function_call = False
+
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=MagicMock()),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": MagicMock(return_value=mock_llm)}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        agent = GraphAgent(cfg)
+
+    agent.llm = mock_llm
+    return agent
+
+
+# ---------------------------------------------------------------------------
+# TaskManager stub factory (bypasses __init__, wires real event queue + agent)
+# ---------------------------------------------------------------------------
+
+
+def _make_task_manager(agent=None, **overrides):
+    """Create a minimal TaskManager stub for event injection testing.
+
+    Uses object.__new__ to bypass __init__ (same pattern as
+    test_graceful_shutdown_on_component_error.py), then sets up:
+    - Real asyncio.Queue for events
+    - Real GraphAgent
+    - Mocked I/O components (output, input, synthesizer)
+    """
+    tm = object.__new__(TaskManager)
+
+    # Wire agent first (we reference it below)
+    graph_agent = agent or _make_graph_agent()
+
+    # Event queue (real)
+    tm.event_queue = asyncio.Queue()
+    tm.queues = {"events": tm.event_queue}
+
+    # Conversation state
+    tm.conversation_ended = False
+    tm.response_in_pipeline = False
+    tm.llm_task = None
+    tm.run_id = f"test-{uuid.uuid4().hex[:8]}"
+    tm.task_id = 0
+    tm.repeat_after_silence_seconds = None
+    tm.conversation_history = ConversationHistory()
+    tm.context_data = graph_agent.context_data  # Share context_data with agent
+
+    # Task config (minimal)
+    tm.task_config = {
+        "task_type": "conversation",
+        "tools_config": {
+            "output": {"format": "pcm", "provider": "plivo"},
+            "llm_agent": {
+                "agent_type": "graph_agent",
+                "llm_config": {"model": "gpt-4o-mini", "provider": "openai"},
+            },
+        },
+    }
+    tm.llm_config = {"model": "gpt-4o-mini", "provider": "openai"}
+
+    # I/O mocks — use MagicMock (not AsyncMock) so get_provider() returns
+    # a plain string.  Only .handle() needs to be async.
+    output_handler = MagicMock()
+    output_handler.get_provider.return_value = "plivo"
+    output_handler.handle = AsyncMock()
+
+    input_handler = MagicMock()
+    input_handler.is_audio_being_played_to_user.return_value = False
+
+    synthesizer_mock = AsyncMock()
+    synthesizer_mock.push = AsyncMock()
+
+    # Interruption manager mock (for __get_updated_meta_info)
+    interruption_manager = MagicMock()
+    interruption_manager.get_next_sequence_id.return_value = 1
+    interruption_manager.get_turn_id.return_value = "turn-1"
+    interruption_manager.is_valid_sequence.return_value = True
+    tm.interruption_manager = interruption_manager
+
+    tm.tools = {
+        "llm_agent": graph_agent,
+        "output": output_handler,
+        "input": input_handler,
+        "synthesizer": synthesizer_mock,
+    }
+
+    # Internal state
+    tm.call_sid = None
+    tm.stream_sid = None
+    tm._component_error = None
+    tm._error_logged = False
+    tm._end_of_conversation_in_progress = False
+    tm.hangup_detail = None
+    tm.event_listener_task = None
+
+    for k, v in overrides.items():
+        setattr(tm, k, v)
+
+    return tm
+
+
+async def _run_listener_and_process(tm, events, settle_time=0.3):
+    """Put events on queue, run _listen_events, wait for processing, cancel."""
+    task = asyncio.create_task(tm._listen_events())
+    try:
+        for event in events:
+            await tm.event_queue.put(event)
+        await asyncio.sleep(settle_time)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 1. _wait_for_safe_point tests
+# ---------------------------------------------------------------------------
+
+
+class TestWaitForSafePoint:
+    @pytest.mark.asyncio
+    async def test_returns_immediately_when_idle(self):
+        """Should return instantly when no audio playing and no response in pipeline."""
+        tm = _make_task_manager()
+        start = time.time()
+        await tm._wait_for_safe_point(timeout=2.0)
+        elapsed = time.time() - start
+        assert elapsed < 0.5
+
+    @pytest.mark.asyncio
+    async def test_waits_for_audio_to_finish(self):
+        """Should wait until audio playback stops."""
+        tm = _make_task_manager()
+        call_count = 0
+
+        def audio_playing():
+            nonlocal call_count
+            call_count += 1
+            return call_count < 3
+
+        tm.tools["input"].is_audio_being_played_to_user = audio_playing
+        await tm._wait_for_safe_point(timeout=2.0)
+        assert call_count >= 3
+
+    @pytest.mark.asyncio
+    async def test_waits_for_response_pipeline(self):
+        """Should wait until response_in_pipeline is False."""
+        tm = _make_task_manager()
+        tm.response_in_pipeline = True
+
+        async def clear_pipeline():
+            await asyncio.sleep(0.2)
+            tm.response_in_pipeline = False
+
+        clear_task = asyncio.create_task(clear_pipeline())
+        await tm._wait_for_safe_point(timeout=2.0)
+        assert not tm.response_in_pipeline
+        await clear_task
+
+    @pytest.mark.asyncio
+    async def test_waits_for_llm_task(self):
+        """Should wait until active LLM task completes."""
+        tm = _make_task_manager()
+
+        async def fake_llm_work():
+            await asyncio.sleep(0.2)
+
+        tm.llm_task = asyncio.create_task(fake_llm_work())
+        await tm._wait_for_safe_point(timeout=2.0)
+        assert tm.llm_task.done()
+
+    @pytest.mark.asyncio
+    async def test_timeout_doesnt_hang(self):
+        """Should return after timeout even if never idle."""
+        tm = _make_task_manager()
+        tm.response_in_pipeline = True
+
+        start = time.time()
+        await tm._wait_for_safe_point(timeout=0.5)
+        elapsed = time.time() - start
+        assert elapsed >= 0.4
+        assert elapsed < 2.0
+
+    @pytest.mark.asyncio
+    async def test_returns_early_if_conversation_ended(self):
+        """Should return immediately if conversation_ended is set."""
+        tm = _make_task_manager()
+        tm.response_in_pipeline = True
+        tm.conversation_ended = True
+
+        start = time.time()
+        await tm._wait_for_safe_point(timeout=5.0)
+        elapsed = time.time() - start
+        assert elapsed < 0.5
+
+
+# ---------------------------------------------------------------------------
+# 2. _listen_events integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestListenEventsIntegration:
+    @pytest.mark.asyncio
+    async def test_matching_event_triggers_proactive_generation(self):
+        """Full flow: event → process_event → _proactive_generate_for_event."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "link_opened", "properties": {"step": "verify"}}])
+
+        assert agent.current_node_id == "verify_details"
+        assert agent.context_data.get("step") == "verify"
+        tm._proactive_generate_for_event.assert_awaited_once()
+        call_args = tm._proactive_generate_for_event.call_args
+        assert call_args[0][0]["event"] == "link_opened"
+        assert call_args[0][1]["matched"] is True
+
+    @pytest.mark.asyncio
+    async def test_event_sets_node_entry_index(self):
+        """After event transition, current_node_entry_index should be set to history length."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        # Simulate some conversation history before the event
+        tm.conversation_history.append_assistant("I've sent you the link.")
+        tm.conversation_history.append_user("Okay, let me check.")
+        tm.conversation_history.append_assistant("Sure, take your time.")
+        history_len = len(tm.conversation_history.get_copy())
+
+        await _run_listener_and_process(tm, [{"event": "link_opened"}])
+
+        assert agent.current_node_id == "verify_details"
+        assert agent.current_node_entry_index == history_len
+
+    @pytest.mark.asyncio
+    async def test_non_matching_event_silent_context_update(self):
+        """Non-matching event should update context but not trigger speech."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "unknown_event", "properties": {"key": "value"}}])
+
+        assert agent.current_node_id == "waiting_for_link"
+        assert agent.context_data.get("key") == "value"
+        tm._proactive_generate_for_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_event_ignored_when_conversation_ended(self):
+        """Events after conversation end should be silently ignored."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm.conversation_ended = True
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "link_opened"}])
+
+        assert agent.current_node_id == "waiting_for_link"
+        tm._proactive_generate_for_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multiple_events_processed_sequentially(self):
+        """Events should be processed FIFO, one at a time."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+
+        call_order = []
+
+        async def tracking_proactive(event, result):
+            call_order.append(event["event"])
+
+        tm._proactive_generate_for_event = tracking_proactive
+
+        await _run_listener_and_process(
+            tm,
+            [
+                {"event": "link_opened", "properties": {"step": "verify"}},
+                {"event": "details_verified"},
+            ],
+            settle_time=0.5,
+        )
+
+        assert call_order == ["link_opened", "details_verified"]
+        assert agent.current_node_id == "select_payment"
+
+    @pytest.mark.asyncio
+    async def test_event_waits_for_safe_point(self):
+        """Events should wait for safe point before processing."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        tm.tools["input"].is_audio_being_played_to_user.return_value = True
+
+        task = asyncio.create_task(tm._listen_events())
+        await tm.event_queue.put({"event": "link_opened"})
+        await asyncio.sleep(0.2)
+
+        # Should NOT have processed yet
+        tm._proactive_generate_for_event.assert_not_awaited()
+        assert agent.current_node_id == "waiting_for_link"
+
+        # Release
+        tm.tools["input"].is_audio_being_played_to_user.return_value = False
+        await asyncio.sleep(0.3)
+
+        assert agent.current_node_id == "verify_details"
+        tm._proactive_generate_for_event.assert_awaited_once()
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 3. _proactive_generate_for_event — static node path
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveGenerateStaticNode:
+    @pytest.mark.asyncio
+    async def test_static_node_synthesizes_audio(self):
+        """Event → static node should call _synthesize with the static message hash."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._synthesize = AsyncMock()
+
+        # Transition to select_payment (static)
+        agent.process_event({"event": "link_opened"})
+        result = agent.process_event({"event": "details_verified"})
+
+        await tm._proactive_generate_for_event({"event": "details_verified"}, result)
+
+        tm._synthesize.assert_awaited_once()
+        synth_call = tm._synthesize.call_args[0][0]
+        assert synth_call["meta_info"]["cached"] is True
+        assert synth_call["meta_info"]["is_md5_hash"] is True
+        assert synth_call["meta_info"]["message_category"] == "event_proactive"
+
+    @pytest.mark.asyncio
+    async def test_static_node_appends_to_history(self):
+        """Static message should be appended to conversation_history."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._synthesize = AsyncMock()
+
+        agent.process_event({"event": "link_opened"})
+        result = agent.process_event({"event": "details_verified"})
+
+        await tm._proactive_generate_for_event({"event": "details_verified"}, result)
+
+        messages = tm.conversation_history.get_copy()
+        assert any("payment method" in (m.get("content", "") or "") for m in messages)
+
+    @pytest.mark.asyncio
+    async def test_static_node_updates_repeat_after_silence(self):
+        """Transitioning to a node should update repeat_after_silence_seconds."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._synthesize = AsyncMock()
+
+        agent.process_event({"event": "link_opened"})
+        result = agent.process_event({"event": "details_verified"})
+
+        await tm._proactive_generate_for_event({"event": "details_verified"}, result)
+
+        # select_payment has no repeat_after_silence_seconds
+        assert tm.repeat_after_silence_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# 4. _proactive_generate_for_event — LLM node path
+# ---------------------------------------------------------------------------
+
+
+class TestProactiveGenerateLLMNode:
+    @pytest.mark.asyncio
+    async def test_llm_node_triggers_generate_proactive(self):
+        """Event → LLM node should call _generate_proactive."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._generate_proactive = AsyncMock()
+
+        result = agent.process_event({"event": "link_opened"})
+
+        await tm._proactive_generate_for_event({"event": "link_opened"}, result)
+
+        tm._generate_proactive.assert_awaited_once()
+        assert agent._event_triggered_generation is True
+
+    @pytest.mark.asyncio
+    async def test_llm_node_sets_event_previous_node(self):
+        """Should set _event_previous_node in context for routing_info."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._generate_proactive = AsyncMock()
+
+        result = agent.process_event({"event": "link_opened"})
+
+        await tm._proactive_generate_for_event({"event": "link_opened"}, result)
+
+        assert agent.context_data.get("_event_previous_node") == "waiting_for_link"
+
+    @pytest.mark.asyncio
+    async def test_llm_node_no_user_message_in_history(self):
+        """Proactive generation should NOT add a user message to history."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+
+        tm.conversation_history.append_assistant("I've sent you the link.")
+
+        # Mock _generate_proactive to avoid the full LLM pipeline
+        tm._generate_proactive = AsyncMock()
+
+        result = agent.process_event({"event": "link_opened"})
+        await tm._proactive_generate_for_event({"event": "link_opened"}, result)
+
+        messages = tm.conversation_history.get_copy()
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        assert len(user_msgs) == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. _generate_proactive tests
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateProactive:
+    @pytest.mark.asyncio
+    async def test_sends_bos_and_eos(self):
+        """Should send BOS and EOS packets to output handler."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._run_llm_task = AsyncMock()
+
+        await tm._generate_proactive()
+
+        output_calls = tm.tools["output"].handle.call_args_list
+        assert output_calls[0][0][0]["data"] == "<beginning_of_stream>"
+        assert output_calls[-1][0][0]["data"] == "<end_of_stream>"
+
+    @pytest.mark.asyncio
+    async def test_sets_response_in_pipeline(self):
+        """Should set response_in_pipeline before running LLM task."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+
+        pipeline_states = []
+
+        async def capture_pipeline_state(msg):
+            pipeline_states.append(tm.response_in_pipeline)
+
+        tm._run_llm_task = capture_pipeline_state
+
+        await tm._generate_proactive()
+
+        assert pipeline_states[0] is True
+
+    @pytest.mark.asyncio
+    async def test_meta_info_has_event_category(self):
+        """Meta info should have message_category='event_proactive'."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+
+        captured_messages = []
+
+        async def capture_msg(msg):
+            captured_messages.append(msg)
+
+        tm._run_llm_task = capture_msg
+
+        await tm._generate_proactive()
+
+        assert captured_messages[0]["meta_info"]["message_category"] == "event_proactive"
+
+
+# ---------------------------------------------------------------------------
+# 6. Full BFSI flow — happy path
+# ---------------------------------------------------------------------------
+
+
+class TestBFSIHappyPath:
+    @pytest.mark.asyncio
+    async def test_complete_payment_flow(self):
+        """Simulate the complete BFSI payment flow with chained events."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+
+        transitions = []
+
+        async def track_proactive(event, result):
+            transitions.append(
+                {
+                    "event": event["event"],
+                    "from": result.get("previous_node"),
+                    "to": result.get("new_node_id"),
+                    "node_type": result.get("node_type"),
+                }
+            )
+
+        tm._proactive_generate_for_event = track_proactive
+
+        # Step 1: link_opened → verify_details (LLM node)
+        await _run_listener_and_process(tm, [{"event": "link_opened", "properties": {"step": "verify"}}])
+        assert agent.current_node_id == "verify_details"
+
+        # Step 2: details_verified → select_payment (static node)
+        await _run_listener_and_process(tm, [{"event": "details_verified"}])
+        assert agent.current_node_id == "select_payment"
+
+        # Step 3: payment_initiated → awaiting_payment (LLM node)
+        await _run_listener_and_process(tm, [{"event": "payment_initiated", "properties": {"method": "UPI"}}])
+        assert agent.current_node_id == "awaiting_payment"
+
+        # Step 4: payment_completed → confirmation (static node)
+        await _run_listener_and_process(tm, [{"event": "payment_completed", "properties": {"ref": "TXN-12345"}}])
+        assert agent.current_node_id == "confirmation"
+
+        # Verify all transitions happened
+        assert len(transitions) == 4
+        assert transitions[0]["event"] == "link_opened"
+        assert transitions[0]["from"] == "waiting_for_link"
+        assert transitions[0]["to"] == "verify_details"
+        assert transitions[0]["node_type"] == NodeType.LLM
+
+        assert transitions[1]["event"] == "details_verified"
+        assert transitions[1]["to"] == "select_payment"
+        assert transitions[1]["node_type"] == NodeType.STATIC
+
+        assert transitions[2]["event"] == "payment_initiated"
+        assert transitions[2]["to"] == "awaiting_payment"
+        assert transitions[2]["node_type"] == NodeType.LLM
+
+        assert transitions[3]["event"] == "payment_completed"
+        assert transitions[3]["to"] == "confirmation"
+        assert transitions[3]["node_type"] == NodeType.STATIC
+
+        # Verify context_data accumulated across events
+        assert agent.context_data["step"] == "verify"
+        assert agent.context_data["method"] == "UPI"
+        assert agent.context_data["ref"] == "TXN-12345"
+
+        # Verify node history
+        assert agent.node_history == [
+            "waiting_for_link",
+            "verify_details",
+            "select_payment",
+            "awaiting_payment",
+            "confirmation",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_payment_failure_and_retry_flow(self):
+        """Test the payment failure → retry path."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        # Fast-forward to awaiting_payment
+        await _run_listener_and_process(
+            tm,
+            [
+                {"event": "link_opened"},
+                {"event": "details_verified"},
+                {"event": "payment_initiated", "properties": {"method": "UPI"}},
+            ],
+            settle_time=0.5,
+        )
+        assert agent.current_node_id == "awaiting_payment"
+
+        # Payment fails
+        await _run_listener_and_process(tm, [{"event": "payment_failed", "properties": {"error_reason": "Timeout"}}])
+        assert agent.current_node_id == "payment_failed"
+        assert agent.context_data["error_reason"] == "Timeout"
+
+        # Retry → back to select_payment
+        await _run_listener_and_process(tm, [{"event": "retry_payment"}])
+        assert agent.current_node_id == "select_payment"
+
+
+# ---------------------------------------------------------------------------
+# 7. Edge cases and robustness
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    @pytest.mark.asyncio
+    async def test_event_on_terminal_node(self):
+        """Event on a node with no event edges should be a no-op."""
+        agent = _make_graph_agent()
+        agent.current_node_id = "help"
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "link_opened"}])
+
+        assert agent.current_node_id == "help"
+        tm._proactive_generate_for_event.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rapid_duplicate_events(self):
+        """Same event fired twice — second doesn't match (different node)."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(
+            tm,
+            [
+                {"event": "link_opened"},
+                {"event": "link_opened"},  # verify_details has no link_opened edge
+            ],
+            settle_time=0.5,
+        )
+
+        assert agent.current_node_id == "verify_details"
+        assert tm._proactive_generate_for_event.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_event_with_empty_properties(self):
+        """Event with empty properties dict should work fine."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "link_opened", "properties": {}}])
+
+        assert agent.current_node_id == "verify_details"
+        tm._proactive_generate_for_event.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_event_with_no_properties_key(self):
+        """Event without properties key should default to empty dict."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "link_opened"}])
+
+        assert agent.current_node_id == "verify_details"
+
+    @pytest.mark.asyncio
+    async def test_context_data_persists_across_events(self):
+        """Properties from all events should accumulate in context_data."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(
+            tm,
+            [
+                {"event": "link_opened", "properties": {"step": "verify", "session": "abc"}},
+            ],
+        )
+        await _run_listener_and_process(
+            tm,
+            [
+                {"event": "details_verified", "properties": {"verified_at": "2024-01-01"}},
+            ],
+        )
+
+        assert agent.context_data["step"] == "verify"
+        assert agent.context_data["session"] == "abc"
+        assert agent.context_data["verified_at"] == "2024-01-01"
+
+    @pytest.mark.asyncio
+    async def test_non_matching_event_still_merges_properties(self):
+        """Even when event doesn't match, properties should update context."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        await _run_listener_and_process(tm, [{"event": "page_scrolled", "properties": {"scroll_depth": 75}}])
+
+        assert agent.current_node_id == "waiting_for_link"
+        assert agent.context_data["scroll_depth"] == 75
+        assert agent.context_data["_last_event"] == "page_scrolled"
+
+    @pytest.mark.asyncio
+    async def test_conversation_ends_mid_processing(self):
+        """If conversation ends while waiting for safe point, should abort."""
+        agent = _make_graph_agent()
+        tm = _make_task_manager(agent=agent)
+        tm._proactive_generate_for_event = AsyncMock()
+
+        tm.response_in_pipeline = True
+
+        task = asyncio.create_task(tm._listen_events())
+        await tm.event_queue.put({"event": "link_opened"})
+        await asyncio.sleep(0.15)
+
+        tm.conversation_ended = True
+        await asyncio.sleep(0.3)
+
+        tm._proactive_generate_for_event.assert_not_awaited()
+
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# 8. Graph agent generate() with event flag — full pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestGraphAgentGenerateEventPath:
+    @pytest.mark.asyncio
+    async def test_event_generate_includes_ephemeral_system_hint(self):
+        """LLM messages should include ephemeral event hint."""
+        agent = _make_graph_agent()
+        agent.process_event({"event": "link_opened"})
+        agent._event_triggered_generation = True
+
+        messages_yielded = None
+        async for chunk in agent.generate([{"role": "assistant", "content": "I sent you the link."}], meta_info={}):
+            if isinstance(chunk, dict) and "messages" in chunk:
+                messages_yielded = chunk["messages"]
+                break
+
+        assert messages_yielded is not None
+        last_msg = messages_yielded[-1]
+        assert last_msg["role"] == "system"
+        assert "link_opened" in last_msg["content"]
+        assert "proactively" in last_msg["content"].lower()
+
+    @pytest.mark.asyncio
+    async def test_event_generate_routing_info_fields(self):
+        """Routing info from event-triggered generate should have all expected fields."""
+        agent = _make_graph_agent()
+        agent.process_event({"event": "link_opened"})
+        agent._event_triggered_generation = True
+
+        routing_info = None
+        async for chunk in agent.generate([], meta_info={}):
+            if isinstance(chunk, dict) and "routing_info" in chunk:
+                routing_info = chunk["routing_info"]
+                break
+
+        assert routing_info is not None
+        assert routing_info["event_triggered"] is True
+        assert routing_info["routing_type"] == "event"
+        assert routing_info["transitioned"] is True
+        assert routing_info["routing_latency_ms"] == 0
+        assert routing_info["confidence"] == 1.0
+        assert "link_opened" in routing_info["reasoning"]
+        assert routing_info["routing_model"] is None
+        assert routing_info["is_silence_trigger"] is False
+
+    @pytest.mark.asyncio
+    async def test_normal_generate_unaffected(self):
+        """Normal (non-event) generate should work unchanged."""
+        agent = _make_graph_agent()
+
+        agent.decide_next_node_with_functions = AsyncMock(return_value=(None, None, 0.0, None, None, None, None))
+
+        chunks = []
+        async for chunk in agent.generate([{"role": "user", "content": "hi"}], meta_info={}):
+            chunks.append(chunk)
+            if isinstance(chunk, dict) and "routing_info" in chunk:
+                ri = chunk["routing_info"]
+                assert ri.get("event_triggered") is None
+                break
+
+    @pytest.mark.asyncio
+    async def test_event_static_node_yields_static_message(self):
+        """Static node via event should yield static_message dict."""
+        agent = _make_graph_agent()
+
+        agent.process_event({"event": "link_opened"})
+        agent.process_event({"event": "details_verified"})
+        agent._event_triggered_generation = True
+
+        static_msg = None
+        async for chunk in agent.generate([], meta_info={}):
+            if isinstance(chunk, dict) and "static_message" in chunk:
+                static_msg = chunk["static_message"]
+                break
+
+        assert static_msg is not None
+        assert "payment method" in static_msg
+
+
+# ---------------------------------------------------------------------------
+# 9. Confirm event edges don't interfere with normal routing
+# ---------------------------------------------------------------------------
+
+
+class TestEventEdgesDoNotInterfereWithNormalRouting:
+    @pytest.mark.asyncio
+    async def test_llm_routing_ignores_event_edges(self):
+        """LLM-based routing should not see event edges."""
+        agent = _make_graph_agent()
+
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.tool_calls = [MagicMock()]
+        mock_response.choices[0].message.tool_calls[0].function.name = "stay_on_current_node"
+        mock_response.choices[0].message.tool_calls[
+            0
+        ].function.arguments = '{"reasoning": "no match", "confidence": 0.9}'
+
+        agent.routing_client = MagicMock()
+        agent.routing_client.chat.completions.create = MagicMock(return_value=mock_response)
+
+        history = [{"role": "user", "content": "hello"}]
+        result = await agent.decide_next_node_with_functions(history)
+
+        create_call = agent.routing_client.chat.completions.create
+        if create_call.called:
+            call_kwargs = create_call.call_args
+            tools = call_kwargs.kwargs.get("tools") or call_kwargs[1].get("tools", [])
+            tool_names = [t["function"]["name"] for t in tools]
+            # Event edge (transition_to_verify_details) should NOT be in tools
+            assert "transition_to_verify_details" not in tool_names
+            # LLM edge should be present
+            assert "go_to_help" in tool_names
+            assert "stay_on_current_node" in tool_names

--- a/tests/tests/test_say_node_and_silence_policy.py
+++ b/tests/tests/test_say_node_and_silence_policy.py
@@ -1,0 +1,335 @@
+import hashlib
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.models import GraphNode, GraphAgentConfig
+from bolna.enums import NodeType, EdgeConditionType
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.helpers.utils import get_md5_hash
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+class TestNodeType:
+    def test_llm_equals_string(self):
+        assert NodeType.LLM == "llm"
+
+    def test_static_equals_string(self):
+        assert NodeType.STATIC == "static"
+
+    def test_default_is_llm(self):
+        node = GraphNode(id="test")
+        assert node.node_type == NodeType.LLM
+
+    def test_static_from_string(self):
+        node = GraphNode(id="test", node_type="static", static_message="Hello")
+        assert node.node_type == NodeType.STATIC
+
+
+class TestGraphNodeModel:
+    def test_backward_compat_no_new_fields(self):
+        node = GraphNode(id="test", prompt="hello")
+        assert node.node_type == NodeType.LLM
+        assert node.static_message is None
+        assert node.repeat_after_silence_seconds is None
+
+    def test_static_node_with_repeat(self):
+        node = GraphNode(
+            id="greeting",
+            node_type=NodeType.STATIC,
+            static_message="Hello! How can I help?",
+            repeat_after_silence_seconds=8.0,
+        )
+        assert node.node_type == NodeType.STATIC
+        assert node.static_message == "Hello! How can I help?"
+        assert node.repeat_after_silence_seconds == 8.0
+
+    def test_prompt_default_empty(self):
+        node = GraphNode(id="test", node_type=NodeType.STATIC, static_message="Hi")
+        assert node.prompt == ""
+
+    def test_json_roundtrip(self):
+        node = GraphNode(
+            id="test",
+            node_type=NodeType.STATIC,
+            static_message="Test message",
+            repeat_after_silence_seconds=5.0,
+        )
+        data = node.model_dump()
+        assert data["node_type"] == "static"
+        assert data["static_message"] == "Test message"
+        assert data["repeat_after_silence_seconds"] == 5.0
+
+        restored = GraphNode(**data)
+        assert restored.node_type == NodeType.STATIC
+        assert restored.static_message == "Test message"
+        assert restored.repeat_after_silence_seconds == 5.0
+
+
+# ---------------------------------------------------------------------------
+# Graph Agent - Static Node Dispatch
+# ---------------------------------------------------------------------------
+
+def _async_iter(items):
+    async def _gen():
+        for item in items:
+            yield item
+    return _gen()
+
+
+def _make_config(**overrides):
+    defaults = {
+        'agent_information': 'Test agent',
+        'model': 'gpt-4o-mini',
+        'provider': 'openai',
+        'temperature': 0.7,
+        'max_tokens': 150,
+        'current_node_id': 'greeting',
+        'nodes': [
+            {
+                'id': 'greeting',
+                'node_type': 'static',
+                'static_message': 'Hello! Welcome to Acme Corp.',
+                'repeat_after_silence_seconds': 8,
+                'edges': [
+                    {
+                        'to_node_id': 'sales',
+                        'condition': 'wants to buy',
+                        'function_name': 'go_to_sales',
+                    },
+                    {
+                        'to_node_id': 'goodbye',
+                        'condition_type': 'expression',
+                        'expression': {
+                            'conditions': [
+                                {'variable': '_silence_repeats', 'operator': 'gte', 'value': 3},
+                            ],
+                        },
+                    },
+                ],
+            },
+            {
+                'id': 'sales',
+                'prompt': 'Help the user with purchasing.',
+                'edges': [],
+            },
+            {
+                'id': 'goodbye',
+                'node_type': 'static',
+                'static_message': 'Goodbye!',
+                'edges': [],
+            },
+        ],
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def _make_agent(config_overrides=None):
+    cfg = _make_config(**(config_overrides or {}))
+    mock_llm = MagicMock()
+    mock_llm.generate_stream = AsyncMock(return_value=_async_iter([]))
+    mock_llm.trigger_function_call = False
+    mock_openai_client = MagicMock()
+    mock_openai_llm_cls = MagicMock(return_value=mock_llm)
+
+    with patch('bolna.agent_types.graph_agent.OpenAI', return_value=mock_openai_client), \
+         patch('bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS', {'openai': mock_openai_llm_cls}), \
+         patch('bolna.agent_types.graph_agent.OpenAiLLM', return_value=MagicMock()):
+        agent = GraphAgent(cfg)
+
+    agent._mock_llm = mock_llm
+    return agent
+
+
+class TestStaticNodeDispatch:
+    @pytest.mark.asyncio
+    async def test_static_node_yields_static_message_and_hash(self):
+        agent = _make_agent()
+        assert agent.current_node_id == 'greeting'
+
+        history = [{'role': 'user', 'content': 'hello'}]
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        routing_chunk = chunks[0]
+        assert 'routing_info' in routing_chunk
+        assert routing_chunk['routing_info']['node_type'] == NodeType.STATIC
+
+        static_chunk = chunks[1]
+        assert 'static_message' in static_chunk
+        assert static_chunk['static_message'] == 'Hello! Welcome to Acme Corp.'
+        expected_hash = get_md5_hash('Hello! Welcome to Acme Corp.')
+        assert static_chunk['static_audio_hash'] == expected_hash
+
+        assert len(chunks) == 2
+
+    @pytest.mark.asyncio
+    async def test_static_node_routing_info_includes_node_type(self):
+        agent = _make_agent()
+        history = [{'role': 'user', 'content': 'hello'}]
+
+        async for chunk in agent.generate(history):
+            if 'routing_info' in chunk:
+                assert chunk['routing_info']['node_type'] == NodeType.STATIC
+                break
+
+    @pytest.mark.asyncio
+    async def test_llm_node_routing_info_has_llm_type(self):
+        agent = _make_agent({'current_node_id': 'sales'})
+        history = [{'role': 'user', 'content': 'I want to buy'}]
+
+        async for chunk in agent.generate(history):
+            if 'routing_info' in chunk:
+                assert chunk['routing_info']['node_type'] == NodeType.LLM
+                break
+
+    @pytest.mark.asyncio
+    async def test_static_node_empty_message_yields_nothing(self):
+        agent = _make_agent({
+            'current_node_id': 'empty_static',
+            'nodes': [
+                {
+                    'id': 'empty_static',
+                    'node_type': 'static',
+                    'static_message': '',
+                    'edges': [],
+                },
+            ],
+        })
+        history = [{'role': 'user', 'content': 'hello'}]
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        assert 'routing_info' in chunks[0]
+
+    @pytest.mark.asyncio
+    async def test_static_node_with_transition(self):
+        agent = _make_agent()
+        history = [{'role': 'user', 'content': 'hello'}]
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        routing = chunks[0]['routing_info']
+        assert routing['current_node'] == 'greeting'
+
+
+class TestSilenceRepeats:
+    @pytest.mark.asyncio
+    async def test_silence_trigger_increments_counter(self):
+        agent = _make_agent()
+        assert agent._silence_repeats == 0
+
+        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        async for _ in agent.generate(history):
+            pass
+
+        assert agent._silence_repeats == 1
+
+    @pytest.mark.asyncio
+    async def test_silence_counter_resets_on_transition(self):
+        agent = _make_agent({'current_node_id': 'sales'})
+        agent._silence_repeats = 5
+
+        history = [{'role': 'user', 'content': 'hello'}]
+        transitioned = False
+        async for chunk in agent.generate(history):
+            if 'routing_info' in chunk and chunk['routing_info'].get('transitioned'):
+                transitioned = True
+
+        if not transitioned:
+            assert agent._silence_repeats == 5
+        else:
+            assert agent._silence_repeats == 0
+
+    @pytest.mark.asyncio
+    async def test_silence_repeats_in_context_data(self):
+        agent = _make_agent()
+        agent._silence_repeats = 3
+
+        history = [{'role': 'user', 'content': 'hello'}]
+        async for _ in agent.generate(history):
+            pass
+
+        assert agent.context_data.get('_silence_repeats') == 3
+
+    @pytest.mark.asyncio
+    async def test_silence_trigger_on_static_node_replays_message(self):
+        agent = _make_agent()
+        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        assert any('static_message' in c for c in chunks)
+        static_chunk = next(c for c in chunks if 'static_message' in c)
+        assert static_chunk['static_message'] == 'Hello! Welcome to Acme Corp.'
+
+    @pytest.mark.asyncio
+    async def test_routing_info_has_is_silence_trigger(self):
+        agent = _make_agent()
+
+        history = [{'role': 'user', 'content': '[silence] User was silent'}]
+        async for chunk in agent.generate(history):
+            if 'routing_info' in chunk:
+                assert chunk['routing_info']['is_silence_trigger'] is True
+                break
+
+    @pytest.mark.asyncio
+    async def test_normal_message_not_silence_trigger(self):
+        agent = _make_agent()
+
+        history = [{'role': 'user', 'content': 'hello'}]
+        async for chunk in agent.generate(history):
+            if 'routing_info' in chunk:
+                assert chunk['routing_info']['is_silence_trigger'] is False
+                break
+
+    @pytest.mark.asyncio
+    async def test_expression_edge_transitions_on_silence_repeats(self):
+        agent = _make_agent()
+        agent._silence_repeats = 2
+
+        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        routing = chunks[0]['routing_info']
+        assert routing['transitioned'] is True
+        assert routing['current_node'] == 'goodbye'
+        assert agent._silence_repeats == 0
+
+    @pytest.mark.asyncio
+    async def test_expression_edge_no_transition_below_threshold(self):
+        agent = _make_agent()
+        agent._silence_repeats = 1
+
+        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        chunks = []
+        async for chunk in agent.generate(history):
+            chunks.append(chunk)
+
+        routing = chunks[0]['routing_info']
+        assert routing['transitioned'] is False
+        assert routing['current_node'] == 'greeting'
+        assert agent._silence_repeats == 2
+
+
+class TestMd5Hash:
+    def test_get_md5_hash_consistency(self):
+        text = "Hello! Welcome to Acme Corp."
+        h1 = get_md5_hash(text)
+        h2 = get_md5_hash(text)
+        assert h1 == h2
+        assert h1 == hashlib.md5(text.encode()).hexdigest()
+
+    def test_different_text_different_hash(self):
+        assert get_md5_hash("hello") != get_md5_hash("goodbye")

--- a/tests/tests/test_say_node_and_silence_policy.py
+++ b/tests/tests/test_say_node_and_silence_policy.py
@@ -12,6 +12,7 @@ from bolna.helpers.utils import get_md5_hash
 # Model tests
 # ---------------------------------------------------------------------------
 
+
 class TestNodeType:
     def test_llm_equals_string(self):
         assert NodeType.LLM == "llm"
@@ -72,54 +73,56 @@ class TestGraphNodeModel:
 # Graph Agent - Static Node Dispatch
 # ---------------------------------------------------------------------------
 
+
 def _async_iter(items):
     async def _gen():
         for item in items:
             yield item
+
     return _gen()
 
 
 def _make_config(**overrides):
     defaults = {
-        'agent_information': 'Test agent',
-        'model': 'gpt-4o-mini',
-        'provider': 'openai',
-        'temperature': 0.7,
-        'max_tokens': 150,
-        'current_node_id': 'greeting',
-        'nodes': [
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "temperature": 0.7,
+        "max_tokens": 150,
+        "current_node_id": "greeting",
+        "nodes": [
             {
-                'id': 'greeting',
-                'node_type': 'static',
-                'static_message': 'Hello! Welcome to Acme Corp.',
-                'repeat_after_silence_seconds': 8,
-                'edges': [
+                "id": "greeting",
+                "node_type": "static",
+                "static_message": "Hello! Welcome to Acme Corp.",
+                "repeat_after_silence_seconds": 8,
+                "edges": [
                     {
-                        'to_node_id': 'sales',
-                        'condition': 'wants to buy',
-                        'function_name': 'go_to_sales',
+                        "to_node_id": "sales",
+                        "condition": "wants to buy",
+                        "function_name": "go_to_sales",
                     },
                     {
-                        'to_node_id': 'goodbye',
-                        'condition_type': 'expression',
-                        'expression': {
-                            'conditions': [
-                                {'variable': '_silence_repeats', 'operator': 'gte', 'value': 3},
+                        "to_node_id": "goodbye",
+                        "condition_type": "expression",
+                        "expression": {
+                            "conditions": [
+                                {"variable": "_silence_repeats", "operator": "gte", "value": 3},
                             ],
                         },
                     },
                 ],
             },
             {
-                'id': 'sales',
-                'prompt': 'Help the user with purchasing.',
-                'edges': [],
+                "id": "sales",
+                "prompt": "Help the user with purchasing.",
+                "edges": [],
             },
             {
-                'id': 'goodbye',
-                'node_type': 'static',
-                'static_message': 'Goodbye!',
-                'edges': [],
+                "id": "goodbye",
+                "node_type": "static",
+                "static_message": "Goodbye!",
+                "edges": [],
             },
         ],
     }
@@ -135,9 +138,11 @@ def _make_agent(config_overrides=None):
     mock_openai_client = MagicMock()
     mock_openai_llm_cls = MagicMock(return_value=mock_llm)
 
-    with patch('bolna.agent_types.graph_agent.OpenAI', return_value=mock_openai_client), \
-         patch('bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS', {'openai': mock_openai_llm_cls}), \
-         patch('bolna.agent_types.graph_agent.OpenAiLLM', return_value=MagicMock()):
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=mock_openai_client),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": mock_openai_llm_cls}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
         agent = GraphAgent(cfg)
 
     agent._mock_llm = mock_llm
@@ -148,76 +153,78 @@ class TestStaticNodeDispatch:
     @pytest.mark.asyncio
     async def test_static_node_yields_static_message_and_hash(self):
         agent = _make_agent()
-        assert agent.current_node_id == 'greeting'
+        assert agent.current_node_id == "greeting"
 
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
         routing_chunk = chunks[0]
-        assert 'routing_info' in routing_chunk
-        assert routing_chunk['routing_info']['node_type'] == NodeType.STATIC
+        assert "routing_info" in routing_chunk
+        assert routing_chunk["routing_info"]["node_type"] == NodeType.STATIC
 
         static_chunk = chunks[1]
-        assert 'static_message' in static_chunk
-        assert static_chunk['static_message'] == 'Hello! Welcome to Acme Corp.'
-        expected_hash = get_md5_hash('Hello! Welcome to Acme Corp.')
-        assert static_chunk['static_audio_hash'] == expected_hash
+        assert "static_message" in static_chunk
+        assert static_chunk["static_message"] == "Hello! Welcome to Acme Corp."
+        expected_hash = get_md5_hash("Hello! Welcome to Acme Corp.")
+        assert static_chunk["static_audio_hash"] == expected_hash
 
         assert len(chunks) == 2
 
     @pytest.mark.asyncio
     async def test_static_node_routing_info_includes_node_type(self):
         agent = _make_agent()
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
 
         async for chunk in agent.generate(history):
-            if 'routing_info' in chunk:
-                assert chunk['routing_info']['node_type'] == NodeType.STATIC
+            if "routing_info" in chunk:
+                assert chunk["routing_info"]["node_type"] == NodeType.STATIC
                 break
 
     @pytest.mark.asyncio
     async def test_llm_node_routing_info_has_llm_type(self):
-        agent = _make_agent({'current_node_id': 'sales'})
-        history = [{'role': 'user', 'content': 'I want to buy'}]
+        agent = _make_agent({"current_node_id": "sales"})
+        history = [{"role": "user", "content": "I want to buy"}]
 
         async for chunk in agent.generate(history):
-            if 'routing_info' in chunk:
-                assert chunk['routing_info']['node_type'] == NodeType.LLM
+            if "routing_info" in chunk:
+                assert chunk["routing_info"]["node_type"] == NodeType.LLM
                 break
 
     @pytest.mark.asyncio
     async def test_static_node_empty_message_yields_nothing(self):
-        agent = _make_agent({
-            'current_node_id': 'empty_static',
-            'nodes': [
-                {
-                    'id': 'empty_static',
-                    'node_type': 'static',
-                    'static_message': '',
-                    'edges': [],
-                },
-            ],
-        })
-        history = [{'role': 'user', 'content': 'hello'}]
+        agent = _make_agent(
+            {
+                "current_node_id": "empty_static",
+                "nodes": [
+                    {
+                        "id": "empty_static",
+                        "node_type": "static",
+                        "static_message": "",
+                        "edges": [],
+                    },
+                ],
+            }
+        )
+        history = [{"role": "user", "content": "hello"}]
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
         assert len(chunks) == 1
-        assert 'routing_info' in chunks[0]
+        assert "routing_info" in chunks[0]
 
     @pytest.mark.asyncio
     async def test_static_node_with_transition(self):
         agent = _make_agent()
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
-        routing = chunks[0]['routing_info']
-        assert routing['current_node'] == 'greeting'
+        routing = chunks[0]["routing_info"]
+        assert routing["current_node"] == "greeting"
 
 
 class TestSilenceRepeats:
@@ -226,7 +233,7 @@ class TestSilenceRepeats:
         agent = _make_agent()
         assert agent._silence_repeats == 0
 
-        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        history = [{"role": "user", "content": "[silence] User was silent for 8 seconds"}]
         async for _ in agent.generate(history):
             pass
 
@@ -234,13 +241,13 @@ class TestSilenceRepeats:
 
     @pytest.mark.asyncio
     async def test_silence_counter_resets_on_transition(self):
-        agent = _make_agent({'current_node_id': 'sales'})
+        agent = _make_agent({"current_node_id": "sales"})
         agent._silence_repeats = 5
 
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
         transitioned = False
         async for chunk in agent.generate(history):
-            if 'routing_info' in chunk and chunk['routing_info'].get('transitioned'):
+            if "routing_info" in chunk and chunk["routing_info"].get("transitioned"):
                 transitioned = True
 
         if not transitioned:
@@ -253,43 +260,43 @@ class TestSilenceRepeats:
         agent = _make_agent()
         agent._silence_repeats = 3
 
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
         async for _ in agent.generate(history):
             pass
 
-        assert agent.context_data.get('_silence_repeats') == 3
+        assert agent.context_data.get("_silence_repeats") == 3
 
     @pytest.mark.asyncio
     async def test_silence_trigger_on_static_node_replays_message(self):
         agent = _make_agent()
-        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        history = [{"role": "user", "content": "[silence] User was silent for 8 seconds"}]
 
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
-        assert any('static_message' in c for c in chunks)
-        static_chunk = next(c for c in chunks if 'static_message' in c)
-        assert static_chunk['static_message'] == 'Hello! Welcome to Acme Corp.'
+        assert any("static_message" in c for c in chunks)
+        static_chunk = next(c for c in chunks if "static_message" in c)
+        assert static_chunk["static_message"] == "Hello! Welcome to Acme Corp."
 
     @pytest.mark.asyncio
     async def test_routing_info_has_is_silence_trigger(self):
         agent = _make_agent()
 
-        history = [{'role': 'user', 'content': '[silence] User was silent'}]
+        history = [{"role": "user", "content": "[silence] User was silent"}]
         async for chunk in agent.generate(history):
-            if 'routing_info' in chunk:
-                assert chunk['routing_info']['is_silence_trigger'] is True
+            if "routing_info" in chunk:
+                assert chunk["routing_info"]["is_silence_trigger"] is True
                 break
 
     @pytest.mark.asyncio
     async def test_normal_message_not_silence_trigger(self):
         agent = _make_agent()
 
-        history = [{'role': 'user', 'content': 'hello'}]
+        history = [{"role": "user", "content": "hello"}]
         async for chunk in agent.generate(history):
-            if 'routing_info' in chunk:
-                assert chunk['routing_info']['is_silence_trigger'] is False
+            if "routing_info" in chunk:
+                assert chunk["routing_info"]["is_silence_trigger"] is False
                 break
 
     @pytest.mark.asyncio
@@ -297,14 +304,14 @@ class TestSilenceRepeats:
         agent = _make_agent()
         agent._silence_repeats = 2
 
-        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        history = [{"role": "user", "content": "[silence] User was silent for 8 seconds"}]
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
-        routing = chunks[0]['routing_info']
-        assert routing['transitioned'] is True
-        assert routing['current_node'] == 'goodbye'
+        routing = chunks[0]["routing_info"]
+        assert routing["transitioned"] is True
+        assert routing["current_node"] == "goodbye"
         assert agent._silence_repeats == 0
 
     @pytest.mark.asyncio
@@ -312,14 +319,14 @@ class TestSilenceRepeats:
         agent = _make_agent()
         agent._silence_repeats = 1
 
-        history = [{'role': 'user', 'content': '[silence] User was silent for 8 seconds'}]
+        history = [{"role": "user", "content": "[silence] User was silent for 8 seconds"}]
         chunks = []
         async for chunk in agent.generate(history):
             chunks.append(chunk)
 
-        routing = chunks[0]['routing_info']
-        assert routing['transitioned'] is False
-        assert routing['current_node'] == 'greeting'
+        routing = chunks[0]["routing_info"]
+        assert routing["transitioned"] is False
+        assert routing["current_node"] == "greeting"
         assert agent._silence_repeats == 2
 
 


### PR DESCRIPTION
## Summary

Adds three features for graph agents:

**Static nodes**: New `node_type: static` with `static_message` field. Skips LLM call entirely, yields pre-generated audio via MD5 hash lookup from S3. Context variables in static messages are substituted via `update_prompt_with_context`.

**Silence repeat**: Configurable `repeat_after_silence_seconds` per node. When both AI and user are silent beyond the threshold, injects a synthetic `[silence]` user message to re-trigger the graph agent. `_silence_repeats` counter exposed in `context_data` so expression edges can handle "give up after N repeats".

**Event injection**: New `EVENT` edge type on graph nodes. External events (via HTTP API) are matched against current node's event edges. On match, transitions the node and triggers proactive speech generation. `_listen_events` loop consumes from an asyncio.Queue, waits for a safe pipeline state, then processes. Handles both static and LLM target nodes.

Key changes:
- `enums.py`: `EVENT` edge type, `NodeType` enum (LLM/STATIC)
- `models.py`: `CallEvent` model, `event_name`/`node_type`/`static_message`/`repeat_after_silence_seconds` fields
- `graph_agent.py`: `process_event()`, `_classify_edges()` excludes event edges from routing, static node and event-triggered paths in `generate()`
- `task_manager.py`: `_listen_events`, `_wait_for_safe_point`, `_proactive_generate_for_event`, `_generate_proactive`, `_inject_and_run_llm` for silence repeat