### PR TITLE
fix: shared SSL context for all WS connections to stop ws-server memory leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.11"
+__version__ = "0.10.12"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/ssl_context.py
+++ b/bolna/helpers/ssl_context.py
@@ -1,0 +1,14 @@
+import ssl
+import threading
+
+_ssl_context: ssl.SSLContext | None = None
+_lock = threading.Lock()
+
+
+def get_ssl_context() -> ssl.SSLContext:
+    global _ssl_context
+    if _ssl_context is None:
+        with _lock:
+            if _ssl_context is None:
+                _ssl_context = ssl.create_default_context()
+    return _ssl_context

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -22,6 +22,7 @@ from websockets.protocol import State as WSState
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX
 from bolna.enums import ReasoningEffort, ResponseStreamEvent, ResponseItemType, Verbosity
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
 from .tool_call_accumulator import ToolCallAccumulator
@@ -85,6 +86,7 @@ class OpenAIWSConnection:
             additional_headers={"Authorization": f"Bearer {self._api_key}"},
             max_size=None,
             close_timeout=5,
+            ssl=get_ssl_context(),
         )
         self._connected_at = time.monotonic()
         logger.info("WebSocket connected to OpenAI Responses API")

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -11,6 +11,7 @@ from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 
 
 logger = configure_logger(__name__)
@@ -217,7 +218,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(websockets.connect(self.ws_url), timeout=10.0)
+            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context()), timeout=10.0)
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -12,6 +12,7 @@ from dotenv import load_dotenv
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import convert_audio_to_wav, create_ws_data_packet
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
 
@@ -202,7 +203,7 @@ class DeepgramSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers={"Authorization": f"Token {self.api_key}"}),
+                websockets.connect(self.ws_url, additional_headers={"Authorization": f"Token {self.api_key}"}, ssl=get_ssl_context()),
                 timeout=10.0,
             )
             if not self.connection_time:

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -11,6 +11,7 @@ import websockets
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import convert_audio_to_wav, create_ws_data_packet, resample
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
 
@@ -252,7 +253,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(websockets.connect(self.ws_url), timeout=10.0)
+            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context()), timeout=10.0)
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")
                 logger.info(f"Elevenlabs WebSocket connected trace_id={self.ws_trace_id}")

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -12,6 +12,7 @@ import os
 import traceback
 from collections import deque
 
+from bolna.helpers.ssl_context import get_ssl_context
 from .base_synthesizer import BaseSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet
@@ -333,7 +334,7 @@ class PixaSynthesizer(BaseSynthesizer):
                 headers["Authorization"] = f"Bearer {self.api_key}"
 
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers=headers), timeout=10.0
+                websockets.connect(self.ws_url, additional_headers=headers, ssl=get_ssl_context()), timeout=10.0
             )
 
             # Send initial configuration

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import convert_audio_to_wav
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
 
@@ -198,6 +199,7 @@ class RimeSynthesizer(StreamSynthesizer):
                 websockets.connect(
                     self.ws_url,
                     additional_headers={"Authorization": f"Bearer {self.api_key}"},
+                    ssl=get_ssl_context(),
                 ),
                 timeout=10.0,
             )

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -12,6 +12,7 @@ from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, get_synth_audio_format, resample, wav_bytes_to_pcm
 from bolna.constants import SARVAM_MODEL_SAMPLING_RATE_MAPPING
 
@@ -181,7 +182,7 @@ class SarvamSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers={"api-subscription-key": self.api_key}),
+                websockets.connect(self.ws_url, additional_headers={"api-subscription-key": self.api_key}, ssl=get_ssl_context()),
                 timeout=10.0,
             )
             bos_message = {

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -9,6 +9,7 @@ import websockets
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 
 logger = configure_logger(__name__)
 
@@ -134,6 +135,7 @@ class SmallestSynthesizer(StreamSynthesizer):
                 websockets.connect(
                     self.ws_url,
                     additional_headers={"Authorization": f"Token {self.api_key}"},
+                    ssl=get_ssl_context(),
                 ),
                 timeout=10.0,
             )

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 logger = configure_logger(__name__)
@@ -505,7 +506,7 @@ class AssemblyAITranscriber(BaseTranscriber):
             headers = {"Authorization": self.api_key}
 
             assemblyai_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=headers), timeout=10.0
