### PR TITLE
feat: LID shadow mode, telemetry, reviewer fixes + null multilingual …

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.22"
+__version__ = "0.10.23"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.21"
+__version__ = "0.10.22"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -348,6 +348,9 @@ class TaskManager(BaseManager):
 
         # Stores structured API call records for dashboard/backend persistence.
         self.function_tool_api_call_details = []
+        # Records every manual switch_language tool call — used post-call to
+        # compare against LID shadow detections (precision / latency analysis).
+        self.language_switch_events: list[dict] = []
         self.hangup_task = None
 
         self.conversation_config = None
@@ -1041,15 +1044,27 @@ class TaskManager(BaseManager):
                         if label == active_label:
                             self.transcriber_provider = cfg.get("provider", cfg.get("model"))
 
+                    # Audio LID tap.
+                    # LID_PROVIDER — which backend to use (default: "sarvam").
+                    # LID_MODE     — "shadow" (default) logs detections without switching;
+                    #                "active" performs live transcriber/synthesizer/prompt swap.
+                    #                Keep "shadow" until detection quality is validated.
+                    LID_PROVIDER = os.getenv("LID_PROVIDER", "sarvam")
+                    _lid_config = {"telephony_provider": provider}
+
                     self.tools["transcriber"] = TranscriberPool(
                         transcribers=transcribers,
                         shared_input_queue=self.audio_queue,
                         output_queue=self.transcriber_output_queue,
                         active_label=active_label,
                         multilingual_config=multilingual,
+                        lid_provider=LID_PROVIDER,
+                        lid_config=_lid_config,
+                        on_lid_switch=self.switch_language,
                     )
                     logger.info(
-                        f"TranscriberPool created with labels={list(transcribers.keys())}, active='{active_label}'"
+                        f"TranscriberPool created with labels={list(transcribers.keys())}, "
+                        f"active='{active_label}', lid_provider={LID_PROVIDER!r}"
                     )
                     return
 
@@ -3329,14 +3344,27 @@ class TaskManager(BaseManager):
         """Get agent name for a language label from configured agent_names."""
         return self.agent_names.get(label, "")
 
-    async def switch_language(self, label, components=None):
+    async def switch_language(self, label, components=None, triggered_by: str = "manual"):
         """Switch the active language for multilingual pools.
 
         Args:
             label: language label to switch to (e.g. "hi", "en").
             components: list of component names to switch. Defaults to both.
+            triggered_by: "manual" (LLM tool call) or "lid" (automatic detection).
+                          Used in post-call telemetry to compare LID shadow detections
+                          against actual LLM-decided switches.
         """
         components = components or ["transcriber", "synthesizer"]
+
+        # Record every switch so shadow-eval can compare LID detections vs.
+        # actual LLM-decided switches on the same call.
+        self.language_switch_events.append({
+            "to_label":       label,
+            "from_label":     self.language,
+            "triggered_by":   triggered_by,
+            "switched_at":    time.time(),
+        })
+
         if "transcriber" in components and isinstance(self.tools.get("transcriber"), TranscriberPool):
             await self.tools["transcriber"].switch(label)
         if "synthesizer" in components and isinstance(self.tools.get("synthesizer"), SynthesizerPool):
@@ -4233,6 +4261,8 @@ class TaskManager(BaseManager):
                     "conversation_time": time.time() - self.start_time,
                     "label_flow": self.label_flow,
                     "function_tool_api_call_details": copy.deepcopy(self.function_tool_api_call_details),
+                    "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
+                    "language_switch_events": list(self.language_switch_events),
                     "call_sid": self.call_sid,
                     "stream_sid": self.stream_sid,
                     "transcriber_duration": self.transcriber_duration,

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -122,6 +122,8 @@ class Transcriber(BaseModel):
     keywords: Optional[str] = None
     task: Optional[str] = "transcribe"
     provider: Optional[str] = "deepgram"
+    multilingual: Optional[Dict[str, Any]] = None
+    active: Optional[str] = None
 
     @field_validator("provider")
     def validate_model(cls, value):

