### PR TITLE
feat: add prompt_cache_key for cross-call cache routing

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.8"
+__version__ = "0.10.9"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1233,8 +1233,8 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
-            if "agent_id" in self.kwargs:
-                injected_cfg["agent_id"] = self.kwargs["agent_id"]
+            if "prompt_cache_key" in self.kwargs:
+                injected_cfg["prompt_cache_key"] = self.kwargs["prompt_cache_key"]
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
 
@@ -1269,8 +1269,8 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
-            if "agent_id" in self.kwargs:
-                injected_cfg["agent_id"] = self.kwargs["agent_id"]
+            if "prompt_cache_key" in self.kwargs:
+                injected_cfg["prompt_cache_key"] = self.kwargs["prompt_cache_key"]
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -157,6 +157,8 @@ class TaskManager(BaseManager):
         # Assistant persistance stuff
         self.assistant_id = assistant_id
         self.run_id = kwargs.get("run_id")
+        if assistant_id:
+            self.kwargs["agent_id"] = assistant_id
 
         self.mark_event_meta_data = MarkEventMetaData()
         self.sampling_rate = 24000
@@ -1233,6 +1235,8 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
+            if "agent_id" in self.kwargs:
+                injected_cfg["agent_id"] = self.kwargs["agent_id"]
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
 
@@ -1267,6 +1271,8 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
+            if "agent_id" in self.kwargs:
+                injected_cfg["agent_id"] = self.kwargs["agent_id"]
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -157,8 +157,6 @@ class TaskManager(BaseManager):
         # Assistant persistance stuff
         self.assistant_id = assistant_id
         self.run_id = kwargs.get("run_id")
-        if assistant_id:
-            self.kwargs["agent_id"] = assistant_id
 
         self.mark_event_meta_data = MarkEventMetaData()
         self.sampling_rate = 24000

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -121,6 +121,7 @@ class GraphAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
+                "agent_id",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -121,7 +121,7 @@ class GraphAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
-                "agent_id",
+                "prompt_cache_key",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -73,7 +73,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
-                "agent_id",
+                "prompt_cache_key",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -73,6 +73,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
+                "agent_id",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -78,6 +78,7 @@ class AzureLLM(OpenAICompatibleLLM):
 
         self.run_id = kwargs.get("run_id", None)
         self.assistant_id = kwargs.get("assistant_id", None)
+        self.agent_id = kwargs.get("agent_id", None)
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
         # Responses API: uses v1 endpoint with regular AsyncOpenAI client
@@ -141,8 +142,8 @@ class AzureLLM(OpenAICompatibleLLM):
         latency_data = None
         stream_usage = None
 
-        if self.assistant_id:
-            model_args["extra_body"] = {"prompt_cache_key": self.assistant_id}
+        if self.agent_id:
+            model_args["extra_body"] = {"prompt_cache_key": self.agent_id}
 
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
@@ -261,7 +262,7 @@ class AzureLLM(OpenAICompatibleLLM):
                 messages=messages,
                 stream=False,
                 response_format=response_format,
-                extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
+                extra_body={"prompt_cache_key": self.agent_id} if self.agent_id else None,
             )
 
             res = completion.choices[0].message.content

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -256,7 +256,11 @@ class AzureLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format,
+                model=self.model,
+                temperature=0.0,
+                messages=messages,
+                stream=False,
+                response_format=response_format,
                 extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
             )
 

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -77,6 +77,7 @@ class AzureLLM(OpenAICompatibleLLM):
         )
 
         self.run_id = kwargs.get("run_id", None)
+        self.assistant_id = kwargs.get("assistant_id", None)
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
         # Responses API: uses v1 endpoint with regular AsyncOpenAI client
@@ -139,6 +140,9 @@ class AzureLLM(OpenAICompatibleLLM):
         first_token_time = None
         latency_data = None
         stream_usage = None
