### PR TITLE
feat: track routing/hangup/voicemail tokens via api_reported usage

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1918,6 +1918,7 @@ class TaskManager(BaseManager):
                     meta_info['llm_metadata'] = meta_info.get('llm_metadata') or {}
                     meta_info['llm_metadata']['graph_routing_info'] = routing_info
 
+                    routing_usage = routing_info.get('routing_usage') or {}
                     if routing_info.get('routing_latency_ms') is not None:
                         self.routing_latencies['turn_latencies'].append({
                             'latency_ms': routing_info['routing_latency_ms'],
@@ -1929,6 +1930,10 @@ class TaskManager(BaseManager):
                             'sequence_id': meta_info.get('sequence_id'),
                             'reasoning': routing_info.get('reasoning'),
                             'confidence': routing_info.get('confidence'),
+                            'input_tokens': routing_usage.get('input_tokens'),
+                            'output_tokens': routing_usage.get('output_tokens'),
+                            'reasoning_tokens': routing_usage.get('reasoning_tokens'),
+                            'cached_tokens': routing_usage.get('cached_tokens'),
                         })
 
                     if routing_info.get('node_history'):
@@ -1941,7 +1946,11 @@ class TaskManager(BaseManager):
                         model=routing_info.get('routing_model', ''),
                         component=LogComponent.GRAPH_ROUTING,
                         direction=LogDirection.RESPONSE,
-                        run_id=self.run_id
+                        run_id=self.run_id,
+                        input_tokens=routing_usage.get('input_tokens'),
+                        output_tokens=routing_usage.get('output_tokens'),
+                        reasoning_tokens=routing_usage.get('reasoning_tokens'),
+                        cached_tokens=routing_usage.get('cached_tokens'),
                     )
                     continue
 
@@ -2068,7 +2077,7 @@ class TaskManager(BaseManager):
             ]
             logger.info(f"##### Answer from the LLM {completion_res}")
             convert_to_request_log(message=format_messages(prompt, use_system_prompt=True), meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.REQUEST, model=self.check_for_completion_llm, run_id=self.run_id)
-            convert_to_request_log(message=completion_res, meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.RESPONSE, model=self.check_for_completion_llm, run_id=self.run_id)
+            convert_to_request_log(message=completion_res, meta_info=meta_info, component=LogComponent.LLM_HANGUP, direction=LogDirection.RESPONSE, model=self.check_for_completion_llm, run_id=self.run_id, input_tokens=metadata.get('input_tokens'), output_tokens=metadata.get('output_tokens'), reasoning_tokens=metadata.get('reasoning_tokens'), cached_tokens=metadata.get('cached_tokens'))
 
             if should_hangup:
                 if self.hangup_triggered or self.conversation_ended:

--- a/bolna/agent_manager/voicemail_handler.py
+++ b/bolna/agent_manager/voicemail_handler.py
@@ -132,7 +132,11 @@ class VoicemailHandler:
                 component=LogComponent.LLM_VOICEMAIL,
                 direction=LogDirection.RESPONSE,
                 model=self.llm_model,
-                run_id=self.tm.run_id
+                run_id=self.tm.run_id,
+                input_tokens=metadata.get('input_tokens'),
+                output_tokens=metadata.get('output_tokens'),
+                reasoning_tokens=metadata.get('reasoning_tokens'),
+                cached_tokens=metadata.get('cached_tokens'),
             )
 
             if is_voicemail:

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -387,6 +387,16 @@ class GraphAgent(BaseAgent):
             response = await asyncio.to_thread(self.routing_client.chat.completions.create, **routing_kwargs)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
+            # Extract token usage from routing LLM call
+            usage_info = None
+            if response.usage:
+                usage_info = {
+                    'input_tokens': response.usage.prompt_tokens,
+                    'output_tokens': response.usage.completion_tokens,
+                    'reasoning_tokens': response.usage.completion_tokens_details.reasoning_tokens if response.usage.completion_tokens_details else None,
+                    'cached_tokens': response.usage.prompt_tokens_details.cached_tokens if response.usage.prompt_tokens_details else None,
+                }
+
             # Extract the function call
             message = response.choices[0].message
             if message.tool_calls:
@@ -401,37 +411,37 @@ class GraphAgent(BaseAgent):
                 logger.info(f"Routing decision (LLM): {function_name} | confidence: {confidence} | reasoning: {reasoning} (latency: {latency_ms:.1f}ms)")
 
                 if function_name == "stay_on_current_node":
