### PR TITLE
feat: add Responses API support with WS transport, truncation, and compaction

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -271,6 +271,9 @@ class TaskManager(BaseManager):
                 if self.llm_agent_config.get('use_responses_api'):
                     self.llm_config['use_responses_api'] = True
 
+                if self.llm_agent_config.get('compact_threshold'):
+                    self.llm_config['compact_threshold'] = self.llm_agent_config['compact_threshold']
+
         # Output stuff
         self.output_task = None
         self.buffered_output_queue = asyncio.Queue()
@@ -991,6 +994,8 @@ class TaskManager(BaseManager):
                 injected_cfg['routing_max_tokens'] = self.kwargs['routing_max_tokens']
             if self.llm_config.get('use_responses_api'):
                 injected_cfg['use_responses_api'] = True
+            if self.llm_config.get('compact_threshold'):
+                injected_cfg['compact_threshold'] = self.llm_config['compact_threshold']
             injected_cfg['buffer_size'] = self.task_config["tools_config"]["synthesizer"].get('buffer_size')
             injected_cfg['language'] = self.language
 
@@ -1023,6 +1028,8 @@ class TaskManager(BaseManager):
                 injected_cfg['service_tier'] = self.kwargs['service_tier']
             if self.llm_config.get('use_responses_api'):
                 injected_cfg['use_responses_api'] = True
+            if self.llm_config.get('compact_threshold'):
+                injected_cfg['compact_threshold'] = self.llm_config['compact_threshold']
             injected_cfg['buffer_size'] = self.task_config["tools_config"]["synthesizer"].get('buffer_size')
             injected_cfg['language'] = self.language
 

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -98,7 +98,7 @@ class GraphAgent(BaseAgent):
                 'provider': provider,
             }
 
-            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api']:
+            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api', 'compact_threshold']:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]
 

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -62,7 +62,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 'provider': provider,
             }
 
-            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api']:
+            for key in ['llm_key', 'base_url', 'api_version', 'language', 'api_tools', 'buffer_size', 'reasoning_effort', 'service_tier', 'use_responses_api', 'compact_threshold']:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -126,14 +126,27 @@ class Verbosity(str, Enum):
 
 
 class ResponseStreamEvent(str, Enum):
-    """Responses API server-sent event types."""
+    """Responses API event types (server-sent and client commands)."""
+    # Server stream events
     CREATED = "response.created"
     COMPLETED = "response.completed"
     FAILED = "response.failed"
     INCOMPLETE = "response.incomplete"
+    IN_PROGRESS = "response.in_progress"
     OUTPUT_TEXT_DELTA = "response.output_text.delta"
     OUTPUT_ITEM_ADDED = "response.output_item.added"
+    OUTPUT_ITEM_DONE = "response.output_item.done"
     FUNCTION_CALL_ARGS_DELTA = "response.function_call_arguments.delta"
+    ERROR = "error"
+
+    # WebSocket client commands
+    CREATE = "response.create"
+    CANCEL = "response.cancel"
+
+    @classmethod
+    def terminal_events(cls):
+        """Events that signal the end of a response stream."""
+        return frozenset({cls.COMPLETED, cls.FAILED, cls.INCOMPLETE, cls.ERROR})
 
     @classmethod
     def all_values(cls):

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -70,7 +70,7 @@ class AzureLLM(OpenAICompatibleLLM):
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
         # Responses API: uses v1 endpoint with regular AsyncOpenAI client
-        self._init_responses_api(kwargs.get("use_responses_api", False))
+        self._init_responses_api(kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold"))
         if self.use_responses_api:
             v1_base_url = f"{azure_endpoint.rstrip('/')}/openai/v1/"
             self._responses_api_client = AsyncOpenAI(

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -54,6 +54,12 @@ class MessageFormatAdapter:
                 })
 
             elif msg.role == ChatRole.ASSISTANT:
