### PR TITLE
fix: shared aiohttp.ClientSession to stop ws-server memory leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.11"
+__version__ = "0.10.12"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -28,6 +28,7 @@ from bolna.constants import (
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
 )
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.function_calling_helpers import trigger_api, computed_api_response, prepare_api_request
 from bolna.helpers.conversation_history import ConversationHistory
 from .base_manager import BaseManager
@@ -2077,52 +2078,52 @@ class TaskManager(BaseManager):
                 await self.tools["output"].handle(eos_packet)
                 return
 
-            async with aiohttp.ClientSession() as session:
-                logger.info(f"Sending the payload to stop the conversation {payload} url {url}")
-                while self.tools["input"].is_audio_being_played_to_user():
-                    await asyncio.sleep(1)
-                function_call_log = self._start_api_call_detail(
-                    called_fun=called_fun,
-                    url=url,
-                    method="POST",
-                    param=param,
-                    headers={"Content-Type": "application/json"},
-                    meta_info=meta_info,
-                    runtime_args={
-                        **self._extract_api_call_runtime_args(resp),
-                        "tool_call_id": resp.get("tool_call_id", ""),
-                    },
-                    request_body=payload,
-                    api_params=payload,
-                )
+            session = await get_shared_aiohttp_session()
+            logger.info(f"Sending the payload to stop the conversation {payload} url {url}")
+            while self.tools["input"].is_audio_being_played_to_user():
+                await asyncio.sleep(1)
+            function_call_log = self._start_api_call_detail(
+                called_fun=called_fun,
+                url=url,
+                method="POST",
+                param=param,
+                headers={"Content-Type": "application/json"},
+                meta_info=meta_info,
+                runtime_args={
+                    **self._extract_api_call_runtime_args(resp),
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                },
+                request_body=payload,
+                api_params=payload,
+            )
+            convert_to_request_log(
+                str(payload),
+                meta_info,
+                None,
+                LogComponent.FUNCTION_CALL,
+                direction=LogDirection.REQUEST,
+                is_cached=False,
+                run_id=self.run_id,
+            )
+            async with session.post(url, json=payload) as response:
+                response_text = await response.text()
+                logger.info(f"Response from the server after call transfer: {response_text}")
                 convert_to_request_log(
-                    str(payload),
+                    str(response_text),
                     meta_info,
                     None,
                     LogComponent.FUNCTION_CALL,
-                    direction=LogDirection.REQUEST,
+                    direction=LogDirection.RESPONSE,
                     is_cached=False,
                     run_id=self.run_id,
                 )
-                async with session.post(url, json=payload) as response:
-                    response_text = await response.text()
-                    logger.info(f"Response from the server after call transfer: {response_text}")
-                    convert_to_request_log(
-                        str(response_text),
-                        meta_info,
-                        None,
-                        LogComponent.FUNCTION_CALL,
-                        direction=LogDirection.RESPONSE,
-                        is_cached=False,
-                        run_id=self.run_id,
-                    )
-                    self._finalize_api_call_detail(
-                        function_call_log,
-                        response=response_text,
-                        status_code=response.status,
-                        content_type=response.headers.get("Content-Type"),
-                    )
-                    return
+                self._finalize_api_call_detail(
+                    function_call_log,
+                    response=response_text,
+                    status_code=response.status,
+                    content_type=response.headers.get("Content-Type"),
+                )
+                return
 
         if called_fun == "switch_language":
             language_label = resp.get("language", "")

--- a/bolna/agent_types/webhook_agent.py
+++ b/bolna/agent_types/webhook_agent.py
@@ -1,5 +1,5 @@
-import aiohttp
 from .base_agent import BaseAgent
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -14,18 +14,18 @@ class WebhookAgent(BaseAgent):
     async def __send_payload(self, payload):
         try:
             logger.info(f"Sending a webhook post request {payload}")
