### PR TITLE
fix: close auxiliary LLM httpx clients on call end

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4118,6 +4118,21 @@ class TaskManager(BaseManager):
                             await agent.llm.close()
                         except Exception as e:
                             logger.error(f"Error closing LLM: {e}")
+                    for attr in ("conversation_completion_llm", "voicemail_llm"):
+                        aux = getattr(agent, attr, None)
+                        if aux and hasattr(aux, "close"):
+                            try:
+                                await aux.close()
+                            except Exception as e:
+                                logger.error(f"Error closing {attr}: {e}")
+                lang_det = getattr(self, "language_detector", None)
+                if lang_det:
+                    aux_llm = getattr(lang_det, "_llm", None)
+                    if aux_llm and hasattr(aux_llm, "close"):
+                        try:
+                            await aux_llm.close()
+                        except Exception as e:
+                            logger.error(f"Error closing language detector LLM: {e}")
                 for tool in self.tools.values():
                     if hasattr(tool, "task_manager_instance"):
                         tool.task_manager_instance = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.3"
+version = "0.10.4"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Closes httpx.AsyncClient instances from auxiliary LLMs that were not covered by PR #639:
- `KnowledgeBaseAgent.conversation_completion_llm` and `voicemail_llm` (2 extra OpenAiLLM per KB call)
- `LanguageDetector._llm` (1 extra OpenAiLLM per call with language detection enabled)

These are closed in the same `finally` block where the main LLM is already closed.