### PR TITLE
Fix/calcom v1 to v2 migration

### DIFF
--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -41,8 +41,7 @@ def _calcom_booking_v1_to_v2(body):
     }
     if low == "phone":
         result["location"] = {"type": "phone"}
-    # Omit location for inPerson and all online/integration types (Google Meet, Zoom, etc.)
-    # so Cal.com uses the default location configured on the event type.
+    # Omit location for inPerson and online types so Cal.com uses the event type default.
     return result
 
 
@@ -163,49 +162,68 @@ def substitute_var_markers(obj, values):
         return obj  # Primitives returned as-is
 
 
-async def trigger_api(url, method, param, api_token, headers_data, meta_info, run_id, **kwargs):
+def prepare_api_request(param, api_token, headers_data, **kwargs):
+    request_body, api_params = None, None
+    if param:
+        # NEW FORMAT: Check for $var markers (type-safe JSON substitution)
+        if isinstance(param, dict) and _contains_var_markers(param):
+            api_params = substitute_var_markers(param, kwargs)
+            request_body = json.dumps(api_params)
+            logger.info("Using $var marker substitution for param")
+        else:
+            # LEGACY FORMAT: String template with %(field)s placeholders
+            if isinstance(param, dict):
+                param = json.dumps(param)
+
+            # JSON-serialize complex values (lists, dicts) for proper string substitution
+            # Python's % formatting uses repr() which produces single quotes,
+            # but JSON requires double quotes for valid JSON output
+            json_kwargs = {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in kwargs.items()}
+
+            code = compile(param % json_kwargs, "<string>", "exec")
+            exec(code, globals(), json_kwargs)
+            request_body = param % json_kwargs
+            api_params = json.loads(request_body)
+
+    headers = {"Content-Type": "application/json"}
+    content_type = "json"
+    if api_token:
+        headers["Authorization"] = api_token
+
+    if headers_data and isinstance(headers_data, dict):
+        for k, v in headers_data.items():
+            headers[k] = v
+
+    if headers.get("Content-Type").lower().startswith("application/x-www-form-urlencoded"):
+        content_type = "form"
+
+    return {
+        "request_body": request_body,
+        "api_params": api_params,
+        "headers": headers,
+        "content_type": content_type,
+    }
+
+
+async def trigger_api(
+    url, method, param, api_token, headers_data, meta_info, run_id, return_response_metadata=False, **kwargs
+):
     try:
-        request_body, api_params = None, None
-        if param:
-            # NEW FORMAT: Check for $var markers (type-safe JSON substitution)
-            if isinstance(param, dict) and _contains_var_markers(param):
-                api_params = substitute_var_markers(param, kwargs)
-                request_body = json.dumps(api_params)
-                logger.info(f"Using $var marker substitution for param")
-            else:
-                # LEGACY FORMAT: String template with %(field)s placeholders
-                if isinstance(param, dict):
-                    param = json.dumps(param)
-
-                # JSON-serialize complex values (lists, dicts) for proper string substitution
-                # Python's % formatting uses repr() which produces single quotes,
-                # but JSON requires double quotes for valid JSON output
-                json_kwargs = {
-                    k: json.dumps(v) if isinstance(v, (list, dict)) else v
-                    for k, v in kwargs.items()
-                }
-
-                code = compile(param % json_kwargs, "<string>", "exec")
-                exec(code, globals(), json_kwargs)
-                request_body = param % json_kwargs
-                api_params = json.loads(request_body)
-
-        headers = {'Content-Type': 'application/json'}
-        content_type = "json"
-        if api_token:
-            headers['Authorization'] = api_token
-
-        if headers_data and isinstance(headers_data, dict):
-            for k, v in headers_data.items():
-                headers[k] = v
-
-        if headers.get('Content-Type').lower().startswith('application/x-www-form-urlencoded'):
-            content_type = 'form'
-
+        prepared_request = prepare_api_request(param, api_token, headers_data, **kwargs)
+        request_body = prepared_request["request_body"]
+        api_params = prepared_request["api_params"]
+        headers = prepared_request["headers"]
+        content_type = prepared_request["content_type"]
         url, api_params, headers = _calcom_prepare(url, method, api_params, headers, api_token)
-
-        convert_to_request_log(request_body, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, is_cached=False, run_id=run_id)
-
+        convert_to_request_log(
+            request_body,
+            meta_info,
+            None,
+            LogComponent.FUNCTION_CALL,
+            direction=LogDirection.REQUEST,
+            is_cached=False,
+            run_id=run_id,
+        )
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
             if method.lower() == "get":
                 logger.info(f"Sending request {request_body}, {url}, {headers}")
@@ -223,6 +241,14 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
 
             if "api.cal.com" in (url or "").lower():
                 response_text = _calcom_unwrap_response(response_text)
