### PR TITLE
feat: real-time event injection for graph agents

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1799,7 +1799,17 @@ class TaskManager(BaseManager):
                 if result.get('matched'):
                     # Set node entry index so _node_turns counts from this point
                     self.tools['llm_agent'].current_node_entry_index = len(self.conversation_history.get_copy())
-                    await self._proactive_generate_for_event(event, result)
+
+                    if self.interruption_manager and self.interruption_manager.is_user_speaking():
+                        # User is mid-speech — skip proactive generation.
+                        # The node already transitioned, so the user's in-progress
+                        # utterance will be routed + answered on the new node.
+                        target_node = result.get('target_node')
+                        if target_node:
+                            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
+                        logger.info(f"Event '{event.get('event')}' transitioned node but user is speaking — deferring to conversation flow")
+                    else:
+                        await self._proactive_generate_for_event(event, result)
                 else:
                     logger.info(f"Event '{event.get('event')}' — no matching edge, context updated silently")
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -34,7 +34,7 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
-from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason
+from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason, NodeType
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
@@ -140,8 +140,10 @@ class TaskManager(BaseManager):
         self.synthesizer_queue = asyncio.Queue()
         self.transcriber_output_queue = asyncio.Queue()
         self.dtmf_queue = asyncio.Queue()
