### PR TITLE
feat: realtime user-bot latency measurement

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.9"
+__version__ = "0.10.10"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -58,6 +58,12 @@ class InterruptionManager:
         self._last_sent_sequence_id: Optional[int] = None  # dedup guard for on_agent_speech_started
         self.longest_agent_monologue_ms: float = 0.0
 
+        # Real-time perceived latency (user-stopped → first-agent-audio), per turn.
+        # _adjusted_user_stop_ts holds wall-clock seconds with vendor endpointing backed out,
+        # consumed by the next on_agent_speech_started so it cannot straddle turns.
+        self._adjusted_user_stop_ts: Optional[float] = None
+        self.realtime_perceived_latencies: List[Dict] = []
+
         logger.info(
             f"InterruptionManager initialized: "
             f"words_for_interruption={number_of_words_for_interruption}, "
@@ -152,11 +158,16 @@ class InterruptionManager:
             self.time_since_first_interim_result = time.time() * 1000
             logger.info(f"First interim at {self.time_since_first_interim_result}")
 
-    def on_user_speech_ended(self, update_utterance_time: bool = True) -> None:
+    def on_user_speech_ended(self, update_utterance_time: bool = True, stop_offset_ms: int = 0) -> None:
         """Called when user stops speaking (speech_final / UtteranceEnd).
 
         update_utterance_time=False keeps the grace period anchored to the last
         real turn (use for false interruptions or late UtteranceEnd events).
+
+        stop_offset_ms is the vendor-reported silence window (e.g. Deepgram's
+        endpointing or utterance_end_ms) that elapsed between the user's actual
+        end-of-speech and this callback firing. Subtracted to recover wall-clock
+        time of true end-of-speech for realtime_perceived_latencies.
         """
         self.callee_speaking = False
         self.let_remaining_audio_pass_through = True
@@ -165,6 +176,7 @@ class InterruptionManager:
         now_s = time.time()
         if update_utterance_time:
             self.utterance_end_time = now_s * 1000
+            self._adjusted_user_stop_ts = now_s - (stop_offset_ms / 1000.0)
 
         if self.callee_speaking_start_time > 0:
             self._total_user_speaking_ms += (now_s - self.callee_speaking_start_time) * 1000
@@ -231,7 +243,23 @@ class InterruptionManager:
         if sequence_id == self._last_sent_sequence_id:
             return
         self._last_sent_sequence_id = sequence_id
-        self._agent_speaking_start_time = time.time()
+        now_s = time.time()
+        self._agent_speaking_start_time = now_s
+
+        if self._adjusted_user_stop_ts is not None:
+            latency_ms = (now_s - self._adjusted_user_stop_ts) * 1000
+            # Sanity bound: drop obvious garbage (negative or multi-call-level delays)
+            if 0 < latency_ms < 30_000:
+                self.realtime_perceived_latencies.append(
+                    {
+                        "sequence_id": sequence_id,
+                        "user_end_s": self._adjusted_user_stop_ts,
+                        "agent_start_s": now_s,
+                        "latency_ms": round(latency_ms, 2),
+                    }
+                )
+            self._adjusted_user_stop_ts = None  # consume — prevents cross-turn pairing
+
         logger.info(f"Agent speech started (sequence_id={sequence_id})")
 
     def on_agent_speech_ended(self) -> None:

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -58,9 +58,6 @@ class InterruptionManager:
         self._last_sent_sequence_id: Optional[int] = None  # dedup guard for on_agent_speech_started
         self.longest_agent_monologue_ms: float = 0.0
 
-        # Real-time perceived latency (user-stopped → first-agent-audio), per turn.
-        # _adjusted_user_stop_ts holds wall-clock seconds with vendor endpointing backed out,
-        # consumed by the next on_agent_speech_started so it cannot straddle turns.
         self._adjusted_user_stop_ts: Optional[float] = None
         self.user_bot_latencies: List[Dict] = []
 
@@ -169,13 +166,8 @@ class InterruptionManager:
         update_utterance_time=False keeps the grace period anchored to the last
         real turn (use for false interruptions or late UtteranceEnd events).
 
-        For user_bot_latencies, the adjusted user-stop timestamp is
-        resolved in priority order:
-          1. user_stop_ts_wall (wall-clock seconds) — when transcriber exposes
-             an audio-time end-of-last-word (Deepgram words[-1].end); most
-             accurate, free of remote-processing tail.
-          2. now - stop_offset_ms — fallback using vendor silence-window config;
-             inherits Deepgram's endpointing processing lag (~100-300ms).
+        user_stop_ts_wall (if present) is preferred over now - stop_offset_ms
+        for user_bot_latencies; the former avoids vendor endpointing lag.
         """
         self.callee_speaking = False
         self.let_remaining_audio_pass_through = True
@@ -259,7 +251,6 @@ class InterruptionManager:
 
         if self._adjusted_user_stop_ts is not None:
             latency_ms = (now_s - self._adjusted_user_stop_ts) * 1000
-            # Sanity bound: drop obvious garbage (negative or multi-call-level delays)
             if 0 < latency_ms < 30_000:
                 self.user_bot_latencies.append(
                     {
@@ -269,7 +260,7 @@ class InterruptionManager:
                         "latency_ms": round(latency_ms, 2),
                     }
                 )
-            self._adjusted_user_stop_ts = None  # consume — prevents cross-turn pairing
+            self._adjusted_user_stop_ts = None
 
         logger.info(f"Agent speech started (sequence_id={sequence_id})")
 

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -62,7 +62,7 @@ class InterruptionManager:
         # _adjusted_user_stop_ts holds wall-clock seconds with vendor endpointing backed out,
         # consumed by the next on_agent_speech_started so it cannot straddle turns.
         self._adjusted_user_stop_ts: Optional[float] = None
-        self.realtime_perceived_latencies: List[Dict] = []
+        self.user_bot_latencies: List[Dict] = []
 
         logger.info(
             f"InterruptionManager initialized: "
@@ -169,7 +169,7 @@ class InterruptionManager:
         update_utterance_time=False keeps the grace period anchored to the last
         real turn (use for false interruptions or late UtteranceEnd events).
 
-        For realtime_perceived_latencies, the adjusted user-stop timestamp is
+        For user_bot_latencies, the adjusted user-stop timestamp is
         resolved in priority order:
           1. user_stop_ts_wall (wall-clock seconds) — when transcriber exposes
              an audio-time end-of-last-word (Deepgram words[-1].end); most
@@ -261,7 +261,7 @@ class InterruptionManager:
             latency_ms = (now_s - self._adjusted_user_stop_ts) * 1000
             # Sanity bound: drop obvious garbage (negative or multi-call-level delays)
             if 0 < latency_ms < 30_000:
-                self.realtime_perceived_latencies.append(
+                self.user_bot_latencies.append(
                     {
                         "sequence_id": sequence_id,
                         "user_end_s": self._adjusted_user_stop_ts,

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -251,15 +251,14 @@ class InterruptionManager:
 
         if self._adjusted_user_stop_ts is not None:
             latency_ms = (now_s - self._adjusted_user_stop_ts) * 1000
-            if 0 < latency_ms < 30_000:
-                self.user_bot_latencies.append(
-                    {
-                        "sequence_id": sequence_id,
-                        "user_end_s": self._adjusted_user_stop_ts,
-                        "agent_start_s": now_s,
-                        "latency_ms": round(latency_ms, 2),
-                    }
-                )
+            self.user_bot_latencies.append(
+                {
+                    "sequence_id": sequence_id,
+                    "user_end_s": self._adjusted_user_stop_ts,
+                    "agent_start_s": now_s,
+                    "latency_ms": round(latency_ms, 2),
+                }
+            )
             self._adjusted_user_stop_ts = None
 
         logger.info(f"Agent speech started (sequence_id={sequence_id})")

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -158,16 +158,24 @@ class InterruptionManager:
             self.time_since_first_interim_result = time.time() * 1000
             logger.info(f"First interim at {self.time_since_first_interim_result}")
 
-    def on_user_speech_ended(self, update_utterance_time: bool = True, stop_offset_ms: int = 0) -> None:
+    def on_user_speech_ended(
+        self,
+        update_utterance_time: bool = True,
+        stop_offset_ms: int = 0,
+        user_stop_ts_wall: Optional[float] = None,
+    ) -> None:
         """Called when user stops speaking (speech_final / UtteranceEnd).
 
         update_utterance_time=False keeps the grace period anchored to the last
         real turn (use for false interruptions or late UtteranceEnd events).
 
-        stop_offset_ms is the vendor-reported silence window (e.g. Deepgram's
-        endpointing or utterance_end_ms) that elapsed between the user's actual
-        end-of-speech and this callback firing. Subtracted to recover wall-clock
-        time of true end-of-speech for realtime_perceived_latencies.
+        For realtime_perceived_latencies, the adjusted user-stop timestamp is
+        resolved in priority order:
+          1. user_stop_ts_wall (wall-clock seconds) — when transcriber exposes
+             an audio-time end-of-last-word (Deepgram words[-1].end); most
+             accurate, free of remote-processing tail.
+          2. now - stop_offset_ms — fallback using vendor silence-window config;
+             inherits Deepgram's endpointing processing lag (~100-300ms).
         """
         self.callee_speaking = False
         self.let_remaining_audio_pass_through = True
@@ -176,7 +184,10 @@ class InterruptionManager:
         now_s = time.time()
         if update_utterance_time:
             self.utterance_end_time = now_s * 1000
-            self._adjusted_user_stop_ts = now_s - (stop_offset_ms / 1000.0)
+            if user_stop_ts_wall is not None:
+                self._adjusted_user_stop_ts = user_stop_ts_wall
+            else:
+                self._adjusted_user_stop_ts = now_s - (stop_offset_ms / 1000.0)
 
         if self.callee_speaking_start_time > 0:
             self._total_user_speaking_ms += (now_s - self.callee_speaking_start_time) * 1000

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4024,14 +4024,14 @@ class TaskManager(BaseManager):
                 # Real-time perceived latency: convert absolute seconds to call-relative ms
                 # (conversation_start_init_ts is already in ms — see line 100).
                 _call_start_ms = self.conversation_start_init_ts
-                _realtime_perceived = [
+                _user_bot_latencies = [
                     {
                         "sequence_id": e["sequence_id"],
                         "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
                         "latency_ms": e["latency_ms"],
                     }
-                    for e in self.interruption_manager.realtime_perceived_latencies
+                    for e in self.interruption_manager.user_bot_latencies
                 ]
 
                 output = {
@@ -4055,7 +4055,7 @@ class TaskManager(BaseManager):
                         "interruption_stats": self.interruption_manager.get_interruption_stats(
                             self.conversation_start_init_ts
                         ),
-                        "realtime_perceived_latencies": _realtime_perceived,
+                        "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
                     },
                     "hangup_detail": self.hangup_detail,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3051,7 +3051,8 @@ class TaskManager(BaseManager):
                             self._speech_started_before_welcome = False
                             continue
 
-                        self.interruption_manager.on_user_speech_ended()
+                        stop_offset_ms = (message.get("meta_info") or {}).get("user_stop_offset_ms", 0)
+                        self.interruption_manager.on_user_speech_ended(stop_offset_ms=stop_offset_ms)
                         temp_transcriber_message = ""
 
                         if self.output_task is None:
@@ -4017,6 +4018,19 @@ class TaskManager(BaseManager):
 
                 welcome_message_sent_ts = self.tools["output"].get_welcome_message_sent_ts()
 
+                # Real-time perceived latency: convert absolute seconds to call-relative ms
+                # (conversation_start_init_ts is already in ms — see line 100).
+                _call_start_ms = self.conversation_start_init_ts
+                _realtime_perceived = [
+                    {
+                        "sequence_id": e["sequence_id"],
+                        "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
+                        "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
+                        "latency_ms": e["latency_ms"],
+                    }
+                    for e in self.interruption_manager.realtime_perceived_latencies
+                ]
+
                 output = {
                     "messages": self.history,
                     "conversation_time": time.time() - self.start_time,
@@ -4038,6 +4052,7 @@ class TaskManager(BaseManager):
                         "interruption_stats": self.interruption_manager.get_interruption_stats(
                             self.conversation_start_init_ts
                         ),
+                        "realtime_perceived_latencies": _realtime_perceived,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
                     },
                     "hangup_detail": self.hangup_detail,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3051,8 +3051,11 @@ class TaskManager(BaseManager):
                             self._speech_started_before_welcome = False
                             continue
 
-                        stop_offset_ms = (message.get("meta_info") or {}).get("user_stop_offset_ms", 0)
-                        self.interruption_manager.on_user_speech_ended(stop_offset_ms=stop_offset_ms)
+                        _meta = message.get("meta_info") or {}
+                        self.interruption_manager.on_user_speech_ended(
+                            stop_offset_ms=_meta.get("user_stop_offset_ms", 0),
+                            user_stop_ts_wall=_meta.get("user_stop_ts_wall"),
+                        )
                         temp_transcriber_message = ""
 
                         if self.output_task is None:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4021,8 +4021,6 @@ class TaskManager(BaseManager):
 
                 welcome_message_sent_ts = self.tools["output"].get_welcome_message_sent_ts()
 
-                # Real-time perceived latency: convert absolute seconds to call-relative ms
-                # (conversation_start_init_ts is already in ms — see line 100).
                 _call_start_ms = self.conversation_start_init_ts
                 _user_bot_latencies = [
                     {

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -612,7 +612,6 @@ class DeepgramTranscriber(BaseTranscriber):
                             pass
                         if self.meta_info is not None:
                             self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
-                            # Deepgram's UtteranceEnd message carries last_word_end (audio-time).
                             last_word_end_audio = msg.get("last_word_end")
                             if last_word_end_audio is not None and self.connection_start_time is not None:
                                 self.meta_info["user_stop_ts_wall"] = (
@@ -686,13 +685,7 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.error(f"not working {e}")
 
     def _compute_last_word_end_wall(self, data):
-        """Return wall-clock seconds when the last transcribed word ended, or None.
-
-        Uses Deepgram's per-word audio-time stamps plus connection_start_time
-        (anchored on first receiver message to wall = now - frames_sent * frame_duration).
-        Accurate to Deepgram's word-boundary precision (~50-100ms typical on TTS audio)
-        and avoids the remote-processing tail that endpointing-based subtraction includes.
-        """
+        """Wall-clock seconds when the last transcribed word ended, or None."""
         try:
             if self.connection_start_time is None:
                 return None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -612,9 +612,7 @@ class DeepgramTranscriber(BaseTranscriber):
                         self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
                         last_word_end_audio = msg.get("last_word_end")
                         if last_word_end_audio is not None:
-                            self.meta_info["user_stop_ts_wall"] = (
-                                self.connection_start_time + last_word_end_audio
-                            )
+                            self.meta_info["user_stop_ts_wall"] = self.connection_start_time + last_word_end_audio
                         yield create_ws_data_packet(data, self.meta_info)
                     else:
                         # Transcript already sent but we still need to notify speech ended

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -565,11 +565,10 @@ class DeepgramTranscriber(BaseTranscriber):
                                     f"Failed to extract transcript from Deepgram response in speech_final: {e}"
                                 )
                                 pass
-                            if self.meta_info is not None:
-                                self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
-                                last_word_end_wall = self._compute_last_word_end_wall(msg)
-                                if last_word_end_wall is not None:
-                                    self.meta_info["user_stop_ts_wall"] = last_word_end_wall
+                            self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
+                            last_word_end_wall = self._compute_last_word_end_wall(msg)
+                            if last_word_end_wall is not None:
+                                self.meta_info["user_stop_ts_wall"] = last_word_end_wall
                             yield create_ws_data_packet(data, self.meta_info)
 
                 elif msg["type"] == "UtteranceEnd":
@@ -610,13 +609,12 @@ class DeepgramTranscriber(BaseTranscriber):
                         except Exception as e:
                             logger.error(f"Failed to extract transcript from Deepgram response: {e}")
                             pass
-                        if self.meta_info is not None:
-                            self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
-                            last_word_end_audio = msg.get("last_word_end")
-                            if last_word_end_audio is not None and self.connection_start_time is not None:
-                                self.meta_info["user_stop_ts_wall"] = (
-                                    self.connection_start_time + last_word_end_audio
-                                )
+                        self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
+                        last_word_end_audio = msg.get("last_word_end")
+                        if last_word_end_audio is not None:
+                            self.meta_info["user_stop_ts_wall"] = (
+                                self.connection_start_time + last_word_end_audio
+                            )
                         yield create_ws_data_packet(data, self.meta_info)
                     else:
                         # Transcript already sent but we still need to notify speech ended
@@ -687,8 +685,6 @@ class DeepgramTranscriber(BaseTranscriber):
     def _compute_last_word_end_wall(self, data):
         """Wall-clock seconds when the last transcribed word ended, or None."""
         try:
-            if self.connection_start_time is None:
-                return None
             alternatives = (data.get("channel") or {}).get("alternatives") or []
             for alternative in alternatives:
                 words = alternative.get("words") or []

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -42,6 +42,8 @@ class DeepgramTranscriber(BaseTranscriber):
     ):
         super().__init__(input_queue)
         self.endpointing = endpointing
+        self.endpointing_ms = int(endpointing)
+        self.utterance_end_ms = 1000 if self.endpointing_ms < 1000 else self.endpointing_ms
         self.language = language
         self.stream = stream
         self.provider = telephony_provider
@@ -107,7 +109,7 @@ class DeepgramTranscriber(BaseTranscriber):
             "vad_events": "true",
             "endpointing": self.endpointing,
             "interim_results": "true",
-            "utterance_end_ms": "1000" if int(self.endpointing) < 1000 else str(self.endpointing),
+            "utterance_end_ms": str(self.utterance_end_ms),
         }
 
         self.audio_frame_duration = 0.5  # We're sending 8k samples with a sample rate of 16k
@@ -563,6 +565,8 @@ class DeepgramTranscriber(BaseTranscriber):
                                     f"Failed to extract transcript from Deepgram response in speech_final: {e}"
                                 )
                                 pass
+                            if self.meta_info is not None:
+                                self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
                             yield create_ws_data_packet(data, self.meta_info)
 
                 elif msg["type"] == "UtteranceEnd":
@@ -603,6 +607,8 @@ class DeepgramTranscriber(BaseTranscriber):
                         except Exception as e:
                             logger.error(f"Failed to extract transcript from Deepgram response: {e}")
                             pass
+                        if self.meta_info is not None:
+                            self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
                         yield create_ws_data_packet(data, self.meta_info)
                     else:
                         # Transcript already sent but we still need to notify speech ended

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -567,6 +567,9 @@ class DeepgramTranscriber(BaseTranscriber):
                                 pass
                             if self.meta_info is not None:
                                 self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
+                                last_word_end_wall = self._compute_last_word_end_wall(msg)
+                                if last_word_end_wall is not None:
+                                    self.meta_info["user_stop_ts_wall"] = last_word_end_wall
                             yield create_ws_data_packet(data, self.meta_info)
 
                 elif msg["type"] == "UtteranceEnd":
@@ -609,6 +612,12 @@ class DeepgramTranscriber(BaseTranscriber):
                             pass
                         if self.meta_info is not None:
                             self.meta_info["user_stop_offset_ms"] = self.utterance_end_ms
+                            # Deepgram's UtteranceEnd message carries last_word_end (audio-time).
+                            last_word_end_audio = msg.get("last_word_end")
+                            if last_word_end_audio is not None and self.connection_start_time is not None:
+                                self.meta_info["user_stop_ts_wall"] = (
+                                    self.connection_start_time + last_word_end_audio
+                                )
                         yield create_ws_data_packet(data, self.meta_info)
                     else:
                         # Transcript already sent but we still need to notify speech ended
@@ -676,15 +685,25 @@ class DeepgramTranscriber(BaseTranscriber):
         except Exception as e:
             logger.error(f"not working {e}")
 
-    def __calculate_utterance_end(self, data):
-        utterance_end = None
-        if "channel" in data and "alternatives" in data["channel"]:
-            for alternative in data["channel"]["alternatives"]:
-                if "words" in alternative:
-                    final_word = alternative["words"][-1]
-                    utterance_end = self.connection_start_time + final_word["end"]
-                    logger.info(f"Final word ended at {utterance_end}")
-        return utterance_end
+    def _compute_last_word_end_wall(self, data):
+        """Return wall-clock seconds when the last transcribed word ended, or None.
+
+        Uses Deepgram's per-word audio-time stamps plus connection_start_time
+        (anchored on first receiver message to wall = now - frames_sent * frame_duration).
+        Accurate to Deepgram's word-boundary precision (~50-100ms typical on TTS audio)
+        and avoids the remote-processing tail that endpointing-based subtraction includes.
+        """
+        try:
+            if self.connection_start_time is None:
+                return None
+            alternatives = (data.get("channel") or {}).get("alternatives") or []
+            for alternative in alternatives:
+                words = alternative.get("words") or []
+                if words:
+                    return self.connection_start_time + words[-1]["end"]
+        except Exception:
+            pass
+        return None
 
     def __set_transcription_cursor(self, data):
         if "start" in data and "duration" in data:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.9"
+version = "0.10.10"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Captures time from user stops speaking to first agent audio chunk, per turn. Emits as latency_dict.user_bot_latencies alongside the existing recording-based perceived_latencies.

Uses Deepgram word-level end timestamps when available (avoids remote-processing tail), falls back to endpointing-offset subtraction for transcribers without word timing.