+
+            if return_response_metadata:
+                return {
+                    "status_code": response.status if response is not None else None,
+                    "body": response_text,
+                    "content_type": response.headers.get("Content-Type") if response is not None else None,
+                }
+
             return response_text
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"
@@ -235,8 +261,15 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
                 component=LogComponent.WARNING,
                 direction=LogDirection.WARNING,
                 is_cached=False,
-                run_id=run_id
+                run_id=run_id,
             )
+        if return_response_metadata:
+            return {
+                "status_code": None,
+                "body": message,
+                "content_type": None,
+                "error": "Timed out after 5 seconds",
+            }
         return message
     except Exception as e:
         message = f"ERROR CALLING API: Please check your API: {e}"
@@ -249,8 +282,15 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
                 component=LogComponent.WARNING,
                 direction=LogDirection.WARNING,
                 is_cached=False,
-                run_id=run_id
+                run_id=run_id,
             )
+        if return_response_metadata:
+            return {
+                "status_code": None,
+                "body": message,
+                "content_type": None,
+                "error": str(e),
+            }
         return message
 
 
@@ -266,7 +306,4 @@ async def computed_api_response(response):
 
 
 def normalize_for_form(data: dict) -> dict:
-    return {
-        k: json.dumps(v) if isinstance(v, (dict, list)) else str(v)
-        for k, v in data.items()
-    }
+    return {k: json.dumps(v) if isinstance(v, (dict, list)) else str(v) for k, v in data.items()}

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -60,7 +60,8 @@ def _calcom_prepare(url, method, api_params, headers, api_token):
         p = urlparse(url)
     except Exception:
         return url, api_params, headers
-    if "api.cal.com" not in (p.netloc or "").lower():
+    host = (p.hostname or "").lower()
+    if host != "api.cal.com" and not host.endswith(".api.cal.com"):
         return url, api_params, headers
     qs = parse_qs(p.query, keep_blank_values=True)
     key = None