+        self.event_queue = kwargs.get("event_queue") or asyncio.Queue()
         self.queues = {
             "dtmf": self.dtmf_queue,
+            "events": self.event_queue,
             "transcriber": self.audio_queue,
             "llm": self.llm_queue,
             "synthesizer": self.synthesizer_queue,
@@ -235,6 +237,7 @@ class TaskManager(BaseManager):
         self._error_logged = False
         self.synthesizer_monitor_task = None
         self.dtmf_task = None
+        self.event_listener_task = None
 
         # state of conversation
         self.current_request_id = None
@@ -1770,6 +1773,108 @@ class TaskManager(BaseManager):
                 logger.info(f"DTMF LLM processing triggered with sequence_id={meta_info['sequence_id']}")
             except Exception as e:
                 logger.info(f"DTMF LLM processing triggered with exception {e}")
+
+    async def _listen_events(self):
+        """Listen for external events and process them through the graph agent.
+        Events trigger node transitions and proactive speech without user input."""
+        logger.info("Event listener started for graph agent")
+        while True:
+            try:
+                event = await self.event_queue.get()
+                if self.conversation_ended:
+                    logger.info(f"Event '{event.get('event')}' ignored — conversation ended")
+                    continue
+
+                logger.info(f"Processing external event: {event.get('event')}")
+
+                # Wait for a safe point (no audio playing, no response in pipeline)
+                await self._wait_for_safe_point()
+
+                if self.conversation_ended:
+                    continue
+
+                # Process through graph agent
+                result = self.tools['llm_agent'].process_event(event)
+
+                if result.get('matched'):
+                    # Set node entry index so _node_turns counts from this point
+                    self.tools['llm_agent'].current_node_entry_index = len(self.conversation_history.get_copy())
+                    await self._proactive_generate_for_event(event, result)
+                else:
+                    logger.info(f"Event '{event.get('event')}' — no matching edge, context updated silently")
+
+            except asyncio.CancelledError:
+                logger.info("Event listener cancelled")
+                break
+            except Exception as e:
+                logger.error(f"Error in event listener: {e}")
+                traceback.print_exc()
+
+    async def _wait_for_safe_point(self, timeout=30.0):
+        """Wait until the pipeline is idle: no audio playing, no response in pipeline, no active LLM task."""
+        start = time.time()
+        while time.time() - start < timeout:
+            if self.conversation_ended:
+                return
+            audio_playing = self.tools["input"].is_audio_being_played_to_user() if "input" in self.tools else False
+            llm_busy = self.llm_task is not None and not self.llm_task.done() if self.llm_task else False
+            if not audio_playing and not self.response_in_pipeline and not llm_busy:
+                return
+            await asyncio.sleep(0.1)
+        logger.warning(f"_wait_for_safe_point timed out after {timeout}s")
+
+    async def _proactive_generate_for_event(self, event: dict, result: dict):
+        """Trigger proactive speech generation after an event-driven transition."""
+        node_type = result.get('node_type', NodeType.LLM)
+        target_node = result.get('target_node')
+
+        # Update repeat_after_silence for the new node
+        if target_node:
+            self.repeat_after_silence_seconds = target_node.get('repeat_after_silence_seconds')
+
+        if node_type == NodeType.STATIC:
+            # Static node: play cached audio directly, no LLM cost
+            static_text = target_node.get('static_message', '') if target_node else ''
+            if static_text:
+                if self.context_data:
+                    static_text = update_prompt_with_context(static_text, self.context_data)
+                self.conversation_history.append_assistant(static_text)
+                meta_info = {
+                    'io': self.tools["output"].get_provider(),
+                    "request_id": str(uuid.uuid4()),
+                    "cached": True,
+                    "sequence_id": -1,
+                    'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+                    "end_of_llm_stream": True,
+                    "text": static_text,
+                    "message_category": "event_proactive",
+                }
+                ws_packet = create_ws_data_packet(get_md5_hash(static_text), meta_info=meta_info, is_md5_hash=True)
+                await self._synthesize(ws_packet)
+        else:
+            # LLM node: set flag and trigger generation without adding a user message
+            self.tools['llm_agent']._event_triggered_generation = True
+            self.tools['llm_agent'].context_data['_event_previous_node'] = result.get('previous_node', '')
+            await self._generate_proactive()
+
+    async def _generate_proactive(self):
+        """Trigger LLM generation proactively (no user message appended to history).
+        Same BOS/EOS structure as _inject_and_run_llm but without conversation_history.append_user()."""
+        meta_info = self.__get_updated_meta_info({
+            'io': self.tools["output"].get_provider(),
+            "request_id": str(uuid.uuid4()),
+            "cached": False,
+            'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
+            "message_category": "event_proactive",
+        })
+        bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
+        await self.tools["output"].handle(bos_packet)
+        self.response_in_pipeline = True
+        task = asyncio.create_task(self._run_llm_task(create_ws_data_packet("", meta_info)))
+        self.llm_task = task
+        await task
+        eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
+        await self.tools["output"].handle(eos_packet)
 
     async def __process_end_of_conversation(self, web_call_timeout=False):
         if self._end_of_conversation_in_progress or self.conversation_ended:
@@ -3924,6 +4029,9 @@ class TaskManager(BaseManager):
                     if self.should_backchannel:
                         self.backchanneling_task = asyncio.create_task(self.__check_for_backchanneling())
 
+                    if self.__is_graph_agent():
+                        self.event_listener_task = asyncio.create_task(self._listen_events())
+
                 try:
                     await asyncio.gather(*tasks)
                 except asyncio.CancelledError:
@@ -4127,6 +4235,7 @@ class TaskManager(BaseManager):
                 # tasks_to_cancel.append(process_task_cancellation(self.initial_silence_task, 'initial_silence_task'))
                 tasks_to_cancel.append(process_task_cancellation(self.first_message_task, "first_message_task"))
                 tasks_to_cancel.append(process_task_cancellation(self.dtmf_task, "dtmf_task"))
+                tasks_to_cancel.append(process_task_cancellation(self.event_listener_task, "event_listener_task"))
                 tasks_to_cancel.append(
                     process_task_cancellation(self.voicemail_handler.check_task, "voicemail_check_task")
                 )

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1868,8 +1868,6 @@ class TaskManager(BaseManager):
             await self._generate_proactive()
 
     async def _generate_proactive(self):
-        """Trigger LLM generation proactively (no user message appended to history).
-        Same BOS/EOS structure as _inject_and_run_llm but without conversation_history.append_user()."""
         meta_info = self.__get_updated_meta_info({
             'io': self.tools["output"].get_provider(),
             "request_id": str(uuid.uuid4()),
@@ -1877,14 +1875,14 @@ class TaskManager(BaseManager):
             'format': self.task_config["tools_config"]["output"].get("format", "pcm"),
             "message_category": "event_proactive",
         })
-        bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
-        await self.tools["output"].handle(bos_packet)
         self.response_in_pipeline = True
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet("", meta_info)))
         self.llm_task = task
