### PR TITLE
fix: send EOS and break on WebSocketDisconnect in telephony _listen

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.6"
+__version__ = "0.10.7"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -160,11 +160,14 @@ class TelephonyInputHandler(DefaultInputHandler):
 
             except WebSocketDisconnect as e:
                 if e.code in (1000, 1001, 1006):
-                    pass
+                    logger.info(f"WebSocket disconnected normally: code={e.code}")
                 else:
                     logger.error(
                         f"WebSocket disconnected unexpectedly: code={e.code}, reason={getattr(e, 'reason', None)}"
                     )
+                ws_data_packet = create_ws_data_packet(data=None, meta_info={"io": "default", "eos": True})
+                self.queues["transcriber"].put_nowait(ws_data_packet)
+                break
 
             except Exception as e:
                 traceback.print_exc()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.6"
+version = "0.10.7"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

When Plivo WebSocket disconnects with normal close codes (1000/1001/1006), the _listen() handler was silently swallowing the exception. No EOS was sent to the transcriber and the loop never broke. This caused Deepgram to wait ~12s for audio that would never arrive, timing out with error 1011.

Now all WebSocketDisconnect codes log, send EOS to the transcriber queue, and break. This matches the behavior of the stop event and generic Exception handlers already in the same method.