### PR TITLE
fix: skip ssl context for ws:// URIs in get_ssl_context

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.12"
+__version__ = "0.10.13"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/ssl_context.py
+++ b/bolna/helpers/ssl_context.py
@@ -5,7 +5,10 @@ _ssl_context: ssl.SSLContext | None = None
 _lock = threading.Lock()
 
 
-def get_ssl_context() -> ssl.SSLContext:
+def get_ssl_context(url: str | None = None) -> ssl.SSLContext | None:
+    if url is not None and not url.startswith("wss://"):
+        return None
+
     global _ssl_context
     if _ssl_context is None:
         with _lock:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -86,7 +86,7 @@ class OpenAIWSConnection:
             additional_headers={"Authorization": f"Bearer {self._api_key}"},
             max_size=None,
             close_timeout=5,
-            ssl=get_ssl_context(),
+            ssl=get_ssl_context(self.WS_URL),
         )
         self._connected_at = time.monotonic()
         logger.info("WebSocket connected to OpenAI Responses API")

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -218,7 +218,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context()), timeout=10.0)
+            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url)), timeout=10.0)
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -203,7 +203,7 @@ class DeepgramSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers={"Authorization": f"Token {self.api_key}"}, ssl=get_ssl_context()),
+                websockets.connect(self.ws_url, additional_headers={"Authorization": f"Token {self.api_key}"}, ssl=get_ssl_context(self.ws_url)),
                 timeout=10.0,
             )
             if not self.connection_time:

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -253,7 +253,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context()), timeout=10.0)
+            websocket = await asyncio.wait_for(websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url)), timeout=10.0)
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")
                 logger.info(f"Elevenlabs WebSocket connected trace_id={self.ws_trace_id}")

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -334,7 +334,7 @@ class PixaSynthesizer(BaseSynthesizer):
                 headers["Authorization"] = f"Bearer {self.api_key}"
 
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers=headers, ssl=get_ssl_context()), timeout=10.0
+                websockets.connect(self.ws_url, additional_headers=headers, ssl=get_ssl_context(self.ws_url)), timeout=10.0
             )
 
             # Send initial configuration

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -199,7 +199,7 @@ class RimeSynthesizer(StreamSynthesizer):
                 websockets.connect(
                     self.ws_url,
                     additional_headers={"Authorization": f"Bearer {self.api_key}"},
-                    ssl=get_ssl_context(),
+                    ssl=get_ssl_context(self.ws_url),
                 ),
                 timeout=10.0,
             )

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -182,7 +182,7 @@ class SarvamSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers={"api-subscription-key": self.api_key}, ssl=get_ssl_context()),
+                websockets.connect(self.ws_url, additional_headers={"api-subscription-key": self.api_key}, ssl=get_ssl_context(self.ws_url)),
                 timeout=10.0,
             )
             bos_message = {

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -135,7 +135,7 @@ class SmallestSynthesizer(StreamSynthesizer):
                 websockets.connect(
                     self.ws_url,
                     additional_headers={"Authorization": f"Token {self.api_key}"},
-                    ssl=get_ssl_context(),
+                    ssl=get_ssl_context(self.ws_url),
                 ),
                 timeout=10.0,
             )

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -506,7 +506,7 @@ class AssemblyAITranscriber(BaseTranscriber):
             headers = {"Authorization": self.api_key}
 
             assemblyai_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=headers, ssl=get_ssl_context()), timeout=10.0
+                websockets.connect(websocket_url, additional_headers=headers, ssl=get_ssl_context(websocket_url)), timeout=10.0
             )
 
             self.websocket_connection = assemblyai_ws

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -652,7 +652,7 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.info(f"Attempting to connect to Deepgram websocket: {websocket_url}")
 
             deepgram_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()),
+                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context(websocket_url)),
                 timeout=10.0,  # 10 second timeout
             )
 

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -539,7 +539,7 @@ class ElevenLabsTranscriber(BaseTranscriber):
             logger.info(f"Attempting to connect to ElevenLabs websocket: {websocket_url}")
 
             elevenlabs_ws = await asyncio.wait_for(
-                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()), timeout=10.0
+                websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context(websocket_url)), timeout=10.0
             )
 
             self.websocket_connection = elevenlabs_ws

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -256,7 +256,7 @@ class GladiaTranscriber(BaseTranscriber):
                 # Step 2: Connect to WebSocket
                 logger.info(f"Connecting to Gladia WebSocket: {self.gladia_ws_url}")
 
-                ws = await asyncio.wait_for(websockets.connect(self.gladia_ws_url, ssl=get_ssl_context()), timeout=timeout)
+                ws = await asyncio.wait_for(websockets.connect(self.gladia_ws_url, ssl=get_ssl_context(self.gladia_ws_url)), timeout=timeout)
 
                 self.websocket_connection = ws
                 self.connection_authenticated = True

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -149,7 +149,7 @@ class PixaTranscriber(BaseTranscriber):
         while attempt < retries:
             try:
                 ws = await asyncio.wait_for(
-                    websockets.connect(ws_url, additional_headers=additional_headers, ssl=get_ssl_context()),
+                    websockets.connect(ws_url, additional_headers=additional_headers, ssl=get_ssl_context(ws_url)),
                     timeout=timeout,
                 )
                 self.websocket_connection = ws

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -440,7 +440,7 @@ class SarvamTranscriber(BaseTranscriber):
             try:
                 logger.info(f"Attempting to connect to Sarvam websocket: {self.ws_url}")
                 ws = await asyncio.wait_for(
-                    websockets.connect(self.ws_url, additional_headers=additional_headers, ssl=get_ssl_context()),
+                    websockets.connect(self.ws_url, additional_headers=additional_headers, ssl=get_ssl_context(self.ws_url)),
                     timeout=timeout,
                 )
                 self.websocket_connection = ws

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -192,7 +192,7 @@ class SmallestTranscriber(BaseTranscriber):
                 logger.info(f"Attempting to connect to Smallest AI WebSocket: {websocket_url}")
 
                 ws = await asyncio.wait_for(
-                    websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context()), timeout=timeout
+                    websockets.connect(websocket_url, additional_headers=additional_headers, ssl=get_ssl_context(websocket_url)), timeout=timeout
                 )
 
                 self.websocket_connection = ws

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.12"
+version = "0.10.13"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

PR #663 unconditionally passed `ssl=get_ssl_context()` to all `websockets.connect()` calls. This breaks for `ws://` URIs because `websockets.connect` raises `ssl argument is incompatible with a ws:// URI` when given an SSL context for a non-TLS scheme.

In prod ws-server, `DEEPGRAM_HOST_PROTOCOL=ws` is set (deepgram via internal proxy), causing every Deepgram connection to fail since the PR was deployed.

## Fix

Make `get_ssl_context()` URL-aware:
- Returns the shared SSLContext if URL starts with `wss://`
- Returns `None` if URL starts with `ws://`
- Returns shared SSLContext if URL is omitted (backward compat)

`ssl=None` is accepted by `websockets.connect()` for both schemes, so the fix is safe.

All 15 call sites updated to pass the URL: `ssl=get_ssl_context(self.ws_url)`.

## What changed
1. `bolna/helpers/ssl_context.py`: helper now accepts optional URL argument
2. 15 call sites updated to pass URL (synthesizers, transcribers, openai realtime LLM)