-        await task
-        eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
-        await self.tools["output"].handle(eos_packet)
+        try:
+            await task
+        except asyncio.CancelledError:
+            logger.info("Proactive generation cancelled by interruption")
+            return
 
     async def __process_end_of_conversation(self, web_call_timeout=False):
         if self._end_of_conversation_in_progress or self.conversation_ended:

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -65,6 +65,7 @@ class GraphAgent(BaseAgent):
         self.node_history = [self.current_node_id]
         self.current_node_entry_index = 0
         self._silence_repeats = 0
+        self._event_triggered_generation = False
         self.rag_configs = self.initialize_rag_configs()
         self.rag_server_url = os.getenv("RAG_SERVER_URL", "http://localhost:8000")
 
@@ -736,7 +737,7 @@ class GraphAgent(BaseAgent):
 
         try:
             # Event-triggered generation: process_event() already handled routing
-            is_event = getattr(self, '_event_triggered_generation', False)
+            is_event = self._event_triggered_generation
             if is_event:
                 self._event_triggered_generation = False
                 current_node = self.get_node_by_id(self.current_node_id)

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -342,11 +342,15 @@ class GraphAgent(BaseAgent):
         return self._get_edge_by_function_name_from_edges(node.get("edges", []), function_name)
 
     def _classify_edges(self, edges: list) -> tuple:
-        """Split edges into (deterministic_edges, llm_edges), sorted by priority."""
+        """Split edges into (deterministic_edges, llm_edges), sorted by priority.
+        Event edges are excluded — they only fire via process_event()."""
         deterministic = []
         llm = []
         for edge in edges:
-            if edge.get("condition_type") in (EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL):
+            ct = edge.get("condition_type")
+            if ct == EdgeConditionType.EVENT:
+                continue  # event edges only fire via process_event()
+            elif ct in (EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL):
                 deterministic.append(edge)
             else:
                 llm.append(edge)
@@ -361,6 +365,59 @@ class GraphAgent(BaseAgent):
             if evaluate_edge_expression(edge, self.context_data):
                 return edge
         return None
+
+    def process_event(self, event: dict) -> dict:
+        """Process an external event. Merges properties into context_data
+        and checks current node's event edges for a matching transition.
+
+        Returns dict with: matched, event, new_node_id, node_type, etc.
+        """
+        parsed = CallEvent(**event) if not isinstance(event, CallEvent) else event
+        event_name = parsed.event
+        properties = parsed.properties or {}
+
+        # Always merge properties into context_data
+        if properties:
+            self.context_data.update(properties)
+        self.context_data["_last_event"] = event_name
+
+        current_node = self.get_node_by_id(self.current_node_id)
+        if not current_node:
+            logger.warning(f"process_event: current node '{self.current_node_id}' not found")
+            return {"matched": False, "event": event_name}
+
+        # Collect event edges, sorted by priority
+        event_edges = [
+            e for e in current_node.get('edges', [])
+            if e.get('condition_type') == EdgeConditionType.EVENT
+        ]
+        event_edges.sort(key=lambda e: e.get('priority') or 0)
+
+        for edge in event_edges:
+            if edge.get('event_name') == event_name:
+                previous_node = self.current_node_id
+                self.current_node_id = edge['to_node_id']
+                self.current_node_entry_index = 0  # caller should set to len(history)
+                self._silence_repeats = 0
+
+                if self.current_node_id not in self.node_history or self.node_history[-1] != self.current_node_id:
+                    self.node_history.append(self.current_node_id)
+
+                target_node = self.get_node_by_id(edge['to_node_id'])
+                node_type = target_node.get('node_type', NodeType.LLM) if target_node else NodeType.LLM
+
+                logger.info(f"Event '{event_name}' matched edge: {previous_node} -> {self.current_node_id}")
+                return {
+                    "matched": True,
+                    "event": event_name,
+                    "previous_node": previous_node,
+                    "new_node_id": edge['to_node_id'],
+                    "node_type": node_type,
+                    "target_node": target_node,
+                }
+
+        logger.info(f"Event '{event_name}' did not match any event edge on node '{self.current_node_id}' — context updated silently")
+        return {"matched": False, "event": event_name}
 
     def _compute_turn_counts(self, history: list) -> tuple:
         """Count (node_turns, total_turns) from history."""
