### PR TITLE
feat: add post-call integrations framework with slack

### DIFF
--- a/bolna/agent_manager/assistant_manager.py
+++ b/bolna/agent_manager/assistant_manager.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import time
 import uuid
@@ -5,7 +6,8 @@ import uuid
 from .base_manager import BaseManager
 from .task_manager import TaskManager
 from bolna.helpers.logger_config import configure_logger
-from bolna.models import AGENT_WELCOME_MESSAGE
+from bolna.integrations import PostCallContext, run_post_call_integrations
+from bolna.models import AGENT_WELCOME_MESSAGE, IntegrationConfig
 from bolna.helpers.utils import update_prompt_with_context
 
 logger = configure_logger(__name__)
@@ -40,6 +42,8 @@ class AssistantManager(BaseManager):
         self.output_queue = output_queue
         self.kwargs = kwargs
         self.conversation_history = conversation_history
+        # keep strong refs so fire-and-forget integration tasks are not GC'd
+        self._background_tasks: set = set()
         if kwargs.get("is_web_based_call", False):
             self.kwargs["agent_welcome_message"] = agent_config.get("agent_welcome_message", AGENT_WELCOME_MESSAGE)
         else:
@@ -55,6 +59,7 @@ class AssistantManager(BaseManager):
             self.run_id = run_id
 
         input_parameters = None
+        all_task_outputs = []
         for task_id, task in enumerate(self.tasks):
             logger.info(f"Running task {task_id}")
             task_manager = TaskManager(
@@ -81,10 +86,59 @@ class AssistantManager(BaseManager):
             )
             task_output = await task_manager.run()
             task_output["run_id"] = self.run_id
+            all_task_outputs.append(task_output)
             yield task_id, copy.deepcopy(task_output)
             self.task_states[task_id] = True
             if task_id == 0:
                 input_parameters = task_output
             if task["task_type"] == "extraction":
                 input_parameters["extraction_details"] = task_output["extracted_data"]
+
+        try:
+            self._fire_post_call_integrations(all_task_outputs)
+        except Exception as e:
+            logger.error(f"failed to schedule post-call integrations: {e}")
+
         logger.info("Done with execution of the agent")
+
+    def _collect_integration_configs(self):
+        seen = set()
+        configs = []
+        for task in self.tasks:
+            tools = task.get("tools_config") or {}
+            for raw in (tools.get("integrations") or []):
+                cfg = raw if isinstance(raw, IntegrationConfig) else IntegrationConfig(**raw)
+                if cfg.provider in seen:
+                    logger.warning(
+                        f"duplicate integration provider '{cfg.provider}' discarded; keeping first config"
+                    )
+                    continue
+                seen.add(cfg.provider)
+                configs.append(cfg)
+        return configs
+
+    def _build_post_call_context(self, all_task_outputs):
+        primary = all_task_outputs[0] if all_task_outputs else {}
+        ctx = PostCallContext(
+            agent_name=self.agent_config.get("agent_name", self.agent_config.get("assistant_name", "")) or "",
+            run_id=self.run_id,
+            call_sid=primary.get("call_sid"),
+            duration_seconds=primary.get("conversation_time"),
+            hangup_reason=str(primary["hangup_detail"]) if primary.get("hangup_detail") else None,
+            recording_url=primary.get("recording_url"),
+        )
+        for output in all_task_outputs:
+            if output.get("task_type") == "summarization" and output.get("summary"):
+                ctx.summary = output["summary"]
+            elif output.get("task_type") == "extraction" and output.get("extracted_data"):
+                ctx.extracted_data = output["extracted_data"]
+        return ctx
+
+    def _fire_post_call_integrations(self, all_task_outputs):
+        configs = self._collect_integration_configs()
+        if not configs:
+            return
+        ctx = self._build_post_call_context(all_task_outputs)
+        task = asyncio.create_task(run_post_call_integrations(configs, ctx))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -173,6 +173,16 @@ class ResponseItemType(str, Enum):
         return [e.value for e in cls]
 
 
+class IntegrationProvider(str, Enum):
+    """Enum for post-call integration providers."""
+
+    SLACK = "slack"
+
+    @classmethod
+    def all_values(cls):
+        return [p.value for p in cls]
+
+
 class HangupReason(str, Enum):
     """Enum for hangup_detail values — why the call ended."""
 

