### PR TITLE
feat: rate-limit Plivo audio send to ~1.2x real-time

### DIFF
--- a/bolna/output_handlers/telephony.py
+++ b/bolna/output_handlers/telephony.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import os
@@ -11,6 +12,8 @@ from bolna.helpers.logger_config import configure_logger
 logger = configure_logger(__name__)
 load_dotenv()
 
+TELEPHONY_MAX_SEND_RATE_FACTOR = float(os.environ.get("TELEPHONY_MAX_SEND_RATE_FACTOR", "1.2"))
+
 
 class TelephonyOutputHandler(DefaultOutputHandler):
     def __init__(self, io_provider, websocket=None, mark_event_meta_data=None, log_dir_name=None):
@@ -21,8 +24,26 @@ class TelephonyOutputHandler(DefaultOutputHandler):
         self.current_request_id = None
         self.rejected_request_ids = set()
 
+        # Rate-limit state (activated per-provider in handle())
+        self._rl_first_send = 0.0
+        self._rl_bytes_sent = 0
+        self._rl_sequence_id = None
+
     async def handle_interruption(self):
-        pass
+        self._rl_first_send = 0.0
+        self._rl_bytes_sent = 0
+        self._rl_sequence_id = None
+
+    async def _rate_limit(self, audio_bytes, audio_format):
+        """Sleep if needed to stay ≤ TELEPHONY_MAX_SEND_RATE_FACTOR × real-time."""
+        if TELEPHONY_MAX_SEND_RATE_FACTOR <= 0 or self._rl_first_send == 0.0:
+            return
+        bytes_per_second = 8000 if audio_format in ('mulaw', 'ulaw') else 16000
+        self._rl_bytes_sent += audio_bytes
+        min_elapsed = self._rl_bytes_sent / (TELEPHONY_MAX_SEND_RATE_FACTOR * bytes_per_second)
+        elapsed = time.monotonic() - self._rl_first_send
+        if elapsed < min_elapsed:
+            await asyncio.sleep(min_elapsed - elapsed)
 
     async def form_media_message(self, audio_data, audio_format):
         pass
@@ -54,6 +75,13 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                     if audio_chunk != b'\x00\x00':
                         audio_format = meta_info.get("format", "wav")
 
+                        # Rate-limit: detect new sequence → reset counters
+                        seq_id = meta_info.get("sequence_id")
+                        if seq_id is not None and seq_id != self._rl_sequence_id:
+                            self._rl_sequence_id = seq_id
+                            self._rl_first_send = 0.0
+                            self._rl_bytes_sent = 0
+
                         # sending of pre-mark message
                         pre_mark_event_meta_data = {
                             "type": "pre_mark_message",
@@ -68,6 +96,8 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                             audio_format = 'wav'
                         media_message = await self.form_media_message(audio_chunk, audio_format)
                         await self.websocket.send_text(json.dumps(media_message))
+                        if self._rl_first_send == 0.0:
+                            self._rl_first_send = time.monotonic()
                         if meta_info.get('message_category', '') == 'agent_welcome_message' and not self.welcome_message_sent_ts:
                             self.welcome_message_sent_ts = time.time() * 1000
                         logger.info(f"Sending media event - {meta_info.get('mark_id')}")
@@ -87,6 +117,10 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                     self.mark_event_meta_data.update_data(mark_id, mark_event_meta_data)
                     mark_message = await self.form_mark_message(mark_id)
                     await self.websocket.send_text(json.dumps(mark_message))
+
+                    # Rate-limit: throttle audio send rate for Plivo
+                    if self.io_provider == 'plivo' and audio_chunk != b'\x00\x00':
+                        await self._rate_limit(len(audio_chunk), meta_info.get('format', 'mulaw'))
                 else:
                     logger.info("Not sending")
             except Exception as e:

--- a/bolna/output_handlers/telephony_providers/plivo.py
+++ b/bolna/output_handlers/telephony_providers/plivo.py
@@ -26,6 +26,7 @@ class PlivoOutputHandler(TelephonyOutputHandler):
             }
             await self.websocket.send_text(json.dumps(message_clear))
             self.mark_event_meta_data.clear_data()
+            await super().handle_interruption()
         except Exception as e:
             logger.info(f"WebSocket closed during interruption: {e}")
             self._closed = True


### PR DESCRIPTION
## Summary

- TTS generates audio much faster than real-time, causing 60s+ buffer buildup in Plivo. Mark ACKs get delayed, hangup timeout expires, thus calls cut off mid-sentence.
- Adds rate-limiting to `TelephonyOutputHandler` base class (same algorithm as SIP-Trunk handler), gated on `io_provider == 'plivo'`
- Caps send rate at 1.2x real-time (configurable via `TELEPHONY_MAX_SEND_RATE_FACTOR` env var, `0` to disable)
- Resets rate-limit counters on sequence change and interruption
- 60s response now builds max ~12s buffer (well within Plivo's 40s limit)