### PR TITLE
fix: stop audio buffer accumulation and break TaskManager reference cycles

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4100,15 +4100,18 @@ class TaskManager(BaseManager):
                 elif self.task_config["task_type"] == "webhook":
                     output = {"status": self.webhook_response, "task_type": "webhook"}
 
-            await asyncio.gather(*tasks_to_cancel)
-
-            for tool in self.tools.values():
-                if hasattr(tool, "task_manager_instance"):
-                    tool.task_manager_instance = None
-            self.tools.clear()
-            self.kwargs.pop("task_manager_instance", None)
-            self.conversation_recording = {"input": {"data": b""}, "output": [], "metadata": {}}
-            self.conversation_history = None
+            try:
+                await asyncio.gather(*tasks_to_cancel)
+            except Exception as e:
+                logger.error(f"Error during task cancellation: {e}")
+            finally:
+                for tool in self.tools.values():
+                    if hasattr(tool, "task_manager_instance"):
+                        tool.task_manager_instance = None
+                self.tools.clear()
+                self.kwargs.pop("task_manager_instance", None)
+                self.conversation_recording = {"input": {"data": b""}, "output": [], "metadata": {}}
+                self.conversation_history = None
 
             return output
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -930,9 +930,10 @@ class TaskManager(BaseManager):
                                 duration = calculate_audio_duration(
                                     len(data), self.sampling_rate, format=message["meta_info"]["format"]
                                 )
-                                self.conversation_recording["output"].append(
-                                    {"data": data, "start_time": time.time(), "duration": duration}
-                                )
+                                if self.should_record:
+                                    self.conversation_recording["output"].append(
+                                        {"data": data, "start_time": time.time(), "duration": duration}
+                                    )
                         except Exception as e:
                             duration = 0.256
                             logger.error(
@@ -3490,9 +3491,10 @@ class TaskManager(BaseManager):
                             duration = calculate_audio_duration(
                                 len(message["data"]), self.sampling_rate, format=message["meta_info"]["format"]
                             )
-                            self.conversation_recording["output"].append(
-                                {"data": message["data"], "start_time": time.time(), "duration": duration}
-                            )
+                            if self.should_record:
+                                self.conversation_recording["output"].append(
+                                    {"data": message["data"], "start_time": time.time(), "duration": duration}
+                                )
                         except Exception as e:
                             duration = 0.256
                             logger.info("Exception in __process_output_loop: {}".format(str(e)))
@@ -4099,6 +4101,15 @@ class TaskManager(BaseManager):
                     output = {"status": self.webhook_response, "task_type": "webhook"}
 
             await asyncio.gather(*tasks_to_cancel)
+
+            for tool in self.tools.values():
+                if hasattr(tool, "task_manager_instance"):
+                    tool.task_manager_instance = None
+            self.tools.clear()
+            self.kwargs.pop("task_manager_instance", None)
+            self.conversation_recording = {"input": {"data": b""}, "output": [], "metadata": {}}
+            self.conversation_history = None
+
             return output
 
     async def handle_cancellation(self, message):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -36,7 +36,6 @@ RECORDING_BUCKET_URL = os.getenv("RECORDING_BUCKET_URL")
 
 _LOG_DIR = "./logs"
 os.makedirs(_LOG_DIR, exist_ok=True)
-_log_header_written: set[str] = set()
 
 
 class DictWithMissing(dict):
@@ -598,11 +597,7 @@ async def write_request_logs(message, run_id):
     header = "Time,Component,Direction,Leg ID,Sequence ID,Model,Data,Input Tokens,Output Tokens,Characters,Latency,Cached,Final Transcript,Engine,Metadata\n"
     log_string = ",".join(['"' + str(item).replace('"', '""') + '"' if item is not None else "" for item in row]) + "\n"
     log_file_path = f"{_LOG_DIR}/{run_id}.csv"
-    if run_id not in _log_header_written:
-        _log_header_written.add(run_id)
-        write_header = not os.path.exists(log_file_path)
-    else:
-        write_header = False
+    write_header = not os.path.exists(log_file_path)
 
     async with aiofiles.open(log_file_path, mode="a") as log_file:
         if write_header:

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -63,9 +63,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             f"?model_id={self.model}&output_format={self.wire_format}"
             f"&inactivity_timeout=170&sync_alignment=true&optimize_streaming_latency=4"
         )
-        self.api_url = (
-            f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
-        )
+        self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
 
         self.context_id = None
         self.ws_send_time = None


### PR DESCRIPTION
## Summary

Pods on bolna-ws-cluster grow from ~1 GB to 5+ GB within 1-2 days and get OOMKilled. few root causes identified via Datadog memory RSS analysis and code dekh ke:

**1. Audio buffer accumulation on non-recording calls**
`conversation_recording["output"]` was appending every audio chunk (raw bytes) for ALL calls, even when `should_record=False` (which includes all web-based calls). For a 10-min call at 8kHz mulaw thats possible ~5 MB, at 24kHz PCM ~30 MB. With concurrent calls, this alone accounts for GBs of wasted memory. subjective as per our old discussions that this is dead code but worth adding if feel

Fix: guard both append sites with `if self.should_record`

**2. TaskManager reference cycle preventing GC**
`self.kwargs["task_manager_instance"] = self` creates a cycle: `TaskManager -> kwargs -> task_manager_instance -> TaskManager`. Additionally, synthesizers store `task_manager_instance`, creating: `TaskManager -> tools["synthesizer"] -> task_manager_instance -> TaskManager`. Combined with pending asyncio task references, CPython's GC often cannot collect these cycles, so dead TaskManagers (10-50 MB each) persist indefinitely. worth cleaning up

**3. No state cleanup in finally block**
After building the output dict, the finally block left all large state intact (tools, conversation_recording, conversation_history, kwargs). Combined with the reference cycle above, each completed call's entire object graph (audio buffers, message history, tool instances, queues) survived in memory.

Fix: after all task cancellation and output construction, break the reference cycle by nulling `task_manager_instance` on all tools, clearing tools/kwargs, and resetting conversation_recording and conversation_history.

**4. Unbounded `_log_header_written` set in utils.py**
Module-level set that added every `run_id` (UUID) and never evicted. Replaced with the `os.path.exists()` check that was already present as fallback, functionally identical behavior.