+
+        if self.assistant_id:
+            model_args["extra_body"] = {"prompt_cache_key": self.assistant_id}
 
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
@@ -252,7 +256,8 @@ class AzureLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format
+                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format,
+                extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
             )
 
             res = completion.choices[0].message.content

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -78,7 +78,7 @@ class AzureLLM(OpenAICompatibleLLM):
 
         self.run_id = kwargs.get("run_id", None)
         self.assistant_id = kwargs.get("assistant_id", None)
-        self.agent_id = kwargs.get("agent_id", None)
+        self.prompt_cache_key = kwargs.get("prompt_cache_key", None)
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
         # Responses API: uses v1 endpoint with regular AsyncOpenAI client
@@ -142,8 +142,8 @@ class AzureLLM(OpenAICompatibleLLM):
         latency_data = None
         stream_usage = None
 
-        if self.agent_id:
-            model_args["extra_body"] = {"prompt_cache_key": self.agent_id}
+        if self.prompt_cache_key:
+            model_args["extra_body"] = {"prompt_cache_key": self.prompt_cache_key}
 
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
@@ -262,7 +262,7 @@ class AzureLLM(OpenAICompatibleLLM):
                 messages=messages,
                 stream=False,
                 response_format=response_format,
-                extra_body={"prompt_cache_key": self.agent_id} if self.agent_id else None,
+                extra_body={"prompt_cache_key": self.prompt_cache_key} if self.prompt_cache_key else None,
             )
 
             res = completion.choices[0].message.content

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -231,6 +231,10 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
+        assistant_id = getattr(self, "assistant_id", None)
+        if assistant_id:
+            create_kwargs["extra_body"] = {"prompt_cache_key": assistant_id}
+
         return create_kwargs, responses_tools
 
     async def _generate_stream_responses(
@@ -437,6 +441,10 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
+
+        assistant_id = getattr(self, "assistant_id", None)
+        if assistant_id:
+            create_kwargs["extra_body"] = {"prompt_cache_key": assistant_id}
 
         llm_host = getattr(self, "llm_host", None)
 

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -231,9 +231,9 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
-        agent_id = getattr(self, "agent_id", None)
-        if agent_id:
-            create_kwargs["extra_body"] = {"prompt_cache_key": agent_id}
+        prompt_cache_key = getattr(self, "prompt_cache_key", None)
+        if prompt_cache_key:
+            create_kwargs["extra_body"] = {"prompt_cache_key": prompt_cache_key}
 
         return create_kwargs, responses_tools
 
@@ -442,9 +442,9 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
-        agent_id = getattr(self, "agent_id", None)
-        if agent_id:
-            create_kwargs["extra_body"] = {"prompt_cache_key": agent_id}
+        prompt_cache_key = getattr(self, "prompt_cache_key", None)
+        if prompt_cache_key:
+            create_kwargs["extra_body"] = {"prompt_cache_key": prompt_cache_key}
 
         llm_host = getattr(self, "llm_host", None)
 

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -231,9 +231,9 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
-        assistant_id = getattr(self, "assistant_id", None)
-        if assistant_id:
-            create_kwargs["extra_body"] = {"prompt_cache_key": assistant_id}
+        agent_id = getattr(self, "agent_id", None)
+        if agent_id:
+            create_kwargs["extra_body"] = {"prompt_cache_key": agent_id}
 
         return create_kwargs, responses_tools
 
@@ -442,9 +442,9 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
-        assistant_id = getattr(self, "assistant_id", None)
-        if assistant_id:
-            create_kwargs["extra_body"] = {"prompt_cache_key": assistant_id}
+        agent_id = getattr(self, "agent_id", None)
+        if agent_id:
+            create_kwargs["extra_body"] = {"prompt_cache_key": agent_id}
 
         llm_host = getattr(self, "llm_host", None)
 

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -199,6 +199,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.tools = [i for i in my_assistant.tools if i.type == "function"]
             # logger.info(f'thread id : {self.thread_id}')
         self.run_id = kwargs.get("run_id", None)
+        self.agent_id = kwargs.get("agent_id", None)
 
         self._init_responses_api(
             kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold")
@@ -261,8 +262,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
         service_tier = None
         stream_usage = None
 
-        if self.assistant_id:
-            model_args["extra_body"] = {"prompt_cache_key": self.assistant_id}
+        if self.agent_id:
+            model_args["extra_body"] = {"prompt_cache_key": self.agent_id}
 
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
@@ -384,7 +385,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 messages=messages,
                 stream=False,
                 response_format=response_format,
-                extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
+                extra_body={"prompt_cache_key": self.agent_id} if self.agent_id else None,
             )
             res = completion.choices[0].message.content
             if ret_metadata:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -379,7 +379,11 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format,
+                model=self.model,
+                temperature=0.0,
+                messages=messages,
+                stream=False,
+                response_format=response_format,
                 extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
             )
             res = completion.choices[0].message.content

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -199,7 +199,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.tools = [i for i in my_assistant.tools if i.type == "function"]
             # logger.info(f'thread id : {self.thread_id}')
         self.run_id = kwargs.get("run_id", None)