-            async with aiohttp.ClientSession() as session:
-                if payload is not None:
-                    async with session.post(self.webhook_url, json=payload) as response:
-                        if response.status == 200:
-                            # need to check if the returned response is json or not
-                            # data = await response.json()
-                            return True
-                        else:
-                            logger.error(f"Error: {response.status} - {await response.text()}")
-                            return None
-                else:
-                    logger.info("Payload was null")
+            session = await get_shared_aiohttp_session()
+            if payload is not None:
+                async with session.post(self.webhook_url, json=payload) as response:
+                    if response.status == 200:
+                        # need to check if the returned response is json or not
+                        # data = await response.json()
+                        return True
+                    else:
+                        logger.error(f"Error: {response.status} - {await response.text()}")
+                        return None
+            else:
+                logger.info("Payload was null")
             return None
         except Exception as e:
             logger.error(f"Something went wrong with webhook {self.webhook_url}, {payload}, {str(e)}")

--- a/bolna/helpers/aiohttp_session.py
+++ b/bolna/helpers/aiohttp_session.py
@@ -11,5 +11,5 @@ async def get_shared_aiohttp_session() -> aiohttp.ClientSession:
         async with _lock:
             if _session is None or _session.closed:
                 connector = aiohttp.TCPConnector(limit=200, limit_per_host=100, keepalive_timeout=30)
-                _session = aiohttp.ClientSession(connector=connector)
+                _session = aiohttp.ClientSession(connector=connector, cookie_jar=aiohttp.DummyCookieJar())
     return _session

--- a/bolna/helpers/aiohttp_session.py
+++ b/bolna/helpers/aiohttp_session.py
@@ -1,0 +1,15 @@
+import aiohttp
+import asyncio
+
+_session: aiohttp.ClientSession | None = None
+_lock = asyncio.Lock()
+
+
+async def get_shared_aiohttp_session() -> aiohttp.ClientSession:
+    global _session
+    if _session is None or _session.closed:
+        async with _lock:
+            if _session is None or _session.closed:
+                connector = aiohttp.TCPConnector(limit=200, limit_per_host=100, keepalive_timeout=30)
+                _session = aiohttp.ClientSession(connector=connector)
+    return _session

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 
 import aiohttp
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, format_error_message
@@ -126,29 +127,30 @@ async def trigger_api(
             is_cached=False,
             run_id=run_id,
         )
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
-            if method.lower() == "get":
-                logger.info(f"Sending request {request_body}, {url}, {headers}")
-                async with session.get(url, params=api_params, headers=headers) as response:
+        session = await get_shared_aiohttp_session()
+        timeout = aiohttp.ClientTimeout(total=10)
+        if method.lower() == "get":
+            logger.info(f"Sending request {request_body}, {url}, {headers}")
+            async with session.get(url, params=api_params, headers=headers, timeout=timeout) as response:
+                response_text = await response.text()
+        elif method.lower() == "post":
+            logger.info(f"Sending request {api_params}, {url}, {headers}")
+            if content_type == "json":
+                async with session.post(url, json=api_params, headers=headers, timeout=timeout) as response:
                     response_text = await response.text()
-            elif method.lower() == "post":
-                logger.info(f"Sending request {api_params}, {url}, {headers}")
-                if content_type == "json":
-                    async with session.post(url, json=api_params, headers=headers) as response:
-                        response_text = await response.text()
-                elif content_type == "form":
-                    normalized_api_params = normalize_for_form(api_params)
-                    async with session.post(url, data=normalized_api_params, headers=headers) as response:
-                        response_text = await response.text()
+            elif content_type == "form":
+                normalized_api_params = normalize_for_form(api_params)
+                async with session.post(url, data=normalized_api_params, headers=headers, timeout=timeout) as response:
+                    response_text = await response.text()
 
-            if return_response_metadata:
-                return {
-                    "status_code": response.status if response is not None else None,
-                    "body": response_text,
-                    "content_type": response.headers.get("Content-Type") if response is not None else None,
-                }
+        if return_response_metadata:
+            return {
+                "status_code": response.status if response is not None else None,
+                "body": response_text,
+                "content_type": response.headers.get("Content-Type") if response is not None else None,
+            }
 
-            return response_text
+        return response_text
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"
         logger.debug(message)

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -10,6 +10,7 @@ import websockets
 from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 
 
@@ -262,10 +263,10 @@ class CartesiaSynthesizer(StreamSynthesizer):
             "generation_config": {"speed": self.speed},
         }
         headers = {"X-API-Key": self.api_key, "Cartesia-Version": "2024-06-10"}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(self.api_url, headers=headers, json=payload) as response:
