### PR TITLE
fix: shared httpx client pool to stop ws-server memory leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.7"
+__version__ = "0.10.8"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -1,7 +1,7 @@
 import os
 import json
-import httpx
 from urllib.parse import urlparse
+from bolna.llms.http_client_pool import get_shared_http_client
 from dotenv import load_dotenv
 from openai import (
     AsyncAzureOpenAI,
@@ -70,8 +70,7 @@ class AzureLLM(OpenAICompatibleLLM):
         api_key = kwargs.get("llm_key", os.getenv("AZURE_OPENAI_API_KEY"))
         api_version = kwargs.get("api_version", os.getenv("AZURE_OPENAI_API_VERSION", "2024-12-01-preview"))
 
-        limits = httpx.Limits(max_connections=50, max_keepalive_connections=50, keepalive_expiry=30)
-        http_client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0))
+        http_client = get_shared_http_client(base_url=azure_endpoint, http2=False)
 
         self.async_client = AsyncAzureOpenAI(
             azure_endpoint=azure_endpoint, api_key=api_key, api_version=api_version, http_client=http_client
@@ -297,8 +296,7 @@ class AzureLLM(OpenAICompatibleLLM):
             raise
 
     async def close(self):
-        if self.async_client:
-            await self.async_client.close()
+        pass
 
     def get_response_format(self, is_json_format: bool):
         if is_json_format and self.model in ("gpt-4-1106-preview", "gpt-3.5-turbo-1106", "gpt-4o-mini", "gpt-4.1-mini"):

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -296,7 +296,7 @@ class AzureLLM(OpenAICompatibleLLM):
             raise
 
     async def close(self):
-        pass
+        pass  # httpx client is shared via pool, don't close it here
 
     def get_response_format(self, is_json_format: bool):
         if is_json_format and self.model in ("gpt-4-1106-preview", "gpt-3.5-turbo-1106", "gpt-4o-mini", "gpt-4.1-mini"):

--- a/bolna/llms/http_client_pool.py
+++ b/bolna/llms/http_client_pool.py
@@ -1,11 +1,18 @@
+import threading
 import httpx
 
 _pool: dict[tuple, httpx.AsyncClient] = {}
+_lock = threading.Lock()
 
 
 def get_shared_http_client(base_url: str | None = None, http2: bool = True) -> httpx.AsyncClient:
     key = (base_url, http2)
-    if key not in _pool:
-        limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=30)
-        _pool[key] = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
-    return _pool[key]
+    client = _pool.get(key)
+    if client is None:
+        with _lock:
+            client = _pool.get(key)
+            if client is None:
+                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=30)
+                client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
+                _pool[key] = client
+    return client

--- a/bolna/llms/http_client_pool.py
+++ b/bolna/llms/http_client_pool.py
@@ -1,0 +1,11 @@
+import httpx
+
+_pool: dict[tuple, httpx.AsyncClient] = {}
+
+
+def get_shared_http_client(base_url: str | None = None, http2: bool = True) -> httpx.AsyncClient:
+    key = (base_url, http2)
+    if key not in _pool:
+        limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=30)
+        _pool[key] = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
+    return _pool[key]

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -3,8 +3,8 @@ import asyncio
 import json
 import time
 from typing import Optional
-import httpx
 from urllib.parse import urlparse
+from bolna.llms.http_client_pool import get_shared_http_client
 from dotenv import load_dotenv
 from openai import (
     AsyncOpenAI,
@@ -173,8 +173,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")
 
-        limits = httpx.Limits(max_connections=50, max_keepalive_connections=50, keepalive_expiry=30)
-        http_client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=True)
+        http_client = get_shared_http_client(base_url=kwargs.get("base_url"), http2=True)
 
         if kwargs.get("provider", "openai") == "custom":
             base_url = kwargs.get("base_url")
@@ -628,5 +627,3 @@ class OpenAiLLM(OpenAICompatibleLLM):
     async def close(self):
         if self._ws_transport:
             await self._ws_transport.disconnect()
-        if self.async_client:
-            await self.async_client.close()

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -625,5 +625,6 @@ class OpenAiLLM(OpenAICompatibleLLM):
             asyncio.ensure_future(self._ws_transport.cancel_response(response_id))
 
     async def close(self):
+        # httpx client is shared via pool, don't close it here
         if self._ws_transport:
             await self._ws_transport.disconnect()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.7"
+version = "0.10.8"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Each call creates up to 4 httpx.AsyncClient instances (one per LLM). Under concurrent load, creating and destroying these clients fragments native memory that the allocator can never reclaim. India ws-server pods were leaking 300 to 470 MB/hour because of this.

Fix: single shared httpx.AsyncClient per unique endpoint, reused across all calls.

Test results (500 calls, 20 concurrent, 4 clients each):
  Per-call churn (old): +10.6 MB
  Shared client (fix):  +0.4 MB after gc + malloc_trim (flat at 2000 calls)

Verified no actual memory growth on the shared client. The small RSS increase in raw measurements is just the allocator holding freed pages, not a leak.

## What changed

1. New `bolna/llms/http_client_pool.py`: singleton pool keyed by (base_url, http2), connection limits raised to 200 since client is shared
2. `OpenAiLLM` and `AzureLLM` now use the shared client instead of creating one per instance
3. `close()` no longer closes the httpx client (it is shared). OpenAiLLM still closes its WS transport