### PR TITLE
fix: close LLM httpx.AsyncClient on call teardown

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4105,6 +4105,12 @@ class TaskManager(BaseManager):
             except Exception as e:
                 logger.error(f"Error during task cancellation: {e}")
             finally:
+                llm_agent = self.tools.get("llm_agent")
+                if llm_agent and hasattr(llm_agent, "llm") and hasattr(llm_agent.llm, "close"):
+                    try:
+                        await llm_agent.llm.close()
+                    except Exception as e:
+                        logger.error(f"Error closing LLM: {e}")
                 for tool in self.tools.values():
                     if hasattr(tool, "task_manager_instance"):
                         tool.task_manager_instance = None

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4105,12 +4105,19 @@ class TaskManager(BaseManager):
             except Exception as e:
                 logger.error(f"Error during task cancellation: {e}")
             finally:
+                llm_agents_to_close = set()
                 llm_agent = self.tools.get("llm_agent")
-                if llm_agent and hasattr(llm_agent, "llm") and hasattr(llm_agent.llm, "close"):
-                    try:
-                        await llm_agent.llm.close()
-                    except Exception as e:
-                        logger.error(f"Error closing LLM: {e}")
+                if llm_agent is not None:
+                    llm_agents_to_close.add(llm_agent)
+                for agent in getattr(self, "llm_agent_map", {}).values():
+                    if agent is not None:
+                        llm_agents_to_close.add(agent)
+                for agent in llm_agents_to_close:
+                    if hasattr(agent, "llm") and hasattr(agent.llm, "close"):
+                        try:
+                            await agent.llm.close()
+                        except Exception as e:
+                            logger.error(f"Error closing LLM: {e}")
                 for tool in self.tools.values():
                     if hasattr(tool, "task_manager_instance"):
                         tool.task_manager_instance = None

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -296,6 +296,10 @@ class AzureLLM(OpenAICompatibleLLM):
             logger.error(f"Azure OpenAI unexpected error: {e}")
             raise
 
+    async def close(self):
+        if self.async_client:
+            await self.async_client.close()
+
     def get_response_format(self, is_json_format: bool):
         if is_json_format and self.model in ("gpt-4-1106-preview", "gpt-3.5-turbo-1106", "gpt-4o-mini", "gpt-4.1-mini"):
             return {"type": "json_object"}

--- a/bolna/llms/llm.py
+++ b/bolna/llms/llm.py
@@ -23,3 +23,10 @@ class BaseLLM:
         conversation state (e.g., OpenAI Responses API).
         """
         pass
+
+    async def close(self):
+        """Release resources (HTTP clients, WebSocket connections, etc.).
+
+        No-op by default. Override in subclasses that hold closeable resources.
+        """
+        pass

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -628,3 +628,5 @@ class OpenAiLLM(OpenAICompatibleLLM):
     async def close(self):
         if self._ws_transport:
             await self._ws_transport.disconnect()
+        if self.async_client:
+            await self.async_client.close()


### PR DESCRIPTION
## Summary

Every voice call creates an `httpx.AsyncClient(http2=True)` in the LLM constructor that is never closed, leaking ~105 KB of SSL + HTTP/2 state per call. At ~150 calls/min across 3 workers this causes ~1.5 GB/hour RSS growth, leading to OOMKills every 2-2.5 hours on ws-server pods. the data is based on what i was able to reproduce locally, calculation could be off but this is part of the leak for sure


**What changed:**
- Added base `close()` method to `BaseLLM`
- Extended `OpenAiLLM.close()` to also close the httpx client (previously only disconnected WS transport)
- Added `close()` to `AzureLLM` that closes the shared httpx client
- Call `llm.close()` in TaskManager's finally block before `tools.clear()`