### PR TITLE
fix: remove handle_cancellation to stop cascading worker crashes

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.4"
+__version__ = "0.10.5"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3937,10 +3937,8 @@ class TaskManager(BaseManager):
                     raise
 
         except asyncio.CancelledError as e:
-            # Cancel all tasks on cancel
             traceback.print_exc()
-            self.transcriber_task.cancel()
-            await self.handle_cancellation(f"Websocket got cancelled {self.task_id}")
+            logger.info(f"Websocket got cancelled {self.task_id}")
 
         except Exception as e:
             # Cancel all tasks on error
@@ -3967,7 +3965,7 @@ class TaskManager(BaseManager):
                     run_id=self.run_id,
                 )
 
-            await self.handle_cancellation(f"Exception occurred {e}")
+            logger.info(f"Exception occurred {e}")
             raise
 
         finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.4"
+version = "0.10.5"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary
- `handle_cancellation()` uses `asyncio.all_tasks()` to cancel every task in the event loop, including uvicorn, other active calls, and background workers
- When any single call hits an error, this kills the entire worker process, causing readiness probe 503s and pod restarts
- Over the last 2 days: **630 pod kills, zero OOMKilled** possible all restarts are from uvicorn dying due to this bug
- The `finally` block already does correct scoped cleanup via `process_task_cancellation()` for call-owned tasks only

## Changes
- Remove `self.transcriber_task.cancel()` from CancelledError handler (unsafe if None, redundant with finally)
- Replace `handle_cancellation()` calls with `logger.info()` in both CancelledError and Exception handlers