### PR TITLE
feat: capture LLM reasoning content in trace data for OpenAI and Gemini

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1822,9 +1822,9 @@ class TaskManager(BaseManager):
 
         self.execute_function_call_task = None
 
-    def __store_into_history(self, meta_info, messages, llm_response, should_trigger_function_call=False, input_tokens=None, output_tokens=None, reasoning_tokens=None, cached_tokens=None):
+    def __store_into_history(self, meta_info, messages, llm_response, should_trigger_function_call=False, input_tokens=None, output_tokens=None, reasoning_tokens=None, cached_tokens=None, reasoning_content=None):
         self.llm_response_generated = True
-        convert_to_request_log(message=llm_response, meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id=self.run_id, input_tokens=input_tokens, output_tokens=output_tokens, reasoning_tokens=reasoning_tokens, cached_tokens=cached_tokens)
+        convert_to_request_log(message=llm_response, meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id=self.run_id, input_tokens=input_tokens, output_tokens=output_tokens, reasoning_tokens=reasoning_tokens, cached_tokens=cached_tokens, reasoning_content=reasoning_content)
         if should_trigger_function_call:
             logger.info(f"There was a function call and need to make that work")
             self.conversation_history.append_assistant(llm_response)
@@ -1848,6 +1848,7 @@ class TaskManager(BaseManager):
 
         llm_response, function_tool, function_tool_message = '', '', ''
         actual_input_tokens, actual_output_tokens, actual_reasoning_tokens, actual_cached_tokens = None, None, None, None
+        actual_reasoning_content = None
         synthesize = True
         if should_bypass_synth:
             synthesize = False
@@ -1953,12 +1954,14 @@ class TaskManager(BaseManager):
                     actual_reasoning_tokens = llm_message.reasoning_tokens
                 if llm_message.cached_tokens is not None:
                     actual_cached_tokens = llm_message.cached_tokens
+                if llm_message.reasoning_content is not None:
+                    actual_reasoning_content = llm_message.reasoning_content
 
                 if trigger_function_call:
                     logger.info(f"Triggering function call for {data}")
                     textual_response = data.textual_response if hasattr(data, 'textual_response') else None
                     if textual_response: #intentionally omitting tool_calls, which will be filled later if the tool_call flow completed (requirement from OpenAI)
-                        self.__store_into_history(meta_info, messages, textual_response, should_trigger_function_call=should_trigger_function_call, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens)
+                        self.__store_into_history(meta_info, messages, textual_response, should_trigger_function_call=should_trigger_function_call, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens, reasoning_content=actual_reasoning_content)
                     await self.__execute_function_call(next_step = next_step, **data.model_dump())
                     return
 
@@ -2002,13 +2005,13 @@ class TaskManager(BaseManager):
 
         filler_message = compute_function_pre_call_message(self.language, function_tool, function_tool_message)
         if self.stream and llm_response != filler_message:
-            self.__store_into_history(meta_info, messages, llm_response, should_trigger_function_call=should_trigger_function_call, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens)
+            self.__store_into_history(meta_info, messages, llm_response, should_trigger_function_call=should_trigger_function_call, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens, reasoning_content=actual_reasoning_content)
         elif not self.stream:
             llm_response = llm_response.strip()
             if self.turn_based_conversation:
                 self.conversation_history.append_assistant(llm_response)
             await self._handle_llm_output(next_step, llm_response, should_bypass_synth, meta_info, is_function_call=should_trigger_function_call)
-            convert_to_request_log(message=llm_response, meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id=self.run_id, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens)
+            convert_to_request_log(message=llm_response, meta_info=meta_info, component=LogComponent.LLM, direction=LogDirection.RESPONSE, model=self.llm_config["model"], run_id=self.run_id, input_tokens=actual_input_tokens, output_tokens=actual_output_tokens, reasoning_tokens=actual_reasoning_tokens, cached_tokens=actual_cached_tokens, reasoning_content=actual_reasoning_content)
 
         # Collect RAG latency if present (from KnowledgeBaseAgent)
         if meta_info.get('rag_latency'):

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -134,6 +134,8 @@ class ResponseStreamEvent(str, Enum):
     OUTPUT_TEXT_DELTA = "response.output_text.delta"
     OUTPUT_ITEM_ADDED = "response.output_item.added"
     FUNCTION_CALL_ARGS_DELTA = "response.function_call_arguments.delta"
+    REASONING_SUMMARY_TEXT_DELTA = "response.reasoning_summary_text.delta"
+    REASONING_SUMMARY_TEXT_DONE = "response.reasoning_summary_text.done"
 
     @classmethod
     def all_values(cls):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -657,7 +657,7 @@ def format_error_message(component, provider, error_str):
     return f"{display} service{provider_str} error: {truncated}"
 
 
