### PR TITLE
feat: auto patch release on merge to master

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,41 @@
+name: Auto Patch Release
+
+on:
+  push:
+    branches: [master]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    # skip bump commits to avoid infinite loop
+    if: "!startsWith(github.event.head_commit.message, 'bump bolna version')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - run: pip install bumpver
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Bump patch version
+        run: bumpver update --patch
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG=$(git describe --tags --abbrev=0)
+          gh release create "$TAG" --title "$TAG" --generate-notes

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -49,4 +49,4 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           cz bump --increment PATCH --yes
-          git push
+          git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,43 +1,52 @@
-name: Auto Patch Release
+name: Auto Version Bump
 
 on:
-  push:
+  pull_request:
     branches: [master]
+    types: [opened, synchronize]
 
 permissions:
   contents: write
-  id-token: write
 
 jobs:
-  release:
+  bump:
     runs-on: ubuntu-latest
-    environment: pypi
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
+    # skip if last push was from the bot (avoids re-trigger after bump commit)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if already bumped
+        id: check
+        run: |
+          LAST_AUTHOR=$(git log -1 --format='%an')
+          if [ "$LAST_AUTHOR" = "github-actions[bot]" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          CURRENT=$(python3 -c "import re; m = re.search(r'__version__\s*=\s*\"(.+?)\"', open('bolna/__init__.py').read()); print(m.group(1))")
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          if [ "$CURRENT" != "$LATEST_TAG" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Set up Python
+        if: steps.check.outputs.skip == 'false'
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
-      - id: cz
-        uses: commitizen-tools/commitizen-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          increment: PATCH
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Bump patch version
+        if: steps.check.outputs.skip == 'false'
         run: |
-          TAG=$(git describe --tags --abbrev=0)
-          gh release create "$TAG" --title "$TAG" --generate-notes
-
-      - run: pip install build
-      - run: python -m build
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+          pip install commitizen
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          cz bump --increment PATCH --yes
+          git push

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,17 +6,18 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
-  bump:
+  release:
     runs-on: ubuntu-latest
+    environment: pypi
     # skip bump commits to avoid infinite loop
     if: "!startsWith(github.event.head_commit.message, 'bump bolna version')"
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,3 +40,9 @@ jobs:
         run: |
           TAG=$(git describe --tags --abbrev=0)
           gh release create "$TAG" --title "$TAG" --generate-notes
+
+      - run: pip install build
+      - run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -12,8 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     environment: pypi
-    # skip bump commits to avoid infinite loop
-    if: "!startsWith(github.event.head_commit.message, 'bump bolna version')"
+    if: "!startsWith(github.event.head_commit.message, 'bump:')"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -24,15 +23,11 @@ jobs:
         with:
           python-version: '3.10'
 
-      - run: pip install bumpver
-
-      - name: Configure git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump patch version
-        run: bumpver update --patch
+      - id: cz
+        uses: commitizen-tools/commitizen-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          increment: PATCH
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,7 +14,7 @@ jobs:
     # skip if last push was from the bot (avoids re-trigger after bump commit)
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
@@ -38,7 +38,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check.outputs.skip == 'false'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,38 +1,55 @@
 name: Publish to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    branches: [master]
 
 permissions:
-  contents: read
+  contents: write
+  id-token: write
 
 jobs:
   publish:
     runs-on: ubuntu-latest
     environment: pypi
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10.13'
+          python-version: '3.10'
 
-      - name: Verify tag matches package version
+      - name: Check if version needs publishing
+        id: check
         run: |
-          PKG_VERSION=$(python -c "import re; m = re.search(r'__version__\s*=\s*\"(.+?)\"', open('bolna/__init__.py').read()); print(m.group(1))")
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag $TAG_VERSION does not match package version $PKG_VERSION"
-            exit 1
+          VERSION=$(python -c "import re; m = re.search(r'__version__\s*=\s*\"(.+?)\"', open('bolna/__init__.py').read()); print(m.group(1))")
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "0.0.0")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [ "$VERSION" != "$LATEST_TAG" ]; then
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "publish=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - run: python -m pip install build
-      - run: python -m build
+      - name: Create tag and GitHub Release
+        if: steps.check.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=${{ steps.check.outputs.version }}
+          git tag "$VERSION"
+          git push origin "$VERSION"
+          gh release create "$VERSION" --title "$VERSION" --generate-notes
+
+      - name: Build
+        if: steps.check.outputs.publish == 'true'
+        run: |
+          pip install build
+          python -m build
 
       - name: Publish to PyPI
+        if: steps.check.outputs.publish == 'true'
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
         if: steps.check.outputs.publish == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.check.outputs.version }}
         run: |
