### PR TITLE
fix: cancel websocket listener task on call end

### DIFF
--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -70,6 +70,14 @@ class TelephonyInputHandler(DefaultInputHandler):
         asyncio.create_task(self._safe_disconnect_stream())
         logger.info("sleeping for 2 seconds so that whatever needs to pass is passed")
         await asyncio.sleep(2)
+        # Cancel the listener task before closing the WebSocket to prevent zombie SSL reads
+        if self.websocket_listen_task and not self.websocket_listen_task.done():
+            self.websocket_listen_task.cancel()
+            try:
+                await self.websocket_listen_task
+            except asyncio.CancelledError:
+                pass
+            logger.info("WebSocket listener task cancelled")
         try:
             await self.websocket.close()
             logger.info("WebSocket connection closed")
@@ -159,12 +167,11 @@ class TelephonyInputHandler(DefaultInputHandler):
                     break
 
             except WebSocketDisconnect as e:
-                if e.code in (1000, 1001, 1006):
-                    pass
-                else:
+                if e.code not in (1000, 1001, 1006):
                     logger.error(
                         f"WebSocket disconnected unexpectedly: code={e.code}, reason={getattr(e, 'reason', None)}"
                     )
+                break
 
             except Exception as e:
                 traceback.print_exc()

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -123,6 +123,13 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         self.running = False
         await self.disconnect_stream()
         await asyncio.sleep(0.5)
+        if self.websocket_listen_task and not self.websocket_listen_task.done():
+            self.websocket_listen_task.cancel()
+            try:
+                await self.websocket_listen_task
+            except asyncio.CancelledError:
+                pass
+            logger.info("WebSocket listener task cancelled")
         try:
             await self.websocket.close()
         except Exception as e:


### PR DESCRIPTION
## Summary

`stop_handler()` closes the WebSocket but never cancels the `_listen()` task. Since `_listen()` uses `while True` (not `while self.running`), the flag set in `stop_handler()` has no effect and the task can only exit via a "stop" event or exception.

Also fixes `_listen()` to `break` on `WebSocketDisconnect` instead of `pass` and the old code possibly looped back to `receive_text()` on a closed socket for codes 1000/1001/1006.

Same cancellation added to SIP trunk's `stop_handler()` for consistency.