-def convert_to_request_log(message, meta_info, model, component=LogComponent.TRANSCRIBER, direction=LogDirection.RESPONSE, is_cached=False, engine=None, run_id=None, input_tokens=None, output_tokens=None, reasoning_tokens=None, cached_tokens=None):
+def convert_to_request_log(message, meta_info, model, component=LogComponent.TRANSCRIBER, direction=LogDirection.RESPONSE, is_cached=False, engine=None, run_id=None, input_tokens=None, output_tokens=None, reasoning_tokens=None, cached_tokens=None, reasoning_content=None):
     log = dict()
     log['direction'] = direction.value if isinstance(direction, Enum) else direction
     log['data'] = message
@@ -682,6 +682,8 @@ def convert_to_request_log(message, meta_info, model, component=LogComponent.TRA
                     llm_metadata['reasoning_tokens'] = reasoning_tokens
                 if cached_tokens:
                     llm_metadata['cached_tokens'] = cached_tokens
+                if reasoning_content:
+                    llm_metadata['reasoning_content'] = reasoning_content
                 llm_metadata['usage_source'] = UsageSource.API_REPORTED.value if (input_tokens is not None or output_tokens is not None) else UsageSource.ESTIMATED.value
                 log['llm_metadata'] = llm_metadata
         case LogComponent.SYNTHESIZER:

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -189,22 +189,22 @@ class GeminiLLM(BaseLLM):
         # User explicitly set a budget — honour it for 2.5 models only.
         # Gemini 3.x uses thinking_level, not thinking_budget; passing budget to 3.x causes 400s.
         if self.thinking_budget and self.thinking_budget > 0 and "2.5" in m:
-            return types.ThinkingConfig(thinking_budget=self.thinking_budget)
+            return types.ThinkingConfig(thinking_budget=self.thinking_budget, include_thoughts=True)
 
         # --- Gemini 3.x family: use thinking_level ---
         if m.startswith("gemini-3"):
             if "pro" in m:
                 # Pro cannot disable thinking; "minimal" is not supported — use "low"
-                return types.ThinkingConfig(thinking_level="low")
+                return types.ThinkingConfig(thinking_level="low", include_thoughts=True)
             else:
                 # Flash / Flash-Lite: "minimal" is closest to off, avoids thought_signature cost
-                return types.ThinkingConfig(thinking_level="minimal")
+                return types.ThinkingConfig(thinking_level="minimal", include_thoughts=True)
 
         # --- Gemini 2.5 family: use thinking_budget ---
         if "2.5" in m:
             if "pro" in m:
                 # Pro cannot disable thinking; minimum budget is 128
-                return types.ThinkingConfig(thinking_budget=128)
+                return types.ThinkingConfig(thinking_budget=128, include_thoughts=True)
             else:
                 # Flash / Flash-Lite: disable with 0
                 return types.ThinkingConfig(thinking_budget=0)
@@ -395,10 +395,12 @@ class GeminiLLM(BaseLLM):
         if latency_data:
             latency_data.total_stream_duration_ms = now_ms() - start_time
 
+        reasoning_content = "\n".join(accumulated_thought_parts) if accumulated_thought_parts else None
+
         if synthesize and buffer.strip():
-            yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data)
+            yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data, reasoning_content=reasoning_content)
         elif not synthesize:
-            yield LLMStreamChunk(data=answer, end_of_stream=True, latency=latency_data)
+            yield LLMStreamChunk(data=answer, end_of_stream=True, latency=latency_data, reasoning_content=reasoning_content)
 
     async def generate(self, messages, request_json=False, ret_metadata=False):
         """Non-streaming — used for voicemail detection and completion checks."""

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -250,7 +250,6 @@ class OpenAICompatibleLLM(BaseLLM):
 
         async for event in stream:
             now = now_ms()
-            logger.info(f"[Responses API] event.type={event.type!r}")
 
             if event.type == ResponseStreamEvent.CREATED:
                 self.previous_response_id = event.response.id
@@ -315,7 +314,6 @@ class OpenAICompatibleLLM(BaseLLM):
                 func_call_args[event.item_id] = func_call_args.get(event.item_id, "") + event.delta
 
             elif event.type == ResponseStreamEvent.REASONING_SUMMARY_TEXT_DELTA:
-                logger.info(f"[Responses API] Reasoning summary delta received: {event.delta!r}")
                 reasoning_summary_parts.append(event.delta)
 
             elif event.type == ResponseStreamEvent.COMPLETED:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -250,6 +250,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         async for event in stream:
             now = now_ms()
+            logger.info(f"[Responses API] event.type={event.type!r}")
 
             if event.type == ResponseStreamEvent.CREATED:
                 self.previous_response_id = event.response.id
@@ -314,6 +315,7 @@ class OpenAICompatibleLLM(BaseLLM):
                 func_call_args[event.item_id] = func_call_args.get(event.item_id, "") + event.delta
 
             elif event.type == ResponseStreamEvent.REASONING_SUMMARY_TEXT_DELTA:
+                logger.info(f"[Responses API] Reasoning summary delta received: {event.delta!r}")
                 reasoning_summary_parts.append(event.delta)
 
             elif event.type == ResponseStreamEvent.COMPLETED:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -128,8 +128,11 @@ class OpenAICompatibleLLM(BaseLLM):
         if self.model.startswith(GPT5_MODEL_PREFIX):
             create_kwargs["temperature"] = 1
             reasoning_effort = self.model_args.get("reasoning_effort")