-          VERSION=${{ steps.check.outputs.version }}
           git tag "$VERSION"
           git push origin "$VERSION"
           gh release create "$VERSION" --title "$VERSION" --generate-notes

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Verify tag matches package version
         run: |
           PKG_VERSION=$(python -c "import re; m = re.search(r'__version__\s*=\s*\"(.+?)\"', open('bolna/__init__.py').read()); print(m.group(1))")
-          TAG_REF=${GITHUB_REF#refs/tags/}
-          TAG_VERSION=${TAG_REF#bolna-}
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
           if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
-            echo "Tag $TAG_REF does not match package version $PKG_VERSION (expected tag bolna-$PKG_VERSION)"
+            echo "Tag $TAG_VERSION does not match package version $PKG_VERSION"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [master]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   id-token: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.3"
+__version__ = "0.10.2"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.2"
+__version__ = "0.10.3"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.3"
+version = "0.10.2"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.2"
+version = "0.10.3"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,23 +42,12 @@ select = [
     "ISC",   # implicit string concatenation bugs
 ]
 
-[tool.bumpver]
-current_version = "0.10.2"
-version_pattern = "MAJOR.MINOR.PATCH"
-commit_message = "bump bolna version {old_version} -> {new_version}"
-tag_message = "bolna-{new_version}"
-tag_scope = "default"
-pre_commit_hook = ""
-post_commit_hook = ""
-commit = true
-tag = true
-push = true
-
-[tool.bumpver.file_patterns]
-"pyproject.toml" = [
-    'current_version = "{version}"',
-    'version = "{version}"',
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.10.2"
+tag_format = "$version"
+version_files = [
+    "pyproject.toml:version",
+    "bolna/__init__.py:__version__",
 ]
-"bolna/__init__.py" = [
-    '^__version__ = "{version}"$',
-]
+update_changelog_on_bump = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,10 +44,9 @@ select = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.10.3"
+version_provider = "pep621"
 tag_format = "$version"
 version_files = [
-    "pyproject.toml:version",
     "bolna/__init__.py:__version__",
 ]
 update_changelog_on_bump = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.2"
+version = "0.10.3"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }
@@ -44,7 +44,7 @@ select = [
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.10.2"
+version = "0.10.3"
 tag_format = "$version"
 version_files = [
     "pyproject.toml:version",


### PR DESCRIPTION
## Summary
Automates patch version bumping and PyPI publishing using commitizen. Replaces bumpver config with commitizen in pyproject.toml.

## How it works

**Two workflows working together:**

1. `auto-release.yml` — runs on every PR targeting master
   - Checks if the version is already bumped (skips if so)
   - Bumps patch version on the PR branch using commitizen
   - The bump commit is part of the PR, goes through normal review flow

2. `publish.yml` — runs on every push to master
   - Compares `__version__` to the latest git tag
   - If version is newer: creates tag, GitHub Release, builds, and publishes to PyPI
   - If version matches latest tag: skips (no-op)

**Flow:** PR opened → version bumped on branch → PR reviewed and merged → tag created → published to PyPI

**Manual minor/major releases:** `cz bump --increment MINOR --yes` on a branch, then open a PR