### PR TITLE
fix: anchor wait_for_current_message timeout on expected playback end

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.14"
+__version__ = "0.10.15"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1715,16 +1715,8 @@ class TaskManager(BaseManager):
         except asyncio.TimeoutError:
             logger.warning("wait_for_current_message: synth pipeline flush timed out after 3s")
 
-        start_time = time.time()
+        entry_time = time.time()
         while not self.conversation_ended:
-            elapsed = time.time() - start_time
-            if elapsed > self.hangup_mark_event_timeout:
-                mark_events = self.mark_event_meta_data.mark_event_meta_data
-                logger.warning(
-                    f"wait_for_current_message timed out after {self.hangup_mark_event_timeout}s with {len(mark_events)} remaining marks"
-                )
-                break
-
             mark_events = self.mark_event_meta_data.mark_event_meta_data
             mark_items_list = [{"mark_id": k, "mark_data": v} for k, v in mark_events.items()]
             logger.info(f"current_list: {mark_items_list}")
@@ -1749,12 +1741,28 @@ class TaskManager(BaseManager):
             if first_item.get("text_synthesized") and first_item.get("is_final_chunk") is True:
                 break
 
-            remaining = self.hangup_mark_event_timeout - elapsed
+            pending_ends = [
+                v.get("sent_ts", 0) + v.get("duration", 0)
+                for v in mark_events.values()
+                if v.get("type") != "pre_mark_message" and v.get("sent_ts")
+            ]
+            expected_play_end = max(pending_ends) if pending_ends else time.time()
+            deadline = expected_play_end + self.hangup_mark_event_timeout
+
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                logger.warning(
+                    f"wait_for_current_message timed out: {len(mark_events)} marks unflushed, "
+                    f"expected_play_end was {expected_play_end - entry_time:.1f}s after entry, "
+                    f"grace {self.hangup_mark_event_timeout}s exceeded"
+                )
+                break
+
             self.mark_event_meta_data.mark_changed.clear()
             try:
                 await asyncio.wait_for(self.mark_event_meta_data.mark_changed.wait(), timeout=remaining)
             except asyncio.TimeoutError:
-                pass  # re-enters loop, hits timeout check at top
+                pass
         return
 
     async def inject_digits_to_conversation(self) -> None:

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -67,6 +67,7 @@ class MarkEventMetaData:
         value["counter"] = self.counter
         self.counter += 1
         self.mark_event_meta_data[mark_id] = value
+        self.mark_changed.set()
 
         if value.get("type") != "pre_mark_message":
             self._mark_stats.total_sent += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.14"
+version = "0.10.15"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The agent waits for audio to finish playing before hanging up, with a 10 second timeout. The bug: that 10 seconds started counting from when the synth was done generating chunks, not from when the user actually finished hearing them.

Result: if the goodbye line was 8 seconds long, we'd cut off the call about 2 seconds after the user started hearing the last sentence.

Fix: the timeout now starts from when the last audio chunk is expected to finish playing on the line. The 10 seconds becomes a buffer for the playback acknowledgement to come back, not for the audio itself.