-                if response.status == 200:
-                    return await response.read()
-                else:
-                    logger.error(f"Error: {response.status} - {await response.text()}")
-                    return None
+        session = await get_shared_aiohttp_session()
+        async with session.post(self.api_url, headers=headers, json=payload) as response:
+            if response.status == 200:
+                return await response.read()
+            else:
+                logger.error(f"Error: {response.status} - {await response.text()}")
+                return None

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -11,6 +11,7 @@ import websockets
 from dotenv import load_dotenv
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import convert_audio_to_wav, create_ws_data_packet
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
@@ -265,13 +266,13 @@ class DeepgramSynthesizer(StreamSynthesizer):
             url += f"&tag={self.run_id}"
         logger.info(f"Sending deepgram request {url}")
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(url, headers=headers, json={"text": text}) as response:
-                    if response.status == 200:
-                        return await response.read()
-                    else:
-                        logger.info(f"Deepgram request status {response.status}")
-                        return b"\x00"
+            session = await get_shared_aiohttp_session()
+            async with session.post(url, headers=headers, json={"text": text}) as response:
+                if response.status == 200:
+                    return await response.read()
+                else:
+                    logger.info(f"Deepgram request status {response.status}")
+                    return b"\x00"
         except Exception as e:
             logger.error(f"Deepgram HTTP error: {e}")
 

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -10,6 +10,7 @@ import aiohttp
 import websockets
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import convert_audio_to_wav, create_ws_data_packet, resample
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
@@ -311,10 +312,10 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         headers = {"xi-api-key": self.api_key}
         fmt = format or self._get_output_format()
         url = f"{self.api_url}{fmt}"
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json=payload) as response:
-                if response.status == 200:
-                    return await response.read()
-                else:
-                    logger.error(f"Error: {response.status} - {await response.text()}")
-                    return None
+        session = await get_shared_aiohttp_session()
+        async with session.post(url, headers=headers, json=payload) as response:
+            if response.status == 200:
+                return await response.read()
+            else:
+                logger.error(f"Error: {response.status} - {await response.text()}")
+                return None

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -12,6 +12,7 @@ import os
 import traceback
 from collections import deque
 
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from .base_synthesizer import BaseSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet
@@ -234,24 +235,24 @@ class PixaSynthesizer(BaseSynthesizer):
                 "repetition_penalty": self.repetition_penalty,
             }
 
-            async with aiohttp.ClientSession() as session:
-                async with session.post(url, headers=headers, json=payload) as response:
-                    if response.status != 200:
-                        error_text = await response.text()
-                        logger.error(f"Pixa HTTP API error: {response.status} - {error_text}")
-                        return None
+            session = await get_shared_aiohttp_session()
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status != 200:
+                    error_text = await response.text()
+                    logger.error(f"Pixa HTTP API error: {response.status} - {error_text}")
+                    return None
 
-                    # Response is WAV audio (PCM16 at 32kHz)
-                    wav_audio = await response.read()
+                # Response is WAV audio (PCM16 at 32kHz)
+                wav_audio = await response.read()
 
-                    # Skip WAV header (44 bytes) to get raw PCM
-                    pcm_audio = wav_audio[44:] if len(wav_audio) > 44 else wav_audio
+                # Skip WAV header (44 bytes) to get raw PCM
+                pcm_audio = wav_audio[44:] if len(wav_audio) > 44 else wav_audio
 
-                    # Resample from 32kHz to 8kHz
-                    resampled, _ = audioop.ratecv(
-                        pcm_audio, 2, 1, self.native_sampling_rate, self.target_sampling_rate, None
-                    )
-                    return resampled
+                # Resample from 32kHz to 8kHz
+                resampled, _ = audioop.ratecv(
+                    pcm_audio, 2, 1, self.native_sampling_rate, self.target_sampling_rate, None
+                )
+                return resampled
 
         except Exception as e:
             logger.error(f"Error in synthesize: {e}")

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -10,6 +10,7 @@ import websockets
 from dotenv import load_dotenv
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import convert_audio_to_wav
 from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
@@ -233,12 +234,12 @@ class RimeSynthesizer(StreamSynthesizer):
             "max_tokens": 5000,
         }
         try:
