### PR TITLE
fix: null heavy TaskManager attributes in finally block to prevent memory leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.7"
+__version__ = "0.10.8"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4142,10 +4142,33 @@ class TaskManager(BaseManager):
                         tool.task_manager_instance = None
                 self.tools.clear()
                 self.kwargs.pop("task_manager_instance", None)
+                self.kwargs.clear()
                 self.conversation_recording = {"input": {"data": b""}, "output": [], "metadata": {}}
                 self.conversation_history = None
                 self.request_logs.clear()
                 self.function_tool_api_call_details.clear()
+                if hasattr(self, "voicemail_handler"):
+                    self.voicemail_handler.tm = None
+                if hasattr(self, "language_detector"):
+                    self.language_detector._transcripts.clear()
+                    self.language_detector._llm = None
+
+                # Null out heavy instance attributes so that even if a stale asyncio
+                # task keeps the TaskManager alive, the data it points to is freed.
+                self.task_config = None
+                self.mark_event_meta_data = None
+                self.interruption_manager = None
+                self.context_data = None
+                self.buffers = None
+                self.queues = None
+                self.synthesizer_tasks = None
+                self.prompts = None
+                self.system_prompt = None
+                self.input_parameters = None
+                self.label_flow = None
+                self.llm_config_map = None
+                self.llm_agent_map = None
+                self.conversation_config = None
 
             return output
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.7"
+version = "0.10.8"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Asyncio tasks hold closure references to TaskManager after call ends, keeping the entire object graph alive (~8-16 KB per call). This nulls heavy attributes (task_config, kwargs, mark_event_meta_data, interruption_manager, queues, buffers, etc.) in the finally block so data is freed even if the TaskManager shell stays alive.

Also breaks VoicemailHandler circular reference and clears LanguageDetector state.

Reproduction test: 72% reduction in per call memory retention (8.1 MB to 2.2 MB for 500 calls).