--- a/bolna/integrations/__init__.py
+++ b/bolna/integrations/__init__.py
@@ -1,0 +1,4 @@
+from .base import PostCallContext, PostCallIntegration
+from .runner import run_post_call_integrations
+
+__all__ = ["PostCallContext", "PostCallIntegration", "run_post_call_integrations"]

--- a/bolna/integrations/base.py
+++ b/bolna/integrations/base.py
@@ -1,0 +1,27 @@
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class PostCallContext:
+    agent_name: str
+    run_id: str
+    call_sid: Optional[str] = None
+    duration_seconds: Optional[float] = None
+    hangup_reason: Optional[str] = None
+    summary: Optional[str] = None
+    extracted_data: dict = field(default_factory=dict)
+    recording_url: Optional[str] = None
+
+
+class PostCallIntegration(ABC):
+    @classmethod
+    @abstractmethod
+    def from_config(cls, config) -> "PostCallIntegration":
+        ...
+
+    # may raise; the runner swallows exceptions and logs
+    @abstractmethod
+    async def execute(self, ctx: PostCallContext) -> None:
+        ...

--- a/bolna/integrations/runner.py
+++ b/bolna/integrations/runner.py
@@ -1,0 +1,65 @@
+import asyncio
+from typing import List, Optional
+
+import aiohttp
+
+from bolna.helpers.logger_config import configure_logger
+from .base import PostCallContext, PostCallIntegration
+
+logger = configure_logger(__name__)
+
+_RETRY_DELAYS = [1.0, 2.0]
+_REQUEST_TIMEOUT = 10.0
+_INTEGRATION_TIMEOUT = 30.0
+
+
+async def _post_with_retry(url: str, payload: dict, headers: Optional[dict] = None) -> None:
+    last_exc: Optional[Exception] = None
+    timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT)
+    attempts = len(_RETRY_DELAYS) + 1
+
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        for attempt in range(attempts):
+            try:
+                async with session.post(url, json=payload, headers=headers) as resp:
+                    if resp.status < 400:
+                        return
+                    body = await resp.text()
+                    if resp.status < 500:
+                        logger.error(f"post to {url} failed with {resp.status}: {body[:200]}")
+                        return
+                    last_exc = RuntimeError(f"HTTP {resp.status}: {body[:200]}")
+            except (aiohttp.ClientConnectionError, asyncio.TimeoutError) as e:
+                last_exc = e
+
+            if attempt < attempts - 1:
+                await asyncio.sleep(_RETRY_DELAYS[attempt])
+
+    if last_exc:
+        raise last_exc
+
+
+async def run_post_call_integrations(integration_configs: List, ctx: PostCallContext) -> None:
+    if not integration_configs:
+        return
+
+    from bolna.providers import SUPPORTED_INTEGRATIONS
+
+    for cfg in integration_configs:
+        provider = cfg.provider
+        cls = SUPPORTED_INTEGRATIONS.get(provider)
+        if cls is None:
+            logger.warning(f"unknown integration provider: {provider}")
+            continue
+        try:
+            integration: PostCallIntegration = cls.from_config(cfg)
+        except Exception as e:
+            logger.error(f"could not build {provider} integration: {e}")
+            continue
+
+        try:
+            await asyncio.wait_for(integration.execute(ctx), timeout=_INTEGRATION_TIMEOUT)
+        except asyncio.TimeoutError:
+            logger.error(f"{provider} integration timed out after {_INTEGRATION_TIMEOUT}s")
+        except Exception as e:
+            logger.error(f"{provider} integration failed: {e}")

