### PR TITLE
feat: local silero vad and pre-speech ring buffer for telephony input

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -140,6 +140,8 @@ class TaskManager(BaseManager):
         self.synthesizer_queue = asyncio.Queue()
         self.transcriber_output_queue = asyncio.Queue()
         self.dtmf_queue = asyncio.Queue()
+        # Populated in __setup_input_handlers when vad_config is set.
+        self.speech_events_queue: asyncio.Queue | None = None
         self.queues = {
             "dtmf": self.dtmf_queue,
             "transcriber": self.audio_queue,
@@ -831,6 +833,12 @@ class TaskManager(BaseManager):
 
                 if self.task_config["tools_config"]["input"]["provider"] == "default":
                     input_kwargs["queue"] = input_queue
+                else:
+                    vad_config = self.task_config["tools_config"]["input"].get("vad_config")
+                    if vad_config:
+                        self.speech_events_queue = asyncio.Queue()
+                        input_kwargs["vad_config"] = vad_config
+                        input_kwargs["speech_events_queue"] = self.speech_events_queue
 
                 input_kwargs["observable_variables"] = self.observable_variables
 
@@ -2909,6 +2917,38 @@ class TaskManager(BaseManager):
                 TranscriberError(connection_error, provider=provider), HangupReason.TRANSCRIBER_CONNECTION_ERROR
             )
 
+    async def _listen_speech_events(self):
+        # Local-VAD pause signal. Word-count interruption gating still happens
+        # in _listen_transcriber, so coughs don't tear down the agent.
+        if self.speech_events_queue is None:
+            return
+        try:
+            while True:
+                if self.hangup_triggered:
+                    break
+                try:
+                    event = await asyncio.wait_for(self.speech_events_queue.get(), timeout=0.5)
+                except asyncio.TimeoutError:
+                    continue
+
+                if not self.tools["input"].welcome_message_played():
+                    continue
+
+                event_type = event.get("type")
+                if event_type == "speech_started":
+                    logger.info(
+                        f"local vad speech_started media_ts={event.get('media_ts_ms')}ms "
+                        f"pre_speech_bytes={event.get('pre_speech_bytes')}"
+                    )
+                    self.interruption_manager.on_user_speech_started()
+                elif event_type == "speech_ended":
+                    logger.info(f"local vad speech_ended media_ts={event.get('media_ts_ms')}ms")
+                    self.interruption_manager.on_user_speech_ended()
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(f"error in _listen_speech_events: {e}")
+
     async def _listen_transcriber(self):
         temp_transcriber_message = ""
         try:
@@ -3848,6 +3888,9 @@ class TaskManager(BaseManager):
                 if "transcriber" in self.tools:
                     tasks.append(asyncio.create_task(self._listen_transcriber()))
                     self.transcriber_task = asyncio.create_task(self.tools["transcriber"].run())
