### PR TITLE
feat: track http synth latencies;  misc bugs

### DIFF
--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -1,4 +1,5 @@
 import io
+import time
 import uuid
 import asyncio
 import re
@@ -21,6 +22,7 @@ class BaseSynthesizer:
         self.first_chunk_generated = False
         self.synthesized_characters = 0
         self.model = "default"
+        self.current_turn_start_time = None
 
     # ------------------------------------------------------------------
     # Common accessors
@@ -50,6 +52,9 @@ class BaseSynthesizer:
         return self.task_manager_instance.is_sequence_id_in_current_ids(sequence_id)
     
     async def push(self, message):
+        meta_info = message.get("meta_info")
+        self._stamp_turn_start(meta_info)
+
         self.internal_queue.put_nowait(message)
 
     # ------------------------------------------------------------------
@@ -95,6 +100,30 @@ class BaseSynthesizer:
     def _stamp_mark_id(self, meta_info):
         meta_info["mark_id"] = str(uuid.uuid4())
 
+    def _stamp_turn_start(self, meta_info):
+        """Only stamp on the first push of a new turn (don't re-stamp on subsequent chunks)."""
+        if self.current_turn_start_time is None:
+            self.current_turn_start_time = time.perf_counter()
+            logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
+        self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
+
+    def _record_turn_latency(self):
+        """Append a latency record for the completed turn."""
+        try:
+            if self.current_turn_start_time is not None:
+                total_stream_duration = time.perf_counter() - self.current_turn_start_time
+                self.turn_latencies.append({
+                    "turn_id": self.current_turn_id,
+                    "sequence_id": self.current_turn_id,
+                    "first_result_latency_ms": round(total_stream_duration * 1000),
+                    "total_stream_duration_ms": round(total_stream_duration * 1000),
+                })
+                self.current_turn_start_time = None
+                self.current_turn_id = None
+        except Exception:
+            logger.warning("Error recording turn latency", exc_info=True)
+            pass
+
     # ------------------------------------------------------------------
     # HTTP generate loop (used by HTTP-only synths and dual-mode synths)
     # ------------------------------------------------------------------
@@ -120,7 +149,7 @@ class BaseSynthesizer:
 
             if not self.should_synthesize_response(meta_info.get("sequence_id")):
                 logger.info(f"Not synthesizing: sequence_id {meta_info.get('sequence_id')} not current")
-                return
+                continue
 
             audio = await self._fetch_http_audio(text, meta_info)
             audio = self._process_http_audio(audio)
@@ -132,6 +161,9 @@ class BaseSynthesizer:
             meta_info["text"] = text
             meta_info["text_synthesized"] = f"{text} "
             self._stamp_mark_id(meta_info)
+
+            self._record_turn_latency()
+
             yield create_ws_data_packet(audio, meta_info)
 
             
@@ -149,7 +181,8 @@ class BaseSynthesizer:
                 meta_info["is_cached"] = False
             self.synthesized_characters += len(text)
             audio = await self._generate_http(text)
-            self.cache.set(text, audio)
+            if audio is not None and audio != b'\x00':
+                self.cache.set(text, audio)
             return audio
         else:
             if meta_info is not None:

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -23,6 +23,7 @@ class BaseSynthesizer:
         self.synthesized_characters = 0
         self.model = "default"
         self.current_turn_start_time = None
+        self.current_turn_id = None
 
     # ------------------------------------------------------------------
     # Common accessors

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -146,7 +146,7 @@ class StreamSynthesizer(BaseSynthesizer):
         if self.stream:
             await self._push_stream(message)
         else:
-            super().push(message)
+            await super().push(copy.deepcopy(message))
 
     async def _push_stream(self, message):
         meta_info = message.get("meta_info")

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -146,7 +146,7 @@ class StreamSynthesizer(BaseSynthesizer):
         if self.stream:
             await self._push_stream(message)
         else:
-            self.internal_queue.put_nowait(copy.deepcopy(message))
+            super().push(message)
 
     async def _push_stream(self, message):
         meta_info = message.get("meta_info")
@@ -270,6 +270,7 @@ class StreamSynthesizer(BaseSynthesizer):
                 self.ws_send_time = None
                 self.current_turn_ttfb = None
         except Exception:
+            logger.warning("Error recording turn latency", exc_info=True)
             pass
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
- Add Latency tracking for HTTP synthesizers
- Prevents early return in generate_http_loop (bug)
- Prevents setting cache on null responses from the synthesizer implementations, usually arising due to API errors