--- a/bolna/transcriber/__init__.py
+++ b/bolna/transcriber/__init__.py
@@ -9,3 +9,4 @@ from .gladia_transcriber import GladiaTranscriber
 from .elevenlabs_transcriber import ElevenLabsTranscriber
 from .smallest_transcriber import SmallestTranscriber
 from .transcriber_pool import TranscriberPool
+from .lid_provider import LIDProvider, SarvamLID

--- a/bolna/transcriber/lid_provider.py
+++ b/bolna/transcriber/lid_provider.py
@@ -1,0 +1,181 @@
+"""
+lid_provider.py — Language Identification (LID) via Sarvam saaras:v3.
+
+Opens a dedicated WebSocket to Sarvam with language-code=unknown so the
+server auto-detects the spoken language and returns language_code in each
+data payload alongside the transcript. Audio is forwarded in real-time
+from the TranscriberPool audio router — zero added latency to the ASR path.
+
+Usage (in TranscriberPool):
+    lid = SarvamLID(on_language=callback, config={...})
+    await lid.start()
+    lid.feed(audio_chunk_bytes)   # called for every incoming audio packet
+    await lid.stop()
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import io
+import json
+import os
+import wave
+from typing import Awaitable, Callable, Optional
+
+from bolna.helpers.logger_config import configure_logger
+
+logger = configure_logger(__name__)
+
+# Signature: async def on_language(lang: str, confidence: float) -> None
+OnLanguageCallback = Callable[[str, float], Awaitable[None]]
+
+
+class SarvamLID:
+    """
+    LID via Sarvam saaras:v3 with language_code=unknown.
+
+    Config keys (all optional, fall back to env vars):
+        sarvam_api_key     — SARVAM_API_KEY env var
+        sarvam_host        — api.sarvam.ai
+        telephony_provider — "twilio" | "plivo" | other
+        sampling_rate      — 16000
+    """
+
+    _WS_BASE = "wss://{host}/speech-to-text/ws"
+
+    def __init__(self, on_language: OnLanguageCallback, config: dict):
+        self.on_language = on_language
+        self.config = config
+        self._api_key = config.get("sarvam_api_key") or os.getenv("SARVAM_API_KEY", "")
+        self._host = config.get("sarvam_host") or os.getenv("SARVAM_HOST", "api.sarvam.ai")
+        self._telephony = config.get("telephony_provider", "")
+        self._sr = int(config.get("sampling_rate", 16000))
+        self._input_sr = 8000 if self._telephony in ("twilio", "plivo") else self._sr
+        self._encoding = "mulaw" if self._telephony == "twilio" else "linear16"
+
+        # Bounded queue: LID is best-effort. If the Sarvam WS stalls, we drop
+        # chunks rather than buffering unboundedly for the entire call duration.
+        self._queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+        self._ws = None
+        self._sender_task: Optional[asyncio.Task] = None
+        self._receiver_task: Optional[asyncio.Task] = None
+        # Set to True if the receiver loop exits abnormally (WS drop / error).
+        # feed() will log a warning when dead so silent stat bias is visible.
+        self._dead: bool = False
+
+    def _build_url(self) -> str:
+        params = {
+            "model": "saaras:v3",
+            "mode": "transcribe",
+            "language-code": "unknown",
+            "high_vad_sensitivity": "true",
+        }
+        qs = "&".join(f"{k}={v}" for k, v in params.items())
+        return f"{self._WS_BASE.format(host=self._host)}?{qs}"
+
+    def _convert_to_wav_b64(self, raw: bytes) -> Optional[str]:
+        """Convert telephony audio to 16kHz WAV base64 for Sarvam."""
+        import audioop
+        try:
+            if self._encoding == "mulaw":
+                raw = audioop.ulaw2lin(raw, 2)
+            if self._input_sr != self._sr:
+                raw, _ = audioop.ratecv(raw, 2, 1, self._input_sr, self._sr, None)
+            buf = io.BytesIO()
+            with wave.open(buf, "wb") as wf:
+                wf.setnchannels(1)
+                wf.setsampwidth(2)
+                wf.setframerate(self._sr)
+                wf.writeframes(raw)
+            return base64.b64encode(buf.getvalue()).decode()
+        except Exception as e:
+            logger.warning(f"SarvamLID audio convert error: {e}")
+            return None
+
+    async def start(self) -> None:
+        import websockets as ws_lib
+        url = self._build_url()
+        headers = {"api-subscription-key": self._api_key}
+        logger.info(f"SarvamLID: connecting to {url}")
+        self._ws = await ws_lib.connect(url, additional_headers=headers)
+        self._sender_task = asyncio.create_task(self._sender_loop())
+        self._receiver_task = asyncio.create_task(self._receiver_loop())
+        logger.info("SarvamLID: connected")
+
+    def feed(self, audio_bytes: bytes) -> None:
+        if self._dead:
+            logger.warning("SarvamLID: feed() called but WS is dead — chunk dropped (LID inactive)")
+            return
+        try:
+            self._queue.put_nowait(audio_bytes)
+        except asyncio.QueueFull:
+            logger.debug("SarvamLID: audio queue full — chunk dropped (backpressure)")
+
+    async def _sender_loop(self) -> None:
+        try:
+            while True:
+                chunk = await self._queue.get()
+                if chunk is None:
+                    break
+                b64 = self._convert_to_wav_b64(chunk)
+                if b64:
+                    msg = {"audio": {"data": b64, "encoding": "audio/wav", "sample_rate": self._sr}}
+                    await self._ws.send(json.dumps(msg))
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(f"SarvamLID sender error: {e}")
+            self._dead = True
+            logger.warning("SarvamLID: sender loop exited abnormally — LID inactive for remainder of call")
+
+    async def _receiver_loop(self) -> None:
+        try:
+            async for raw in self._ws:
+                try:
+                    data = json.loads(raw) if isinstance(raw, str) else {}
+                    if data.get("type") == "data":
+                        payload = data.get("data", {})
+                        lang = payload.get("language_code", "")
+                        # Sarvam returns language_probability=None when operating in
+                        # unknown-language mode — the language_code is the signal.
+                        # conf is passed through for API compatibility but the pool's
+                        # confidence gate is skipped for Sarvam (see _handle_lid_signal).
+                        conf = float(payload.get("language_probability") or 0.0)
+                        if lang and lang != "unknown":
+                            short = lang.split("-")[0].lower()
+                            logger.info(f"SarvamLID: detected {lang!r} (short={short!r}, conf={conf:.2f})")
+                            await self.on_language(short, conf)
+                except Exception as e:
+                    logger.error(f"SarvamLID receiver parse error: {e}")
+        except asyncio.CancelledError:
+            pass
+        except Exception as e:
+            logger.error(f"SarvamLID receiver error: {e}")
+            self._dead = True
+            logger.warning("SarvamLID: receiver loop exited abnormally — LID inactive for remainder of call")
+
+    async def stop(self) -> None:
+        self._queue.put_nowait(None)
+        for task in (self._sender_task, self._receiver_task):
+            if task and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+        logger.info("SarvamLID: stopped")
+
+
+# Thin factory shim for backward compatibility
+class LIDProvider:
+    @classmethod
+    def create(cls, provider: str, on_language: OnLanguageCallback, config: dict) -> SarvamLID:
+        if provider.lower() != "sarvam":
+            logger.warning(f"LIDProvider: unknown provider '{provider}', falling back to sarvam")
+        return SarvamLID(on_language=on_language, config=config)

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -1,7 +1,16 @@
 import asyncio
+import os
+import time
+from typing import Callable, Awaitable, Optional
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
+
+# LID_MODE controls whether confirmed detections actually switch the stack.
+#   "shadow"  — log detections + suppressed_reason but never call switch/on_lid_switch
+#   "active"  — live switching (opt-in)
+# Default is "shadow" so the feature is safe to deploy without data first.
+_LID_MODE = os.getenv("LID_MODE", "shadow").lower()
 
 
 class TranscriberPool:
@@ -22,7 +31,17 @@ class TranscriberPool:
     # heartbeats are being sent.  10s gives a comfortable safety margin.
     _KEEPALIVE_INTERVAL = 10
 
-    def __init__(self, transcribers, shared_input_queue, output_queue, active_label, multilingual_config):
+    # ── LID defaults ──────────────────────────────────────────────────────
+    # Require this many consecutive same-language detections before switching.
+    _LID_DEBOUNCE_COUNT = 2
+    # Minimum confidence score to accept a LID detection.
+    _LID_CONFIDENCE_THRESHOLD = 0.70
+    # Seconds to wait after a switch before accepting new LID signals.
+    _LID_COOLDOWN_S = 10.0
+
+    def __init__(self, transcribers, shared_input_queue, output_queue, active_label, multilingual_config,
+                 lid_provider: str = None, lid_config: dict = None,
+                 on_lid_switch: Optional[Callable[[str], Awaitable[None]]] = None):
         """
         Args:
             transcribers: dict mapping label -> transcriber instance.
