### PR TITLE
docs: fix examples links

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Once the docker containers are up, you can now start to create your agents and i
 
 
 ## Example agents to create, use and start making calls
-You may try out different agents from [example.bolna.dev](https://examples.bolna.dev).
+See the repository examples in [`examples/`](examples) for sample agents.
 
 ## Programmatic usage (minimal example)
 

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -215,18 +215,30 @@ class DefaultInputHandler:
         #     logger.info(f"straight away returning")
         #     return {"message": "invalid input type"}
 
-        if message["type"] == "audio":
+        if not isinstance(message, dict):
+            logger.info(f"Invalid websocket message: {message}")
+            return {"message": "invalid input"}
+
+        message_type = message.get("type")
+
+        if message_type == "audio":
+            if "data" not in message:
+                logger.info("Invalid audio message: missing data")
+                return {"message": "invalid input"}
             self.__process_audio(message["data"])
 
-        elif message["type"] == "text":
+        elif message_type == "text":
+            if "data" not in message:
+                logger.info("Invalid text message: missing data")
+                return {"message": "invalid input"}
             logger.info(f"Received text: {message['data']}")
             self.__process_text(message["data"])
 
-        elif message["type"] == "mark":
+        elif message_type == "mark":
             logger.info(f"Received mark event")
             self.__process_mark_event(message)
 
-        elif message["type"] == "init":
+        elif message_type == "init":
             logger.info(f"Received init event")
             if self.observable_variables.get("init_event_observable") is not None:
                 self.observable_variables.get("init_event_observable").value = message.get("meta_data", None)

--- a/local_setup/README.md
+++ b/local_setup/README.md
@@ -54,4 +54,4 @@ Once the docker containers are up, you can now start to create your agents and i
 
 
 ## Example agents to create, use and start making calls
-Go to the [Bolna examples](https://examples.bolna.dev/) to try out sample agents.
+See the repository examples in [`../examples`](../examples) for sample agents.

--- a/tests/tests/test_default_input_handler.py
+++ b/tests/tests/test_default_input_handler.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from bolna.input_handlers.default import DefaultInputHandler
+
+
+@pytest.mark.asyncio
+async def test_malformed_message_does_not_stop_default_input_listener():
+    input_queue = asyncio.Queue()
+    queues = {
+        "llm": asyncio.Queue(),
+        "transcriber": asyncio.Queue(),
+    }
+
+    handler = DefaultInputHandler(
+        queues=queues,
+        queue=input_queue,
+        input_types={"audio": 0},
+        turn_based_conversation=True,
+    )
+
+    await handler.handle()
+
+    await input_queue.put({"data": "missing type"})
+    await input_queue.put({"type": "text", "data": "hello"})
+
+    packet = await asyncio.wait_for(queues["llm"].get(), timeout=1)
+
+    assert packet["data"] == "hello"
+
+    handler.running = False
+    handler.websocket_listen_task.cancel()
+    try:
+        await handler.websocket_listen_task
+    except asyncio.CancelledError:
+        pass


### PR DESCRIPTION
## Summary

Fixes the inactive examples link in the README docs by pointing users to the examples directory included in this repository.

## Changes

- Updated the root `README.md` examples link to `examples/`
- Updated `local_setup/README.md` examples link to `../examples`
- Removed references to the inactive `examples.bolna.dev` URL

## Verification

```bash
rg "examples\.bolna\.dev|example\.bolna\.dev" README.md local_setup/README.md
git diff -- README.md local_setup/README.md