+                if msg.content is not None:
+                    input_items.append({
+                        "type": ResponseItemType.MESSAGE,
+                        "role": ChatRole.ASSISTANT,
+                        "content": msg.content,
+                    })
                 if msg.tool_calls:
                     for tc in msg.tool_calls:
                         input_items.append({
@@ -61,13 +67,6 @@ class MessageFormatAdapter:
                             "call_id": tc.id,
                             "name": tc.function.name,
                             "arguments": tc.function.arguments,
-                        })
-                else:
-                    if msg.content is not None:
-                        input_items.append({
-                            "type": ResponseItemType.MESSAGE,
-                            "role": ChatRole.ASSISTANT,
-                            "content": msg.content,
                         })
 
             elif msg.role == ChatRole.TOOL:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -270,7 +270,7 @@ class OpenAICompatibleLLM(BaseLLM):
                 first_token_time = now
                 self.started_streaming = True
                 latency_data = LatencyData(
-                    sequence_id=meta_info.get("sequence_id"),
+                    sequence_id=meta_info.get("sequence_id") if meta_info else None,
                     first_token_latency_ms=first_token_time - start_time,
                     total_stream_duration_ms=None,
                     service_tier=service_tier,

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 
 from openai import BadRequestError, APIError
 
@@ -7,7 +8,7 @@ from bolna.enums import ChatRole, ResponseStreamEvent, ResponseItemType, LogComp
 from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
 from .llm import BaseLLM
 from .message_models import MessageFormatAdapter
-from .types import LLMStreamChunk, LatencyData, FunctionCallPayload
+from .types import APIParams, LLMStreamChunk, LatencyData, FunctionCallPayload
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -21,9 +22,11 @@ class OpenAICompatibleLLM(BaseLLM):
     - Override _responses_client property if they need a different client
     """
 
-    def _init_responses_api(self, use_responses_api: bool = False):
+    def _init_responses_api(self, use_responses_api: bool = False, compact_threshold: Optional[int] = None):
         self.use_responses_api = use_responses_api
         self.previous_response_id = None
+        self._pending_call_ids: set[str] = set()
+        self.compact_threshold = compact_threshold
 
     @property
     def _responses_client(self):
@@ -34,17 +37,23 @@ class OpenAICompatibleLLM(BaseLLM):
         """
         return self.async_client
 
-    # ------------------------------------------------------------------
-    # Input building
-    # ------------------------------------------------------------------
-
     def _build_responses_input(self, messages):
         """Build (instructions, input_items) for Responses API.
 
         When previous_response_id is set, only sends new items since last
         server response. Otherwise sends the full conversation.
+
+        Tool call guard: if the previous response made function calls whose
+        outputs are not yet in the history, fall back to full context to
+        avoid 400 errors from the server.
         """
         if self.previous_response_id:
+            if self._pending_call_ids:
+                completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
+                if not self._pending_call_ids.issubset(completed):
+                    logger.info("Pending tool call outputs missing, sending full context")
+                    self.previous_response_id = None
+                    return MessageFormatAdapter.chat_to_responses_input(messages)
             return self._extract_new_input(messages)
         return MessageFormatAdapter.chat_to_responses_input(messages)
 
@@ -74,10 +83,6 @@ class OpenAICompatibleLLM(BaseLLM):
         _, input_items = MessageFormatAdapter.chat_to_responses_input(new_messages)
         return instructions, input_items
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
-
     @staticmethod
     def _is_stale_response_error(error):
         """Check if an API error is likely due to a stale previous_response_id.
@@ -98,15 +103,10 @@ class OpenAICompatibleLLM(BaseLLM):
 
     def invalidate_response_chain(self):
         self.previous_response_id = None
+        self._pending_call_ids = set()
 
-    # ------------------------------------------------------------------
-    # Streaming
-    # ------------------------------------------------------------------
-
-    async def _generate_stream_responses(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
-        if not messages:
-            raise ValueError("No messages provided")
-
+    def _build_responses_create_kwargs(self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None):
+        """Build create kwargs common to both HTTP SSE and WebSocket streaming paths."""
         instructions, input_items = self._build_responses_input(messages)
         responses_tools = MessageFormatAdapter.chat_tools_to_responses_tools(self._parse_tools())
 
@@ -114,12 +114,18 @@ class OpenAICompatibleLLM(BaseLLM):
             "model": self.model,
             "instructions": instructions or None,
             "input": input_items,
-            "stream": True,
-            "store": True,
+            "store": store,
+            "truncation": "auto",
             "max_output_tokens": self.max_tokens,
             "temperature": self.temperature,
             "user": f"{self.run_id}#{meta_info['turn_id']}" if meta_info else None,
         }
+
+        if stream is not None:
+            create_kwargs["stream"] = stream
+
+        if self.compact_threshold:
+            create_kwargs["context_management"] = [{"type": "compaction", "compact_threshold": self.compact_threshold}]
 
         service_tier = self.model_args.get("service_tier")
         if service_tier:
@@ -145,10 +151,20 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
+        return create_kwargs, responses_tools
+
+    async def _generate_stream_responses(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
+        if not messages:
+            raise ValueError("No messages provided")
+
+        create_kwargs, responses_tools = self._build_responses_create_kwargs(
+            messages, meta_info, request_json, tool_choice, store=True, stream=True
+        )
+
         answer, buffer = "", ""
-        func_call_args = {}  # item_id -> accumulated arguments
-        func_call_names = {}  # item_id -> function name
-        func_call_ids = {}  # item_id -> call_id
+        func_call_args = {}
+        func_call_names = {}
+        func_call_ids = {}
         gave_pre_call_msg = False
         received_textual = False
 
@@ -225,7 +241,8 @@ class OpenAICompatibleLLM(BaseLLM):
 
                     if not gave_pre_call_msg and not received_textual and self.trigger_function_call:
                         gave_pre_call_msg = True
-                        api_tool_pre_call_message = self.api_params.get(item.name, {}).get('pre_call_message', None)
+                        func_params = self.api_params.get(item.name)
+                        api_tool_pre_call_message = APIParams.model_validate(func_params).pre_call_message if func_params else None
                         detected_lang = meta_info.get('detected_language') if meta_info else None
                         active_language = detected_lang or self.language
                         pre_msg = compute_function_pre_call_message(active_language, item.name, api_tool_pre_call_message)
@@ -238,6 +255,7 @@ class OpenAICompatibleLLM(BaseLLM):
             elif event.type == ResponseStreamEvent.COMPLETED:
                 if hasattr(event.response, 'id'):
                     self.previous_response_id = event.response.id
+                self._pending_call_ids = set(func_call_ids.values())
                 service_tier = service_tier or getattr(event.response, 'service_tier', None)
                 if hasattr(event.response, 'usage') and event.response.usage:
                     response_usage = event.response.usage
@@ -255,16 +273,15 @@ class OpenAICompatibleLLM(BaseLLM):
             arguments_str = func_call_args[first_item_id]
 
             if func_name in self.api_params:
-                func_conf = self.api_params[func_name]
+                func_conf = APIParams.model_validate(self.api_params[func_name])
                 logger.info(f"Payload to send {arguments_str} func_dict {func_conf}")
 
-                method = func_conf.get('method')
                 api_call_payload = FunctionCallPayload(
-                    url=func_conf.get('url'),
-                    method=method.lower() if method else None,
-                    param=func_conf.get('param'),
-                    api_token=func_conf.get('api_token'),
-                    headers=func_conf.get('headers'),
+                    url=func_conf.url,
+                    method=func_conf.method.lower() if func_conf.method else None,
+                    param=func_conf.param,
+                    api_token=func_conf.api_token,
+                    headers=func_conf.headers,
                     model_args=create_kwargs,
                     meta_info=meta_info,
                     called_fun=func_name,
@@ -298,7 +315,6 @@ class OpenAICompatibleLLM(BaseLLM):
 
                 yield LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
 
-        # Extract actual token counts from response usage
         usage_kwargs = {}
         if response_usage:
             usage_kwargs['input_tokens'] = getattr(response_usage, 'input_tokens', None)
@@ -317,10 +333,6 @@ class OpenAICompatibleLLM(BaseLLM):
 
         self.started_streaming = False
 
-    # ------------------------------------------------------------------
-    # Non-streaming
-    # ------------------------------------------------------------------
-
     async def _generate_responses(self, messages, request_json=False, ret_metadata=False):
         instructions, input_items = self._build_responses_input(messages)
 
@@ -329,9 +341,13 @@ class OpenAICompatibleLLM(BaseLLM):
             "instructions": instructions or None,
             "input": input_items,
             "store": True,
+            "truncation": "auto",
             "max_output_tokens": self.max_tokens,
             "temperature": 0.0,  # Intentional: non-streaming uses deterministic output
         }
+
+        if self.compact_threshold:
+            create_kwargs["context_management"] = [{"type": "compaction", "compact_threshold": self.compact_threshold}]
 
         service_tier = self.model_args.get("service_tier")
         if service_tier:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -105,6 +105,63 @@ class OpenAICompatibleLLM(BaseLLM):
         self.previous_response_id = None
         self._pending_call_ids = set()
 
+    def _build_function_call_chunk(self, func_call_args, func_call_names, func_call_ids,
+                                    responses_tools, create_kwargs, meta_info,
+                                    answer, received_textual, latency_data):
+        """Build LLMStreamChunk with FunctionCallPayload from accumulated function call data, or None."""
+        if not (func_call_args and self.trigger_function_call):
+            return None
+
+        first_item_id = next(iter(func_call_args))
+        func_name = func_call_names[first_item_id]
+        call_id = func_call_ids[first_item_id]
+        arguments_str = func_call_args[first_item_id]
+
+        if func_name not in self.api_params:
+            return None
+
+        func_conf = APIParams.model_validate(self.api_params[func_name])
+        logger.info(f"Payload to send {arguments_str} func_dict {func_conf}")
+
+        api_call_payload = FunctionCallPayload(
+            url=func_conf.url,
+            method=func_conf.method.lower() if func_conf.method else None,
+            param=func_conf.param,
+            api_token=func_conf.api_token,
+            headers=func_conf.headers,
+            model_args=create_kwargs,
+            meta_info=meta_info,
+            called_fun=func_name,
+            model_response=[{
+                "index": 0,
+                "id": call_id,
+                "function": {"name": func_name, "arguments": arguments_str},
+                "type": "function",
+            }],
+            tool_call_id=call_id,
+            textual_response=answer.strip() if received_textual else None,
+        )
+
+        tool_spec = next((t for t in responses_tools if t["name"] == func_name), None)
+        if tool_spec:
+            try:
+                parsed_args = json.loads(arguments_str)
+                required_keys = tool_spec.get("parameters", {}).get("required", [])
+                if tool_spec.get("parameters") is not None and all(k in parsed_args for k in required_keys):
+                    convert_to_request_log(arguments_str, meta_info, self.model, LogComponent.LLM,
+                                           direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
+                    for k, v in parsed_args.items():
+                        setattr(api_call_payload, k, v)
+                else:
+                    api_call_payload.resp = None
+            except (json.JSONDecodeError, KeyError) as e:
+                logger.error(f"Error parsing function arguments: {e}")
+                api_call_payload.resp = None
+        else:
+            api_call_payload.resp = None
+
+        return LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
+
     def _build_responses_create_kwargs(self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None):
         """Build create kwargs common to both HTTP SSE and WebSocket streaming paths."""
         instructions, input_items = self._build_responses_input(messages)
@@ -198,7 +255,7 @@ class OpenAICompatibleLLM(BaseLLM):
             if event.type == ResponseStreamEvent.FAILED:
                 error_info = getattr(event.response, 'error', None) or getattr(event.response, 'last_error', None)
                 logger.error(f"Responses API stream failed: {error_info}")
-                self.previous_response_id = None
+                self.invalidate_response_chain()
                 raise APIError(
                     message=f"Response failed: {error_info}",
                     request=None, body=None
@@ -206,7 +263,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
             if event.type == ResponseStreamEvent.INCOMPLETE:
                 logger.warning("Responses API stream incomplete, partial response returned")
-                self.previous_response_id = None
+                self.invalidate_response_chain()
                 break
 
             if not first_token_time and event.type in (ResponseStreamEvent.OUTPUT_TEXT_DELTA, ResponseStreamEvent.FUNCTION_CALL_ARGS_DELTA):
@@ -266,54 +323,13 @@ class OpenAICompatibleLLM(BaseLLM):
             if service_tier:
                 latency_data.service_tier = service_tier
 
-        if func_call_args and self.trigger_function_call:
-            first_item_id = next(iter(func_call_args))
-            func_name = func_call_names[first_item_id]
-            call_id = func_call_ids[first_item_id]
-            arguments_str = func_call_args[first_item_id]
-
-            if func_name in self.api_params:
-                func_conf = APIParams.model_validate(self.api_params[func_name])
-                logger.info(f"Payload to send {arguments_str} func_dict {func_conf}")
-
-                api_call_payload = FunctionCallPayload(
-                    url=func_conf.url,
-                    method=func_conf.method.lower() if func_conf.method else None,
-                    param=func_conf.param,
-                    api_token=func_conf.api_token,
-                    headers=func_conf.headers,
-                    model_args=create_kwargs,
-                    meta_info=meta_info,
-                    called_fun=func_name,
-                    model_response=[{
-                        "index": 0,
-                        "id": call_id,
-                        "function": {"name": func_name, "arguments": arguments_str},
-                        "type": "function",
-                    }],
-                    tool_call_id=call_id,
-                    textual_response=answer.strip() if received_textual else None,
-                )
-
-                tool_spec = next((t for t in responses_tools if t["name"] == func_name), None)
-                if tool_spec:
-                    try:
-                        parsed_args = json.loads(arguments_str)
-                        required_keys = tool_spec.get("parameters", {}).get("required", [])
-                        if tool_spec.get("parameters") is not None and all(k in parsed_args for k in required_keys):
-                            convert_to_request_log(arguments_str, meta_info, self.model, LogComponent.LLM,
-                                                   direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
-                            for k, v in parsed_args.items():
-                                setattr(api_call_payload, k, v)
-                        else:
-                            api_call_payload.resp = None
-                    except (json.JSONDecodeError, KeyError) as e:
-                        logger.error(f"Error parsing function arguments: {e}")
-                        api_call_payload.resp = None
-                else:
-                    api_call_payload.resp = None
-
-                yield LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
+        fc_chunk = self._build_function_call_chunk(
+            func_call_args, func_call_names, func_call_ids,
+            responses_tools, create_kwargs, meta_info,
+            answer, received_textual, latency_data
+        )
+        if fc_chunk:
+            yield fc_chunk
 
         usage_kwargs = {}
         if response_usage:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -23,7 +23,7 @@ logger = configure_logger(__name__)
 load_dotenv()
 
 
-class OpenAIWSTransport:
+class OpenAIWSConnection:
     """Persistent WebSocket connection to wss://api.openai.com/v1/responses.
 
     - Eager connect at init, ready before first LLM call
@@ -189,7 +189,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self._ws_transport = None
         if self.use_responses_api and kwargs.get("provider", "openai") != "custom" and not base_url:
-            self._ws_transport = OpenAIWSTransport(api_key=api_key)
+            self._ws_transport = OpenAIWSConnection(api_key=api_key)
             self._ws_transport.start_connect()
 
     async def generate_stream(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -1,20 +1,100 @@
 import os
+import asyncio
+import json
+import time
 import httpx
 from urllib.parse import urlparse
 from dotenv import load_dotenv
 from openai import AsyncOpenAI, OpenAI, AuthenticationError, PermissionDeniedError, NotFoundError, RateLimitError, APIError, APIConnectionError
-import json
+
+import websockets
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX
-from bolna.enums import ReasoningEffort, Verbosity
-from bolna.helpers.utils import now_ms
+from bolna.enums import ChatRole, ReasoningEffort, ResponseStreamEvent, ResponseItemType, Verbosity, LogComponent, LogDirection
+from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
+from .message_models import MessageFormatAdapter
 from .tool_call_accumulator import ToolCallAccumulator
-from .types import LLMStreamChunk, LatencyData
+from .types import APIParams, LLMStreamChunk, LatencyData, FunctionCallPayload
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
 load_dotenv()
+
+
+class OpenAIWSTransport:
+    """Persistent WebSocket connection to wss://api.openai.com/v1/responses.
+
+    - Lazy connect on first use
+    - Auto-reconnect on connection drop or before 60-min server limit
+    - Sequential: one in-flight response at a time (API constraint)
+    """
+
+    WS_URL = "wss://api.openai.com/v1/responses"
+    RECONNECT_BEFORE_SECS = 55 * 60
+    TERMINAL_EVENTS = ResponseStreamEvent.terminal_events()
+
+    def __init__(self, api_key: str):
+        self._api_key = api_key
+        self._ws = None
+        self._connected_at: float = 0
+        self._lock = asyncio.Lock()
+
+    async def ensure_connected(self):
+        if self._ws is not None:
+            elapsed = time.monotonic() - self._connected_at
+            if elapsed < self.RECONNECT_BEFORE_SECS:
+                return
+            logger.info("WebSocket approaching 60-min limit, reconnecting")
+            await self._close_ws()
+
+        self._ws = await websockets.connect(
+            self.WS_URL,
+            additional_headers={"Authorization": f"Bearer {self._api_key}"},
+            max_size=None,
+            close_timeout=5,
+        )
+        self._connected_at = time.monotonic()
+        logger.info("WebSocket connected to OpenAI Responses API")
+
+    async def stream_response(self, create_params: dict):
+        """Send response.create and yield raw event dicts until terminal event."""
+        async with self._lock:
+            await self.ensure_connected()
+            await self._ws.send(json.dumps({"type": ResponseStreamEvent.CREATE, **create_params}))
+
+            async for raw_msg in self._ws:
+                evt = json.loads(raw_msg)
+                evt_type = evt.get("type", "")
+                yield evt
+                if evt_type in self.TERMINAL_EVENTS:
+                    return
+
+    async def cancel_response(self, response_id: str):
+        """Cancel an in-flight response. Best-effort, errors are non-critical."""
+        if self._ws is None:
+            return
+        try:
+            await self._ws.send(json.dumps({
+                "type": ResponseStreamEvent.CANCEL,
+                "response_id": response_id,
+            }))
+            async for raw_msg in self._ws:
+                if json.loads(raw_msg).get("type") in self.TERMINAL_EVENTS:
+                    break
+        except Exception:
+            pass
+
+    async def disconnect(self):
+        await self._close_ws()
+
+    async def _close_ws(self):
+        if self._ws is not None:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
 
 
 class OpenAiLLM(OpenAICompatibleLLM):
@@ -85,12 +165,20 @@ class OpenAiLLM(OpenAICompatibleLLM):
             #logger.info(f'thread id : {self.thread_id}')
         self.run_id = kwargs.get("run_id", None)
 
-        self._init_responses_api(kwargs.get("use_responses_api", False))
+        self._init_responses_api(kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold"))
+
+        self._ws_transport = None
+        if self.use_responses_api and kwargs.get("provider", "openai") != "custom" and not base_url:
+            self._ws_transport = OpenAIWSTransport(api_key=api_key)
 
     async def generate_stream(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
         if self.use_responses_api:
-            async for chunk in self._generate_stream_responses(messages, synthesize, request_json, meta_info, tool_choice):
-                yield chunk
+            if self._ws_transport:
+                async for chunk in self._generate_stream_ws_responses(messages, synthesize, request_json, meta_info, tool_choice):
+                    yield chunk
+            else:
+                async for chunk in self._generate_stream_responses(messages, synthesize, request_json, meta_info, tool_choice):
+                    yield chunk
         else:
             async for chunk in self._generate_stream_chat(messages, synthesize, request_json, meta_info, tool_choice):
                 yield chunk
@@ -210,7 +298,6 @@ class OpenAiLLM(OpenAICompatibleLLM):
             if api_call_payload:
                 yield LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
 
-        # Extract actual token counts from stream usage
         usage_kwargs = {}
         if stream_usage:
             usage_kwargs['input_tokens'] = getattr(stream_usage, 'prompt_tokens', None)
@@ -285,3 +372,212 @@ class OpenAiLLM(OpenAICompatibleLLM):
             return {"type": "json_object"}
         else:
             return {"type": "text"}
+
+    async def _generate_stream_ws_responses(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
+        """Stream via persistent WebSocket — same interface as _generate_stream_responses."""
+        if not messages:
+            raise ValueError("No messages provided")
+
+        create_params, responses_tools = self._build_responses_create_kwargs(
+            messages, meta_info, request_json, tool_choice, store=False
+        )
+
+        # WS endpoint requires integer temperature (float causes silent connection close)
+        temp = create_params.get("temperature")
+        if temp is not None:
+            create_params["temperature"] = int(round(temp))
+
+        answer, buffer = "", ""
+        func_call_args = {}
+        func_call_names = {}
+        func_call_ids = {}
+        gave_pre_call_msg = False
+        received_textual = False
+
+        start_time = now_ms()
+        first_token_time = None
+        latency_data = None
+        ws_service_tier = None
+        llm_host = self.llm_host
+        response_usage = None
+
+        try:
+            async for evt in self._ws_transport.stream_response(create_params):
+                now = now_ms()
+                evt_type = evt.get("type", "")
+
+                if evt_type == ResponseStreamEvent.ERROR:
+                    error_info = evt.get("error", {})
+                    error_code = error_info.get("code", "")
+                    if error_code == "previous_response_not_found" and self.previous_response_id:
+                        logger.warning(f"WS previous_response_id not found, retrying with full history")
+                        self.previous_response_id = None
+                        async for chunk in self._generate_stream_ws_responses(messages, synthesize, request_json, meta_info, tool_choice):
+                            yield chunk
+                        return
+                    logger.error(f"WebSocket Responses API error: {error_info}")
+                    raise APIError(message=f"WS response error: {error_info}", request=None, body=None)
+
+                if evt_type == ResponseStreamEvent.CREATED:
+                    resp = evt.get("response", {})
+                    self.previous_response_id = resp.get("id")
+                    ws_service_tier = resp.get("service_tier")
+                    continue
+
+                if evt_type == ResponseStreamEvent.FAILED:
+                    resp = evt.get("response", {})
+                    error_info = resp.get("error") or resp.get("last_error")
+                    logger.error(f"WS Responses API stream failed: {error_info}")
+                    self.previous_response_id = None
+                    raise APIError(message=f"Response failed: {error_info}", request=None, body=None)
+
+                if evt_type == ResponseStreamEvent.INCOMPLETE:
+                    logger.warning("WS Responses API stream incomplete")
+                    self.previous_response_id = None
+                    break
+
+                if not first_token_time and evt_type in (ResponseStreamEvent.OUTPUT_TEXT_DELTA, ResponseStreamEvent.FUNCTION_CALL_ARGS_DELTA):
+                    first_token_time = now
+                    self.started_streaming = True
+                    latency_data = LatencyData(
+                        sequence_id=meta_info.get("sequence_id"),
+                        first_token_latency_ms=first_token_time - start_time,
+                        total_stream_duration_ms=None,
+                        service_tier=ws_service_tier,
+                        llm_host=llm_host,
+                    )
+
+                if evt_type == ResponseStreamEvent.OUTPUT_TEXT_DELTA:
+                    received_textual = True
+                    delta = evt.get("delta", "")
+                    answer += delta
+                    buffer += delta
+                    if synthesize and len(buffer) >= self.buffer_size:
+                        split = buffer.rsplit(" ", 1)
+                        yield LLMStreamChunk(data=split[0], end_of_stream=False, latency=latency_data)
+                        buffer = split[1] if len(split) > 1 else ""
+
+                elif evt_type == ResponseStreamEvent.OUTPUT_ITEM_ADDED:
+                    item = evt.get("item", {})
+                    if item.get("type") == ResponseItemType.FUNCTION_CALL:
+                        if buffer:
+                            yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data)
+                            buffer = ""
+                        item_id = item.get("id", "")
+                        func_call_args[item_id] = ""
+                        func_call_names[item_id] = item.get("name", "")
+                        func_call_ids[item_id] = item.get("call_id", "")
+
+                        if not gave_pre_call_msg and not received_textual and self.trigger_function_call:
+                            gave_pre_call_msg = True
+                            func_name = item.get("name", "")
+                            func_params = self.api_params.get(func_name)
+                            api_tool_pre_call_message = APIParams.model_validate(func_params).pre_call_message if func_params else None
+                            detected_lang = meta_info.get('detected_language') if meta_info else None
+                            active_language = detected_lang or self.language
+                            pre_msg = compute_function_pre_call_message(active_language, func_name, api_tool_pre_call_message)
+                            if pre_msg:
+                                yield LLMStreamChunk(data=pre_msg, end_of_stream=True, latency=latency_data, function_name=func_name, function_message=api_tool_pre_call_message)
+
+                elif evt_type == ResponseStreamEvent.FUNCTION_CALL_ARGS_DELTA:
+                    item_id = evt.get("item_id", "")
+                    func_call_args[item_id] = func_call_args.get(item_id, "") + evt.get("delta", "")
+
+                elif evt_type == ResponseStreamEvent.COMPLETED:
+                    resp = evt.get("response", {})
+                    self.previous_response_id = resp.get("id", self.previous_response_id)
+                    self._pending_call_ids = set(func_call_ids.values())
+                    ws_service_tier = ws_service_tier or resp.get("service_tier")
+                    response_usage = resp.get("usage")
+                    break
+
+        except APIError:
+            raise
+        except Exception as e:
+            logger.error(f"WS streaming error: {e}, falling back to HTTP SSE")
+            self.previous_response_id = None
+            async for chunk in self._generate_stream_responses(messages, synthesize, request_json, meta_info, tool_choice):
+                yield chunk
+            return
+
+        if latency_data:
+            latency_data.total_stream_duration_ms = now_ms() - start_time
+            if ws_service_tier:
+                latency_data.service_tier = ws_service_tier
+
+        if func_call_args and self.trigger_function_call:
+            first_item_id = next(iter(func_call_args))
+            func_name = func_call_names[first_item_id]
+            call_id = func_call_ids[first_item_id]
+            arguments_str = func_call_args[first_item_id]
+
+            if func_name in self.api_params:
+                func_conf = APIParams.model_validate(self.api_params[func_name])
+                logger.info(f"Payload to send {arguments_str} func_dict {func_conf}")
+
+                api_call_payload = FunctionCallPayload(
+                    url=func_conf.url,
+                    method=func_conf.method.lower() if func_conf.method else None,
+                    param=func_conf.param,
+                    api_token=func_conf.api_token,
+                    headers=func_conf.headers,
+                    model_args=create_params,
+                    meta_info=meta_info,
+                    called_fun=func_name,
+                    model_response=[{
+                        "index": 0,
+                        "id": call_id,
+                        "function": {"name": func_name, "arguments": arguments_str},
+                        "type": "function",
+                    }],
+                    tool_call_id=call_id,
+                    textual_response=answer.strip() if received_textual else None,
+                )
+
+                tool_spec = next((t for t in responses_tools if t["name"] == func_name), None)
+                if tool_spec:
+                    try:
+                        parsed_args = json.loads(arguments_str)
+                        required_keys = tool_spec.get("parameters", {}).get("required", [])
+                        if tool_spec.get("parameters") is not None and all(k in parsed_args for k in required_keys):
+                            convert_to_request_log(arguments_str, meta_info, self.model, LogComponent.LLM,
+                                                   direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
+                            for k, v in parsed_args.items():
+                                setattr(api_call_payload, k, v)
+                        else:
+                            api_call_payload.resp = None
+                    except (json.JSONDecodeError, KeyError) as e:
+                        logger.error(f"Error parsing function arguments: {e}")
+                        api_call_payload.resp = None
+                else:
+                    api_call_payload.resp = None
+
+                yield LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
+
+        usage_kwargs = {}
+        if response_usage and isinstance(response_usage, dict):
+            usage_kwargs['input_tokens'] = response_usage.get('input_tokens')
+            usage_kwargs['output_tokens'] = response_usage.get('output_tokens')
+            output_details = response_usage.get('output_tokens_details', {}) or {}
+            if output_details.get('reasoning_tokens'):
+                usage_kwargs['reasoning_tokens'] = output_details['reasoning_tokens']
+            input_details = response_usage.get('input_tokens_details', {}) or {}
+            if input_details.get('cached_tokens'):
+                usage_kwargs['cached_tokens'] = input_details['cached_tokens']
+
+        if synthesize:
+            yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data, **usage_kwargs)
+        else:
+            yield LLMStreamChunk(data=answer, end_of_stream=True, latency=latency_data, **usage_kwargs)
+
+        self.started_streaming = False
+
+    def invalidate_response_chain(self):
+        response_id = self.previous_response_id
+        super().invalidate_response_chain()
+        if self._ws_transport and response_id:
+            asyncio.ensure_future(self._ws_transport.cancel_response(response_id))
+
+    async def close(self):
+        if self._ws_transport:
+            await self._ws_transport.disconnect()

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -16,7 +16,7 @@ from bolna.helpers.utils import convert_to_request_log, compute_function_pre_cal
 from .openai_base import OpenAICompatibleLLM
 from .message_models import MessageFormatAdapter
 from .tool_call_accumulator import ToolCallAccumulator
-from .types import APIParams, LLMStreamChunk, LatencyData, FunctionCallPayload
+from .types import APIParams, LLMStreamChunk, LatencyData
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -399,11 +399,12 @@ class OpenAiLLM(OpenAICompatibleLLM):
         if not messages:
             raise ValueError("No messages provided")
 
+        # store=False: WS previous_response_id uses connection-local cache, not server storage
         create_params, responses_tools = self._build_responses_create_kwargs(
             messages, meta_info, request_json, tool_choice, store=False
         )
 
-        # WS endpoint requires integer temperature (float causes silent connection close)
+        # WS endpoint silently closes on float temperature — coerce to int
         temp = create_params.get("temperature")
         if temp is not None:
             create_params["temperature"] = int(round(temp))
@@ -449,12 +450,12 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     resp = evt.get("response", {})
                     error_info = resp.get("error") or resp.get("last_error")
                     logger.error(f"WS Responses API stream failed: {error_info}")
-                    self.previous_response_id = None
+                    self.invalidate_response_chain()
                     raise APIError(message=f"Response failed: {error_info}", request=None, body=None)
 
                 if evt_type == ResponseStreamEvent.INCOMPLETE:
                     logger.warning("WS Responses API stream incomplete")
-                    self.previous_response_id = None
+                    self.invalidate_response_chain()
                     break
 
                 if not first_token_time and evt_type in (ResponseStreamEvent.OUTPUT_TEXT_DELTA, ResponseStreamEvent.FUNCTION_CALL_ARGS_DELTA):
@@ -514,6 +515,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         except APIError:
             raise
+        except asyncio.CancelledError:
+            raise
         except Exception as e:
             logger.error(f"WS streaming error: {e}, falling back to HTTP SSE")
             self.previous_response_id = None
@@ -526,54 +529,13 @@ class OpenAiLLM(OpenAICompatibleLLM):
             if ws_service_tier:
                 latency_data.service_tier = ws_service_tier
 
-        if func_call_args and self.trigger_function_call:
-            first_item_id = next(iter(func_call_args))
-            func_name = func_call_names[first_item_id]
-            call_id = func_call_ids[first_item_id]
-            arguments_str = func_call_args[first_item_id]
-
-            if func_name in self.api_params:
-                func_conf = APIParams.model_validate(self.api_params[func_name])
-                logger.info(f"Payload to send {arguments_str} func_dict {func_conf}")
-
-                api_call_payload = FunctionCallPayload(
-                    url=func_conf.url,
-                    method=func_conf.method.lower() if func_conf.method else None,
-                    param=func_conf.param,
-                    api_token=func_conf.api_token,
-                    headers=func_conf.headers,
-                    model_args=create_params,
-                    meta_info=meta_info,
-                    called_fun=func_name,
-                    model_response=[{
-                        "index": 0,
-                        "id": call_id,
-                        "function": {"name": func_name, "arguments": arguments_str},
-                        "type": "function",
-                    }],
-                    tool_call_id=call_id,
-                    textual_response=answer.strip() if received_textual else None,
-                )
-
-                tool_spec = next((t for t in responses_tools if t["name"] == func_name), None)
-                if tool_spec:
-                    try:
-                        parsed_args = json.loads(arguments_str)
-                        required_keys = tool_spec.get("parameters", {}).get("required", [])
-                        if tool_spec.get("parameters") is not None and all(k in parsed_args for k in required_keys):
-                            convert_to_request_log(arguments_str, meta_info, self.model, LogComponent.LLM,
-                                                   direction=LogDirection.RESPONSE, is_cached=False, run_id=self.run_id)
-                            for k, v in parsed_args.items():
-                                setattr(api_call_payload, k, v)
-                        else:
-                            api_call_payload.resp = None
-                    except (json.JSONDecodeError, KeyError) as e:
-                        logger.error(f"Error parsing function arguments: {e}")
-                        api_call_payload.resp = None
-                else:
-                    api_call_payload.resp = None
-
-                yield LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
+        fc_chunk = self._build_function_call_chunk(
+            func_call_args, func_call_names, func_call_ids,
+            responses_tools, create_params, meta_info,
+            answer, received_textual, latency_data
+        )
+        if fc_chunk:
+            yield fc_chunk
 
         usage_kwargs = {}
         if response_usage and isinstance(response_usage, dict):

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -519,7 +519,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             raise
         except Exception as e:
             logger.error(f"WS streaming error: {e}, falling back to HTTP SSE")
-            self.previous_response_id = None
+            self.invalidate_response_chain()
             async for chunk in self._generate_stream_responses(messages, synthesize, request_json, meta_info, tool_choice):
                 yield chunk
             return

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -25,7 +25,7 @@ load_dotenv()
 class OpenAIWSTransport:
     """Persistent WebSocket connection to wss://api.openai.com/v1/responses.
 
-    - Lazy connect on first use
+    - Eager connect at init, ready before first LLM call
     - Auto-reconnect on connection drop or before 60-min server limit
     - Sequential: one in-flight response at a time (API constraint)
     """
@@ -39,8 +39,24 @@ class OpenAIWSTransport:
         self._ws = None
         self._connected_at: float = 0
         self._lock = asyncio.Lock()
+        self._connect_task: asyncio.Task | None = None
+
+    def start_connect(self):
+        """Kick off WS connection eagerly. Must be called from a running event loop."""
+        self._connect_task = asyncio.create_task(self._do_connect())
+
+    async def _do_connect(self):
+        """Background connect with error handling — exceptions surface in ensure_connected."""
+        try:
+            await self._connect()
+        except Exception as e:
+            logger.warning(f"Eager WS connect failed, will retry on first use: {e}")
 
     async def ensure_connected(self):
+        if self._connect_task and not self._connect_task.done():
+            await self._connect_task
+            self._connect_task = None
+
         if self._ws is not None:
             elapsed = time.monotonic() - self._connected_at
             if elapsed < self.RECONNECT_BEFORE_SECS:
@@ -48,6 +64,9 @@ class OpenAIWSTransport:
             logger.info("WebSocket approaching 60-min limit, reconnecting")
             await self._close_ws()
 
+        await self._connect()
+
+    async def _connect(self):
         self._ws = await websockets.connect(
             self.WS_URL,
             additional_headers={"Authorization": f"Bearer {self._api_key}"},
@@ -170,6 +189,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self._ws_transport = None
         if self.use_responses_api and kwargs.get("provider", "openai") != "custom" and not base_url:
             self._ws_transport = OpenAIWSTransport(api_key=api_key)
+            self._ws_transport.start_connect()
 
     async def generate_stream(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
         if self.use_responses_api:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -58,11 +58,14 @@ class OpenAIWSConnection:
             self._connect_task = None
 
         if self._ws is not None:
-            elapsed = time.monotonic() - self._connected_at
-            if elapsed < self.RECONNECT_BEFORE_SECS:
+            if not self._ws.open:
+                logger.info("WebSocket closed unexpectedly, reconnecting")
+                await self._close_ws()
+            elif time.monotonic() - self._connected_at >= self.RECONNECT_BEFORE_SECS:
+                logger.info("WebSocket approaching 60-min limit, reconnecting")
+                await self._close_ws()
+            else:
                 return
-            logger.info("WebSocket approaching 60-min limit, reconnecting")
-            await self._close_ws()
 
         await self._connect()
 

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -2,6 +2,7 @@ import os
 import asyncio
 import json
 import time
+from typing import Optional
 import httpx
 from urllib.parse import urlparse
 from dotenv import load_dotenv
@@ -39,7 +40,7 @@ class OpenAIWSTransport:
         self._ws = None
         self._connected_at: float = 0
         self._lock = asyncio.Lock()
-        self._connect_task: asyncio.Task | None = None
+        self._connect_task: Optional[asyncio.Task] = None
 
     def start_connect(self):
         """Kick off WS connection eagerly. Must be called from a running event loop."""
@@ -280,7 +281,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.started_streaming = True
 
                 latency_data = LatencyData(
-                    sequence_id=meta_info.get("sequence_id"),
+                    sequence_id=meta_info.get("sequence_id") if meta_info else None,
                     first_token_latency_ms=first_token_time - start_time,
                     total_stream_duration_ms=None,
                     service_tier=service_tier,
@@ -460,7 +461,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     first_token_time = now
                     self.started_streaming = True
                     latency_data = LatencyData(
-                        sequence_id=meta_info.get("sequence_id"),
+                        sequence_id=meta_info.get("sequence_id") if meta_info else None,
                         first_token_latency_ms=first_token_time - start_time,
                         total_stream_duration_ms=None,
                         service_tier=ws_service_tier,

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -11,10 +11,9 @@ from openai import AsyncOpenAI, OpenAI, AuthenticationError, PermissionDeniedErr
 import websockets
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX
-from bolna.enums import ChatRole, ReasoningEffort, ResponseStreamEvent, ResponseItemType, Verbosity, LogComponent, LogDirection
-from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
+from bolna.enums import ReasoningEffort, ResponseStreamEvent, ResponseItemType, Verbosity
+from bolna.helpers.utils import compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
-from .message_models import MessageFormatAdapter
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import APIParams, LLMStreamChunk, LatencyData
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -3,6 +3,15 @@ from typing import Any, Optional, Union
 from pydantic import BaseModel, ConfigDict
 
 
+class APIParams(BaseModel):
+    url: Optional[str] = None
+    method: Optional[str] = "POST"
+    api_token: Optional[str] = None
+    param: Optional[Union[str, dict]] = None
+    headers: Optional[Union[str, dict]] = None
+    pre_call_message: Optional[Union[str, dict]] = None
+
+
 class LatencyData(BaseModel):
     sequence_id: Optional[int] = None
     first_token_latency_ms: Optional[float] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -248,6 +248,7 @@ class Llm(BaseModel):
     reasoning_effort: Optional[ReasoningEffort] = None
     verbosity: Optional[Verbosity] = None
     use_responses_api: Optional[bool] = False
+    compact_threshold: Optional[int] = None
 
     @model_validator(mode="after")
     def validate_reasoning_effort_for_model(self):
@@ -423,12 +424,7 @@ class ToolDescriptionLegacy(BaseModel):
     parameters: Dict
 
 
-class APIParams(BaseModel):
-    url: Optional[str] = None
-    method: Optional[str] = "POST"
-    api_token: Optional[str] = None
-    param: Optional[Union[str, dict]] = None
-    headers: Optional[Union[str, dict]] = None
+from bolna.llms.types import APIParams  # noqa: E402 — canonical definition in llms/types.py
 
 
 class ToolModel(BaseModel):


### PR DESCRIPTION
## Summary
- Persistent WebSocket transport for OpenAI Responses API (eager connect at init, auto-reconnect, 60-min limit handling, HTTP SSE fallback)
- Automatic truncation (`truncation: "auto"`) and context compaction via `compact_threshold` config
- Tool call guard: prevents stale `previous_response_id` errors when function outputs are pending
- `ResponseStreamEvent` enums for WS client commands (CREATE, CANCEL, ERROR)
- `APIParams` model validation replacing raw `.get()` dict access for function call payloads
- `MessageFormatAdapter` for chat-to-responses format conversion (messages → input items)