### PR TITLE
fix: ignore speech started effects

### DIFF
--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -44,7 +44,6 @@ class AzureTranscriber(BaseTranscriber):
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
         self.current_turn_id = None
-        self.speech_start_time = None
 
         if self.audio_provider in ("twilio", "exotel", "plivo"):
             self.encoding = "mulaw" if self.audio_provider in ("twilio",) else "linear16"

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -66,18 +66,14 @@ class DeepgramTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.0
         self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
         #Message states
-        self.curr_message = ''
-        self.finalized_transcript = ""
         self.final_transcript = ""
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.websocket_connection = None
         self.connection_authenticated = False
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.current_turn_interim_details = []
         self.audio_frame_timestamps = []  # List of (frame_start, frame_end, send_timestamp)
-        self.turn_counter = 0
+        self.turn_counter = 1
         # Timeout tracking for stuck utterances
         self.last_interim_time = None
         self.interim_timeout = kwargs.get("interim_timeout", 5.0)  # Default 5 seconds
@@ -182,8 +178,6 @@ class DeepgramTranscriber(BaseTranscriber):
 
     def _reset_turn_state(self):
         """Reset turn state variables after finalizing a transcript"""
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -206,6 +200,14 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.warning("No transcript available to force-finalize")
             self._reset_turn_state()
             return
+        
+        # Create transcript message (same format as UtteranceEnd)
+        data = {
+            "type": "transcript",
+            "content": transcript_to_send,
+            "force_finalized": True  # For debugging
+        }
+
 
         # Build turn latencies (same as UtteranceEnd logic)
         try:
@@ -222,13 +224,7 @@ class DeepgramTranscriber(BaseTranscriber):
         except Exception as e:
             logger.error(f"Error building turn latencies: {e}")
 
-        # Create transcript message (same format as UtteranceEnd)
-        data = {
-            "type": "transcript",
-            "content": transcript_to_send,
-            "force_finalized": True  # For debugging
-        }
-
+        self._increment_turn()
         logger.info(f"Force-finalized transcript after timeout: {transcript_to_send}")
 
         # Send to queue (unblocks _listen_transcriber)
@@ -348,6 +344,16 @@ class DeepgramTranscriber(BaseTranscriber):
 
     def get_meta_info(self):
         return self.meta_info
+    
+
+    def _increment_turn(self):
+        self.turn_counter += 1
+        self.current_turn_id = self.turn_counter
+        self.current_turn_interim_details = []
+        self.is_transcript_sent_for_processing = False
+
+        logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
+
 
     async def sender(self, ws=None):
         try:
@@ -445,13 +451,6 @@ class DeepgramTranscriber(BaseTranscriber):
 
                 if msg["type"] == "SpeechStarted":
                     logger.info("Received SpeechStarted event from deepgram")
-                    self.turn_counter += 1
-                    self.current_turn_id = self.turn_counter
-                    self.speech_start_time = timestamp_ms()
-                    self.current_turn_interim_details = []
-                    self.is_transcript_sent_for_processing = False
-
-                    logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                     yield create_ws_data_packet("speech_started", self.meta_info)
                     pass
 
@@ -506,6 +505,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                 "content": self.final_transcript
                             }
 
+
                             # Build turn_latencies with new metrics before resetting
                             try:
                                 first_interim_to_final_ms, last_interim_to_final_ms = self.calculate_interim_to_final_latencies(self.current_turn_interim_details)
@@ -519,8 +519,6 @@ class DeepgramTranscriber(BaseTranscriber):
                                 })
 
                                 # Complete turn reset
-                                self.speech_start_time = None
-                                self.speech_end_time = None
                                 self.current_turn_interim_details = []
                                 self.current_turn_start_time = None
                                 self.current_turn_id = None
@@ -529,6 +527,8 @@ class DeepgramTranscriber(BaseTranscriber):
                             except Exception as e:
                                 logger.error(f"Failed to extract transcript from Deepgram response in speech_final: {e}")
                                 pass
+
+                            self._increment_turn()
                             yield create_ws_data_packet(data, self.meta_info)
 
                 elif msg["type"] == "UtteranceEnd":
@@ -540,6 +540,7 @@ class DeepgramTranscriber(BaseTranscriber):
                             "type": "transcript",
                             "content": self.final_transcript
                         }
+
 
                         # Build turn_latencies with new metrics before resetting
                         try:
@@ -554,8 +555,6 @@ class DeepgramTranscriber(BaseTranscriber):
                             })
 
                             # Complete turn reset
-                            self.speech_start_time = None
-                            self.speech_end_time = None
                             self.current_turn_interim_details = []
                             self.current_turn_start_time = None
                             self.current_turn_id = None