@@ -678,6 +735,55 @@ class GraphAgent(BaseAgent):
             self.context_data["detected_language"] = detected_language
 
         try:
+            # Event-triggered generation: process_event() already handled routing
+            is_event = getattr(self, '_event_triggered_generation', False)
+            if is_event:
+                self._event_triggered_generation = False
+                current_node = self.get_node_by_id(self.current_node_id)
+                node_type = current_node.get('node_type', NodeType.LLM) if current_node else NodeType.LLM
+
+                yield {
+                    'routing_info': {
+                        'previous_node': self.context_data.get('_event_previous_node', self.current_node_id),
+                        'current_node': self.current_node_id,
+                        'transitioned': True,
+                        'routing_type': 'event',
+                        'routing_model': None,
+                        'routing_provider': None,
+                        'routing_latency_ms': 0,
+                        'extracted_params': {},
+                        'node_history': list(self.node_history),
+                        'routing_messages': None,
+                        'routing_tools': None,
+                        'reasoning': f"event:{self.context_data.get('_last_event', '')}",
+                        'confidence': 1.0,
+                        'node_type': node_type,
+                        'is_silence_trigger': False,
+                        'event_triggered': True,
+                    }
+                }
+
+                if node_type == NodeType.STATIC:
+                    static_text = current_node.get('static_message', '') if current_node else ''
+                    if static_text:
+                        if self.context_data:
+                            static_text = update_prompt_with_context(static_text, self.context_data)
+                        yield {
+                            'static_message': static_text,
+                            'static_audio_hash': get_md5_hash(static_text),
+                        }
+                    return
+
+                messages = await self._build_messages(message)
+                # Inject ephemeral event hint (NOT persisted in conversation_history)
+                event_name = self.context_data.get('_last_event', '')
+                messages.append({"role": "system", "content": f"[Event: {event_name}. Respond proactively — speak first, do not wait for the user.]"})
+                yield {'messages': messages}
+                tool_choice = self._get_tool_choice_for_node()
+                async for chunk in self.llm.generate_stream(messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice):
+                    yield chunk
+                return
+
             is_silence_trigger = bool(message and message[-1].get('content', '').startswith('[silence]'))
             if is_silence_trigger:
                 self._silence_repeats += 1

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -261,6 +261,7 @@ class EdgeConditionType(str, Enum):
     LLM = "llm"
     EXPRESSION = "expression"
     UNCONDITIONAL = "unconditional"
+    EVENT = "event"
 
 
 class NodeType(str, Enum):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -315,6 +315,11 @@ class ExpressionGroup(BaseModel):
     logic: ExpressionLogic = ExpressionLogic.AND
     conditions: List[ExpressionCondition] = Field(default_factory=list)
 
+class CallEvent(BaseModel):
+    """Incoming external event payload."""
+    event: str
+    properties: Optional[Dict[str, Any]] = None
+    timestamp: Optional[float] = None
 
 class GraphEdge(BaseModel):
     """Edge definition for graph-based conversation flow.
@@ -327,6 +332,7 @@ class GraphEdge(BaseModel):
     condition: str = ""  # Human-readable description of when to transition
     condition_type: Optional[EdgeConditionType] = None  # None → "llm" (backward compat)
     expression: Optional[ExpressionGroup] = None  # required when condition_type == "expression"
+    event_name: Optional[str] = None  # Matches CallEvent.event when condition_type="event"
     # Function definition for LLM to call (auto-generated if not provided)
     function_name: Optional[str] = None  # e.g., "go_to_city_question"
     function_description: Optional[str] = None  # Detailed description for LLM


### PR DESCRIPTION
## Summary
- Adds `EVENT` edge type to `EdgeConditionType` event edges only fire via external HTTP events, not speech routing
- `process_event()` on GraphAgent: matches incoming event to current node's event edges, transitions + merges properties into context_data
- `_classify_edges()` skips event edges so they don't interfere with normal LLM/expression routing
- `generate()` event-triggered path: skips routing, injects ephemeral system hint, handles static + LLM nodes
- TaskManager: event queue, `_listen_events()` loop, `_wait_for_safe_point()`, `_proactive_generate_for_event()`, `_generate_proactive()`
- Safe-point buffering ensures events never interrupt active speech