-                    return None, None, latency_ms, messages, tools, reasoning, confidence
+                    return None, None, latency_ms, messages, tools, reasoning, confidence, usage_info
 
                 # Find the edge for this function
                 edge = self._get_edge_by_function_name_from_edges(llm_edges, function_name)
                 if edge:
-                    return edge['to_node_id'], function_args, latency_ms, messages, tools, reasoning, confidence
+                    return edge['to_node_id'], function_args, latency_ms, messages, tools, reasoning, confidence, usage_info
                 else:
                     logger.warning(f"Function {function_name} not found in edges")
-                    return None, None, latency_ms, messages, tools, reasoning, confidence
+                    return None, None, latency_ms, messages, tools, reasoning, confidence, usage_info
             else:
                 logger.warning("No tool call in response")
-                return None, None, latency_ms, messages, tools, None, None
+                return None, None, latency_ms, messages, tools, None, None, usage_info
 
         except Exception as e:
             latency_ms = (time.perf_counter() - start_time) * 1000
             logger.error(f"Routing error: {e} (latency: {latency_ms:.1f}ms)")
-            return None, None, latency_ms, messages, tools, None, None
+            return None, None, latency_ms, messages, tools, None, None, None
 
-    async def decide_next_node_with_functions(self, history: List[dict]) -> Tuple[Optional[str], Optional[Dict[str, Any]], float, Optional[List[dict]], Optional[List[dict]], Optional[str], Optional[float]]:
+    async def decide_next_node_with_functions(self, history: List[dict]) -> Tuple[Optional[str], Optional[Dict[str, Any]], float, Optional[List[dict]], Optional[List[dict]], Optional[str], Optional[float], Optional[dict]]:
         """Two-phase routing: deterministic expressions first, then LLM fallback."""
         start_time = time.perf_counter()
 
         current_node = self.get_node_by_id(self.current_node_id)
         if not current_node:
             logger.error(f"Current node '{self.current_node_id}' not found")
-            return None, None, 0, None, None, None, None
+            return None, None, 0, None, None, None, None, None
 
         edges = current_node.get('edges', [])
         if not edges:
             logger.debug(f"Node '{self.current_node_id}' has no edges, staying on current node")
-            return None, None, 0, None, None, None, None
+            return None, None, 0, None, None, None, None, None
 
         # Inject time variables and turn counts for expression evaluation
         timezone_str = self.context_data.get('recipient_data', {}).get('timezone') if isinstance(self.context_data.get('recipient_data'), dict) else None
@@ -452,13 +462,13 @@ class GraphAgent(BaseAgent):
                 ct = matched_edge.get('condition_type', EdgeConditionType.EXPRESSION)
                 reasoning = f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{matched_edge.get('condition', ct)}"
                 logger.info(f"Routing decision (deterministic): -> {matched_edge['to_node_id']} | {reasoning} (latency: {latency_ms:.1f}ms)")
-                return matched_edge['to_node_id'], None, latency_ms, None, None, reasoning, 1.0
+                return matched_edge['to_node_id'], None, latency_ms, None, None, reasoning, 1.0, None
 
         # Phase 2: LLM
         if llm_edges:
             return await self._decide_next_node_llm(current_node, llm_edges, history, start_time)
 
-        return None, None, 0, None, None, None, None
+        return None, None, 0, None, None, None, None, None
 
     def get_node_by_id(self, node_id: str) -> Optional[dict]:
         return next((node for node in self.config.get('nodes', []) if node['id'] == node_id), None)
@@ -559,7 +569,7 @@ class GraphAgent(BaseAgent):
 
         try:
             previous_node = self.current_node_id
-            next_node_id, extracted_params, routing_latency_ms, routing_messages, routing_tools, reasoning, confidence = await self.decide_next_node_with_functions(message)
+            next_node_id, extracted_params, routing_latency_ms, routing_messages, routing_tools, reasoning, confidence, routing_usage = await self.decide_next_node_with_functions(message)
 
             if next_node_id:
                 logger.info(f"Transitioning: {self.current_node_id} -> {next_node_id} (params: {extracted_params})")
@@ -588,6 +598,7 @@ class GraphAgent(BaseAgent):
                     'routing_tools': routing_tools,
                     'reasoning': reasoning,
                     'confidence': confidence,