@@ -564,13 +563,13 @@ class DeepgramTranscriber(BaseTranscriber):
                         except Exception as e:
                             logger.error(f"Failed to extract transcript from Deepgram response: {e}")
                             pass
+                        
+                        self._increment_turn()
                         yield create_ws_data_packet(data, self.meta_info)
                     else:
                         # Transcript already sent but we still need to notify speech ended
                         # This prevents callee_speaking from staying True indefinitely
                         logger.info(f"UtteranceEnd received but transcript already processed, yielding speech_ended notification")
-                        self.speech_start_time = None
-                        self.speech_end_time = None
                         self.current_turn_interim_details = []
                         self.current_turn_start_time = None
                         self.current_turn_id = None

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -64,16 +64,12 @@ class ElevenLabsTranscriber(BaseTranscriber):
         self.min_silence_duration_ms = max(50, min(2000, kwargs.get("min_silence_duration_ms", 300)))
 
         # Message states
-        self.curr_message = ''
-        self.finalized_transcript = ""
         self.final_transcript = ""
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.websocket_connection = None
         self.connection_authenticated = False
         self.connection_error = None
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.current_turn_interim_details = []
         self.audio_frame_timestamps = []
         self.turn_counter = 0
@@ -138,8 +134,6 @@ class ElevenLabsTranscriber(BaseTranscriber):
 
     def _reset_turn_state(self):
         """Reset turn state variables after finalizing a transcript"""
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -376,7 +370,6 @@ class ElevenLabsTranscriber(BaseTranscriber):
                         if not self.current_turn_id:
                             self.turn_counter += 1
                             self.current_turn_id = self.turn_counter
-                            self.speech_start_time = timestamp_ms()
                             self.current_turn_interim_details = []
                             logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                             yield create_ws_data_packet("speech_started", self.meta_info)
@@ -437,8 +430,6 @@ class ElevenLabsTranscriber(BaseTranscriber):
                             })
 
                             # Complete turn reset - set flag to False to allow next utterance
-                            self.speech_start_time = None
-                            self.speech_end_time = None
                             self.current_turn_interim_details = []
                             self.current_turn_start_time = None
                             self.current_turn_id = None

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -113,8 +113,6 @@ class GladiaTranscriber(BaseTranscriber):
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_turn_interim_details = []
-        self.speech_start_time = None
-        self.speech_end_time = None
 
         # Latency tracking
         self.first_result_latency_ms = None
@@ -328,8 +326,6 @@ class GladiaTranscriber(BaseTranscriber):
 
     def _reset_turn_state(self):
         """Reset turn state after finalizing a transcript."""
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -654,7 +650,6 @@ class GladiaTranscriber(BaseTranscriber):
                     logger.info("Received speech_begin event from Gladia")
                     self.turn_counter += 1
                     self.current_turn_id = self.turn_counter
-                    self.speech_start_time = timestamp_ms()
                     self.current_turn_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
@@ -664,7 +659,6 @@ class GladiaTranscriber(BaseTranscriber):
                 elif msg_type == "speech_end" or (msg_type == "event" and data.get("data", {}).get("type") == "speech_end"):
                     # Speech ended event
                     logger.info("Received speech_end event from Gladia")
-                    self.speech_end_time = timestamp_ms()
 
                 elif msg_type == "error":
                     error_data = data.get("data", {})

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -86,8 +86,6 @@ class SarvamTranscriber(BaseTranscriber):
         self.turn_counter = 0
         self.turn_first_result_latency = None
         
-        self.curr_message = ''
-        self.finalized_transcript = ""
         self.interruption_signalled = False
 
         self.api_url = None

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -102,8 +102,6 @@ class SmallestTranscriber(BaseTranscriber):
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_turn_interim_details = []
-        self.speech_start_time = None
-        self.speech_end_time = None
 
         # Latency tracking
         self.first_result_latency_ms = None
@@ -254,8 +252,6 @@ class SmallestTranscriber(BaseTranscriber):
 
     def _reset_turn_state(self):
         """Reset turn state after finalizing a transcript."""
-        self.speech_start_time = None
-        self.speech_end_time = None
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -448,7 +444,6 @@ class SmallestTranscriber(BaseTranscriber):
                     # Signal speech started (Smallest doesn't have VAD events)
                     self.turn_counter += 1
                     self.current_turn_id = self.turn_counter
-                    self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
 


### PR DESCRIPTION
**Issue**:
Deepgram transcriber makes the task manager stuck in callee speaking forever, leading to WAIT status for every audio chunk.

**Cause**:
On SpeechStarted events which are generated indepedently from the normal transcript flow (ref: Deepgram docs), the existing interim transcript would be dropped. This caused an issue as VAD events are highly unreliable and often false positives. 

**Fix**:
Perform turn tracking via yielded transcripts rather than relying on SpeechStarted. 

Note: This PR also removes a few unused attributes across transcribers.