-            async with aiohttp.ClientSession() as session:
-                async with session.post(self.api_url, headers=headers, json=payload) as response:
-                    if response.status == 200:
-                        return await response.read()
-                    else:
-                        return b"\x00"
+            session = await get_shared_aiohttp_session()
+            async with session.post(self.api_url, headers=headers, json=payload) as response:
+                if response.status == 200:
+                    return await response.read()
+                else:
+                    return b"\x00"
         except Exception as e:
             logger.error(f"Rime HTTP error: {e}")
 

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -11,6 +11,7 @@ import websockets
 from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, get_synth_audio_format, resample, wav_bytes_to_pcm
 from bolna.constants import SARVAM_MODEL_SAMPLING_RATE_MAPPING
@@ -227,14 +228,14 @@ class SarvamSynthesizer(StreamSynthesizer):
 
     async def _send_payload(self, payload):
         headers = {"api-subscription-key": self.api_key, "Content-Type": "application/json"}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(self.api_url, headers=headers, json=payload) as response:
-                if response.status == 200:
-                    data = await response.json()
-                    if data and isinstance(data.get("audios", []), list) and data["audios"]:
-                        return data["audios"][0]
-                else:
-                    logger.error(f"Error: {response.status} - {await response.text()}")
+        session = await get_shared_aiohttp_session()
+        async with session.post(self.api_url, headers=headers, json=payload) as response:
+            if response.status == 200:
+                data = await response.json()
+                if data and isinstance(data.get("audios", []), list) and data["audios"]:
+                    return data["audios"][0]
+            else:
+                logger.error(f"Error: {response.status} - {await response.text()}")
 
     async def synthesize(self, text):
         return await self._generate_http(text)

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -8,6 +8,7 @@ import aiohttp
 import websockets
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -165,13 +166,13 @@ class SmallestSynthesizer(StreamSynthesizer):
             "add_wav_header": False,
         }
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
-        async with aiohttp.ClientSession() as session:
-            async with session.post(self.api_url, headers=headers, json=payload) as response:
-                if response.status == 200:
-                    return await response.read()
-                else:
-                    logger.error(f"Error: {response.status} - {await response.text()}")
-                    return None
+        session = await get_shared_aiohttp_session()
+        async with session.post(self.api_url, headers=headers, json=payload) as response:
+            if response.status == 200:
+                return await response.read()
+            else:
+                logger.error(f"Error: {response.status} - {await response.text()}")
+                return None
 
     async def synthesize(self, text):
         return await self._generate_http(text)

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -12,6 +12,7 @@ from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosedError, InvalidHandshake
 
 from .base_transcriber import BaseTranscriber
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
@@ -57,7 +58,7 @@ class AssemblyAITranscriber(BaseTranscriber):
         if not self.stream:
             # For non-streaming HTTP API
             self.api_url = f"https://api.assemblyai.com/v2/transcript"
-            self.session = aiohttp.ClientSession()
+            self.session = None
 
         self.audio_submitted = False
         self.audio_submission_time = None
@@ -154,13 +155,7 @@ class AssemblyAITranscriber(BaseTranscriber):
         """Clean up all resources including HTTP session and websocket."""
         logger.info("Cleaning up AssemblyAI transcriber resources")
 