@@ -239,7 +240,8 @@ async def trigger_api(
                     async with session.post(url, data=normalized_api_params, headers=headers) as response:
                         response_text = await response.text()
 
-            if "api.cal.com" in (url or "").lower():
+            parsed_host = urlparse(url or "").hostname or ""
+            if parsed_host == "api.cal.com" or parsed_host.endswith(".api.cal.com"):
                 response_text = _calcom_unwrap_response(response_text)
 
             if return_response_metadata:

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -65,67 +65,46 @@ def substitute_var_markers(obj, values):
         return obj  # Primitives returned as-is
 
 
-def prepare_api_request(param, api_token, headers_data, **kwargs):
-    request_body, api_params = None, None
-    if param:
-        # NEW FORMAT: Check for $var markers (type-safe JSON substitution)
-        if isinstance(param, dict) and _contains_var_markers(param):
-            api_params = substitute_var_markers(param, kwargs)
-            request_body = json.dumps(api_params)
-            logger.info("Using $var marker substitution for param")
-        else:
-            # LEGACY FORMAT: String template with %(field)s placeholders
-            if isinstance(param, dict):
-                param = json.dumps(param)
-
-            # JSON-serialize complex values (lists, dicts) for proper string substitution
-            # Python's % formatting uses repr() which produces single quotes,
-            # but JSON requires double quotes for valid JSON output
-            json_kwargs = {k: json.dumps(v) if isinstance(v, (list, dict)) else v for k, v in kwargs.items()}
-
-            code = compile(param % json_kwargs, "<string>", "exec")
-            exec(code, globals(), json_kwargs)
-            request_body = param % json_kwargs
-            api_params = json.loads(request_body)
-
-    headers = {"Content-Type": "application/json"}
-    content_type = "json"
-    if api_token:
-        headers["Authorization"] = api_token
-
-    if headers_data and isinstance(headers_data, dict):
-        for k, v in headers_data.items():
-            headers[k] = v
-
-    if headers.get("Content-Type").lower().startswith("application/x-www-form-urlencoded"):
-        content_type = "form"
-
-    return {
-        "request_body": request_body,
-        "api_params": api_params,
-        "headers": headers,
-        "content_type": content_type,
-    }
-
-
-async def trigger_api(
-    url, method, param, api_token, headers_data, meta_info, run_id, return_response_metadata=False, **kwargs
-):
+async def trigger_api(url, method, param, api_token, headers_data, meta_info, run_id, **kwargs):
     try:
-        prepared_request = prepare_api_request(param, api_token, headers_data, **kwargs)
-        request_body = prepared_request["request_body"]
-        api_params = prepared_request["api_params"]
-        headers = prepared_request["headers"]
-        content_type = prepared_request["content_type"]
-        convert_to_request_log(
-            request_body,
-            meta_info,
-            None,
-            LogComponent.FUNCTION_CALL,
-            direction=LogDirection.REQUEST,
-            is_cached=False,
-            run_id=run_id,
-        )
+        request_body, api_params = None, None
+        if param:
+            # NEW FORMAT: Check for $var markers (type-safe JSON substitution)
+            if isinstance(param, dict) and _contains_var_markers(param):
+                api_params = substitute_var_markers(param, kwargs)
+                request_body = json.dumps(api_params)
+                logger.info(f"Using $var marker substitution for param")
+            else:
+                # LEGACY FORMAT: String template with %(field)s placeholders
+                if isinstance(param, dict):
+                    param = json.dumps(param)
+
+                # JSON-serialize complex values (lists, dicts) for proper string substitution
+                # Python's % formatting uses repr() which produces single quotes,
+                # but JSON requires double quotes for valid JSON output
+                json_kwargs = {
+                    k: json.dumps(v) if isinstance(v, (list, dict)) else v
+                    for k, v in kwargs.items()
+                }
+
+                code = compile(param % json_kwargs, "<string>", "exec")
+                exec(code, globals(), json_kwargs)
+                request_body = param % json_kwargs
+                api_params = json.loads(request_body)
+
+        headers = {'Content-Type': 'application/json'}
+        content_type = "json"
+        if api_token:
+            headers['Authorization'] = api_token
+
+        if headers_data and isinstance(headers_data, dict):
+            for k, v in headers_data.items():
+                headers[k] = v
+
+        if headers.get('Content-Type').lower().startswith('application/x-www-form-urlencoded'):
+            content_type = 'form'
+        convert_to_request_log(request_body, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, is_cached=False, run_id=run_id)
+
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
             if method.lower() == "get":
                 logger.info(f"Sending request {request_body}, {url}, {headers}")
@@ -141,13 +120,6 @@ async def trigger_api(
                     async with session.post(url, data=normalized_api_params, headers=headers) as response:
                         response_text = await response.text()
 
-            if return_response_metadata:
-                return {
-                    "status_code": response.status if response is not None else None,
-                    "body": response_text,
-                    "content_type": response.headers.get("Content-Type") if response is not None else None,
-                }
-
             return response_text
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"
@@ -160,15 +132,8 @@ async def trigger_api(
                 component=LogComponent.WARNING,
                 direction=LogDirection.WARNING,
                 is_cached=False,
-                run_id=run_id,
+                run_id=run_id
             )
-        if return_response_metadata:
-            return {
-                "status_code": None,
-                "body": message,
-                "content_type": None,
-                "error": "Timed out after 5 seconds",
-            }
         return message
     except Exception as e:
         message = f"ERROR CALLING API: Please check your API: {e}"
@@ -181,15 +146,8 @@ async def trigger_api(
                 component=LogComponent.WARNING,
                 direction=LogDirection.WARNING,
                 is_cached=False,
-                run_id=run_id,
+                run_id=run_id
             )
-        if return_response_metadata:
-            return {
-                "status_code": None,
-                "body": message,
-                "content_type": None,
-                "error": str(e),
-            }
         return message
 
 
@@ -205,4 +163,7 @@ async def computed_api_response(response):
 
 
 def normalize_for_form(data: dict) -> dict:
-    return {k: json.dumps(v) if isinstance(v, (dict, list)) else str(v) for k, v in data.items()}
+    return {
+        k: json.dumps(v) if isinstance(v, (dict, list)) else str(v)
+        for k, v in data.items()
+    }

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -1,5 +1,7 @@
 import asyncio
 import json
+import re
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
 
 import aiohttp
 from bolna.helpers.logger_config import configure_logger
@@ -7,6 +9,102 @@ from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, format_error_message
 
 logger = configure_logger(__name__)
+
+
+def _calcom_z(s):
+    if s is None:
+        return s
+    s = str(s).strip()
+    if not s:
+        return s
+    if s.endswith("Z") or re.search(r"[+-]\d{2}:\d{2}$", s):
+        return s
+    return s + "Z" if "T" in s else s
+
+
+def _calcom_booking_v1_to_v2(body):
+    if not isinstance(body, dict) or "responses" not in body:
+        return body
+    r = body.get("responses") or {}
+    loc = (r.get("location") or {}).get("value") or ""
+    low = str(loc).lower()
+    result = {
+        "eventTypeId": body.get("eventTypeId"),
+        "start": _calcom_z(body.get("start")),
+        "attendee": {
+            "name": r.get("name"),
+            "email": r.get("email"),
+            "timeZone": body.get("timeZone"),
+            "language": body.get("language") or "en",
+        },
+        "metadata": body.get("metadata") or {},
+    }
+    if low == "phone":
+        result["location"] = {"type": "phone"}
+    # Omit location for inPerson and all online/integration types (Google Meet, Zoom, etc.)
+    # so Cal.com uses the default location configured on the event type.
+    return result
+
+
+def _calcom_slot_params(params):
+    if not isinstance(params, dict):
+        return params
+    out = dict(params)
+    for k in ("startTime", "endTime"):
+        if k in out and out[k] is not None:
+            out[k] = _calcom_z(out[k])
+    return out
+
+
+def _calcom_prepare(url, method, api_params, headers, api_token):
+    try:
+        p = urlparse(url)
+    except Exception:
+        return url, api_params, headers
+    if "api.cal.com" not in (p.netloc or "").lower():
+        return url, api_params, headers
+    qs = parse_qs(p.query, keep_blank_values=True)
+    key = None
+    if "apiKey" in qs:
+        key = (qs["apiKey"][0] or None) if qs["apiKey"] else None
+        del qs["apiKey"]
+    if not key and headers.get("Authorization"):
+        a = str(headers["Authorization"]).strip()
+        key = a[7:].strip() if a.lower().startswith("bearer ") else a
+    if not key and api_token:
+        a = str(api_token).strip()
+        key = a[7:].strip() if a.lower().startswith("bearer ") else a
+    path = p.path or ""
+    if "/v1/slots/available" in path:
+        path = path.replace("/v1/slots/available", "/v2/slots/available", 1)
+    elif "/v1/slots" in path:
+        path = path.replace("/v1/slots", "/v2/slots/available", 1)
+    elif "/v1/bookings" in path:
+        path = path.replace("/v1/bookings", "/v2/bookings", 1)
+    elif "/v1/" in path:
+        path = path.replace("/v1/", "/v2/", 1)
+    new_url = urlunparse((p.scheme, p.netloc, path, p.params, urlencode(qs, doseq=True), p.fragment))
+    h = dict(headers)
+    if key:
+        h["Authorization"] = f"Bearer {key}"
+        h["cal-api-version"] = "2024-08-13"
+    new_params = api_params
+    m = method.lower()
+    if m == "post" and isinstance(api_params, dict) and "bookings" in path and "responses" in api_params:
+        new_params = _calcom_booking_v1_to_v2(api_params)
+    if m == "get" and isinstance(api_params, dict) and "slots" in path:
+        new_params = _calcom_slot_params(api_params)
+    return new_url, new_params, h
+
+
+def _calcom_unwrap_response(text):
+    try:
+        o = json.loads(text)
+        if isinstance(o, dict) and o.get("status") == "success" and "data" in o:
+            return json.dumps(o["data"])
+    except Exception:
+        pass
+    return text
 
 
 def _contains_var_markers(obj):
@@ -103,6 +201,9 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
 
         if headers.get('Content-Type').lower().startswith('application/x-www-form-urlencoded'):
             content_type = 'form'
+
+        url, api_params, headers = _calcom_prepare(url, method, api_params, headers, api_token)
+
         convert_to_request_log(request_body, meta_info , None, LogComponent.FUNCTION_CALL, direction=LogDirection.REQUEST, is_cached=False, run_id=run_id)
 
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=5)) as session:
@@ -120,6 +221,8 @@ async def trigger_api(url, method, param, api_token, headers_data, meta_info, ru
                     async with session.post(url, data=normalized_api_params, headers=headers) as response:
                         response_text = await response.text()
 
+            if "api.cal.com" in (url or "").lower():
+                response_text = _calcom_unwrap_response(response_text)
             return response_text
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"


### PR DESCRIPTION
Cal.com integration has been updated from v1 to v2 API.

- All Cal.com API calls now use v2 endpoints instead of the deprecated v1 endpoints
- Authentication has been migrated from `apiKey` query parameter to `Authorization: Bearer` header
- `cal-api-version: 2024-08-13` header is now sent on all Cal.com requests as required by the v2 API
- Booking request body format has been updated to match v2 schema — attendee details are now sent in the `attendee` object instead of the old `responses` wrapper
- Slot availability queries now correctly append timezone offset to timestamps as required by v2
- Location field is omitted from booking requests so Cal.com automatically uses the default location configured on the event type (Google Meet, Zoom, etc.)
- Cal.com v2 API response envelope (`{"status": "success", "data": {...}}`) is unwrapped so the agent receives clean data
- The account connection verification endpoint has been updated to use v2


Agents already created and stored in the database have Cal.com v1 URLs and apiKey query param format hardcoded in their tool configs. Changing the source templates would only fix newly created agents — all existing agents in production would silently break. By handling the v1→v2 migration at the request execution layer, every agent regardless of when it was created or how its tools are configured gets the correct v2 behaviour automatically, with zero data migration required.


<img width="716" height="856" alt="image" src="https://github.com/user-attachments/assets/c888d0aa-649d-4fd2-a5f8-fcf068805b55" />