+                    'routing_usage': routing_usage,
                 }
             }
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -528,7 +528,7 @@ async def write_request_logs(message, run_id):
         component_details = [message_data, None, None, None, message.get('latency', None), None, None, None]
         metadata = message.get('function_call_metadata', {})
     elif message["component"] == LogComponent.GRAPH_ROUTING:
-        component_details = [message_data, None, None, None, message.get('latency', None), False, None, None]
+        component_details = [message_data, message.get('input_tokens', 0), message.get('output_tokens', 0), None, message.get('latency', None), False, None, None]
         metadata = message.get('graph_routing_metadata', {})
     elif message["component"] == LogComponent.ERROR:
         component_details = [message_data, None, None, None, message.get('latency', None), False, None, None]
@@ -694,9 +694,32 @@ def convert_to_request_log(message, meta_info, model, component=LogComponent.TRA
             log['latency'] = None
         case LogComponent.GRAPH_ROUTING:
             log['latency'] = None
-            log['graph_routing_metadata'] = meta_info.get('llm_metadata', {})
+            if direction == LogDirection.RESPONSE:
+                log['input_tokens'] = input_tokens or 0
+                log['output_tokens'] = output_tokens or 0
+                graph_routing_metadata = meta_info.get('llm_metadata', {})
+                if not isinstance(graph_routing_metadata, dict):
+                    graph_routing_metadata = {}
+                if reasoning_tokens:
+                    graph_routing_metadata['reasoning_tokens'] = reasoning_tokens
+                if cached_tokens:
+                    graph_routing_metadata['cached_tokens'] = cached_tokens
+                graph_routing_metadata['usage_source'] = UsageSource.API_REPORTED.value if (input_tokens is not None or output_tokens is not None) else UsageSource.ESTIMATED.value
+                log['graph_routing_metadata'] = graph_routing_metadata
+            else:
+                log['graph_routing_metadata'] = meta_info.get('llm_metadata', {})
         case LogComponent.LLM_HANGUP | LogComponent.LLM_VOICEMAIL | LogComponent.LLM_LANGUAGE_DETECTION:
             log['latency'] = meta_info.get('llm_latency', None) if direction == LogDirection.RESPONSE else None
+            if direction == LogDirection.RESPONSE:
+                log['input_tokens'] = input_tokens or 0
+                log['output_tokens'] = output_tokens or 0
+                llm_metadata = {}
+                if reasoning_tokens:
+                    llm_metadata['reasoning_tokens'] = reasoning_tokens
+                if cached_tokens:
+                    llm_metadata['cached_tokens'] = cached_tokens
+                llm_metadata['usage_source'] = UsageSource.API_REPORTED.value if (input_tokens is not None or output_tokens is not None) else UsageSource.ESTIMATED.value
+                log['llm_metadata'] = llm_metadata
     log['engine'] = engine
     asyncio.create_task(write_request_logs(log, run_id))
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -697,9 +697,7 @@ def convert_to_request_log(message, meta_info, model, component=LogComponent.TRA
             if direction == LogDirection.RESPONSE:
                 log['input_tokens'] = input_tokens or 0
                 log['output_tokens'] = output_tokens or 0
-                graph_routing_metadata = meta_info.get('llm_metadata', {})
-                if not isinstance(graph_routing_metadata, dict):
-                    graph_routing_metadata = {}
+                graph_routing_metadata = dict(meta_info.get('llm_metadata') or {})
                 if reasoning_tokens:
                     graph_routing_metadata['reasoning_tokens'] = reasoning_tokens
                 if cached_tokens:


### PR DESCRIPTION
## Summary

Graph agents were losing routing LLM tokens entirely, and hangup/voicemail tokens existed in metadata but never made it to CSV logs. This PR fixes the full pipeline so all token consumption is tracked with `usage_source: api_reported`.

**What changed:**
1. `graph_agent.py`: Extract `response.usage` from routing LLM calls, pass as 8th return tuple element through to `routing_info`
2. `task_manager.py`: Pass routing tokens to both routing latencies and `convert_to_request_log`. Pass hangup metadata tokens to CSV log
3. `voicemail_handler.py`: Pass voicemail metadata tokens to CSV log
4. `utils.py`: `GRAPH_ROUTING` and `LLM_HANGUP`/`LLM_VOICEMAIL` cases now write `input_tokens`, `output_tokens`, `usage_source`, `reasoning_tokens`, `cached_tokens` to CSV