-        self.agent_id = kwargs.get("agent_id", None)
+        self.prompt_cache_key = kwargs.get("prompt_cache_key", None)
 
         self._init_responses_api(
             kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold")
@@ -262,8 +262,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
         service_tier = None
         stream_usage = None
 
-        if self.agent_id:
-            model_args["extra_body"] = {"prompt_cache_key": self.agent_id}
+        if self.prompt_cache_key:
+            model_args["extra_body"] = {"prompt_cache_key": self.prompt_cache_key}
 
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
@@ -385,7 +385,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 messages=messages,
                 stream=False,
                 response_format=response_format,
-                extra_body={"prompt_cache_key": self.agent_id} if self.agent_id else None,
+                extra_body={"prompt_cache_key": self.prompt_cache_key} if self.prompt_cache_key else None,
             )
             res = completion.choices[0].message.content
             if ret_metadata:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -261,6 +261,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
         service_tier = None
         stream_usage = None
 
+        if self.assistant_id:
+            model_args["extra_body"] = {"prompt_cache_key": self.assistant_id}
+
         try:
             completion_stream = await self.async_client.chat.completions.create(**model_args)
         except AuthenticationError as e:
@@ -376,7 +379,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format
+                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format,
+                extra_body={"prompt_cache_key": self.assistant_id} if self.assistant_id else None,
             )
             res = completion.choices[0].message.content
             if ret_metadata:
@@ -435,6 +439,11 @@ class OpenAiLLM(OpenAICompatibleLLM):
         create_params, responses_tools = self._build_responses_create_kwargs(
             messages, meta_info, request_json, tool_choice, store=False
         )
+
+        # extra_body is an SDK concept; WS sends raw JSON, so merge its contents at top level
+        extra_body = create_params.pop("extra_body", None)
+        if extra_body:
+            create_params.update(extra_body)
 
         # WS endpoint silently closes on float temperature — coerce to int
         temp = create_params.get("temperature")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.8"
+version = "0.10.9"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Adds `prompt_cache_key=agent_id` to all OpenAI and Azure LLM API call sites so that calls for the same agent route to the same GPU server, enabling cross-call cache hits on the system prompt.

Previously, each new call landed on a random server and started with a cold cache on the first turn. Now the first turn reuses the cached system prompt from previous calls for the same agent.

Caller-controlled opt-in: bolna sets `prompt_cache_key` only when `agent_id` is explicitly passed in kwargs. See https://github.com/bolna-ai/dashboard-backend/pull/2041 for the allowlist consumer.

## What changed

| File | Change |
|------|--------|
| `task_manager.py` | Forward `agent_id` to LLM when caller passes it in kwargs |
| `openai_llm.py` | `extra_body` with `prompt_cache_key` in streaming and non-streaming chat completions; pop and merge for WebSocket path |
| `azure_llm.py` | Store `agent_id`; `extra_body` in streaming and non-streaming chat completions |
| `openai_base.py` | `extra_body` in `_build_responses_create_kwargs` and `_generate_responses` |
| `graph_agent.py`, `knowledgebase_agent.py` | Pass `agent_id` through to LLM initialization |

All changes guarded by `if self.agent_id`, no effect when absent.