--- a/bolna/integrations/slack.py
+++ b/bolna/integrations/slack.py
@@ -1,0 +1,104 @@
+import os
+from typing import Optional
+
+from bolna.helpers.logger_config import configure_logger
+from .base import PostCallContext, PostCallIntegration
+from .runner import _post_with_retry
+
+logger = configure_logger(__name__)
+
+_MAX_SUMMARY_CHARS = 2800
+_MAX_FIELD_VALUE_CHARS = 250
+
+
+class SlackIntegration(PostCallIntegration):
+    def __init__(self, webhook_url: str):
+        self.webhook_url = webhook_url
+
+    @classmethod
+    def from_config(cls, config) -> "SlackIntegration":
+        webhook_url = config.provider_config.webhook_url or os.getenv("SLACK_WEBHOOK_URL")
+        if not webhook_url:
+            raise ValueError("slack webhook_url not provided in config or SLACK_WEBHOOK_URL env")
+        return cls(webhook_url=webhook_url)
+
+    async def execute(self, ctx: PostCallContext) -> None:
+        payload = {"blocks": _build_slack_blocks(ctx)}
+        await _post_with_retry(self.webhook_url, payload)
+
+
+def _format_duration(seconds: Optional[float]) -> str:
+    if seconds is None or seconds <= 0:
+        return "n/a"
+    minutes, secs = divmod(int(seconds), 60)
+    if minutes:
+        return f"{minutes}m {secs}s"
+    return f"{secs}s"
+
+
+def _truncate(value: str, limit: int) -> str:
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+def _build_slack_blocks(ctx: PostCallContext) -> list:
+    blocks = [
+        {
+            "type": "header",
+            "text": {"type": "plain_text", "text": f"call ended — {ctx.agent_name}"},
+        },
+    ]
+
+    context_parts = []
+    if ctx.call_sid:
+        context_parts.append(f"*call_sid:* `{ctx.call_sid}`")
+    context_parts.append(f"*duration:* {_format_duration(ctx.duration_seconds)}")
+    if ctx.hangup_reason:
+        context_parts.append(f"*hangup:* {ctx.hangup_reason}")
+    context_parts.append(f"*run_id:* `{ctx.run_id}`")
+    blocks.append(
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": "  ·  ".join(context_parts)},
+        }
+    )
+
+    if ctx.summary:
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": f"*summary*\n{_truncate(ctx.summary, _MAX_SUMMARY_CHARS)}",
+                },
+            }
+        )
+
+    if ctx.extracted_data:
+        fields = []
+        for key, value in ctx.extracted_data.items():
+            label = str(key).replace("_", " ")
+            text = _truncate(str(value), _MAX_FIELD_VALUE_CHARS) if value not in (None, "") else "_n/a_"
+            fields.append({"type": "mrkdwn", "text": f"*{label}*\n{text}"})
+            if len(fields) == 10:
+                break
+        blocks.append({"type": "divider"})
+        blocks.append({"type": "section", "fields": fields})
+
+    if ctx.recording_url:
+        blocks.append(
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": {"type": "plain_text", "text": "open recording"},
+                        "url": ctx.recording_url,
+                    }
+                ],
+            }
+        )
+
+    return blocks

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -12,6 +12,7 @@ from .enums import (
     ExpressionOperator,
     ExpressionLogic,
     EdgeConditionType,
+    IntegrationProvider,
 )
 from .constants import MODEL_REASONING_EFFORT_MAP
 
@@ -464,6 +465,30 @@ class ToolModel(BaseModel):
     tools_params: Dict[str, APIParams]
 
 
+class SlackIntegrationConfig(BaseModel):
+    webhook_url: Optional[str] = None
+
+
+class IntegrationConfig(BaseModel):
+    provider: str
+    provider_config: SlackIntegrationConfig
+
+    @model_validator(mode="before")
+    def preprocess(cls, values):
+        provider = values.get("provider")
+        config = values.get("provider_config", {})
+
+        if provider == IntegrationProvider.SLACK.value:
+            if isinstance(config, dict):
+                values["provider_config"] = SlackIntegrationConfig(**config)
+
+        return values
+
+    @field_validator("provider")
+    def validate_model(cls, value):
+        return validate_attribute(value, IntegrationProvider.all_values(), "integration provider")
+
+
 class ToolsConfig(BaseModel):
     llm_agent: Optional[Union[LlmAgent, SimpleLlmAgent]] = None
     synthesizer: Optional[Synthesizer] = None
@@ -471,6 +496,7 @@ class ToolsConfig(BaseModel):
     input: Optional[IOModel] = None
     output: Optional[IOModel] = None
     api_tools: Optional[ToolModel] = None
+    integrations: Optional[List[IntegrationConfig]] = None
     switch_tool_description: Optional[str] = None
     switch_handoff_messages: Optional[Dict[str, str]] = None
     agent_names: Optional[Dict[str, str]] = None

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -38,7 +38,8 @@ from .output_handlers import (
     SipTrunkOutputHandler,
 )
 from .llms import OpenAiLLM, LiteLLM, AzureLLM, GeminiLLM
