### PR TITLE
Add name field support to knowledge base sources

### DIFF
--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -96,13 +96,27 @@ class KnowledgeBaseAgent(BaseAgent):
 
         collections = []
         used_sources = rag_config.get("used_sources", None)
+        normalized_used_sources = []
 
         if "vector_store" in rag_config:
             provider_config = rag_config["vector_store"].get("provider_config", {})
 
             if used_sources:
                 for source in used_sources:
-                    vector_id = source.get("vector_id")
+                    if not isinstance(source, dict):
+                        continue
+
+                    try:
+                        normalized_source = KnowledgeBaseSource(**source).model_dump()
+                    except ValidationError:
+                        normalized_source = dict(source)
+
+                    if normalized_source.get("name") is None:
+                        # Default name to source for backward compatibility and usability.
+                        normalized_source["name"] = normalized_source.get("source")
+
+                    normalized_used_sources.append(normalized_source)
+                    vector_id = normalized_source.get("vector_id")
                     if vector_id:
                         collections.append(vector_id)
 
@@ -121,7 +135,7 @@ class KnowledgeBaseAgent(BaseAgent):
         return {
             "collections": collections,
             "similarity_top_k": rag_config.get("similarity_top_k", 10),
-            "used_sources": used_sources,
+            "used_sources": normalized_used_sources or used_sources,
         }
 
     async def check_for_completion(self, messages, check_for_completion_prompt):
@@ -245,6 +259,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 context_entry = {
                     "text": context.text,
                     "score": context.score,
+                    "name": source_info.get("name"),
                     "vector_id": source_info.get("vector_id"),
                     "rag_id": source_info.get("rag_id"),
                     "source": source_info.get("source"),

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, Literal, Optional, List, Union, Dict, Callable
-from pydantic import BaseModel, Field, field_validator, ValidationError, Json, model_validator
+from pydantic import BaseModel, Field, field_validator, ValidationError, Json, model_validator, ConfigDict
 from pydantic_core import PydanticCustomError
 from .providers import *
 from .enums import (
@@ -379,12 +379,57 @@ class GraphAgentConfig(Llm):
         return self
 
 
+class KnowledgeBaseSource(BaseModel):
+    vector_id: Optional[str] = None
+    rag_id: Optional[str] = None
+    source: Optional[str] = None
+    name: Optional[str] = None
+
+    # Keep this permissive so unexpected source metadata is preserved.
+    model_config = ConfigDict(extra="allow")
+
+
+def normalize_knowledge_base_sources(rag_config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Lightweight normalization for used_sources when present, without enforcing a global schema."""
+    if not isinstance(rag_config, dict):
+        return rag_config
+
+    used_sources = rag_config.get("used_sources")
+    if not isinstance(used_sources, list):
+        return rag_config
+
+    normalized_rag_config = dict(rag_config)
+    normalized_sources = []
+
+    for source in used_sources:
+        if not isinstance(source, dict):
+            normalized_sources.append(source)
+            continue
+
+        try:
+            normalized_source = KnowledgeBaseSource(**source).model_dump()
+        except ValidationError:
+            normalized_source = dict(source)
+
+        if normalized_source.get("name") is None:
+            # Default name to source for backward compatibility and usability.
+            normalized_source["name"] = normalized_source.get("source")
+        normalized_sources.append(normalized_source)
+
+    normalized_rag_config["used_sources"] = normalized_sources
+    return normalized_rag_config
+
+
 class KnowledgeAgentConfig(Llm):
     agent_information: Optional[str] = "Knowledge-based AI assistant"
     prompt: Optional[str] = None
     rag_config: Optional[Dict] = None
     llm_provider: Optional[str] = "openai"
     context_data: Optional[dict] = None
+
+    @field_validator("rag_config", mode="before")
+    def validate_rag_config(cls, value):
+        return normalize_knowledge_base_sources(value)
 
 
 class AgentRouteConfig(BaseModel):

--- a/tests/tests/test_knowledgebase_name.py
+++ b/tests/tests/test_knowledgebase_name.py
@@ -1,0 +1,54 @@
+from bolna.agent_types.knowledgebase_agent import KnowledgeBaseAgent
+from bolna.models import KnowledgeAgentConfig
+
+
+def test_knowledge_agent_config_accepts_name_and_defaults_to_source():
+    config = KnowledgeAgentConfig(
+        rag_config={
+            "vector_store": {"provider_config": {"vector_ids": ["kb-1", "kb-2"]}},
+            "used_sources": [
+                {"vector_id": "kb-1", "source": "https://docs.example.com", "name": "Docs"},
+                {"vector_id": "kb-2", "source": "https://faq.example.com"},
+            ],
+        }
+    )
+
+    assert config.rag_config["used_sources"][0]["name"] == "Docs"
+    assert config.rag_config["used_sources"][1]["name"] == "https://faq.example.com"
+
+
+def test_initialize_rag_config_preserves_names_for_used_sources():
+    agent = KnowledgeBaseAgent.__new__(KnowledgeBaseAgent)
+    agent.config = {
+        "rag_config": {
+            "vector_store": {"provider_config": {"vector_ids": ["kb-1", "kb-2"]}},
+            "used_sources": [
+                {"vector_id": "kb-1", "source": "https://docs.example.com", "name": "Docs"},
+                {"vector_id": "kb-2", "source": "https://faq.example.com"},
+            ],
+        }
+    }
+
+    rag_config = agent._initialize_rag_config()
+
+    assert rag_config["collections"] == ["kb-1", "kb-2"]
+    assert rag_config["used_sources"][0]["name"] == "Docs"
+    assert rag_config["used_sources"][1]["name"] == "https://faq.example.com"
+
+
+def test_knowledge_agent_config_preserves_unexpected_source_fields():
+    config = KnowledgeAgentConfig(
+        rag_config={
+            "vector_store": {"provider_config": {"vector_ids": ["kb-1"]}},
+            "used_sources": [
+                {
+                    "vector_id": "kb-1",
+                    "source": "https://docs.example.com",
+                    "name": "Docs",
+                    "custom_metadata": {"category": "guides"},
+                }
+            ],
+        }
+    )
+
+    assert config.rag_config["used_sources"][0]["custom_metadata"] == {"category": "guides"}


### PR DESCRIPTION
### Add support for `name` field in knowledge base sources

This PR adds optional support for a `name` field in `rag_config.used_sources` to make knowledge bases easier to identify.

#### Changes

* Added lightweight normalization for KB sources
* Introduced optional `name` field (backward compatible)
* Default fallback: `name` → `source` when not provided
* Propagated `name` into runtime context metadata
* Added tests for explicit and fallback behavior

#### Notes

* No breaking changes — existing configs continue to work
* Normalization is defensive and allows extra fields

Closes #647
