### PR TITLE
fix: update blame-ignore-revs to squash-merged commit hash

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,2 @@
 # ruff format — whole-codebase formatting
-0292626044d34017ff9ed3a9ac8d00b5126d771a
+06cb23b1adeeb39ca872526a299c742f79156d5d


### PR DESCRIPTION
## Summary
The format PR (#588) was squash-merged, so the commit hash in `.git-blame-ignore-revs` (pointing to the pre-squash commit) no longer exists on master. Updated to point to the actual squash-merge commit `06cb23b`.