### PR TITLE
feat: emit synthesizer_chunk_marks in latency_dict for post-call audio analysis

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.47"
+__version__ = "0.10.48"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5102,6 +5102,7 @@ class TaskManager(BaseManager):
                         ),
                         "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
+                        "synthesizer_chunk_marks": self.mark_event_meta_data.get_chunk_marks(),
                     },
                     "hangup_detail": self.hangup_detail,
                     "has_transfer": self.has_transfer,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5209,7 +5209,6 @@ class TaskManager(BaseManager):
                         "asr_start_ms",
                         "asr_finalized_ms",
                         "asr_turn_start_ms",
-                        "final_transcript",
                     ):
                         _t.pop(_f, None)
 

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -60,6 +60,7 @@ class MarkEventMetaData:
     def __init__(self):
         self.mark_event_meta_data = {}
         self.previous_mark_event_meta_data = {}
+        self._mark_history: Dict[str, Dict] = {}
         self.counter = 0
         self.mark_changed = asyncio.Event()
         self._mark_stats = MarkStats()
@@ -70,8 +71,12 @@ class MarkEventMetaData:
 
     def update_data(self, mark_id, value):
         value["counter"] = self.counter
+        value.setdefault("acked", False)
+        value.setdefault("ack_ts", None)
         self.counter += 1
         self.mark_event_meta_data[mark_id] = value