+            reasoning_config = {}
             if reasoning_effort:
-                create_kwargs["reasoning"] = {"effort": reasoning_effort}
+                reasoning_config["effort"] = reasoning_effort
+            reasoning_config["summary"] = "auto"
+            create_kwargs["reasoning"] = reasoning_config
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
@@ -151,6 +154,7 @@ class OpenAICompatibleLLM(BaseLLM):
         func_call_ids = {}  # item_id -> call_id
         gave_pre_call_msg = False
         received_textual = False
+        reasoning_summary_parts = []
 
         start_time = now_ms()
         first_token_time = None
@@ -235,6 +239,9 @@ class OpenAICompatibleLLM(BaseLLM):
             elif event.type == ResponseStreamEvent.FUNCTION_CALL_ARGS_DELTA:
                 func_call_args[event.item_id] = func_call_args.get(event.item_id, "") + event.delta
 
+            elif event.type == ResponseStreamEvent.REASONING_SUMMARY_TEXT_DELTA:
+                reasoning_summary_parts.append(event.delta)
+
             elif event.type == ResponseStreamEvent.COMPLETED:
                 if hasattr(event.response, 'id'):
                     self.previous_response_id = event.response.id
@@ -310,6 +317,10 @@ class OpenAICompatibleLLM(BaseLLM):
             if input_details:
                 usage_kwargs['cached_tokens'] = getattr(input_details, 'cached_tokens', None)
 
+        reasoning_content = "".join(reasoning_summary_parts) if reasoning_summary_parts else None
+        if reasoning_content:
+            usage_kwargs['reasoning_content'] = reasoning_content
+
         if synthesize:
             yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data, **usage_kwargs)
         else:
@@ -339,9 +350,12 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if self.model.startswith(GPT5_MODEL_PREFIX):
             create_kwargs["temperature"] = 1
+            reasoning_config = {}
             reasoning_effort = self.model_args.get("reasoning_effort")
             if reasoning_effort:
-                create_kwargs["reasoning"] = {"effort": reasoning_effort}
+                reasoning_config["effort"] = reasoning_effort
+            reasoning_config["summary"] = "auto"
+            create_kwargs["reasoning"] = reasoning_config
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
@@ -373,6 +387,17 @@ class OpenAICompatibleLLM(BaseLLM):
                     input_details = getattr(response.usage, 'input_tokens_details', None)
                     if input_details:
                         metadata['cached_tokens'] = getattr(input_details, 'cached_tokens', None)
+
+                reasoning_texts = []
+                if hasattr(response, 'output') and response.output:
+                    for item in response.output:
+                        if getattr(item, 'type', None) == 'reasoning' and hasattr(item, 'summary'):
+                            for part in (item.summary or []):
+                                if getattr(part, 'text', None):
+                                    reasoning_texts.append(part.text)
+                if reasoning_texts:
+                    metadata['reasoning_content'] = "\n".join(reasoning_texts)
+
                 return res, metadata
             return res
         except Exception as e:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -418,6 +418,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         func_call_ids = {}
         gave_pre_call_msg = False
         received_textual = False
+        reasoning_summary_parts = []
 
         start_time = now_ms()
         first_token_time = None
@@ -481,6 +482,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         split = buffer.rsplit(" ", 1)
                         yield LLMStreamChunk(data=split[0], end_of_stream=False, latency=latency_data)
                         buffer = split[1] if len(split) > 1 else ""
+
+                elif evt_type == ResponseStreamEvent.REASONING_SUMMARY_TEXT_DELTA:
+                    reasoning_summary_parts.append(evt.get("delta", ""))
 
                 elif evt_type == ResponseStreamEvent.OUTPUT_ITEM_ADDED:
                     item = evt.get("item", {})
@@ -550,6 +554,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
             input_details = response_usage.get('input_tokens_details', {}) or {}
             if input_details.get('cached_tokens'):
                 usage_kwargs['cached_tokens'] = input_details['cached_tokens']
+
+        reasoning_content = "".join(reasoning_summary_parts) if reasoning_summary_parts else None
+        if reasoning_content:
+            usage_kwargs['reasoning_content'] = reasoning_content
 
         if synthesize:
             yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data, **usage_kwargs)

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -40,3 +40,4 @@ class LLMStreamChunk(BaseModel):
     output_tokens: Optional[int] = None
     reasoning_tokens: Optional[int] = None
     cached_tokens: Optional[int] = None
+    reasoning_content: Optional[str] = None


### PR DESCRIPTION
- Capture reasoning from OpenAI GPT-5 — Enabled reasoning summaries via the Responses API (summary: "auto") and collected reasoning text from streaming events.

- Capture thinking from Google Gemini — Added include_thoughts=True to ThinkingConfig for Gemini 3.x and 2.5 Pro models to receive thought summaries in streaming responses.

- Pipeline plumbing — Added reasoning_content field to the LLM stream chunk model, accumulated it in the task manager, and passed it through to trace logging.

- Trace data — Included reasoning_content in the llm_metadata of request logs so the model's reasoning is captured alongside every LLM response in production trace data.