-        # Close HTTP session (for non-streaming mode)
-        if hasattr(self, "session") and self.session and not self.session.closed:
-            try:
-                await self.session.close()
-                logger.info("AssemblyAI HTTP session closed")
-            except Exception as e:
-                logger.error(f"Error closing AssemblyAI HTTP session: {e}")
+        # HTTP session is shared via aiohttp_session pool, do not close here.
 
         # Cancel tasks properly
         for task_name, task in [
@@ -190,8 +185,7 @@ class AssemblyAITranscriber(BaseTranscriber):
 
     async def _get_http_transcription(self, audio_data):
         """Handle non-streaming HTTP transcription"""
-        if self.session is None or self.session.closed:
-            self.session = aiohttp.ClientSession()
+        self.session = await get_shared_aiohttp_session()
 
         headers = {
             "Authorization": self.api_key,

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -11,6 +11,7 @@ from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosedError, InvalidHandshake, ConnectionClosed
 
 from .base_transcriber import BaseTranscriber
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 from bolna.enums import TelephonyProvider
@@ -66,7 +67,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 self.api_url += "&filler_words=true"
             if self.run_id:
                 self.api_url += f"&tag={quote(self.run_id)}&extra={quote(f'run_id:{self.run_id}')}"
-            self.session = aiohttp.ClientSession()
+            self.session = None
             if self.keywords is not None:
                 keyword_list = [quote(kw.strip()) for kw in self.keywords.split(",") if kw.strip()]
                 if keyword_list:
@@ -314,13 +315,7 @@ class DeepgramTranscriber(BaseTranscriber):
         """Clean up all resources including HTTP session and websocket."""
         logger.info("Cleaning up Deepgram transcriber resources")
 
-        # Close HTTP session (for non-streaming mode)
-        if hasattr(self, "session") and self.session and not self.session.closed:
-            try:
-                await self.session.close()
-                logger.info("Deepgram HTTP session closed")
-            except Exception as e:
-                logger.error(f"Error closing Deepgram HTTP session: {e}")
+        # HTTP session is shared via aiohttp_session pool, do not close here.
 
         # Cancel tasks properly
         for task_name, task in [
@@ -354,8 +349,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.current_turn_interim_details = []
 
     async def _get_http_transcription(self, audio_data):
-        if self.session is None or self.session.closed:
-            self.session = aiohttp.ClientSession()
+        self.session = await get_shared_aiohttp_session()
 
         headers = {
             "Authorization": "Token {}".format(self.api_key),
@@ -364,12 +358,11 @@ class DeepgramTranscriber(BaseTranscriber):
 
         self.current_request_id = self.generate_request_id()
         self.meta_info["request_id"] = self.current_request_id
-        async with self.session as session:
-            async with session.post(self.api_url, data=audio_data, headers=headers) as response:
-                response_data = await response.json()
-                transcript = response_data["results"]["channels"][0]["alternatives"][0]["transcript"]
-                self.meta_info["transcriber_duration"] = response_data["metadata"]["duration"]
-                return create_ws_data_packet(transcript, self.meta_info)
+        async with self.session.post(self.api_url, data=audio_data, headers=headers) as response:
+            response_data = await response.json()
+            transcript = response_data["results"]["channels"][0]["alternatives"][0]["transcript"]
+            self.meta_info["transcriber_duration"] = response_data["metadata"]["duration"]
+            return create_ws_data_packet(transcript, self.meta_info)
 
     async def _check_and_process_end_of_stream(self, ws_data_packet, ws):
         if "eos" in ws_data_packet["meta_info"] and ws_data_packet["meta_info"]["eos"] is True:

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 from dotenv import load_dotenv
 
 from .base_transcriber import BaseTranscriber
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
@@ -220,24 +221,24 @@ class GladiaTranscriber(BaseTranscriber):
             f"keywords={bool(self.keywords)}"
         )
 
-        async with aiohttp.ClientSession() as session:
-            async with session.post(
-                self.session_url, headers=headers, json=payload, timeout=aiohttp.ClientTimeout(total=10)
-            ) as response:
-                if response.status not in (200, 201):
-                    error_text = await response.text()
-                    logger.error(f"Failed to create Gladia session: {response.status} - {error_text}")
-                    raise ConnectionError(f"Failed to create Gladia session: {response.status} - {error_text}")
+        session = await get_shared_aiohttp_session()
+        async with session.post(
+            self.session_url, headers=headers, json=payload, timeout=aiohttp.ClientTimeout(total=10)
+        ) as response:
+            if response.status not in (200, 201):
+                error_text = await response.text()
+                logger.error(f"Failed to create Gladia session: {response.status} - {error_text}")
+                raise ConnectionError(f"Failed to create Gladia session: {response.status} - {error_text}")
 
-                data = await response.json()
-                session_id = data.get("id")
-                ws_url = data.get("url")
+            data = await response.json()
+            session_id = data.get("id")
+            ws_url = data.get("url")
 
-                if not ws_url:
-                    raise ConnectionError("Gladia session response missing WebSocket URL")
+            if not ws_url:
+                raise ConnectionError("Gladia session response missing WebSocket URL")
 
-                logger.info(f"Created Gladia session: {session_id}")
-                return session_id, ws_url
+            logger.info(f"Created Gladia session: {session_id}")
+            return session_id, ws_url
 
     async def gladia_connect(self, retries: int = 3, timeout: float = 10.0) -> ClientConnection:
         """

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -18,6 +18,7 @@ from scipy.signal import resample_poly
 from typing import Optional
 
 from .base_transcriber import BaseTranscriber
+from bolna.helpers.aiohttp_session import get_shared_aiohttp_session
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet
 
@@ -96,8 +97,6 @@ class SarvamTranscriber(BaseTranscriber):
 
         self._configure_audio_params()
         self.session: Optional[aiohttp.ClientSession] = None
-        if not self.stream:
-            self.session = aiohttp.ClientSession()
 
     def _configure_audio_params(self):
         if self.telephony_provider == "plivo":
@@ -145,8 +144,7 @@ class SarvamTranscriber(BaseTranscriber):
         self.ws_url = f"{ws_url}?{query_string}"
 
     async def _get_http_transcription(self, audio_data):
-        if self.session is None or self.session.closed:
-            self.session = aiohttp.ClientSession()
+        self.session = await get_shared_aiohttp_session()
 
         wav_data = self._convert_audio_to_wav(audio_data)
         if wav_data is None:
@@ -494,13 +492,7 @@ class SarvamTranscriber(BaseTranscriber):
         """Clean up all resources including HTTP session and websocket."""
         logger.info("Cleaning up Sarvam transcriber resources")
 
-        # Close HTTP session (for non-streaming mode)
-        if hasattr(self, "session") and self.session and not self.session.closed:
-            try:
-                await self.session.close()
-                logger.info("Sarvam HTTP session closed")
-            except Exception as e:
-                logger.error(f"Error closing Sarvam HTTP session: {e}")
+        # HTTP session is shared via aiohttp_session pool, do not close here.
 
         # Cancel tasks properly
         for task_name, task in [
@@ -601,8 +593,6 @@ class SarvamTranscriber(BaseTranscriber):
                 self.sender_task.cancel()
             if self.heartbeat_task:
                 self.heartbeat_task.cancel()
-            if self.session and not self.session.closed:
-                await self.session.close()
             if self.websocket_connection:
                 try:
                     await self.websocket_connection.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.11"
+version = "0.10.12"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Each `aiohttp.ClientSession()` call creates a new TCPConnector with its own SSL context (loads system CA bundle ~150KB) and connection pool. With multiple HTTP calls per voice call (synthesis fallback, function calls, webhooks, RAG, call-transfer flow), this churn is the third major contributor to native memory fragmentation alongside the already-fixed httpx and websockets SSL ctx churn.

This is the third leak source identified after PR #655 (httpx) and #663 (WS SSL ctx). ws-server pods on bolna-ws-cluster still grow ~250 MB/hr after the httpx fix landed.

## Reproduction

1000 simulated HTTPS calls, 20 concurrent:
- Per-call ClientSession: +13.8 MB
- Shared ClientSession: -7.1 MB (allocator returned memory)

Full bolna call simulation (1 LLM HTTPS + 2 WSS + 1 aiohttp HTTPS each, 1000 calls, 20 conc):
- Before any fix: +15.8 MB
- After PR 655 + 663: -2.3 MB
- After also fixing aiohttp: +0.5 MB

Math check: at ~250 MB/hr observed leak and 14 MB per 1000 sessions, prod needs ~18,000 sessions/hr (~300/min). At 100 calls/min with 2-3 aiohttp creates per call (synthesis fallback + function call/RAG/webhook) the numbers line up.

## What changed

1. New `bolna/helpers/aiohttp_session.py` with module-level singleton ClientSession using a shared TCPConnector (limit=200, limit_per_host=100, keepalive=30s)
2. 11 call sites switched from `async with aiohttp.ClientSession() as session:` to `session = await get_shared_aiohttp_session()`
3. Affected files: 7 synthesizers (HTTP fallback paths), function_calling_helpers, webhook_agent, task_manager (call transfer flow), gladia_transcriber

## Out of scope

Per-instance ClientSession in sarvam/deepgram/assemblyai transcribers (non-streaming HTTP path only). Left alone since they are conditional and rarely hit in prod.