+        if value.get("type") != "pre_mark_message":
+            self._mark_history[mark_id] = value
         logger.info(
             "BOLNA_TRACE_MARK update mark_id=%s type=%s seq=%s turn=%s response_uid=%s group_uid=%s counter=%s dur=%.3f text_len=%s",
             mark_id,
@@ -144,6 +149,10 @@ class MarkEventMetaData:
         return (self.heard_text_by_response.get(response_uid) or "").strip()
 
     def fetch_data(self, mark_id):
+        entry = self.mark_event_meta_data.get(mark_id)
+        if entry is not None and entry.get("type") != "pre_mark_message":
+            entry["acked"] = True
+            entry["ack_ts"] = time.time()
         result = self.mark_event_meta_data.pop(mark_id, {})
         if result:
             logger.info(
@@ -170,6 +179,7 @@ class MarkEventMetaData:
 
         for mark_id, value in self.mark_event_meta_data.items():
             if value.get("type") != "pre_mark_message":
+                value["cleared_on_interrupt"] = True
                 seq = value.get("sequence_id")
                 if seq is not None and seq in self._mark_stats.per_sequence:
                     self._mark_stats.per_sequence[seq].interrupted = True
@@ -217,6 +227,36 @@ class MarkEventMetaData:
 
     def fetch_cleared_mark_event_data(self):
         return self.previous_mark_event_meta_data
+
+    def get_chunk_marks(self) -> List[Dict]:
+        """Per-mark wall-clock detail for post-call audio analysis.
+
+        Returns one dict per agent audio chunk (excluding pre_mark_message), ordered
+        by send counter. Each entry carries the actually-spoken text, send/ack
+        timestamps, sequence/turn linkage, and an interruption flag.
+        """
+        out = []
+        for mark_id, data in self._mark_history.items():
+            if data.get("type") == "pre_mark_message":
+                continue
+            out.append(
+                {
+                    "mark_id": mark_id,
+                    "sequence_id": data.get("sequence_id"),
+                    "type": data.get("type"),
+                    "text_synthesized": data.get("text_synthesized", ""),
+                    "is_first_chunk": data.get("is_first_chunk", False),
+                    "is_final_chunk": data.get("is_final_chunk", False),
+                    "sent_ts": data.get("sent_ts"),
+                    "duration": data.get("duration"),
+                    "counter": data.get("counter"),
+                    "acked": data.get("acked", False),
+                    "ack_ts": data.get("ack_ts"),
+                    "cleared_on_interrupt": data.get("cleared_on_interrupt", False),
+                }
+            )
+        out.sort(key=lambda m: m["sent_ts"] if m.get("sent_ts") is not None else 0)
+        return out
 
     def __str__(self):
         return f"{self.mark_event_meta_data}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.47"
+version = "0.10.48"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_mark_event_chunk_marks.py
+++ b/tests/tests/test_mark_event_chunk_marks.py
@@ -1,0 +1,105 @@
+"""Tests for the post-call observability primitives on MarkEventMetaData.
+
+Covers get_chunk_marks(), ack persistence on fetch_data, cleared_on_interrupt
+flagging, ordering by sent_ts, and pre_mark_message exclusion.
+"""
+
+import time
+
+import pytest
+
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+
+
+def _audio_chunk(seq_id: int, text: str, sent_ts: float, duration: float = 0.5) -> dict:
+    return {
+        "type": "",
+        "text_synthesized": text,
+        "is_first_chunk": False,
+        "is_final_chunk": False,
+        "sequence_id": seq_id,
+        "duration": duration,
+        "sent_ts": sent_ts,
+    }
+
+
+class TestGetChunkMarks:
+    def test_excludes_pre_mark_messages(self):
+        m = MarkEventMetaData()
+        m.update_data("pre-1", {"type": "pre_mark_message"})
+        m.update_data("audio-1", _audio_chunk(1, "hello", 100.0))
+
+        marks = m.get_chunk_marks()
+        assert len(marks) == 1
+        assert marks[0]["mark_id"] == "audio-1"
+        assert marks[0]["text_synthesized"] == "hello"
+
+    def test_marks_sorted_by_sent_ts(self):
+        m = MarkEventMetaData()
+        m.update_data("c", _audio_chunk(1, "third", 300.0))
+        m.update_data("a", _audio_chunk(1, "first", 100.0))
+        m.update_data("b", _audio_chunk(1, "second", 200.0))
+
+        marks = m.get_chunk_marks()
+        assert [mark["text_synthesized"] for mark in marks] == ["first", "second", "third"]
+
+    def test_initial_state_unacked(self):
+        m = MarkEventMetaData()
+        m.update_data("audio-1", _audio_chunk(1, "hi", 100.0))
+
+        marks = m.get_chunk_marks()
+        assert marks[0]["acked"] is False
+        assert marks[0]["ack_ts"] is None
+
+    def test_fetch_data_marks_as_acked_and_persists_in_history(self):
+        m = MarkEventMetaData()
+        m.update_data("audio-1", _audio_chunk(1, "hi", 100.0))
+
+        before = time.time()
+        popped = m.fetch_data("audio-1")
+        after = time.time()
+
+        assert popped["acked"] is True
+        assert before <= popped["ack_ts"] <= after
+        assert "audio-1" not in m.mark_event_meta_data
+
+        marks = m.get_chunk_marks()
+        assert len(marks) == 1
+        assert marks[0]["acked"] is True
+        assert marks[0]["ack_ts"] == popped["ack_ts"]
+
+    def test_clear_data_flags_unacked_marks(self):
+        m = MarkEventMetaData()
+        m.update_data("acked-mark", _audio_chunk(1, "got it", 100.0))
+        m.update_data("dropped-mark", _audio_chunk(1, "interrupted tail", 150.0))
+
+        m.fetch_data("acked-mark")
+        m.clear_data()
+
+        by_id = {mark["mark_id"]: mark for mark in m.get_chunk_marks()}
+        assert by_id["acked-mark"]["acked"] is True
+        assert by_id["acked-mark"]["cleared_on_interrupt"] is False
+        assert by_id["dropped-mark"]["acked"] is False
+        assert by_id["dropped-mark"]["cleared_on_interrupt"] is True
+
+    def test_history_survives_repeated_clears(self):
+        m = MarkEventMetaData()
+        m.update_data("turn1-chunk", _audio_chunk(1, "first turn", 100.0))
+        m.fetch_data("turn1-chunk")
+        m.clear_data()
+
+        m.update_data("turn2-chunk", _audio_chunk(2, "second turn", 200.0))
+        m.fetch_data("turn2-chunk")
+
+        marks = m.get_chunk_marks()
+        assert len(marks) == 2
+        assert {mark["sequence_id"] for mark in marks} == {1, 2}
+
+    def test_multi_chunk_sequence_kept_in_send_order(self):
+        m = MarkEventMetaData()
+        for i, ts in enumerate([100.0, 100.5, 101.0]):
+            m.update_data(f"chunk-{i}", _audio_chunk(7, f"part-{i}", ts))
+
+        marks = m.get_chunk_marks()
+        assert [mark["text_synthesized"] for mark in marks] == ["part-0", "part-1", "part-2"]
+        assert all(mark["sequence_id"] == 7 for mark in marks)


### PR DESCRIPTION
Adds `synthesizer_chunk_marks` to `latency_dict` so dashboard-backend's post-call audio analyzer can compute per-chunk TTS quality, truncation, and dropout metrics.

## What's added

* `MarkEventMetaData._mark_history` — durable per-chunk record that survives `clear_data()` on interruption.
* `acked` / `ack_ts` flags set on each mark when telephony acknowledges; `cleared_on_interrupt` flag set when user barges in.
* `get_chunk_marks()` returns ordered list of agent audio chunks with `mark_id`, `sequence_id`, `text_synthesized`, `sent_ts`, `duration`, `acked`, `ack_ts`, `cleared_on_interrupt`.
* `latency_dict.synthesizer_chunk_marks` populated at end-of-call.

`final_transcript` on transcriber turn_latencies was already added by #690.