### PR TITLE
fix: clear observable variable observers on call cleanup

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.5"
+__version__ = "0.10.6"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4141,6 +4141,8 @@ class TaskManager(BaseManager):
                 self.kwargs.pop("task_manager_instance", None)
                 self.conversation_recording = {"input": {"data": b""}, "output": [], "metadata": {}}
                 self.conversation_history = None
+                self.request_logs.clear()
+                self.function_tool_api_call_details.clear()
 
             return output
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4131,6 +4131,9 @@ class TaskManager(BaseManager):
                             await aux_llm.close()
                         except Exception as e:
                             logger.error(f"Error closing language detector LLM: {e}")
+                for obs in self.observable_variables.values():
+                    obs._observers.clear()
+                self.observable_variables.clear()
                 for tool in self.tools.values():
                     if hasattr(tool, "task_manager_instance"):
                         tool.task_manager_instance = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.5"
+version = "0.10.6"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Clears observer references and accumulated lists in the TaskManager finally block to prevent per-call memory leaks.

**ObservableVariable observers**: Bound methods (e.g. `self.agent_hangup_observer`) hold strong references back to the TaskManager. Without clearing, the reference cycle prevents the TaskManager and all its buffers from being freed by reference counting. Objects accumulate until the cyclic GC's gen2 sweep, which runs infrequently under load. Reproduced locally: 1000 simulated calls leaked 480 MB without the fix vs 1.8 MB with it.

**request_logs / function_tool_api_call_details**: These lists accumulate entries throughout the call but are never cleared after the output dict is built. Clearing them in the finally block frees the memory immediately after the call ends.