@@ -33,6 +52,10 @@ class TranscriberPool:
                           write to the same one).
             active_label: which transcriber label should receive audio initially.
             multilingual_config: raw multilingual config dict from task_config
+            lid_provider: "sarvam" | None (disables LID tap)
+            lid_config: extra config forwarded to the LID backend
+            on_lid_switch: async callback(label) invoked when LID confirms a switch.
+                           Typically wired to TaskManager.switch_language().
         """
         self.transcribers = transcribers
         self.shared_input_queue = shared_input_queue
@@ -44,6 +67,34 @@ class TranscriberPool:
         self._router_task = None
         self._keepalive_task = None
         self._multilingual_config = multilingual_config
+
+        # ── LID tap state ──────────────────────────────────────────────────
+        self._lid_provider_name = lid_provider
+        self._lid_config = lid_config or {}
+        self._lid: Optional[object] = None          # LIDProvider instance
+        self._lid_task: Optional[asyncio.Task] = None
+        self._on_lid_switch = on_lid_switch
+        # "shadow" logs detections without switching; "active" performs live switch.
+        self._lid_mode = _LID_MODE
+        # Accumulates detection events during the call; flushed into task_output
+        # at call end so server.py can persist them in bulk — same pattern as
+        # function_tool_api_call_details / call_interruption_stats.
+        self.lid_detection_events: list[dict] = []
+
+        # Debounce state
+        self._lid_pending_lang: Optional[str] = None
+        self._lid_pending_count: int = 0
+        self._lid_last_switch_time: float = 0.0
+
+        # Map language ISO codes → transcriber labels (built from multilingual_config)
+        # e.g. {"hi": "hindi", "en": "english"}
+        self._lang_to_label: dict[str, str] = {}
+        if multilingual_config:
+            for label, cfg in multilingual_config.items():
+                lang = (cfg.get("language_code") or cfg.get("language") or "").lower()
+                short = lang.split("-")[0]
+                if short:
+                    self._lang_to_label[short] = label
 
     # ------------------------------------------------------------------
     # Properties that delegate to the active transcriber
@@ -79,7 +130,7 @@ class TranscriberPool:
         return self.transcribers[self.active_label].get_meta_info()
 
     async def run(self):
-        """Start all transcribers, the audio router, and the standby keepalive."""
+        """Start all transcribers, the audio router, standby keepalive, and LID tap."""
         for label, transcriber in self.transcribers.items():
             logger.info(f"TranscriberPool: starting transcriber '{label}'")
             await transcriber.run()
@@ -87,6 +138,10 @@ class TranscriberPool:
         self._router_task = asyncio.create_task(self._audio_router())
         self._keepalive_task = asyncio.create_task(self._standby_keepalive())
         logger.info(f"TranscriberPool: audio router started, active='{self.active_label}'")
+
+        # Start LID tap if configured
+        if self._lid_provider_name:
+            await self._start_lid_tap()
 
     @staticmethod
     def _silence_frame(encoding):
@@ -97,12 +152,21 @@ class TranscriberPool:
         return b"\x00" * 320
 
     async def _audio_router(self):
-        """Read from the shared input queue and forward to the active transcriber's private queue."""
+        """Read from the shared input queue, forward to active transcriber, and feed LID tap."""
         try:
             while True:
                 packet = await self.shared_input_queue.get()
                 active = self.active_label
                 self.transcribers[active].input_queue.put_nowait(packet)