-from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider
+from .integrations.slack import SlackIntegration
+from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider, IntegrationProvider
 
 SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.POLLY.value: PollySynthesizer,
@@ -117,4 +118,7 @@ SUPPORTED_OUTPUT_TELEPHONY_HANDLERS = {
     TelephonyProvider.PLIVO.value: PlivoOutputHandler,
     TelephonyProvider.VOBIZ.value: VobizOutputHandler,
     TelephonyProvider.SIP_TRUNK.value: SipTrunkOutputHandler,
+}
+SUPPORTED_INTEGRATIONS = {
+    IntegrationProvider.SLACK.value: SlackIntegration,
 }

--- a/tests/tests/test_assistant_manager_integrations.py
+++ b/tests/tests/test_assistant_manager_integrations.py
@@ -1,0 +1,101 @@
+"""AssistantManager post-call integration wiring: coerce raw dicts, dedup, strong ref."""
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+from bolna.agent_manager.assistant_manager import AssistantManager
+from bolna.models import IntegrationConfig
+
+
+def _make_manager(tasks):
+    return AssistantManager(agent_config={"agent_name": "a", "tasks": tasks}, turn_based_conversation=True)
+
+
+def test_collect_coerces_raw_dicts():
+    tasks = [
+        {
+            "tools_config": {
+                "integrations": [
+                    {"provider": "slack", "provider_config": {"webhook_url": "https://x/1"}}
+                ]
+            }
+        }
+    ]
+    mgr = _make_manager(tasks)
+    configs = mgr._collect_integration_configs()
+    assert len(configs) == 1
+    assert isinstance(configs[0], IntegrationConfig)
+    assert configs[0].provider == "slack"
+
+
+def test_collect_dedupes_across_tasks():
+    task = {
+        "tools_config": {
+            "integrations": [
+                {"provider": "slack", "provider_config": {"webhook_url": "https://x/1"}}
+            ]
+        }
+    }
+    mgr = _make_manager([task, task])
+    configs = mgr._collect_integration_configs()
+    assert len(configs) == 1
+
+
+def test_collect_handles_missing_tools_config():
+    mgr = _make_manager([{}, {"tools_config": None}])
+    assert mgr._collect_integration_configs() == []
+
+
+def test_build_context_pulls_from_task_outputs():
+    mgr = _make_manager([{}])
+    outputs = [
+        {
+            "call_sid": "CA1",
+            "conversation_time": 45.0,
+            "hangup_detail": "inactivity_timeout",
+            "recording_url": "https://r",
+        },
+        {"task_type": "summarization", "summary": "ok"},
+        {"task_type": "extraction", "extracted_data": {"outcome": "resolved"}},
+    ]
+    ctx = mgr._build_post_call_context(outputs)
+    assert ctx.call_sid == "CA1"
+    assert ctx.duration_seconds == 45.0
+    assert ctx.hangup_reason == "inactivity_timeout"
+    assert ctx.summary == "ok"
+    assert ctx.extracted_data == {"outcome": "resolved"}
+
+
+@pytest.mark.asyncio
+async def test_fire_post_call_integrations_holds_task_ref():
+    tasks = [
+        {
+            "tools_config": {
+                "integrations": [
+                    {"provider": "slack", "provider_config": {"webhook_url": "https://x/1"}}
+                ]
+            }
+        }
+    ]
+    mgr = _make_manager(tasks)
+    fired = asyncio.Event()
+
+    async def fake_runner(configs, ctx):
+        fired.set()
+
+    with patch("bolna.agent_manager.assistant_manager.run_post_call_integrations", new=fake_runner):
+        mgr._fire_post_call_integrations([{}])
+        assert len(mgr._background_tasks) == 1
+        await asyncio.wait_for(fired.wait(), timeout=1.0)
+    # done callback clears the set
+    await asyncio.sleep(0)
+    assert len(mgr._background_tasks) == 0
+
+
+def test_no_fire_when_no_configs():
+    mgr = _make_manager([{"tools_config": {}}])
+    # should not raise, should not create any task
+    mgr._fire_post_call_integrations([{}])
+    assert len(mgr._background_tasks) == 0

