### PR TITLE
fix: revert log header check to in-memory set

### DIFF
--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -36,6 +36,7 @@ RECORDING_BUCKET_URL = os.getenv("RECORDING_BUCKET_URL")
 
 _LOG_DIR = "./logs"
 os.makedirs(_LOG_DIR, exist_ok=True)
+_log_header_written = set()
 
 
 class DictWithMissing(dict):
@@ -597,7 +598,11 @@ async def write_request_logs(message, run_id):
     header = "Time,Component,Direction,Leg ID,Sequence ID,Model,Data,Input Tokens,Output Tokens,Characters,Latency,Cached,Final Transcript,Engine,Metadata\n"
     log_string = ",".join(['"' + str(item).replace('"', '""') + '"' if item is not None else "" for item in row]) + "\n"
     log_file_path = f"{_LOG_DIR}/{run_id}.csv"
-    write_header = not os.path.exists(log_file_path)
+    if run_id not in _log_header_written:
+        _log_header_written.add(run_id)
+        write_header = not os.path.exists(log_file_path)
+    else:
+        write_header = False
 
     async with aiofiles.open(log_file_path, mode="a") as log_file:
         if write_header:


### PR DESCRIPTION
## Summary

Reverts the CSV log header check from `os.path.exists(log_file_path)` back to an in-memory set (`_log_header_written`).

`os.path.exists` is a blocking syscall that stalls the async event loop on every log write. The in-memory set avoids this entirely and since calls don't survive pod restarts anyway, the set never needs to persist.