+
+                if self.speech_events_queue is not None:
+                    tasks.append(asyncio.create_task(self._listen_speech_events()))
 
                 if self.turn_based_conversation and self._is_conversation_task():
                     logger.info(

--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -1,8 +1,10 @@
 import traceback
 from .default import DefaultInputHandler
 import asyncio
+import audioop
 import base64
 import json
+import time
 from starlette.websockets import WebSocketDisconnect
 from dotenv import load_dotenv
 from bolna.helpers.utils import create_ws_data_packet
@@ -22,6 +24,8 @@ class TelephonyInputHandler(DefaultInputHandler):
         turn_based_conversation=False,
         is_welcome_message_played=False,
         observable_variables=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
         super().__init__(
             queues,
@@ -34,12 +38,111 @@ class TelephonyInputHandler(DefaultInputHandler):
         )
         self.stream_sid = None
         self.call_sid = None
-        self.buffer = []
+        # On the instance so the local-VAD path can clear it on speech_started
+        # without re-sending audio already covered by the pre-speech flush.
+        self.media_buffer: list[bytes] = []
         self.message_count = 0
         # self.mark_event_meta_data = mark_event_meta_data
         self.last_media_received = 0
         self.io_provider = None
         self.websocket_listen_task = None
+
+        self._vad_config = vad_config
+        self._speech_events_queue = speech_events_queue
+        self._turn_detector = self._build_turn_detector(vad_config)
+
+    @staticmethod
+    def _build_turn_detector(vad_config):
+        if not vad_config:
+            return None
+        # Deferred so installations that don't enable local VAD skip the
+        # torch / onnxruntime import cost.
+        from bolna.vad import PreSpeechRingBuffer, SileroVAD, TurnDetector
+
+        sample_rate = vad_config.get("sample_rate", 8000)
+        vad = SileroVAD(
+            sample_rate=sample_rate,
+            threshold=vad_config.get("threshold", 0.5),
+            min_silence_duration_ms=vad_config.get("min_silence_ms", 100),
+            speech_pad_ms=vad_config.get("speech_pad_ms", 30),
+        )
+        # 1 byte/sample because we hold raw mulaw for replay; VAD gets the
+        # decoded int16 copy separately.
+        ring = PreSpeechRingBuffer.from_duration(
+            duration_ms=vad_config.get("pre_speech_ms", 500),
+            sample_rate_hz=sample_rate,
+            bytes_per_sample=1,
+        )
+        return TurnDetector(vad=vad, pre_speech_buffer=ring)
+
+    async def _handle_vad_gated_frame(self, mulaw_bytes, media_ts_ms, meta_info):
+        try:
+            pcm_int16 = audioop.ulaw2lin(mulaw_bytes, 2)
+        except Exception as e:
+            logger.info(f"mulaw decode failed, skipping VAD for frame: {e}")
+            return
+
+        events = list(self._turn_detector.feed(pcm_int16, raw_audio=mulaw_bytes))
+        now_monotonic = time.monotonic()
+
+        if self._speech_events_queue is not None:
+            for ev in events:
+                self._speech_events_queue.put_nowait({
+                    "type": ev.type.value,
+                    "source": "local_silero",
+                    "media_ts_ms": media_ts_ms,
+                    "wall_clock_monotonic": now_monotonic,
+                    "sample_offset": ev.sample_offset,
+                    "pre_speech_bytes": len(ev.pre_speech_audio),
+                    "call_sid": self.call_sid,
+                    "stream_sid": self.stream_sid,
+                })
+
+        # If both events fired for this frame, last-state-wins: speech_started
+        # carries all the audio in its pre-speech flush.
+        last_started = next(
+            (e for e in reversed(events) if e.type.value == "speech_started"),
+            None,
+        )
+        last_ended = next(
+            (e for e in reversed(events) if e.type.value == "speech_ended"),
+            None,
+        )
+
+        if last_started is not None and (
+            last_ended is None
+            or last_started.sample_offset >= last_ended.sample_offset
+        ):
+            if last_started.pre_speech_audio:
+                await self._flush_pre_speech_to_transcriber(
+                    last_started.pre_speech_audio, meta_info
+                )
+            self.media_buffer = []
+            self.message_count = 0
+            return
+        if last_ended is not None:
+            if self.media_buffer:
+                await self.ingest_audio(b"".join(self.media_buffer), meta_info)
+            self.media_buffer = []
+            self.message_count = 0
+            return
+
+        if not self._turn_detector.is_in_speech:
+            return
+
+        self.media_buffer.append(mulaw_bytes)
+        self.message_count += 1
+        if self.message_count == 10:
+            await self.ingest_audio(b"".join(self.media_buffer), meta_info)
+            self.media_buffer = []
+            self.message_count = 0
+
+    async def _flush_pre_speech_to_transcriber(self, mulaw_bytes, template_meta_info):
+        meta_info = dict(template_meta_info)
+        meta_info["is_pre_speech_flush"] = True
+        self.queues["transcriber"].put_nowait(
+            create_ws_data_packet(data=mulaw_bytes, meta_info=meta_info)
+        )
 
     def get_stream_sid(self):
         return self.stream_sid
@@ -95,7 +198,7 @@ class TelephonyInputHandler(DefaultInputHandler):
         return False
 
     async def _listen(self):
-        buffer = []
+        self.media_buffer = []
         while True:
             try:
                 message = await self.websocket.receive_text()
@@ -124,15 +227,20 @@ class TelephonyInputHandler(DefaultInputHandler):
                             #await self.ingest_audio(b"\xff" * bytes_to_fill, meta_info)
                         """
                         self.last_media_received = media_ts
-                        buffer.append(media_audio)
-                        self.message_count += 1
+                        if self._turn_detector is not None:
+                            await self._handle_vad_gated_frame(
+                                media_audio, media_ts, meta_info
+                            )
+                        else:
+                            self.media_buffer.append(media_audio)
+                            self.message_count += 1
 
-                        # Send 100 ms of audio to deepgram
-                        if self.message_count == 10:
-                            merged_audio = b"".join(buffer)
-                            buffer = []
-                            await self.ingest_audio(merged_audio, meta_info)
-                            self.message_count = 0
+                            # Flush every ~200ms of audio to the transcriber.
+                            if self.message_count == 10:
+                                merged_audio = b"".join(self.media_buffer)
+                                self.media_buffer = []
+                                await self.ingest_audio(merged_audio, meta_info)
+                                self.message_count = 0
                     else:
                         logger.info("Getting media elements but not inbound media")
 

--- a/bolna/input_handlers/telephony_providers/exotel.py
+++ b/bolna/input_handlers/telephony_providers/exotel.py
@@ -16,6 +16,8 @@ class ExotelInputHandler(TelephonyInputHandler):
         turn_based_conversation=False,
         is_welcome_message_played=False,
         observable_variables=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
         super().__init__(
             queues,
@@ -25,6 +27,8 @@ class ExotelInputHandler(TelephonyInputHandler):
             turn_based_conversation,
             is_welcome_message_played=is_welcome_message_played,
             observable_variables=observable_variables,
+            vad_config=vad_config,
+            speech_events_queue=speech_events_queue,
         )
         self.io_provider = "exotel"
 

--- a/bolna/input_handlers/telephony_providers/plivo.py
+++ b/bolna/input_handlers/telephony_providers/plivo.py
@@ -18,6 +18,8 @@ class PlivoInputHandler(TelephonyInputHandler):
         turn_based_conversation=False,
         is_welcome_message_played=False,
         observable_variables=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
         super().__init__(
             queues,
@@ -27,6 +29,8 @@ class PlivoInputHandler(TelephonyInputHandler):
             turn_based_conversation,
             is_welcome_message_played=is_welcome_message_played,
             observable_variables=observable_variables,
+            vad_config=vad_config,
+            speech_events_queue=speech_events_queue,
         )
         self.io_provider = "plivo"
         self.client = plivosdk.RestClient(os.getenv("PLIVO_AUTH_ID"), os.getenv("PLIVO_AUTH_TOKEN"))

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -63,7 +63,18 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         asterisk_media_start=None,
         agent_config=None,
         ws_context_data=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
+        # SipTrunk implements its own _listen() and does not yet route audio
+        # through TelephonyInputHandler's VAD-gated path. Accept the kwargs
+        # so task_manager construction does not blow up, but warn loudly so
+        # operators know the local VAD is silently no-op for SIP trunks.
+        if vad_config:
+            logger.warning(
+                "vad_config supplied to SipTrunkInputHandler but SIP trunk path "
+                "does not route through the local VAD layer yet -- ignoring."
+            )
         super().__init__(
             queues,
             websocket,

--- a/bolna/input_handlers/telephony_providers/twilio.py
+++ b/bolna/input_handlers/telephony_providers/twilio.py
@@ -16,6 +16,8 @@ class TwilioInputHandler(TelephonyInputHandler):
         turn_based_conversation=False,
         is_welcome_message_played=False,
         observable_variables=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
         super().__init__(
             queues,
@@ -25,6 +27,8 @@ class TwilioInputHandler(TelephonyInputHandler):
             turn_based_conversation,
             is_welcome_message_played=is_welcome_message_played,
             observable_variables=observable_variables,
+            vad_config=vad_config,
+            speech_events_queue=speech_events_queue,
         )
         self.io_provider = "twilio"
 

--- a/bolna/input_handlers/telephony_providers/vobiz.py
+++ b/bolna/input_handlers/telephony_providers/vobiz.py
@@ -19,6 +19,8 @@ class VobizInputHandler(TelephonyInputHandler):
         turn_based_conversation=False,
         is_welcome_message_played=False,
         observable_variables=None,
+        vad_config=None,
+        speech_events_queue=None,
     ):
         super().__init__(
             queues,
@@ -28,6 +30,8 @@ class VobizInputHandler(TelephonyInputHandler):
             turn_based_conversation,
             is_welcome_message_played=is_welcome_message_played,
             observable_variables=observable_variables,
+            vad_config=vad_config,
+            speech_events_queue=speech_events_queue,
         )
         self.io_provider = "vobiz"
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -191,9 +191,18 @@ class Synthesizer(BaseModel):
         return validate_attribute(value, SynthesizerProvider.all_values())
 
 
+class VadConfig(BaseModel):
+    sample_rate: Literal[8000, 16000] = 8000
+    threshold: float = Field(default=0.5, ge=0.0, le=1.0)
+    min_silence_ms: int = Field(default=100, ge=0, le=5000)
+    speech_pad_ms: int = Field(default=30, ge=0, le=500)
+    pre_speech_ms: int = Field(default=500, ge=0, le=2000)
+
+
 class IOModel(BaseModel):
     provider: str
     format: Optional[str] = "wav"
+    vad_config: Optional[VadConfig] = None
 
     @field_validator("provider")
     def validate_provider(cls, value):

--- a/bolna/vad/__init__.py
+++ b/bolna/vad/__init__.py
@@ -1,0 +1,11 @@
+from .pre_speech_buffer import PreSpeechRingBuffer
+from .silero_vad import SileroVAD
+from .turn_detector import SpeechEvent, SpeechEventType, TurnDetector
+
+__all__ = [
+    "PreSpeechRingBuffer",
+    "SileroVAD",
+    "SpeechEvent",
+    "SpeechEventType",
+    "TurnDetector",
+]

--- a/bolna/vad/pre_speech_buffer.py
+++ b/bolna/vad/pre_speech_buffer.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from collections import deque
+
+
+class PreSpeechRingBuffer:
+    def __init__(self, capacity_bytes: int) -> None:
+        if capacity_bytes <= 0:
+            raise ValueError("capacity_bytes must be positive")
+        self.capacity_bytes = capacity_bytes
+        self._chunks: deque[bytes] = deque()
+        self._size = 0
+
+    @classmethod
+    def from_duration(
+        cls, duration_ms: int, sample_rate_hz: int, bytes_per_sample: int
+    ) -> "PreSpeechRingBuffer":
+        capacity = duration_ms * sample_rate_hz * bytes_per_sample // 1000
+        return cls(capacity_bytes=capacity)
+
+    def append(self, audio_bytes: bytes) -> None:
+        if not audio_bytes:
+            return
+        self._chunks.append(audio_bytes)
+        self._size += len(audio_bytes)
+
+        while self._size > self.capacity_bytes and self._chunks:
+            head = self._chunks[0]
+            overflow = self._size - self.capacity_bytes
+            if len(head) <= overflow:
+                self._chunks.popleft()
+                self._size -= len(head)
+            else:
+                self._chunks[0] = head[overflow:]
+                self._size -= overflow
+
+    def flush(self) -> bytes:
+        if not self._chunks:
+            return b""
+        out = b"".join(self._chunks)
+        self._chunks.clear()
+        self._size = 0
+        return out
+
+    def __len__(self) -> int:
+        return self._size
+
+    @property
+    def is_full(self) -> bool:
+        return self._size >= self.capacity_bytes

--- a/bolna/vad/silero_vad.py
+++ b/bolna/vad/silero_vad.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import numpy as np
+import torch
+from silero_vad import VADIterator, load_silero_vad
+
+from .turn_detector import SpeechEvent, SpeechEventType
+
+
+# Silero requires fixed chunk sizes per sample rate.
+SUPPORTED_RATES: dict[int, int] = {8000: 256, 16000: 512}
+
+
+class SileroVAD:
+    def __init__(
+        self,
+        sample_rate: int = 8000,
+        threshold: float = 0.5,
+        min_silence_duration_ms: int = 100,
+        speech_pad_ms: int = 30,
+    ) -> None:
+        if sample_rate not in SUPPORTED_RATES:
+            raise ValueError(
+                f"sample_rate must be one of {sorted(SUPPORTED_RATES)}; got {sample_rate}"
+            )
+        self.sample_rate = sample_rate
+        self.chunk_samples = SUPPORTED_RATES[sample_rate]
+        self.chunk_bytes = self.chunk_samples * 2
+
+        self._model = load_silero_vad(onnx=True)
+        self._iter = VADIterator(
+            self._model,
+            threshold=threshold,
+            sampling_rate=sample_rate,
+            min_silence_duration_ms=min_silence_duration_ms,
+            speech_pad_ms=speech_pad_ms,
+        )
+        self._byte_buffer = bytearray()
+        self._samples_consumed = 0
+
+    def reset(self) -> None:
+        self._iter.reset_states()
+        self._byte_buffer.clear()
+        self._samples_consumed = 0
+
+    def feed(self, pcm_int16_bytes: bytes) -> Iterator[SpeechEvent]:
+        if not pcm_int16_bytes:
+            return
+        self._byte_buffer.extend(pcm_int16_bytes)
+
+        while len(self._byte_buffer) >= self.chunk_bytes:
+            chunk_bytes = bytes(self._byte_buffer[: self.chunk_bytes])
+            del self._byte_buffer[: self.chunk_bytes]
+
+            samples_int16 = np.frombuffer(chunk_bytes, dtype=np.int16)
+            samples_f32 = samples_int16.astype(np.float32) / 32768.0
+            tensor = torch.from_numpy(samples_f32)
+
+            event = self._iter(tensor)
+            self._samples_consumed += self.chunk_samples
+
+            if event is None:
+                continue
+
+            if "start" in event:
+                yield SpeechEvent(
+                    type=SpeechEventType.SPEECH_STARTED,
+                    sample_offset=int(event["start"]),
+                )
+            elif "end" in event:
+                yield SpeechEvent(
+                    type=SpeechEventType.SPEECH_ENDED,
+                    sample_offset=int(event["end"]),
+                )
+
+    @property
+    def samples_consumed(self) -> int:
+        return self._samples_consumed

--- a/bolna/vad/turn_detector.py
+++ b/bolna/vad/turn_detector.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Iterator
+
+from .pre_speech_buffer import PreSpeechRingBuffer
+
+
+class SpeechEventType(str, Enum):
+    SPEECH_STARTED = "speech_started"
+    SPEECH_ENDED = "speech_ended"
+
+
+@dataclass
+class SpeechEvent:
+    type: SpeechEventType
+    sample_offset: int
+    pre_speech_audio: bytes = b""
+
+
+@dataclass
+class TurnDetector:
+    vad: "object"
+    pre_speech_buffer: PreSpeechRingBuffer
+    _is_in_speech: bool = field(default=False, init=False)
+
+    def feed(
+        self,
+        pcm_int16_bytes: bytes,
+        raw_audio: bytes | None = None,
+    ) -> Iterator[SpeechEvent]:
+        # raw_audio lets the caller stash the original on-wire encoding
+        # (mulaw etc) in the buffer while the VAD sees the decoded PCM.
+        self.pre_speech_buffer.append(raw_audio if raw_audio is not None else pcm_int16_bytes)
+
+        for event in self.vad.feed(pcm_int16_bytes):  # type: ignore[attr-defined]
+            if event.type is SpeechEventType.SPEECH_STARTED and not self._is_in_speech:
+                self._is_in_speech = True
+                yield SpeechEvent(
+                    type=SpeechEventType.SPEECH_STARTED,
+                    sample_offset=event.sample_offset,
+                    pre_speech_audio=self.pre_speech_buffer.flush(),
+                )
+            elif event.type is SpeechEventType.SPEECH_ENDED and self._is_in_speech:
+                self._is_in_speech = False
+                yield SpeechEvent(
+                    type=SpeechEventType.SPEECH_ENDED,
+                    sample_offset=event.sample_offset,
+                )
+
+    @property
+    def is_in_speech(self) -> bool:
+        return self._is_in_speech

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["pip-tools", "pre-commit", "pytest", "pytest-asyncio", "ruff"]
+vad = ["silero-vad>=5.1"]
 
 [tool.setuptools]
 package-dir = {"bolna" = "bolna"}

--- a/tests/tests/vad/test_input_handler_subclasses.py
+++ b/tests/tests/vad/test_input_handler_subclasses.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from unittest.mock import patch
+
+import pytest
+
+os.environ.setdefault("PLIVO_AUTH_ID", "test")
+os.environ.setdefault("PLIVO_AUTH_TOKEN", "test")
+
+from bolna.input_handlers.telephony import TelephonyInputHandler
+from bolna.input_handlers.telephony_providers.exotel import ExotelInputHandler
+from bolna.input_handlers.telephony_providers.plivo import PlivoInputHandler
+from bolna.input_handlers.telephony_providers.twilio import TwilioInputHandler
+from bolna.input_handlers.telephony_providers.vobiz import VobizInputHandler
+
+
+def _common_kwargs(speech_events_queue=None, vad_config=None):
+    return dict(
+        queues={
+            "transcriber": asyncio.Queue(),
+            "dtmf": asyncio.Queue(),
+        },
+        websocket=None,
+        input_types={"audio": 1},
+        mark_event_meta_data=None,
+        turn_based_conversation=False,
+        is_welcome_message_played=False,
+        observable_variables={},
+        vad_config=vad_config,
+        speech_events_queue=speech_events_queue,
+    )
+
+
+PROVIDER_CLASSES = [
+    ("twilio", TwilioInputHandler),
+    ("plivo", PlivoInputHandler),
+    ("vobiz", VobizInputHandler),
+    ("exotel", ExotelInputHandler),
+]
+
+
+def _instantiate(cls, **kwargs):
+    # PlivoInputHandler instantiates a RestClient in __init__ which validates creds.
+    if cls is PlivoInputHandler:
+        with patch("bolna.input_handlers.telephony_providers.plivo.plivosdk.RestClient"):
+            return cls(**kwargs)
+    return cls(**kwargs)
+
+
+@pytest.mark.parametrize("io_provider,cls", PROVIDER_CLASSES)
+def test_subclass_accepts_vad_kwargs_without_typeerror(io_provider, cls):
+    queue = asyncio.Queue()
+    handler = _instantiate(cls, **_common_kwargs(speech_events_queue=queue, vad_config=None))
+    assert handler.io_provider == io_provider
+    assert handler._turn_detector is None
+    assert handler._speech_events_queue is queue
+
+
+@pytest.mark.parametrize("io_provider,cls", PROVIDER_CLASSES)
+def test_subclass_builds_turn_detector_when_vad_enabled(io_provider, cls):
+    queue = asyncio.Queue()
+    cfg = {
+        "sample_rate": 8000,
+        "threshold": 0.5,
+        "min_silence_ms": 100,
+        "speech_pad_ms": 30,
+        "pre_speech_ms": 500,
+    }
+    handler = _instantiate(cls, **_common_kwargs(speech_events_queue=queue, vad_config=cfg))
+    assert handler.io_provider == io_provider
+    assert handler._turn_detector is not None
+    # The detector should report not-yet-in-speech and respect the configured
+    # 500ms at 8kHz mulaw == 4000 bytes
+    assert handler._turn_detector.is_in_speech is False
+    assert handler._turn_detector.pre_speech_buffer.capacity_bytes == 4000
+
+
+def test_base_class_accepts_kwargs_too():
+    handler = TelephonyInputHandler(**_common_kwargs(vad_config=None))
+    assert handler._turn_detector is None

--- a/tests/tests/vad/test_pre_speech_buffer.py
+++ b/tests/tests/vad/test_pre_speech_buffer.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from bolna.vad import PreSpeechRingBuffer
+
+
+def test_rejects_non_positive_capacity() -> None:
+    with pytest.raises(ValueError):
+        PreSpeechRingBuffer(capacity_bytes=0)
+    with pytest.raises(ValueError):
+        PreSpeechRingBuffer(capacity_bytes=-5)
+
+
+def test_from_duration_computes_capacity() -> None:
+    # 500ms at 8kHz mulaw (1 byte/sample) -> 4000 bytes
+    rb = PreSpeechRingBuffer.from_duration(
+        duration_ms=500, sample_rate_hz=8000, bytes_per_sample=1
+    )
+    assert rb.capacity_bytes == 4000
+
+    # 500ms at 16kHz int16 (2 bytes/sample) -> 16000 bytes
+    rb = PreSpeechRingBuffer.from_duration(
+        duration_ms=500, sample_rate_hz=16000, bytes_per_sample=2
+    )
+    assert rb.capacity_bytes == 16000
+
+
+def test_append_below_capacity_keeps_everything() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=100)
+    rb.append(b"a" * 30)
+    rb.append(b"b" * 40)
+    assert len(rb) == 70
+    assert rb.flush() == b"a" * 30 + b"b" * 40
+
+
+def test_append_trims_oldest_bytes_on_overflow() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=10)
+    rb.append(b"aaaa")      # size=4
+    rb.append(b"bbbb")      # size=8
+    rb.append(b"cccccc")    # size=14 -> trim 4 -> keeps last 10: "aaabbbbcccccc"[-10:]
+    assert len(rb) == 10
+    assert rb.flush() == b"aabbbbcccccc"[-10:]
+
+
+def test_append_can_trim_mid_chunk() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=5)
+    rb.append(b"abcdef")    # overflows immediately; should keep last 5
+    assert rb.flush() == b"bcdef"
+
+
+def test_flush_empties_buffer() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=50)
+    rb.append(b"hello")
+    assert rb.flush() == b"hello"
+    assert len(rb) == 0
+    assert rb.flush() == b""
+
+
+def test_append_empty_bytes_is_noop() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=10)
+    rb.append(b"")
+    assert len(rb) == 0
+    assert not rb.is_full
+
+
+def test_is_full_flag() -> None:
+    rb = PreSpeechRingBuffer(capacity_bytes=8)
+    rb.append(b"1234")
+    assert not rb.is_full
+    rb.append(b"5678")
+    assert rb.is_full
+    rb.append(b"9")  # one byte spills; still full
+    assert rb.is_full
+    assert rb.flush() == b"23456789"
+
+
+def test_chronological_order_preserved_across_overflow() -> None:
+    """After many overflows the buffer still yields bytes in arrival order."""
+    rb = PreSpeechRingBuffer(capacity_bytes=6)
+    for chunk in [b"12", b"34", b"56", b"78", b"90"]:
+        rb.append(chunk)
+    # Overall stream was "1234567890"; capacity 6 -> last 6 = "567890"
+    assert rb.flush() == b"567890"

--- a/tests/tests/vad/test_silero_vad.py
+++ b/tests/tests/vad/test_silero_vad.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+
+import pytest
+
+from bolna.vad import SileroVAD, SpeechEventType
+
+FIXTURE_DIR = Path(__file__).resolve().parents[2] / "benchmarks" / "fixtures"
+LEADING_SPEECH = FIXTURE_DIR / "leading_speech.wav"
+PURE_SILENCE = FIXTURE_DIR / "pure_silence.wav"
+
+
+def _read_pcm_16k_int16(wav_path: Path) -> bytes:
+    with wave.open(str(wav_path), "rb") as w:
+        assert w.getframerate() == 16000, "fixture must be 16kHz"
+        assert w.getsampwidth() == 2, "fixture must be 16-bit"
+        assert w.getnchannels() == 1, "fixture must be mono"
+        return w.readframes(w.getnframes())
+
+
+def test_rejects_unsupported_sample_rate() -> None:
+    with pytest.raises(ValueError):
+        SileroVAD(sample_rate=22050)
+
+
+def test_chunk_size_bytes_matches_sample_rate() -> None:
+    assert SileroVAD(sample_rate=8000).chunk_bytes == 256 * 2
+    assert SileroVAD(sample_rate=16000).chunk_bytes == 512 * 2
+
+
+def test_speech_clip_yields_speech_started() -> None:
+    if not LEADING_SPEECH.exists():
+        pytest.skip(f"missing fixture: {LEADING_SPEECH}")
+    pcm = _read_pcm_16k_int16(LEADING_SPEECH)
+
+    vad = SileroVAD(sample_rate=16000, threshold=0.5, min_silence_duration_ms=100)
+    events = list(vad.feed(pcm))
+
+    start_events = [e for e in events if e.type is SpeechEventType.SPEECH_STARTED]
+    assert len(start_events) >= 1, "expected at least one speech_started event"
+
+    # Fixture puts speech onset at 1500ms. With speech_pad_ms=30 default
+    # silero may report a few tens of ms early; allow a generous window.
+    first_start_ms = start_events[0].sample_offset * 1000 / 16000
+    assert 1200 <= first_start_ms <= 1800, (
+        f"first speech_started reported at {first_start_ms}ms, expected ~1500ms"
+    )
+
+
+def test_digital_silence_yields_no_events() -> None:
+    if not PURE_SILENCE.exists():
+        pytest.skip(f"missing fixture: {PURE_SILENCE}")
+    pcm = _read_pcm_16k_int16(PURE_SILENCE)
+
+    vad = SileroVAD(sample_rate=16000, threshold=0.5, min_silence_duration_ms=100)
+    events = list(vad.feed(pcm))
+
+    assert events == [], f"expected no events on digital silence, got {events}"
+
+
+def test_buffers_partial_chunks_until_full() -> None:
+    """Feeding fewer than chunk_bytes should simply buffer, not fire any VAD calls."""
+    vad = SileroVAD(sample_rate=16000)
+
+    # Feed a single byte; the model should not run since chunk is incomplete.
+    events = list(vad.feed(b"\x00"))
+    assert events == []
+    assert vad.samples_consumed == 0
+
+
+def test_reset_clears_internal_state() -> None:
+    vad = SileroVAD(sample_rate=16000)
+    # feed() is a generator; exhaust it so the VAD actually processes the chunk.
+    list(vad.feed(b"\x00" * vad.chunk_bytes))
+    assert vad.samples_consumed == vad.chunk_samples
+    vad.reset()
+    assert vad.samples_consumed == 0

--- a/tests/tests/vad/test_turn_detector.py
+++ b/tests/tests/vad/test_turn_detector.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from bolna.vad import PreSpeechRingBuffer, SpeechEvent, SpeechEventType, TurnDetector
+
+
+class StubVAD:
+    def __init__(self, scripted_events: list[list[SpeechEvent]]) -> None:
+        self._scripted = list(scripted_events)
+        self.calls_with_pcm: list[bytes] = []
+
+    def feed(self, pcm: bytes):
+        self.calls_with_pcm.append(pcm)
+        if not self._scripted:
+            return iter([])
+        return iter(self._scripted.pop(0))
+
+
+def _make_detector(scripted: list[list[SpeechEvent]], capacity: int = 32) -> TurnDetector:
+    ring = PreSpeechRingBuffer(capacity_bytes=capacity)
+    return TurnDetector(vad=StubVAD(scripted), pre_speech_buffer=ring)
+
+
+def test_silent_frames_do_not_yield_events() -> None:
+    det = _make_detector(scripted=[[], [], []])
+    out = []
+    for chunk in [b"aa", b"bb", b"cc"]:
+        out.extend(det.feed(chunk))
+    assert out == []
+    assert not det.is_in_speech
+
+
+def test_raw_audio_is_stored_in_ring_buffer_not_vad_pcm() -> None:
+    """When raw_audio is supplied the buffer should hold that, not the VAD copy."""
+    scripted = [[SpeechEvent(type=SpeechEventType.SPEECH_STARTED, sample_offset=0)]]
+    det = _make_detector(scripted, capacity=32)
+
+    events = list(det.feed(pcm_int16_bytes=b"VAD-FMT", raw_audio=b"RAW-WIRE"))
+
+    assert len(events) == 1
+    assert events[0].type is SpeechEventType.SPEECH_STARTED
+    assert events[0].pre_speech_audio == b"RAW-WIRE"
+
+
+def test_pre_speech_buffer_flushed_on_speech_started() -> None:
+    scripted = [
+        [],  # frame 1: silence, buffer fills
+        [],  # frame 2: silence, buffer fills
+        [SpeechEvent(type=SpeechEventType.SPEECH_STARTED, sample_offset=12)],
+    ]
+    det = _make_detector(scripted, capacity=32)
+
+    # First two frames only load the ring buffer
+    for chunk in [b"1111", b"2222"]:
+        assert list(det.feed(chunk, raw_audio=chunk)) == []
+
+    # Third frame carries the speech_started; pre_speech_audio should
+    # contain the frames that preceded it *plus* this frame (since it
+    # was appended before the event was yielded).
+    events = list(det.feed(b"3333", raw_audio=b"3333"))
+    assert [e.type for e in events] == [SpeechEventType.SPEECH_STARTED]
+    assert events[0].pre_speech_audio == b"111122223333"
+    assert events[0].sample_offset == 12
+    assert det.is_in_speech
+
+
+def test_state_tracking_ignores_duplicate_events() -> None:
+    """Two speech_started events in a row should only flip state once."""
+    scripted = [
+        [SpeechEvent(type=SpeechEventType.SPEECH_STARTED, sample_offset=0)],
+        [SpeechEvent(type=SpeechEventType.SPEECH_STARTED, sample_offset=10)],
+        [SpeechEvent(type=SpeechEventType.SPEECH_ENDED, sample_offset=20)],
+    ]
+    det = _make_detector(scripted, capacity=16)
+
+    first = list(det.feed(b"aa", raw_audio=b"aa"))
+    second = list(det.feed(b"bb", raw_audio=b"bb"))
+    third = list(det.feed(b"cc", raw_audio=b"cc"))
+
+    assert [e.type for e in first] == [SpeechEventType.SPEECH_STARTED]
+    assert second == []                          # duplicate start -> suppressed
+    assert [e.type for e in third] == [SpeechEventType.SPEECH_ENDED]
+    assert not det.is_in_speech
+
+
+def test_speech_ended_without_prior_start_is_suppressed() -> None:
+    scripted = [[SpeechEvent(type=SpeechEventType.SPEECH_ENDED, sample_offset=5)]]
+    det = _make_detector(scripted, capacity=16)
+    assert list(det.feed(b"xx", raw_audio=b"xx")) == []
+    assert not det.is_in_speech
+
+
+def test_ring_buffer_defaults_to_vad_input_when_raw_audio_omitted() -> None:
+    """For standalone callers not doing dual-format streaming."""
+    scripted = [[], [SpeechEvent(type=SpeechEventType.SPEECH_STARTED, sample_offset=0)]]
+    det = _make_detector(scripted, capacity=16)
+    list(det.feed(b"aaaa"))  # no raw_audio argument
+    events = list(det.feed(b"bbbb"))
+    assert events[0].pre_speech_audio == b"aaaabbbb"

--- a/tests/tests/vad/test_vad_config_schema.py
+++ b/tests/tests/vad/test_vad_config_schema.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from bolna.models import IOModel, VadConfig
+
+
+def test_defaults() -> None:
+    cfg = VadConfig()
+    assert cfg.sample_rate == 8000
+    assert cfg.threshold == 0.5
+    assert cfg.min_silence_ms == 100
+    assert cfg.speech_pad_ms == 30
+    assert cfg.pre_speech_ms == 500
+
+
+def test_io_model_accepts_nested_vad_config() -> None:
+    io = IOModel.model_validate(
+        {
+            "provider": "twilio",
+            "format": "mulaw",
+            "vad_config": {
+                "sample_rate": 8000,
+                "threshold": 0.4,
+                "pre_speech_ms": 750,
+            },
+        }
+    )
+    assert io.vad_config is not None
+    assert io.vad_config.threshold == 0.4
+    assert io.vad_config.pre_speech_ms == 750
+    # Fields not supplied fall back to defaults
+    assert io.vad_config.min_silence_ms == 100
+
+
+def test_io_model_without_vad_config_is_unchanged() -> None:
+    io = IOModel.model_validate({"provider": "twilio"})
+    assert io.vad_config is None
+
+
+def test_threshold_bounds() -> None:
+    with pytest.raises(ValidationError):
+        VadConfig(threshold=1.5)
+    with pytest.raises(ValidationError):
+        VadConfig(threshold=-0.1)
+
+
+def test_sample_rate_must_be_supported() -> None:
+    with pytest.raises(ValidationError):
+        VadConfig(sample_rate=22050)
+    assert VadConfig(sample_rate=16000).sample_rate == 16000
+
+
+def test_ms_fields_reject_negatives() -> None:
+    with pytest.raises(ValidationError):
+        VadConfig(pre_speech_ms=-1)
+    with pytest.raises(ValidationError):
+        VadConfig(min_silence_ms=-1)
+    with pytest.raises(ValidationError):
+        VadConfig(speech_pad_ms=-1)
+
+
+def test_ms_fields_reject_unreasonably_large_values() -> None:
+    with pytest.raises(ValidationError):
+        VadConfig(pre_speech_ms=5000)
+    with pytest.raises(ValidationError):
+        VadConfig(speech_pad_ms=1000)


### PR DESCRIPTION
bolna has no in-process VAD today every "user is speaking" decision waits on the ASR providers speech_started over the network, so first syllables get clipped and barge-in pays a full round-trip. This adds an opt-in local silero VAD with a 500ms pre-speech ring buffer in `TelephonyInputHandler`, when enabled, audio is gated locally and speech events feed `interruption_manager` directly. set `vad_config` on the input section of the agent JSON to turn it on; off by default, byte-identical to main otherwise.

I tested this end-to-end against a real Deepgram session on a 6-second speech clip. With the local VAD on, we send 31.7% fewer bytes to Deepgram (48000 → 32800), the transcript and WER (0.083) come out identical, and Bolna learns the user is speaking at 1522ms instead of waiting until Deepgrams SpeechStarted at 2050ms about 527ms faster barge-in. Full harness and the little benchmarks can be seen at: https://github.com/bolna-ai/bolna/commit/3b7ac0a957ff399159404ae3123ad27ae114dce8