--- a/tests/tests/test_integration_models.py
+++ b/tests/tests/test_integration_models.py
@@ -1,0 +1,51 @@
+"""Pydantic validation for IntegrationConfig + ToolsConfig.integrations."""
+
+import pytest
+from pydantic import ValidationError
+
+from bolna.models import IntegrationConfig, SlackIntegrationConfig, ToolsConfig
+
+
+def test_slack_config_with_explicit_url():
+    cfg = IntegrationConfig(
+        provider="slack",
+        provider_config={"webhook_url": "https://hooks.slack.com/services/AAA/BBB/CCC"},
+    )
+    assert cfg.provider == "slack"
+    assert isinstance(cfg.provider_config, SlackIntegrationConfig)
+    assert cfg.provider_config.webhook_url == "https://hooks.slack.com/services/AAA/BBB/CCC"
+
+
+def test_slack_config_with_no_url_is_valid():
+    # url can be omitted at parse time; runner falls back to env
+    cfg = IntegrationConfig(provider="slack", provider_config={})
+    assert cfg.provider_config.webhook_url is None
+
+
+def test_unknown_provider_rejected():
+    with pytest.raises(ValidationError):
+        IntegrationConfig(provider="discord", provider_config={})
+
+
+def test_tools_config_accepts_integrations_list():
+    tc = ToolsConfig(
+        integrations=[
+            {
+                "provider": "slack",
+                "provider_config": {"webhook_url": "https://hooks.slack.com/services/x/y/z"},
+            }
+        ]
+    )
+    assert tc.integrations is not None
+    assert len(tc.integrations) == 1
+    assert tc.integrations[0].provider == "slack"
+
+
+def test_tools_config_integrations_optional():
+    tc = ToolsConfig()
+    assert tc.integrations is None
+
+
+def test_tools_config_empty_integrations_list():
+    tc = ToolsConfig(integrations=[])
+    assert tc.integrations == []