+                websockets.connect(websocket_url, additional_headers=headers, ssl=get_ssl_context()), timeout=10.0
             )
 
             self.websocket_connection = assemblyai_ws

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -12,6 +12,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 from bolna.enums import TelephonyProvider
 
@@ -651,7 +652,7 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.info(f"Attempting to connect to Deepgram websocket: {websocket_url}")
 
             deepgram_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=additional_headers),
+                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()),
                 timeout=10.0,  # 10 second timeout
             )
 

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -12,6 +12,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 
@@ -538,7 +539,7 @@ class ElevenLabsTranscriber(BaseTranscriber):
             logger.info(f"Attempting to connect to ElevenLabs websocket: {websocket_url}")
 
             elevenlabs_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=additional_headers), timeout=10.0
+                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()), timeout=10.0
             )
 
             self.websocket_connection = elevenlabs_ws

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -14,6 +14,7 @@ from dotenv import load_dotenv
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
@@ -255,7 +256,7 @@ class GladiaTranscriber(BaseTranscriber):
                 # Step 2: Connect to WebSocket
                 logger.info(f"Connecting to Gladia WebSocket: {self.gladia_ws_url}")
 
-                ws = await asyncio.wait_for(websockets.connect(self.gladia_ws_url), timeout=timeout)
+                ws = await asyncio.wait_for(websockets.connect(self.gladia_ws_url, ssl=get_ssl_context()), timeout=timeout)
 
                 self.websocket_connection = ws
                 self.connection_authenticated = True

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -10,6 +10,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
@@ -148,7 +149,7 @@ class PixaTranscriber(BaseTranscriber):
         while attempt < retries:
             try:
                 ws = await asyncio.wait_for(
-                    websockets.connect(ws_url, additional_headers=additional_headers),
+                    websockets.connect(ws_url, additional_headers=additional_headers, ssl=get_ssl_context()),
                     timeout=timeout,
                 )
                 self.websocket_connection = ws

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet
 
 load_dotenv()
@@ -439,7 +440,7 @@ class SarvamTranscriber(BaseTranscriber):
             try:
                 logger.info(f"Attempting to connect to Sarvam websocket: {self.ws_url}")
                 ws = await asyncio.wait_for(
-                    websockets.connect(self.ws_url, additional_headers=additional_headers),
+                    websockets.connect(self.ws_url, additional_headers=additional_headers, ssl=get_ssl_context()),
                     timeout=timeout,
                 )
                 self.websocket_connection = ws

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
@@ -191,7 +192,7 @@ class SmallestTranscriber(BaseTranscriber):
                 logger.info(f"Attempting to connect to Smallest AI WebSocket: {websocket_url}")
 
                 ws = await asyncio.wait_for(
-                    websockets.connect(websocket_url, additional_headers=additional_headers), timeout=timeout
+                    websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()), timeout=timeout
                 )
 
                 self.websocket_connection = ws

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.11"
+version = "0.10.12"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Every websockets.connect() call to a wss:// URL in bolna creates a new ssl.SSLContext under the hood, which loads the system CA bundle (~150KB) plus session caches and BIO buffers into native memory. With 2-3 WS connections per call (transcriber + synthesizer + sometimes OpenAI Realtime) and hundreds of calls/min in prod, this churn fragments native memory the same way per-call httpx clients did.

This is the secondary leak source remaining after PR #655. ws-server pods on bolna-ws-cluster are still growing 200-300 MB/hr after the httpx fix; reproduction confirms SSL context churn is a major contributor.

## Reproduction

500 simulated calls, 20 concurrent, 2 WS connections each:
- New SSL context per WS (current pattern): +15.2 MB
- Shared SSL context (this fix): +0.7 MB
- 95% reduction

1000 calls: +16.8 MB vs +0.5 MB (97% reduction)

## What changed

1. New bolna/helpers/ssl_context.py with module-level singleton SSLContext (lazy init with threading lock)
2. All 15 websockets.connect() call sites now pass ssl=get_ssl_context()
3. Affected files: 7 transcribers, 7 synthesizers, 1 LLM (OpenAI Realtime WS)