+
+                # Feed raw audio to LID tap (if running)
+                if self._lid is not None:
+                    audio_data = packet.get("data") if isinstance(packet, dict) else None
+                    if audio_data and isinstance(audio_data, bytes):
+                        try:
+                            self._lid.feed(audio_data)
+                        except Exception as e:
+                            logger.debug(f"TranscriberPool: LID feed error: {e}")
         except asyncio.CancelledError:
             logger.info("TranscriberPool: audio router cancelled")
 
@@ -136,6 +200,153 @@ class TranscriberPool:
                     )
         except asyncio.CancelledError:
             logger.info("TranscriberPool: standby keepalive cancelled")
+
+    async def _start_lid_tap(self) -> None:
+        """Instantiate and connect the configured LID provider."""
+        try:
+            from bolna.transcriber.lid_provider import LIDProvider
+            self._lid = LIDProvider.create(
+                provider=self._lid_provider_name,
+                on_language=self._handle_lid_signal,
+                config=self._lid_config,
+            )
+            await self._lid.start()
+            logger.info(f"TranscriberPool: LID tap started (provider={self._lid_provider_name})")
+        except Exception as e:
+            logger.error(f"TranscriberPool: failed to start LID tap: {e}")
+            self._lid = None
+
+    def _record_lid_event(
+        self,
+        detected_lang: str,
+        confidence: float,
+        target_label: Optional[str],
+        would_switch: bool,
+        suppressed_reason: Optional[str],
+    ) -> None:
+        """Append a detection event to lid_detection_events.
+
+        Events are collected in-memory during the call and returned in task_output
+        so server.py can persist them in bulk — identical to how
+        function_tool_api_call_details works for tool_call_api_logs.
+        No DB, no HTTP, no callbacks needed inside bolna.
+        """
+        self.lid_detection_events.append({
+            "detected_lang": detected_lang,
+            "confidence": confidence,
+            "active_label": self.active_label,
+            "target_label": target_label,
+            "lid_mode": self._lid_mode,
+            "would_switch": would_switch,
+            "suppressed_reason": suppressed_reason,
+        })
+
+    async def _handle_lid_signal(self, lang: str, confidence: float) -> None:
+        """
+        Called by the LID provider every time it detects a language.
+
+        Applies debounce (N consecutive same-language detections above threshold)
+        and cooldown (no switching within X seconds of the last switch).
+
+        In shadow mode (LID_MODE=shadow, the default): logs what would happen but
+        never calls switch() or on_lid_switch.
+
+        In active mode (LID_MODE=active): delegates the full transition to
+        on_lid_switch (TaskManager.switch_language), which owns transcriber +
+        synthesizer + system-prompt atomically. We do NOT call self.switch() here
+        to avoid the double-switch race where the transcriber flips before the
+        synthesizer and prompt catch up.
+        """
+        # Skip confidence check for Sarvam — it doesn't return language_probability
+        # in unknown-language mode; the language_code itself is the detection signal.
+        if self._lid_provider_name != "sarvam" and confidence < self._LID_CONFIDENCE_THRESHOLD:
+            logger.debug(
+                f"TranscriberPool LID: {lang} conf={confidence:.2f} below threshold — suppressed"
+            )
+            return
+
+        # Use same fallback as _lang_to_label build: language_code first, then language.
+        _active_cfg = self._multilingual_config.get(self.active_label, {})
+        active_lang = (
+            _active_cfg.get("language_code") or _active_cfg.get("language") or ""
+        ).split("-")[0].lower()
+        if lang == active_lang:
+            self._lid_pending_lang = None
+            self._lid_pending_count = 0
+            return
+
+        # Cooldown check
+        now = time.monotonic()
+        if now - self._lid_last_switch_time < self._LID_COOLDOWN_S:
+            logger.debug(
+                f"TranscriberPool LID: cooldown active — suppressed {lang} "
+                f"(suppressed_reason=cooldown)"
+            )
+            return
+
+        # Debounce accumulation
+        if lang == self._lid_pending_lang:
+            self._lid_pending_count += 1
+        else:
+            self._lid_pending_lang = lang
+            self._lid_pending_count = 1
+
+        logger.debug(
+            f"TranscriberPool LID: {lang} conf={confidence:.2f} "
+            f"count={self._lid_pending_count}/{self._LID_DEBOUNCE_COUNT}"
+        )
+
+        if self._lid_pending_count < self._LID_DEBOUNCE_COUNT:
+            return
+
+        target_label = self._lang_to_label.get(lang)
+        if not target_label:
+            logger.warning(
+                f"TranscriberPool LID: detected lang '{lang}' has no matching transcriber. "
+                f"Available: {self._lang_to_label}"
+            )
+            return
+
+        if target_label == self.active_label:
+            return
+
+        self._lid_pending_lang = None
+        self._lid_pending_count = 0
+
+        if self._lid_mode == "shadow":
+            logger.info(
+                f"TranscriberPool LID [shadow]: would switch {self.active_label} → {target_label} "
+                f"(lang={lang}, conf={confidence:.2f}, suppressed_reason=shadow_mode)"
+            )
+            self._lid_last_switch_time = now
+            self._record_lid_event(
+                detected_lang=lang,
+                confidence=confidence,
+                target_label=target_label,
+                would_switch=False,
+                suppressed_reason="shadow_mode",
+            )
+            return
+
+        # Active mode — hand full transition to on_lid_switch so transcriber,
+        # synthesizer, and system-prompt all flip atomically.
+        logger.info(
+            f"TranscriberPool LID [active]: switching {self.active_label} → {target_label} "
+            f"(lang={lang}, conf={confidence:.2f})"
+        )
+        self._lid_last_switch_time = now
+        self._record_lid_event(
+            detected_lang=lang,
+            confidence=confidence,
+            target_label=target_label,
+            would_switch=True,
+            suppressed_reason=None,
+        )
+        if self._on_lid_switch:
+            try:
+                await self._on_lid_switch(target_label, triggered_by="lid")
+            except Exception as e:
+                logger.error(f"TranscriberPool: on_lid_switch callback error: {e}")
 
     async def switch(self, label):
         """Switch which transcriber receives audio.
@@ -180,7 +391,7 @@ class TranscriberPool:
         return info
 
     async def cleanup(self):
-        """Clean up all transcribers and cancel pool tasks."""
+        """Clean up all transcribers, cancel pool tasks, and stop LID tap."""
         for task_name, task in [("router", self._router_task), ("keepalive", self._keepalive_task)]:
             if task and not task.done():
                 task.cancel()
@@ -189,6 +400,14 @@ class TranscriberPool:
                 except asyncio.CancelledError:
                     pass
                 logger.info(f"TranscriberPool: {task_name} task cancelled")
+
+        # Stop LID tap
+        if self._lid is not None:
+            try:
+                await self._lid.stop()
+                logger.info("TranscriberPool: LID tap stopped")
+            except Exception as e:
+                logger.warning(f"TranscriberPool: error stopping LID tap: {e}")
 
         for label, transcriber in self.transcribers.items():
             logger.info(f"TranscriberPool: cleaning up '{label}'")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.21"
+version = "0.10.22"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.22"
+version = "0.10.23"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Adds Language Identification (LID) via Sarvam saaras:v3 to the transcriber pipeline.

What's in:

lid_provider.py — Sarvam LID client with bounded queue (maxsize=200), WebSocket health flag (_dead), and backpressure handling
transcriber_pool.py — LID tap on the audio router with debounce (2 consecutive), cooldown (10s), and shadow mode (LID_MODE=shadow default — logs detections, never switches live)
task_manager.py — records manual switch_language calls with triggered_by for post-call shadow evaluation; exposes lid_detection_events + language_switch_events in task_output