--- a/tests/tests/test_post_call_runner.py
+++ b/tests/tests/test_post_call_runner.py
@@ -1,0 +1,202 @@
+"""Runner: dedup, retry, swallow-on-failure, timeout."""
+
+import asyncio
+from unittest.mock import patch
+
+import aiohttp
+import pytest
+
+from bolna.integrations.base import PostCallContext, PostCallIntegration
+from bolna.integrations.runner import _post_with_retry, run_post_call_integrations
+
+
+def _ctx():
+    return PostCallContext(agent_name="agent", run_id="r-1")
+
+
+class _Cfg:
+    def __init__(self, provider):
+        self.provider = provider
+
+
+class _Recorder(PostCallIntegration):
+    def __init__(self, fail_with=None, sleep=None):
+        self.fail_with = fail_with
+        self.sleep = sleep
+        self.calls = 0
+
+    @classmethod
+    def from_config(cls, config):
+        return cls()
+
+    async def execute(self, ctx):
+        self.calls += 1
+        if self.sleep:
+            await asyncio.sleep(self.sleep)
+        if self.fail_with:
+            raise self.fail_with
+
+
+@pytest.mark.asyncio
+async def test_run_with_no_configs_is_noop():
+    await run_post_call_integrations([], _ctx())
+    await run_post_call_integrations(None, _ctx())
+
+
+@pytest.mark.asyncio
+async def test_unknown_provider_is_logged_and_skipped():
+    await run_post_call_integrations([_Cfg("nonexistent")], _ctx())
+
+
+@pytest.mark.asyncio
+async def test_known_provider_is_invoked():
+    rec = _Recorder()
+    with patch.dict(
+        "bolna.providers.SUPPORTED_INTEGRATIONS",
+        {"slack": type("S", (), {"from_config": classmethod(lambda c, cfg: rec)})},
+    ):
+        await run_post_call_integrations([_Cfg("slack")], _ctx())
+    assert rec.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failing_integration_is_swallowed():
+    rec = _Recorder(fail_with=RuntimeError("boom"))
+    with patch.dict(
+        "bolna.providers.SUPPORTED_INTEGRATIONS",
+        {"slack": type("S", (), {"from_config": classmethod(lambda c, cfg: rec)})},
+    ):
+        await run_post_call_integrations([_Cfg("slack")], _ctx())
+    assert rec.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_integration_timeout_is_swallowed(monkeypatch):
+    monkeypatch.setattr("bolna.integrations.runner._INTEGRATION_TIMEOUT", 0.05)
+    rec = _Recorder(sleep=0.5)
+    with patch.dict(
+        "bolna.providers.SUPPORTED_INTEGRATIONS",
+        {"slack": type("S", (), {"from_config": classmethod(lambda c, cfg: rec)})},
+    ):
+        await run_post_call_integrations([_Cfg("slack")], _ctx())
+
+
+@pytest.mark.asyncio
+async def test_from_config_failure_does_not_block_other_providers():
+    good = _Recorder()
+
+    class Bad:
+        @classmethod
+        def from_config(cls, config):
+            raise ValueError("missing creds")
+
+    with patch.dict(
+        "bolna.providers.SUPPORTED_INTEGRATIONS",
+        {"slack": Bad, "notion": type("N", (), {"from_config": classmethod(lambda c, cfg: good)})},
+    ):
+        await run_post_call_integrations([_Cfg("slack"), _Cfg("notion")], _ctx())
+    assert good.calls == 1
+
+
+# ---------- _post_with_retry ----------
+
+
+class _MockResponse:
+    def __init__(self, status, text="ok"):
+        self.status = status
+        self._text = text
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _MockSession:
+    def __init__(self, statuses=None, exc=None):
+        self._responses = [_MockResponse(s) for s in (statuses or [])]
+        self._exc = exc
+        self.posts = []
+
+    def post(self, url, json=None, headers=None):
+        self.posts.append((url, json, headers))
+        if self._exc:
+            raise self._exc
+        return self._responses.pop(0)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _patch_session(session):
+    return patch("aiohttp.ClientSession", lambda *a, **kw: session)
+
+
+@pytest.mark.asyncio
+async def test_post_retry_2xx_returns_immediately():
+    session = _MockSession(statuses=[200])
+    with _patch_session(session):
+        await _post_with_retry("https://example", {"x": 1})
+    assert len(session.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_retry_4xx_no_retry():
+    session = _MockSession(statuses=[400])
+    with _patch_session(session):
+        await _post_with_retry("https://example", {"x": 1})
+    assert len(session.posts) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_retry_5xx_then_success(monkeypatch):
+    monkeypatch.setattr("bolna.integrations.runner._RETRY_DELAYS", [0.0, 0.0])
+    session = _MockSession(statuses=[503, 503, 200])
+    with _patch_session(session):
+        await _post_with_retry("https://example", {"x": 1})
+    assert len(session.posts) == 3
+
+
+@pytest.mark.asyncio
+async def test_post_retry_5xx_exhausted_raises(monkeypatch):
+    monkeypatch.setattr("bolna.integrations.runner._RETRY_DELAYS", [0.0, 0.0])
+    session = _MockSession(statuses=[500, 500, 500])
+    with _patch_session(session):
+        with pytest.raises(RuntimeError):
+            await _post_with_retry("https://example", {"x": 1})
+    assert len(session.posts) == 3
+
+
+@pytest.mark.asyncio
+async def test_post_retry_connection_error_then_success(monkeypatch):
+    monkeypatch.setattr("bolna.integrations.runner._RETRY_DELAYS", [0.0, 0.0])
+
+    calls = {"n": 0}
+    ok = _MockResponse(200)
+
+    class _FlakySession:
+        def __init__(self, *a, **kw):
+            pass
+
+        def post(self, url, json=None, headers=None):
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise aiohttp.ClientConnectionError("transient")
+            return ok
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+    with patch("aiohttp.ClientSession", _FlakySession):
+        await _post_with_retry("https://example", {"x": 1})
+    assert calls["n"] == 3

--- a/tests/tests/test_slack_integration.py
+++ b/tests/tests/test_slack_integration.py
@@ -1,0 +1,104 @@
+"""SlackIntegration: from_config env fallback, block builder shape, execute path."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bolna.integrations.base import PostCallContext
+from bolna.integrations.slack import SlackIntegration, _build_slack_blocks, _format_duration
+from bolna.models import IntegrationConfig
+
+
+def _make_config(webhook_url=None):
+    return IntegrationConfig(provider="slack", provider_config={"webhook_url": webhook_url})
+
+
+def _ctx(**overrides):
+    base = dict(
+        agent_name="loan-collections",
+        run_id="r-abc",
+        call_sid="CA123",
+        duration_seconds=92.5,
+        hangup_reason="llm_prompted_hangup",
+        summary="customer agreed to repay by friday.",
+        extracted_data={"customer_name": "Ananya", "promise_to_pay": "2026-04-25"},
+        recording_url="https://s3.example/rec.wav",
+    )
+    base.update(overrides)
+    return PostCallContext(**base)
+
+
+def test_from_config_uses_explicit_url():
+    integ = SlackIntegration.from_config(_make_config("https://hooks.slack.com/services/x/y/z"))
+    assert integ.webhook_url == "https://hooks.slack.com/services/x/y/z"
+
+
+def test_from_config_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("SLACK_WEBHOOK_URL", "https://hooks.slack.com/env-url")
+    integ = SlackIntegration.from_config(_make_config())
+    assert integ.webhook_url == "https://hooks.slack.com/env-url"
+
+
+def test_from_config_raises_without_url(monkeypatch):
+    monkeypatch.delenv("SLACK_WEBHOOK_URL", raising=False)
+    with pytest.raises(ValueError):
+        SlackIntegration.from_config(_make_config())
+
+
+def test_format_duration():
+    assert _format_duration(None) == "n/a"
+    assert _format_duration(0) == "n/a"
+    assert _format_duration(45) == "45s"
+    assert _format_duration(92.5) == "1m 32s"
+    assert _format_duration(3600) == "60m 0s"
+
+
+def test_blocks_full_context():
+    blocks = _build_slack_blocks(_ctx())
+    types = [b["type"] for b in blocks]
+    assert types[0] == "header"
+    assert "loan-collections" in blocks[0]["text"]["text"]
+    section = blocks[1]["text"]["text"]
+    assert "CA123" in section
+    assert "1m 32s" in section
+    assert "llm_prompted_hangup" in section
+    # summary + extracted_data each preceded by a divider
+    assert types.count("divider") == 2
+    assert any(b.get("type") == "section" and "summary" in b.get("text", {}).get("text", "") for b in blocks)
+    assert any(b.get("type") == "actions" for b in blocks)
+
+
+def test_blocks_minimal_context():
+    blocks = _build_slack_blocks(PostCallContext(agent_name="a", run_id="r-1"))
+    types = [b["type"] for b in blocks]
+    assert types == ["header", "section"]
+
+
+def test_blocks_omits_recording_when_absent():
+    blocks = _build_slack_blocks(_ctx(recording_url=None))
+    assert not any(b["type"] == "actions" for b in blocks)
+
+
+def test_blocks_caps_extracted_fields_at_ten():
+    big = {f"field_{i}": str(i) for i in range(20)}
+    blocks = _build_slack_blocks(_ctx(extracted_data=big))
+    fields_block = next(b for b in blocks if b.get("fields"))
+    assert len(fields_block["fields"]) == 10
+
+
+def test_blocks_truncate_long_summary():
+    long_summary = "x" * 5000
+    blocks = _build_slack_blocks(_ctx(summary=long_summary))
+    summary_block = next(b for b in blocks if "summary" in b.get("text", {}).get("text", ""))
+    assert len(summary_block["text"]["text"]) < 3000
+
+
+@pytest.mark.asyncio
+async def test_execute_posts_to_webhook():
+    integ = SlackIntegration(webhook_url="https://hooks.slack.com/services/x/y/z")
+    with patch("bolna.integrations.slack._post_with_retry", new=AsyncMock()) as mocked:
+        await integ.execute(_ctx())
+    mocked.assert_awaited_once()
+    args, _ = mocked.call_args
+    assert args[0] == "https://hooks.slack.com/services/x/y/z"
+    assert "blocks" in args[1]


### PR DESCRIPTION
Have added a post call integrations framework so that other integrations like notion, hubspot and linear can be dropped in easily later. Slack is the first concrete one, configured per agent via `tools_config.integrations` in the agent json, fires from `AssistantManager` after all post call tasks finish, so the slack message gets summary, extracted data, call_sid, duration and hangup reason. Fire and forget with retries and bounded timeout so it never blocks call teardown. 

Tested locally end to end with real deepgram and a real slack webhook.

<img width="1191" height="283" alt="image" src="https://github.com/user-attachments/assets/13f93b34-4b0c-423a-84e2-f8830bb1cc0d" />
