### PR TITLE
feat: add end-to-end observability timestamps for call progression

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.41"
+__version__ = "0.10.42"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.37"
+__version__ = "0.10.38"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.38"
+__version__ = "0.10.39"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.29"
+__version__ = "0.10.30"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.42"
+__version__ = "0.10.43"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.40"
+__version__ = "0.10.41"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -60,6 +60,7 @@ class InterruptionManager:
 
         self._adjusted_user_stop_ts: Optional[float] = None
         self._last_user_start_ts: float = -1
+        self._pending_user_start_ts: float = -1  # snapshot of user_start paired with _adjusted_user_stop_ts
         self.user_bot_latencies: List[Dict] = []
 
         logger.info(
@@ -182,6 +183,7 @@ class InterruptionManager:
                 self._adjusted_user_stop_ts = user_stop_ts_wall
             else:
                 self._adjusted_user_stop_ts = now_s - (stop_offset_ms / 1000.0)
+            self._pending_user_start_ts = self._last_user_start_ts
 
         if self.callee_speaking_start_time > 0:
             self._total_user_speaking_ms += (now_s - self.callee_speaking_start_time) * 1000
@@ -258,13 +260,14 @@ class InterruptionManager:
             self.user_bot_latencies.append(
                 {
                     "sequence_id": sequence_id,
-                    "user_start_s": self._last_user_start_ts if self._last_user_start_ts > 0 else None,
+                    "user_start_s": self._pending_user_start_ts if self._pending_user_start_ts > 0 else None,
                     "user_end_s": self._adjusted_user_stop_ts,
                     "agent_start_s": now_s,
                     "latency_ms": round(latency_ms, 2),
                 }
             )
             self._adjusted_user_stop_ts = None
+            self._pending_user_start_ts = -1
 
         logger.info(f"Agent speech started (sequence_id={sequence_id})")
 

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -59,6 +59,7 @@ class InterruptionManager:
         self.longest_agent_monologue_ms: float = 0.0
 
         self._adjusted_user_stop_ts: Optional[float] = None
+        self._last_user_start_ts: float = -1
         self.user_bot_latencies: List[Dict] = []
 
         logger.info(
@@ -145,6 +146,7 @@ class InterruptionManager:
         if not self.callee_speaking:
             self.callee_speaking = True
             self.callee_speaking_start_time = time.time()
+            self._last_user_start_ts = self.callee_speaking_start_time
             logger.info("User started speaking")
 
     def on_interim_transcript_received(self) -> None:
@@ -203,6 +205,7 @@ class InterruptionManager:
 
         event: Dict = {
             "type": "user_interrupted_agent",
+            "turn_id": self.turn_id,
             "user_start_s": self.callee_speaking_start_time if self.callee_speaking_start_time > 0 else None,
             "user_end_s": None,
             "recovery_completed": False,
@@ -224,6 +227,7 @@ class InterruptionManager:
 
         event: Dict = {
             "type": "agent_interrupted_user",
+            "turn_id": self.turn_id,
             "user_start_s": self.callee_speaking_start_time if self.callee_speaking_start_time > 0 else None,
             "user_end_s": None,
             "recovery_completed": False,
@@ -254,6 +258,7 @@ class InterruptionManager:
             self.user_bot_latencies.append(
                 {
                     "sequence_id": sequence_id,
+                    "user_start_s": self._last_user_start_ts if self._last_user_start_ts > 0 else None,
                     "user_end_s": self._adjusted_user_stop_ts,
                     "agent_start_s": now_s,
                     "latency_ms": round(latency_ms, 2),

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -260,7 +260,8 @@ class InterruptionManager:
             self.user_bot_latencies.append(
                 {
                     "sequence_id": sequence_id,
-                    "user_start_s": self._pending_user_start_ts if self._pending_user_start_ts > 0 else None,
+                    "user_start_s": self._last_user_start_ts if self._last_user_start_ts > 0 else None,
+                    "user_first_start_s": self._pending_user_start_ts if self._pending_user_start_ts > 0 else None,
                     "user_end_s": self._adjusted_user_stop_ts,
                     "agent_start_s": now_s,
                     "latency_ms": round(latency_ms, 2),

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -269,6 +269,20 @@ class InterruptionManager:
             )
             self._adjusted_user_stop_ts = None
             self._pending_user_start_ts = -1
+        else:
+            # Tool-call follow-up or any agent response without a preceding user turn
+            # in this sequence (e.g. seq=5 after a tool call consumed seq=4's user timing).
+            # Record agent_start_s so agent_speech_start appears in the progression.
+            self.user_bot_latencies.append(
+                {
+                    "sequence_id": sequence_id,
+                    "user_start_s": None,
+                    "user_first_start_s": None,
+                    "user_end_s": None,
+                    "agent_start_s": now_s,
+                    "latency_ms": None,
+                }
+            )
 
         logger.info(f"Agent speech started (sequence_id={sequence_id})")
 

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -220,7 +220,7 @@ class InterruptionManager:
             f"Interruption triggered — turn_id={self.turn_id}, user_interrupted_agent_count={self.user_interrupted_agent_count}"
         )
 
-    def on_agent_interrupted_user(self) -> None:
+    def on_agent_interrupted_user(self, asr_turn_id: Optional[int] = None) -> None:
         """Agent responded prematurely and was cancelled within the grace period.
         Does NOT set _awaiting_recovery — recovery is only tracked for user barge-ins
         to keep barge_in_recovery_rate denominator consistent with user_interrupted_agent_count.
@@ -231,6 +231,7 @@ class InterruptionManager:
         event: Dict = {
             "type": "agent_interrupted_user",
             "turn_id": self.turn_id,
+            "asr_turn_id": asr_turn_id,
             "user_start_s": self.callee_speaking_start_time if self.callee_speaking_start_time > 0 else None,
             "user_end_s": None,
             "recovery_completed": False,

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -197,7 +197,7 @@ class InterruptionManager:
 
     # ── Interruption event callbacks ──────────────────────────────────────────
 
-    def on_interruption_triggered(self) -> None:
+    def on_interruption_triggered(self, asr_turn_id: Optional[int] = None) -> None:
         """User barged in while agent was speaking. user_end_s filled later by on_user_speech_ended()."""
         self.turn_id += 1
         self.user_interrupted_agent_count += 1
@@ -208,6 +208,7 @@ class InterruptionManager:
         event: Dict = {
             "type": "user_interrupted_agent",
             "turn_id": self.turn_id,
+            "asr_turn_id": asr_turn_id,
             "user_start_s": self.callee_speaking_start_time if self.callee_speaking_start_time > 0 else None,
             "user_end_s": None,
             "recovery_completed": False,
@@ -350,6 +351,7 @@ class InterruptionManager:
             entry: Dict = {
                 "type": e["type"],
                 "recovery_completed": e["recovery_completed"],
+                "asr_turn_id": e.get("asr_turn_id"),
             }
             if e.get("user_start_s") is not None:
                 entry["user_start_ms"] = round(e["user_start_s"] * 1000 - call_start_ms, 2)

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -276,6 +276,20 @@ class InterruptionManager:
         """Clean end of agent audio (end_of_synthesizer_stream in SEND path)."""
         self._finalize_agent_speaking_session()
 
+    def on_agent_audio_fully_played(self, sequence_id: int, ts: float) -> None:
+        """Record when the telephony provider ACKed the last audio mark for a sequence.
+
+        Called from final_chunk_played_observer via task_manager when is_final_chunk
+        mark is received back. This is the actual end of audio playback at the caller's
+        phone — more accurate than on_agent_speech_ended which fires at ElevenLabs
+        stream-end (much earlier than real playback end).
+        """
+        for entry in reversed(self.user_bot_latencies):
+            if entry.get("sequence_id") == sequence_id:
+                entry["agent_end_s"] = ts
+                logger.info(f"Recorded agent audio fully played: sequence_id={sequence_id}")
+                return
+
     def _finalize_agent_speaking_session(self) -> None:
         """Close current agent speaking window; called on clean end or barge-in."""
         if self._agent_speaking_start_time <= 0:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -617,6 +617,7 @@ class TaskManager(BaseManager):
             "meta": {
                 "request_id": meta_info.get("request_id"),
                 "sequence_id": meta_info.get("sequence_id"),
+                "turn_id": meta_info.get("turn_id"),
             },
             "started_at": datetime.now().isoformat(),
             "status": "pending",

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4265,6 +4265,8 @@ class TaskManager(BaseManager):
                         _turn["asr_start_ms"] = round(_turn.pop("asr_start_epoch_ms") - _call_start_ms, 2)
                     if _turn.get("asr_finalized_epoch_ms") is not None:
                         _turn["asr_finalized_ms"] = round(_turn.pop("asr_finalized_epoch_ms") - _call_start_ms, 2)
+                    if _turn.get("asr_turn_start_epoch_ms") is not None:
+                        _turn["asr_turn_start_ms"] = round(_turn.pop("asr_turn_start_epoch_ms") - _call_start_ms, 2)
 
                 # Collect language detection latency if available
                 if hasattr(self, "language_detector") and self.language_detector.latency_data:
@@ -4275,6 +4277,7 @@ class TaskManager(BaseManager):
                     {
                         "sequence_id": e["sequence_id"],
                         "user_start_ms": round(e["user_start_s"] * 1000 - _call_start_ms, 2) if e.get("user_start_s") and e["user_start_s"] > 0 else None,
+                        "user_first_start_ms": round(e["user_first_start_s"] * 1000 - _call_start_ms, 2) if e.get("user_first_start_s") and e["user_first_start_s"] > 0 else None,
                         "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
                         "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1622,7 +1622,10 @@ class TaskManager(BaseManager):
 
         new_sequence_id = self.interruption_manager.get_next_sequence_id()
         meta_info_copy["sequence_id"] = new_sequence_id
-        meta_info_copy["turn_id"] = getattr(self.tools.get("transcriber"), "turn_counter", 0)
+        _transcriber = self.tools.get("transcriber")
+        if hasattr(_transcriber, "transcribers") and hasattr(_transcriber, "active_label"):
+            _transcriber = _transcriber.transcribers.get(_transcriber.active_label, _transcriber)
+        meta_info_copy["turn_id"] = getattr(_transcriber, "turn_counter", 0)
 
         return meta_info_copy
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2599,6 +2599,7 @@ class TaskManager(BaseManager):
                     is_cached=False,
                     run_id=self.run_id,
                 )
+                _transfer_end_recorded = False
                 try:
                     async with session.post(url, json=payload) as response:
                         response_text = await response.text()
@@ -2628,6 +2629,7 @@ class TaskManager(BaseManager):
                             "latency_ms": function_call_log.get("latency_ms"),
                             "success": response.status < 400,
                         })
+                        _transfer_end_recorded = True
                 except Exception as transfer_exc:
                     logger.warning(f"Transfer webhook did not respond (call likely redirected): {transfer_exc}")
                     self._finalize_api_call_detail(function_call_log, error=transfer_exc)
@@ -2641,6 +2643,23 @@ class TaskManager(BaseManager):
                         "latency_ms": function_call_log.get("latency_ms"),
                         "success": None,
                     })
+                    _transfer_end_recorded = True
+                finally:
+                    # CancelledError (BaseException) bypasses except — ensure transfer_end is
+                    # always recorded so it appears in progression_data even if the task is
+                    # cancelled mid-flight when Plivo terminates the call.
+                    if not _transfer_end_recorded:
+                        self._finalize_api_call_detail(function_call_log, error="cancelled")
+                        self.transfer_call_events.append({
+                            "type": "transfer_end",
+                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                            "tool_call_id": resp.get("tool_call_id", ""),
+                            "turn_id": meta_info.get("turn_id"),
+                            "sequence_id": meta_info.get("sequence_id"),
+                            "status_code": None,
+                            "latency_ms": function_call_log.get("latency_ms"),
+                            "success": None,
+                        })
                 return
 
         if called_fun == "switch_language":
@@ -4366,8 +4385,9 @@ class TaskManager(BaseManager):
                         self.response_in_pipeline = False
                         await self.tools["output"].handle(message)
                         # Track when agent audio first starts flowing for this sequence.
-                        # Deduplicated inside on_agent_speech_started — safe to call per chunk.
-                        if sequence_id is not None and sequence_id != -1:
+                        # Only fire on real audio bytes — BOS/EOS control packets are strings
+                        # and fire before _synthesize() sets tts_start_ms, causing inversion.
+                        if sequence_id is not None and sequence_id != -1 and isinstance(message.get("data"), bytes):
                             self.interruption_manager.on_agent_speech_started(sequence_id)
                         try:
                             duration = calculate_audio_duration(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4957,6 +4957,11 @@ class TaskManager(BaseManager):
                     if _seq is not None and _seq in _seq_to_asr_turn:
                         _ub["turn_id"] = _seq_to_asr_turn[_seq]
 
+                for _tts_t in output["progression_data"]["synthesizer_latencies"].get("turn_latencies", []):
+                    _seq = _tts_t.get("sequence_id")
+                    if _seq is not None and _seq in _seq_to_asr_turn:
+                        _tts_t["turn_id"] = _seq_to_asr_turn[_seq]
+
                 # Strip PR-added fields from latency_dict sub-dicts so latency_dict stays at master state.
                 # progression_data (deep-copied above) keeps the full enriched versions.
                 _llm_turns = (output["latency_dict"]["llm_latencies"] or {}).get("turn_latencies", [])

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2599,35 +2599,49 @@ class TaskManager(BaseManager):
                     is_cached=False,
                     run_id=self.run_id,
                 )
-                async with session.post(url, json=payload) as response:
-                    response_text = await response.text()
-                    logger.info(f"Response from the server after call transfer: {response_text}")
-                    convert_to_request_log(
-                        str(response_text),
-                        meta_info,
-                        None,
-                        LogComponent.FUNCTION_CALL,
-                        direction=LogDirection.RESPONSE,
-                        is_cached=False,
-                        run_id=self.run_id,
-                    )
-                    self._finalize_api_call_detail(
-                        function_call_log,
-                        response=response_text,
-                        status_code=response.status,
-                        content_type=response.headers.get("Content-Type"),
-                    )
+                try:
+                    async with session.post(url, json=payload) as response:
+                        response_text = await response.text()
+                        logger.info(f"Response from the server after call transfer: {response_text}")
+                        convert_to_request_log(
+                            str(response_text),
+                            meta_info,
+                            None,
+                            LogComponent.FUNCTION_CALL,
+                            direction=LogDirection.RESPONSE,
+                            is_cached=False,
+                            run_id=self.run_id,
+                        )
+                        self._finalize_api_call_detail(
+                            function_call_log,
+                            response=response_text,
+                            status_code=response.status,
+                            content_type=response.headers.get("Content-Type"),
+                        )
+                        self.transfer_call_events.append({
+                            "type": "transfer_end",
+                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                            "tool_call_id": resp.get("tool_call_id", ""),
+                            "turn_id": meta_info.get("turn_id"),
+                            "sequence_id": meta_info.get("sequence_id"),
+                            "status_code": response.status,
+                            "latency_ms": function_call_log.get("latency_ms"),
+                            "success": response.status < 400,
+                        })
+                except Exception as transfer_exc:
+                    logger.warning(f"Transfer webhook did not respond (call likely redirected): {transfer_exc}")
+                    self._finalize_api_call_detail(function_call_log, error=transfer_exc)
                     self.transfer_call_events.append({
                         "type": "transfer_end",
                         "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
                         "tool_call_id": resp.get("tool_call_id", ""),
                         "turn_id": meta_info.get("turn_id"),
                         "sequence_id": meta_info.get("sequence_id"),
-                        "status_code": response.status,
+                        "status_code": None,
                         "latency_ms": function_call_log.get("latency_ms"),
-                        "success": response.status < 400,
+                        "success": None,
                     })
-                    return
+                return
 
         if called_fun == "switch_language":
             language_label = resp.get("language", "")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3371,12 +3371,14 @@ class TaskManager(BaseManager):
             logger.info(f"process_call_hangup: Hangup already in progress or conversation ended, skipping")
             return
 
-        # Set immediately to prevent user interruptions from cancelling hangup
+        # hangup_triggered flag set immediately to prevent user interruptions from cancelling hangup.
+        # hangup_triggered_at is set AFTER the goodbye plays so progression shows
+        # the actual disconnect time, not the decision time (use hangup_decision_at for that).
         self.hangup_triggered = True
-        self.hangup_triggered_at = time.time()  # Track when hangup was triggered for timeout monitoring
         message = self.call_hangup_message if not self.voicemail_handler.detected else ""
         if not message or message.strip() == "":
             self.hangup_message_queued = False  # No hangup message to wait for
+            self.hangup_triggered_at = time.time()
             await self.__process_end_of_conversation()
         else:
             self.hangup_message_queued = True  # Hangup message will be synthesized
@@ -3392,6 +3394,8 @@ class TaskManager(BaseManager):
                 "end_of_llm_stream": True,
             }
             await self._synthesize(create_ws_data_packet(message, meta_info=meta_info))
+            # Stamp after goodbye is queued — actual disconnect happens after it plays
+            self.hangup_triggered_at = time.time()
         return
 
     async def _listen_llm_input_queue(self):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5137,12 +5137,20 @@ class TaskManager(BaseManager):
                         "output_tokens",
                         "reasoning_tokens",
                         "cached_tokens",
+                        "model",
+                        "connection_latency_ms",
                     ):
                         _t.pop(_f, None)
 
                 _asr_turns = (output["latency_dict"]["transcriber_latencies"] or {}).get("turn_latencies", [])
                 for _t in _asr_turns:
-                    for _f in ("asr_start_ms", "asr_finalized_ms", "asr_turn_start_ms", "final_transcript"):
+                    for _f in (
+                        "asr_start_ms",
+                        "asr_finalized_ms",
+                        "asr_turn_start_ms",
+                        "final_transcript",
+                        "was_interrupted",
+                    ):
                         _t.pop(_f, None)
 
                 _tts_turns = (output["latency_dict"]["synthesizer_latencies"] or {}).get("turn_latencies", [])

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4928,6 +4928,11 @@ class TaskManager(BaseManager):
         finally:
             self._component_error = None
 
+            # Cancel llm_task first and await it so that any transfer_end appended
+            # in __execute_function_call's finally block is captured before
+            # progression_data snapshots transfer_call_events below.
+            await process_task_cancellation(self.llm_task, "llm_task")
+
             # Construct output
             tasks_to_cancel = []
             tasks_to_cancel.append(process_task_cancellation(self.first_message_task_new, "first_message_task_new"))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4333,17 +4333,12 @@ class TaskManager(BaseManager):
                         "rag_latencies": self.rag_latencies,
                         "routing_latencies": self.routing_latencies,
                         "welcome_message_sent_ts": None,
-                        "welcome_message_duration_ms": self.welcome_message_duration_ms,
                         "stream_sid_ts": None,
                         "interruption_stats": self.interruption_manager.get_interruption_stats(
                             self.conversation_start_init_ts
                         ),
                         "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
-                        "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
-                        "hangup_detail": str(self.hangup_detail) if self.hangup_detail else None,
-                        "voicemail_detected": self.voicemail_handler.detected,
-                        "call_start_epoch_ms": self.conversation_start_init_ts,
                     },
                     "hangup_detail": self.hangup_detail,
                     "has_transfer": self.has_transfer,
@@ -4365,6 +4360,47 @@ class TaskManager(BaseManager):
                         output["latency_dict"]["stream_sid_ts"] = self.stream_sid_ts - self.conversation_start_init_ts
                 except Exception as e:
                     logger.error(f"error in logging audio latency ts {str(e)}")
+
+                output["progression_data"] = {
+                    "call_start_epoch_ms": self.conversation_start_init_ts,
+                    "llm_latencies": copy.deepcopy(output["latency_dict"]["llm_latencies"]),
+                    "transcriber_latencies": copy.deepcopy(output["latency_dict"]["transcriber_latencies"]),
+                    "synthesizer_latencies": copy.deepcopy(output["latency_dict"]["synthesizer_latencies"]),
+                    "rag_latencies": output["latency_dict"]["rag_latencies"],
+                    "routing_latencies": copy.deepcopy(output["latency_dict"]["routing_latencies"]),
+                    "welcome_message_sent_ts": output["latency_dict"]["welcome_message_sent_ts"],
+                    "welcome_message_duration_ms": self.welcome_message_duration_ms,
+                    "interruption_stats": output["latency_dict"]["interruption_stats"],
+                    "user_bot_latencies": copy.deepcopy(output["latency_dict"]["user_bot_latencies"]),
+                    "mark_tracking": output["latency_dict"]["mark_tracking"],
+                    "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
+                    "hangup_detail": str(self.hangup_detail) if self.hangup_detail else None,
+                    "voicemail_detected": self.voicemail_handler.detected,
+                }
+
+                # Strip PR-added fields from latency_dict sub-dicts so latency_dict stays at master state.
+                # progression_data (deep-copied above) keeps the full enriched versions.
+                _llm_turns = (output["latency_dict"]["llm_latencies"] or {}).get("turn_latencies", [])
+                for _t in _llm_turns:
+                    for _f in ("turn_id", "llm_start_ms", "response_text"):
+                        _t.pop(_f, None)
+
+                _asr_turns = (output["latency_dict"]["transcriber_latencies"] or {}).get("turn_latencies", [])
+                for _t in _asr_turns:
+                    for _f in ("asr_start_ms", "asr_finalized_ms", "asr_turn_start_ms", "final_transcript"):
+                        _t.pop(_f, None)
+
+                _tts_turns = (output["latency_dict"]["synthesizer_latencies"] or {}).get("turn_latencies", [])
+                for _t in _tts_turns:
+                    _t.pop("tts_start_ms", None)
+
+                for _e in output["latency_dict"]["user_bot_latencies"]:
+                    for _f in ("user_first_start_ms", "agent_end_ms"):
+                        _e.pop(_f, None)
+
+                _routing_turns = (output["latency_dict"]["routing_latencies"] or {}).get("turn_latencies", [])
+                for _t in _routing_turns:
+                    _t.pop("routing_end_ms", None)
 
                 tasks_to_cancel.append(process_task_cancellation(self.output_task, "output_task"))
                 tasks_to_cancel.append(process_task_cancellation(self.hangup_task, "hangup_task"))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -104,6 +104,7 @@ class TaskManager(BaseManager):
         self.rag_latencies = {"turn_latencies": []}
         self.routing_latencies = {"turn_latencies": []}
         self.stream_sid_ts = None
+        self.welcome_message_duration_ms = None
 
         self.task_config = task
 
@@ -945,12 +946,14 @@ class TaskManager(BaseManager):
                                 duration = calculate_audio_duration(
                                     len(data), self.sampling_rate, format=message["meta_info"]["format"]
                                 )
+                                self.welcome_message_duration_ms = round(duration * 1000, 2)
                                 if self.should_record:
                                     self.conversation_recording["output"].append(
                                         {"data": data, "start_time": time.time(), "duration": duration}
                                     )
                         except Exception as e:
                             duration = 0.256
+                            self.welcome_message_duration_ms = round(duration * 1000, 2)
                             logger.error(
                                 "Exception in __forced_first_message for duration calculation: {}".format(str(e))
                             )
@@ -2613,6 +2616,7 @@ class TaskManager(BaseManager):
                         self.routing_latencies["turn_latencies"].append(
                             {
                                 "latency_ms": routing_info["routing_latency_ms"],
+                                "routing_end_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
                                 "routing_model": routing_info.get("routing_model"),
                                 "routing_provider": routing_info.get("routing_provider"),
                                 "previous_node": routing_info.get("previous_node"),
@@ -4329,6 +4333,7 @@ class TaskManager(BaseManager):
                         "rag_latencies": self.rag_latencies,
                         "routing_latencies": self.routing_latencies,
                         "welcome_message_sent_ts": None,
+                        "welcome_message_duration_ms": self.welcome_message_duration_ms,
                         "stream_sid_ts": None,
                         "interruption_stats": self.interruption_manager.get_interruption_stats(
                             self.conversation_start_init_ts

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4251,6 +4251,8 @@ class TaskManager(BaseManager):
                 # Annotate each transcriber turn with was_interrupted so callers
                 # can see which ASR turns had a user barge-in without cross-referencing
                 # the separate interruption_events list.
+                _call_start_ms = self.conversation_start_init_ts
+
                 _interrupted_ids = self.interruption_manager.interrupted_transcriber_turn_ids
                 for _turn in self.transcriber_latencies.turn_latencies:
                     _tid = _turn.get("turn_id") or _turn.get("sequence_id")
@@ -4265,8 +4267,6 @@ class TaskManager(BaseManager):
                     self.llm_latencies.other_latencies.append(self.language_detector.latency_data)
 
                 welcome_message_sent_ts = self.tools["output"].get_welcome_message_sent_ts()
-
-                _call_start_ms = self.conversation_start_init_ts
                 _user_bot_latencies = [
                     {
                         "sequence_id": e["sequence_id"],

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -106,6 +106,8 @@ class TaskManager(BaseManager):
         self.stream_sid_ts = None
         self.welcome_message_duration_ms = None
         self.transcriber_error_events: list[dict] = []
+        self.blocked_audio_events: list[dict] = []
+        self._blocked_sequences: set = set()  # dedup: only record first block per sequence
 
         self.task_config = task
 
@@ -3787,7 +3789,10 @@ class TaskManager(BaseManager):
                         ):
                             logger.info(f"Condition for interruption hit")
                             self.interruption_manager.on_user_speech_started()
-                            _asr_turn_id = getattr(self.tools.get("transcriber"), "current_turn_id", None)
+                            _t = self.tools.get("transcriber")
+                            if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
+                                _t = _t.transcribers.get(_t.active_label, _t)
+                            _asr_turn_id = getattr(_t, "current_turn_id", None)
                             self.interruption_manager.on_interruption_triggered(asr_turn_id=_asr_turn_id)
                             # Also record in the interrupted set for was_interrupted annotation
                             self.interruption_manager.record_interrupted_transcriber_turn(_asr_turn_id)
@@ -4423,6 +4428,14 @@ class TaskManager(BaseManager):
                     elif status == "BLOCK":
                         # Audio blocked (user speaking or invalid sequence) - discard
                         logger.info(f"Audio blocked: discarding message (sequence_id={sequence_id})")
+                        if sequence_id is not None and sequence_id not in self._blocked_sequences:
+                            self._blocked_sequences.add(sequence_id)
+                            self.blocked_audio_events.append({
+                                "sequence_id": sequence_id,
+                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                                "is_audio_playing": self.tools["input"].is_audio_being_played_to_user(),
+                                "response_in_pipeline": self.response_in_pipeline,
+                            })
                         self._drop_staged_assistant_history(sequence_id, "output_blocked")
                         # Null byte (b'\x00') is the end-of-stream control signal, not audio.
                         # Always send it through handle() so the is_final_chunk post-mark is
@@ -5093,6 +5106,7 @@ class TaskManager(BaseManager):
                     "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
                     "transcriber_error_events": list(self.transcriber_error_events),
                     "transcriber_reconnect_count": getattr(self.tools.get("transcriber"), "reconnect_count", 0),
+                    "blocked_audio_events": list(self.blocked_audio_events),
                     "welcome_message_played_ts": (
                         round(
                             self.tools["input"].welcome_message_played_ts - self.conversation_start_init_ts,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4336,6 +4336,8 @@ class TaskManager(BaseManager):
                         "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
                         "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
+                        "hangup_detail": str(self.hangup_detail) if self.hangup_detail else None,
+                        "voicemail_detected": self.voicemail_handler.detected,
                         "call_start_epoch_ms": self.conversation_start_init_ts,
                     },
                     "hangup_detail": self.hangup_detail,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3372,8 +3372,9 @@ class TaskManager(BaseManager):
             return
 
         # hangup_triggered flag set immediately to prevent user interruptions from cancelling hangup.
-        # hangup_triggered_at is set AFTER the goodbye plays so progression shows
-        # the actual disconnect time, not the decision time (use hangup_decision_at for that).
+        # hangup_triggered_at is stamped after the goodbye is queued for synthesis (not at playback end).
+        # For short goodbye messages this is close enough to playback start; use hangup_decision_at
+        # to get the earlier decision timestamp.
         self.hangup_triggered = True
         message = self.call_hangup_message if not self.voicemail_handler.detected else ""
         if not message or message.strip() == "":
@@ -5169,7 +5170,6 @@ class TaskManager(BaseManager):
                         "asr_finalized_ms",
                         "asr_turn_start_ms",
                         "final_transcript",
-                        "was_interrupted",
                     ):
                         _t.pop(_f, None)
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4941,6 +4941,22 @@ class TaskManager(BaseManager):
                     "voicemail_detected": self.voicemail_handler.detected,
                 }
 
+                # In progression_data: promote asr_turn_id to turn_id on LLM entries so the
+                # progression service can group by turn_id directly without seq indirection.
+                # Also stamp turn_id on user_bot_latencies using the same asr_turn map.
+                _seq_to_asr_turn: dict = {}
+                for _lt in output["progression_data"]["llm_latencies"].get("turn_latencies", []):
+                    _seq = _lt.get("sequence_id")
+                    _asr_tid = _lt.get("asr_turn_id")
+                    if _seq is not None and _asr_tid is not None:
+                        _seq_to_asr_turn[_seq] = _asr_tid
+                        _lt["turn_id"] = _asr_tid  # overwrite _response_turn_id with asr_turn_id
+
+                for _ub in output["progression_data"]["user_bot_latencies"]:
+                    _seq = _ub.get("sequence_id")
+                    if _seq is not None and _seq in _seq_to_asr_turn:
+                        _ub["turn_id"] = _seq_to_asr_turn[_seq]
+
                 # Strip PR-added fields from latency_dict sub-dicts so latency_dict stays at master state.
                 # progression_data (deep-copied above) keeps the full enriched versions.
                 _llm_turns = (output["latency_dict"]["llm_latencies"] or {}).get("turn_latencies", [])

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4434,12 +4434,14 @@ class TaskManager(BaseManager):
                         logger.info(f"Audio blocked: discarding message (sequence_id={sequence_id})")
                         if sequence_id is not None and sequence_id not in self._blocked_sequences:
                             self._blocked_sequences.add(sequence_id)
-                            self.blocked_audio_events.append({
-                                "sequence_id": sequence_id,
-                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                                "is_audio_playing": self.tools["input"].is_audio_being_played_to_user(),
-                                "response_in_pipeline": self.response_in_pipeline,
-                            })
+                            self.blocked_audio_events.append(
+                                {
+                                    "sequence_id": sequence_id,
+                                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                                    "is_audio_playing": self.tools["input"].is_audio_being_played_to_user(),
+                                    "response_in_pipeline": self.response_in_pipeline,
+                                }
+                            )
                         self._drop_staged_assistant_history(sequence_id, "output_blocked")
                         # Null byte (b'\x00') is the end-of-stream control signal, not audio.
                         # Always send it through handle() so the is_final_chunk post-mark is

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -105,6 +105,7 @@ class TaskManager(BaseManager):
         self.routing_latencies = {"turn_latencies": []}
         self.stream_sid_ts = None
         self.welcome_message_duration_ms = None
+        self.transcriber_error_events: list[dict] = []
 
         self.task_config = task
 
@@ -3608,6 +3609,13 @@ class TaskManager(BaseManager):
     async def _log_transcriber_connection_error(self, connection_error):
         if connection_error:
             provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
+            self.transcriber_error_events.append(
+                {
+                    "error": connection_error,
+                    "provider": provider,
+                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                }
+            )
             await self._end_call_on_component_error(
                 TranscriberError(connection_error, provider=provider), HangupReason.TRANSCRIBER_CONNECTION_ERROR
             )
@@ -4969,6 +4977,17 @@ class TaskManager(BaseManager):
                     else None,
                     "hangup_detail": self.hangup_detail.value if self.hangup_detail else None,
                     "voicemail_detected": self.voicemail_handler.detected,
+                    "language_switch_events": list(self.language_switch_events),
+                    "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
+                    "transcriber_error_events": list(self.transcriber_error_events),
+                    "welcome_message_played_ts": (
+                        round(
+                            self.tools["input"].welcome_message_played_ts - self.conversation_start_init_ts,
+                            2,
+                        )
+                        if getattr(self.tools.get("input"), "welcome_message_played_ts", None)
+                        else None
+                    ),
                 }
 
                 # In progression_data: promote asr_turn_id to turn_id on LLM entries so the

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -170,6 +170,7 @@ class TaskManager(BaseManager):
         self.hangup_triggered_at = None
         self.hangup_decision_at = None
         self.dtmf_events: list[dict] = []
+        self.non_fatal_llm_error_events: list[dict] = []
         self._agent_end_timestamps: dict = {}
         self.hangup_message_queued = False
         self.switch_handoff_messages = {}
@@ -3184,6 +3185,7 @@ class TaskManager(BaseManager):
         should_bypass_synth = "bypass_synth" in meta_info and meta_info["bypass_synth"] is True
         next_step = self._get_next_step(sequence, "llm")
         meta_info["llm_start_time"] = time.time()
+        meta_info["_non_fatal_errors"] = []
 
         if self.turn_based_conversation:
             self.history.append({"role": "user", "content": message["data"]})
@@ -3201,6 +3203,10 @@ class TaskManager(BaseManager):
             )
 
         await self.__do_llm_generation(messages, meta_info, next_step, should_bypass_synth)
+
+        for _err in meta_info.get("_non_fatal_errors", []):
+            self.non_fatal_llm_error_events.append(_err)
+
         # TODO : Write a better check for completion prompt
 
         # Hangup detection - now supported for all agent types including graph_agent
@@ -4990,6 +4996,7 @@ class TaskManager(BaseManager):
                     "voicemail_detected": self.voicemail_handler.detected,
                     "voicemail_check_count": self.voicemail_handler.check_count,
                     "dtmf_events": list(self.dtmf_events),
+                    "non_fatal_llm_error_events": list(self.non_fatal_llm_error_events),
                     "language_switch_events": list(self.language_switch_events),
                     "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
                     "transcriber_error_events": list(self.transcriber_error_events),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3702,15 +3702,18 @@ class TaskManager(BaseManager):
             await self.__process_end_of_conversation()
 
     async def _log_transcriber_connection_error(self, connection_error):
+        provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
+        # Always record the drop — "error" when exception drove it, "drop" for clean closes
+        # (e.g. Sarvam normal end-of-stream, Deepgram inactivity timeout on standby).
+        self.transcriber_error_events.append(
+            {
+                "event": "error" if connection_error else "drop",
+                "error": connection_error,
+                "provider": provider,
+                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+            }
+        )
         if connection_error:
-            provider = self.task_config["tools_config"]["transcriber"].get("provider", "unknown")
-            self.transcriber_error_events.append(
-                {
-                    "error": connection_error,
-                    "provider": provider,
-                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                }
-            )
             await self._end_call_on_component_error(
                 TranscriberError(connection_error, provider=provider), HangupReason.TRANSCRIBER_CONNECTION_ERROR
             )
@@ -5089,6 +5092,7 @@ class TaskManager(BaseManager):
                     "transfer_call_events": list(self.transfer_call_events),
                     "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
                     "transcriber_error_events": list(self.transcriber_error_events),
+                    "transcriber_reconnect_count": getattr(self.tools.get("transcriber"), "reconnect_count", 0),
                     "welcome_message_played_ts": (
                         round(
                             self.tools["input"].welcome_message_played_ts - self.conversation_start_init_ts,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -363,6 +363,7 @@ class TaskManager(BaseManager):
         # Records every manual switch_language tool call — used post-call to
         # compare against LID shadow detections (precision / latency analysis).
         self.language_switch_events: list[dict] = []
+        self.transfer_call_events: list[dict] = []
         self.hangup_task = None
 
         self.conversation_config = None
@@ -2505,6 +2506,17 @@ class TaskManager(BaseManager):
             if self.tools["input"].io_provider != "default":
                 payload["call_sid"] = self.tools["input"].get_call_sid()
 
+            self.transfer_call_events.append({
+                "type": "transfer_start",
+                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                "tool_name": called_fun,
+                "tool_call_id": resp.get("tool_call_id", ""),
+                "turn_id": meta_info.get("turn_id"),
+                "sequence_id": meta_info.get("sequence_id"),
+                "transfer_number": payload.get("call_transfer_number"),
+                "provider": self.tools["input"].io_provider,
+            })
+
             if self.tools["input"].io_provider == "default":
                 mock_response = (
                     f"This is a mocked response demonstrating a successful transfer of call to {call_transfer_number}"
@@ -2542,6 +2554,16 @@ class TaskManager(BaseManager):
                 self._finalize_api_call_detail(
                     function_call_log, response=mock_response, status_code=200, content_type="text/plain"
                 )
+                self.transfer_call_events.append({
+                    "type": "transfer_end",
+                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                    "turn_id": meta_info.get("turn_id"),
+                    "sequence_id": meta_info.get("sequence_id"),
+                    "status_code": 200,
+                    "latency_ms": function_call_log.get("latency_ms"),
+                    "success": True,
+                })
 
                 bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
                 await self.tools["output"].handle(bos_packet)
@@ -2595,6 +2617,16 @@ class TaskManager(BaseManager):
                         status_code=response.status,
                         content_type=response.headers.get("Content-Type"),
                     )
+                    self.transfer_call_events.append({
+                        "type": "transfer_end",
+                        "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                        "tool_call_id": resp.get("tool_call_id", ""),
+                        "turn_id": meta_info.get("turn_id"),
+                        "sequence_id": meta_info.get("sequence_id"),
+                        "status_code": response.status,
+                        "latency_ms": function_call_log.get("latency_ms"),
+                        "success": response.status < 400,
+                    })
                     return
 
         if called_fun == "switch_language":
@@ -3212,7 +3244,7 @@ class TaskManager(BaseManager):
         # Hangup detection - now supported for all agent types including graph_agent
         if self.use_llm_to_determine_hangup and not self.turn_based_conversation:
             completion_res, metadata = await self.tools["llm_agent"].check_for_completion(
-                messages, self.check_for_completion_prompt
+                messages, self.check_for_completion_prompt, meta_info=meta_info
             )
 
             should_hangup = (
@@ -4998,6 +5030,7 @@ class TaskManager(BaseManager):
                     "dtmf_events": list(self.dtmf_events),
                     "non_fatal_llm_error_events": list(self.non_fatal_llm_error_events),
                     "language_switch_events": list(self.language_switch_events),
+                    "transfer_call_events": list(self.transfer_call_events),
                     "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
                     "transcriber_error_events": list(self.transcriber_error_events),
                     "welcome_message_played_ts": (

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4956,7 +4956,9 @@ class TaskManager(BaseManager):
                         "user_first_start_ms": round(e["user_first_start_s"] * 1000 - _call_start_ms, 2)
                         if e.get("user_first_start_s") and e["user_first_start_s"] > 0
                         else None,
-                        "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
+                        "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2)
+                        if e.get("user_end_s") is not None
+                        else None,
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
                         "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),
                         "latency_ms": e["latency_ms"],

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5023,14 +5023,13 @@ class TaskManager(BaseManager):
                         if e.get("user_end_s") is not None
                         else None,
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
-                        "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),
                         "latency_ms": e["latency_ms"],
-                        # agent_end_ms: actual playback end from provider mark ACK (more accurate
-                        # than ElevenLabs stream end). Present only when the final mark was ACKed.
-                        **(
-                            {"agent_end_ms": round(e["agent_end_s"] * 1000 - _call_start_ms, 2)}
+                        # agent_end_ms: mark ACK from provider (actual playback end, most accurate).
+                        # None when the final mark was never ACKed (e.g. call dropped mid-audio).
+                        "agent_end_ms": (
+                            round(e["agent_end_s"] * 1000 - _call_start_ms, 2)
                             if e.get("agent_end_s") is not None
-                            else {}
+                            else None
                         ),
                     }
                     for e in self.interruption_manager.user_bot_latencies

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2506,16 +2506,18 @@ class TaskManager(BaseManager):
             if self.tools["input"].io_provider != "default":
                 payload["call_sid"] = self.tools["input"].get_call_sid()
 
-            self.transfer_call_events.append({
-                "type": "transfer_start",
-                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                "tool_name": called_fun,
-                "tool_call_id": resp.get("tool_call_id", ""),
-                "turn_id": meta_info.get("turn_id"),
-                "sequence_id": meta_info.get("sequence_id"),
-                "transfer_number": payload.get("call_transfer_number"),
-                "provider": self.tools["input"].io_provider,
-            })
+            self.transfer_call_events.append(
+                {
+                    "type": "transfer_start",
+                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                    "tool_name": called_fun,
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                    "turn_id": meta_info.get("turn_id"),
+                    "sequence_id": meta_info.get("sequence_id"),
+                    "transfer_number": payload.get("call_transfer_number"),
+                    "provider": self.tools["input"].io_provider,
+                }
+            )
 
             if self.tools["input"].io_provider == "default":
                 mock_response = (
@@ -2554,16 +2556,18 @@ class TaskManager(BaseManager):
                 self._finalize_api_call_detail(
                     function_call_log, response=mock_response, status_code=200, content_type="text/plain"
                 )
-                self.transfer_call_events.append({
-                    "type": "transfer_end",
-                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                    "tool_call_id": resp.get("tool_call_id", ""),
-                    "turn_id": meta_info.get("turn_id"),
-                    "sequence_id": meta_info.get("sequence_id"),
-                    "status_code": 200,
-                    "latency_ms": function_call_log.get("latency_ms"),
-                    "success": True,
-                })
+                self.transfer_call_events.append(
+                    {
+                        "type": "transfer_end",
+                        "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                        "tool_call_id": resp.get("tool_call_id", ""),
+                        "turn_id": meta_info.get("turn_id"),
+                        "sequence_id": meta_info.get("sequence_id"),
+                        "status_code": 200,
+                        "latency_ms": function_call_log.get("latency_ms"),
+                        "success": True,
+                    }
+                )
 
                 bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
                 await self.tools["output"].handle(bos_packet)
@@ -2619,38 +2623,24 @@ class TaskManager(BaseManager):
                             status_code=response.status,
                             content_type=response.headers.get("Content-Type"),
                         )
-                        self.transfer_call_events.append({
-                            "type": "transfer_end",
-                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                            "tool_call_id": resp.get("tool_call_id", ""),
-                            "turn_id": meta_info.get("turn_id"),
-                            "sequence_id": meta_info.get("sequence_id"),
-                            "status_code": response.status,
-                            "latency_ms": function_call_log.get("latency_ms"),
-                            "success": response.status < 400,
-                        })
+                        self.transfer_call_events.append(
+                            {
+                                "type": "transfer_end",
+                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                                "tool_call_id": resp.get("tool_call_id", ""),
+                                "turn_id": meta_info.get("turn_id"),
+                                "sequence_id": meta_info.get("sequence_id"),
+                                "status_code": response.status,
+                                "latency_ms": function_call_log.get("latency_ms"),
+                                "success": response.status < 400,
+                            }
+                        )
                         _transfer_end_recorded = True
                 except Exception as transfer_exc:
                     logger.warning(f"Transfer webhook did not respond (call likely redirected): {transfer_exc}")
                     self._finalize_api_call_detail(function_call_log, error=transfer_exc)
-                    self.transfer_call_events.append({
-                        "type": "transfer_end",
-                        "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                        "tool_call_id": resp.get("tool_call_id", ""),
-                        "turn_id": meta_info.get("turn_id"),
-                        "sequence_id": meta_info.get("sequence_id"),
-                        "status_code": None,
-                        "latency_ms": function_call_log.get("latency_ms"),
-                        "success": None,
-                    })
-                    _transfer_end_recorded = True
-                finally:
-                    # CancelledError (BaseException) bypasses except — ensure transfer_end is
-                    # always recorded so it appears in progression_data even if the task is
-                    # cancelled mid-flight when Plivo terminates the call.
-                    if not _transfer_end_recorded:
-                        self._finalize_api_call_detail(function_call_log, error="cancelled")
-                        self.transfer_call_events.append({
+                    self.transfer_call_events.append(
+                        {
                             "type": "transfer_end",
                             "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
                             "tool_call_id": resp.get("tool_call_id", ""),
@@ -2659,7 +2649,27 @@ class TaskManager(BaseManager):
                             "status_code": None,
                             "latency_ms": function_call_log.get("latency_ms"),
                             "success": None,
-                        })
+                        }
+                    )
+                    _transfer_end_recorded = True
+                finally:
+                    # CancelledError (BaseException) bypasses except — ensure transfer_end is
+                    # always recorded so it appears in progression_data even if the task is
+                    # cancelled mid-flight when Plivo terminates the call.
+                    if not _transfer_end_recorded:
+                        self._finalize_api_call_detail(function_call_log, error="cancelled")
+                        self.transfer_call_events.append(
+                            {
+                                "type": "transfer_end",
+                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                                "tool_call_id": resp.get("tool_call_id", ""),
+                                "turn_id": meta_info.get("turn_id"),
+                                "sequence_id": meta_info.get("sequence_id"),
+                                "status_code": None,
+                                "latency_ms": function_call_log.get("latency_ms"),
+                                "success": None,
+                            }
+                        )
                 return
 
         if called_fun == "switch_language":

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -168,6 +168,8 @@ class TaskManager(BaseManager):
         self.has_transfer = False
         self.hangup_triggered = False
         self.hangup_triggered_at = None
+        self.hangup_decision_at = None
+        self.dtmf_events: list[dict] = []
         self._agent_end_timestamps: dict = {}
         self.hangup_message_queued = False
         self.switch_handoff_messages = {}
@@ -2114,6 +2116,10 @@ class TaskManager(BaseManager):
                 dtmf_digits = await self.queues["dtmf"].get()
                 logger.info(f"DTMF collected {dtmf_digits}")
 
+                _dtmf_ts = round(time.time() * 1000 - self.conversation_start_init_ts, 2)
+                for _digit in dtmf_digits:
+                    self.dtmf_events.append({"digit": _digit, "ts_ms": _dtmf_ts})
+
                 dtmf_message = "dtmf_number: " + dtmf_digits
                 base_meta_info = {
                     "io": self.tools["input"].io_provider,
@@ -3269,6 +3275,8 @@ class TaskManager(BaseManager):
         llm_response = ""
 
     async def process_call_hangup(self):
+        if self.hangup_decision_at is None:
+            self.hangup_decision_at = time.time()
         # Guard: Prevent multiple concurrent hangup attempts
         if self.hangup_triggered or self.conversation_ended:
             logger.info(f"process_call_hangup: Hangup already in progress or conversation ended, skipping")
@@ -4976,7 +4984,12 @@ class TaskManager(BaseManager):
                     if self.hangup_triggered_at
                     else None,
                     "hangup_detail": self.hangup_detail.value if self.hangup_detail else None,
+                    "hangup_decision_ms": round(self.hangup_decision_at * 1000 - self.conversation_start_init_ts, 2)
+                    if self.hangup_decision_at
+                    else None,
                     "voicemail_detected": self.voicemail_handler.detected,
+                    "voicemail_check_count": self.voicemail_handler.check_count,
+                    "dtmf_events": list(self.dtmf_events),
                     "language_switch_events": list(self.language_switch_events),
                     "lid_detection_events": list(getattr(self.tools.get("transcriber"), "lid_detection_events", [])),
                     "transcriber_error_events": list(self.transcriber_error_events),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2693,6 +2693,16 @@ class TaskManager(BaseManager):
 
                 if trigger_function_call:
                     logger.info(f"Triggering function call for {data}")
+                    # Stamp total_stream_duration_ms before early return — function call chunk carries the final latency
+                    if latency:
+                        fc_latency_dict = latency.model_dump()
+                        fc_latency_dict["turn_id"] = meta_info.get("turn_id")
+                        fc_latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
+                        prev = self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
+                        if prev and prev.get("sequence_id") == fc_latency_dict.get("sequence_id"):
+                            self.llm_latencies.turn_latencies[-1] = fc_latency_dict
+                        else:
+                            self.llm_latencies.turn_latencies.append(fc_latency_dict)
                     textual_response = data.textual_response if hasattr(data, "textual_response") else None
                     if textual_response:  # intentionally omitting tool_calls, which will be filled later if the tool_call flow completed (requirement from OpenAI)
                         self.__store_into_history(
@@ -2783,6 +2793,10 @@ class TaskManager(BaseManager):
                 cached_tokens=actual_cached_tokens,
                 reasoning_content=actual_reasoning_content,
             )
+
+        # Stamp full response text on the last LLM turn entry (new field, no existing fields changed)
+        if llm_response.strip() and self.llm_latencies.turn_latencies:
+            self.llm_latencies.turn_latencies[-1]["response_text"] = llm_response.strip()
 
         # Collect RAG latency if present (from KnowledgeBaseAgent)
         if meta_info.get("rag_latency"):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3780,10 +3780,9 @@ class TaskManager(BaseManager):
                         ):
                             logger.info(f"Condition for interruption hit")
                             self.interruption_manager.on_user_speech_started()
-                            self.interruption_manager.on_interruption_triggered()
-                            # Tag the ASR turn that was active at interrupt time so
-                            # we can annotate turn_latencies with was_interrupted=True
                             _asr_turn_id = getattr(self.tools.get("transcriber"), "current_turn_id", None)
+                            self.interruption_manager.on_interruption_triggered(asr_turn_id=_asr_turn_id)
+                            # Also record in the interrupted set for was_interrupted annotation
                             self.interruption_manager.record_interrupted_transcriber_turn(_asr_turn_id)
                             self.tools["input"].update_is_audio_being_played(False)
                             await self.__cleanup_downstream_tasks()

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -166,6 +166,7 @@ class TaskManager(BaseManager):
         self.has_transfer = False
         self.hangup_triggered = False
         self.hangup_triggered_at = None
+        self._agent_end_timestamps: dict = {}
         self.hangup_message_queued = False
         self.switch_handoff_messages = {}
         self.agent_names = {}
@@ -1621,7 +1622,7 @@ class TaskManager(BaseManager):
 
         new_sequence_id = self.interruption_manager.get_next_sequence_id()
         meta_info_copy["sequence_id"] = new_sequence_id
-        meta_info_copy["turn_id"] = self.interruption_manager.get_turn_id()
+        meta_info_copy["turn_id"] = getattr(self.tools.get("transcriber"), "turn_counter", 0)
 
         return meta_info_copy
 
@@ -2706,6 +2707,8 @@ class TaskManager(BaseManager):
 
                 if latency:
                     latency_dict = latency.model_dump()
+                    latency_dict["turn_id"] = meta_info.get("turn_id")
+                    latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
                     previous_latency_item = (
                         self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                     )
@@ -2821,12 +2824,14 @@ class TaskManager(BaseManager):
             self.llm_latencies.other_latencies.append(
                 {
                     "type": "hangup_check",
+                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
                     "latency_ms": metadata.get("latency_ms", None),
                     "model": self.check_for_completion_llm,
                     "provider": "openai",  # TODO: Make dynamic based on provider used
                     "service_tier": metadata.get("service_tier", None),
                     "llm_host": metadata.get("llm_host", None),
                     "sequence_id": meta_info.get("sequence_id"),
+                    "turn_id": meta_info.get("turn_id"),
                 }
             )
 
@@ -3569,6 +3574,7 @@ class TaskManager(BaseManager):
         text = message["data"]
         meta_info["type"] = "audio"
         meta_info["synthesizer_start_time"] = time.time()
+        meta_info["tts_start_ms"] = round(meta_info["synthesizer_start_time"] * 1000 - self.conversation_start_init_ts, 2)
         try:
             if not self.conversation_ended and (
                 "is_first_message" in meta_info
@@ -3737,6 +3743,9 @@ class TaskManager(BaseManager):
                 ):
                     self._turn_audio_flushed.set()
                     if message["meta_info"].get("end_of_synthesizer_stream", False):
+                        _seq = message["meta_info"].get("sequence_id")
+                        if _seq is not None:
+                            self._agent_end_timestamps[_seq] = round(time.time() * 1000 - self.conversation_start_init_ts, 2)
                         self.interruption_manager.on_successful_response_delivered()
                         self.interruption_manager.on_agent_speech_ended()
                     # Reset asked_if_user_is_still_there flag after any message except is_user_online_message
@@ -4246,6 +4255,10 @@ class TaskManager(BaseManager):
                 for _turn in self.transcriber_latencies.turn_latencies:
                     _tid = _turn.get("turn_id") or _turn.get("sequence_id")
                     _turn["was_interrupted"] = _tid in _interrupted_ids if _tid is not None else False
+                    if _turn.get("asr_start_epoch_ms") is not None:
+                        _turn["asr_start_ms"] = round(_turn.pop("asr_start_epoch_ms") - _call_start_ms, 2)
+                    if _turn.get("asr_finalized_epoch_ms") is not None:
+                        _turn["asr_finalized_ms"] = round(_turn.pop("asr_finalized_epoch_ms") - _call_start_ms, 2)
 
                 # Collect language detection latency if available
                 if hasattr(self, "language_detector") and self.language_detector.latency_data:
@@ -4257,8 +4270,10 @@ class TaskManager(BaseManager):
                 _user_bot_latencies = [
                     {
                         "sequence_id": e["sequence_id"],
+                        "user_start_ms": round(e["user_start_s"] * 1000 - _call_start_ms, 2) if e.get("user_start_s") and e["user_start_s"] > 0 else None,
                         "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
+                        "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),
                         "latency_ms": e["latency_ms"],
                     }
                     for e in self.interruption_manager.user_bot_latencies
@@ -4289,6 +4304,8 @@ class TaskManager(BaseManager):
                         ),
                         "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
+                        "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
+                        "call_start_epoch_ms": self.conversation_start_init_ts,
                     },
                     "hangup_detail": self.hangup_detail,
                     "has_transfer": self.has_transfer,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3032,7 +3032,11 @@ class TaskManager(BaseManager):
                     if latency:
                         fc_latency_dict = latency.model_dump()
                         fc_latency_dict["turn_id"] = meta_info.get("turn_id")
-                        fc_latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
+                        fc_latency_dict["llm_start_ms"] = (
+                            round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2)
+                            if meta_info.get("llm_start_time")
+                            else None
+                        )
                         _t = self.tools.get("transcriber")
                         if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                             _t = _t.transcribers.get(_t.active_label, _t)
@@ -3061,7 +3065,11 @@ class TaskManager(BaseManager):
                 if latency:
                     latency_dict = latency.model_dump()
                     latency_dict["turn_id"] = meta_info.get("turn_id")
-                    latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
+                    latency_dict["llm_start_ms"] = (
+                        round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2)
+                        if meta_info.get("llm_start_time")
+                        else None
+                    )
                     _t = self.tools.get("transcriber")
                     if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                         _t = _t.transcribers.get(_t.active_label, _t)
@@ -4162,7 +4170,9 @@ class TaskManager(BaseManager):
         text = message["data"]
         meta_info["type"] = "audio"
         meta_info["synthesizer_start_time"] = time.time()
-        meta_info["tts_start_ms"] = round(meta_info["synthesizer_start_time"] * 1000 - self.conversation_start_init_ts, 2)
+        meta_info["tts_start_ms"] = round(
+            meta_info["synthesizer_start_time"] * 1000 - self.conversation_start_init_ts, 2
+        )
         try:
             if not self.conversation_ended and (
                 "is_first_message" in meta_info
@@ -4335,7 +4345,9 @@ class TaskManager(BaseManager):
                     if message["meta_info"].get("end_of_synthesizer_stream", False):
                         _seq = message["meta_info"].get("sequence_id")
                         if _seq is not None:
-                            self._agent_end_timestamps[_seq] = round(time.time() * 1000 - self.conversation_start_init_ts, 2)
+                            self._agent_end_timestamps[_seq] = round(
+                                time.time() * 1000 - self.conversation_start_init_ts, 2
+                            )
                         self.interruption_manager.on_successful_response_delivered(sequence_id)
                         self.interruption_manager.on_agent_speech_ended()
                     # Reset asked_if_user_is_still_there flag after any message except is_user_online_message
@@ -4862,15 +4874,23 @@ class TaskManager(BaseManager):
                 _user_bot_latencies = [
                     {
                         "sequence_id": e["sequence_id"],
-                        "user_start_ms": round(e["user_start_s"] * 1000 - _call_start_ms, 2) if e.get("user_start_s") and e["user_start_s"] > 0 else None,
-                        "user_first_start_ms": round(e["user_first_start_s"] * 1000 - _call_start_ms, 2) if e.get("user_first_start_s") and e["user_first_start_s"] > 0 else None,
+                        "user_start_ms": round(e["user_start_s"] * 1000 - _call_start_ms, 2)
+                        if e.get("user_start_s") and e["user_start_s"] > 0
+                        else None,
+                        "user_first_start_ms": round(e["user_first_start_s"] * 1000 - _call_start_ms, 2)
+                        if e.get("user_first_start_s") and e["user_first_start_s"] > 0
+                        else None,
                         "user_end_ms": round(e["user_end_s"] * 1000 - _call_start_ms, 2),
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
                         "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),
                         "latency_ms": e["latency_ms"],
                         # agent_end_ms: actual playback end from provider mark ACK (more accurate
                         # than ElevenLabs stream end). Present only when the final mark was ACKed.
-                        **({"agent_end_ms": round(e["agent_end_s"] * 1000 - _call_start_ms, 2)} if e.get("agent_end_s") is not None else {}),
+                        **(
+                            {"agent_end_ms": round(e["agent_end_s"] * 1000 - _call_start_ms, 2)}
+                            if e.get("agent_end_s") is not None
+                            else {}
+                        ),
                     }
                     for e in self.interruption_manager.user_bot_latencies
                 ]
@@ -4936,7 +4956,9 @@ class TaskManager(BaseManager):
                     "interruption_stats": output["latency_dict"]["interruption_stats"],
                     "user_bot_latencies": copy.deepcopy(output["latency_dict"]["user_bot_latencies"]),
                     "mark_tracking": output["latency_dict"]["mark_tracking"],
-                    "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
+                    "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2)
+                    if self.hangup_triggered_at
+                    else None,
                     "hangup_detail": self.hangup_detail.value if self.hangup_detail else None,
                     "voicemail_detected": self.voicemail_handler.detected,
                 }

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3114,6 +3114,7 @@ class TaskManager(BaseManager):
                         if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                             _t = _t.transcribers.get(_t.active_label, _t)
                         fc_latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
+                        fc_latency_dict["model"] = self.llm_config.get("model") if self.llm_config else None
                         fc_latency_dict["input_tokens"] = actual_input_tokens
                         fc_latency_dict["output_tokens"] = actual_output_tokens
                         fc_latency_dict["reasoning_tokens"] = actual_reasoning_tokens
@@ -3151,6 +3152,7 @@ class TaskManager(BaseManager):
                     if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                         _t = _t.transcribers.get(_t.active_label, _t)
                     latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
+                    latency_dict["model"] = self.llm_config.get("model") if self.llm_config else None
                     latency_dict["input_tokens"] = actual_input_tokens
                     latency_dict["output_tokens"] = actual_output_tokens
                     latency_dict["reasoning_tokens"] = actual_reasoning_tokens

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3041,6 +3041,10 @@ class TaskManager(BaseManager):
                         if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                             _t = _t.transcribers.get(_t.active_label, _t)
                         fc_latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
+                        fc_latency_dict["input_tokens"] = actual_input_tokens
+                        fc_latency_dict["output_tokens"] = actual_output_tokens
+                        fc_latency_dict["reasoning_tokens"] = actual_reasoning_tokens
+                        fc_latency_dict["cached_tokens"] = actual_cached_tokens
                         prev = self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                         if prev and prev.get("sequence_id") == fc_latency_dict.get("sequence_id"):
                             self.llm_latencies.turn_latencies[-1] = fc_latency_dict
@@ -3074,6 +3078,10 @@ class TaskManager(BaseManager):
                     if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
                         _t = _t.transcribers.get(_t.active_label, _t)
                     latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
+                    latency_dict["input_tokens"] = actual_input_tokens
+                    latency_dict["output_tokens"] = actual_output_tokens
+                    latency_dict["reasoning_tokens"] = actual_reasoning_tokens
+                    latency_dict["cached_tokens"] = actual_cached_tokens
                     previous_latency_item = (
                         self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                     )
@@ -4988,7 +4996,16 @@ class TaskManager(BaseManager):
                 # progression_data (deep-copied above) keeps the full enriched versions.
                 _llm_turns = (output["latency_dict"]["llm_latencies"] or {}).get("turn_latencies", [])
                 for _t in _llm_turns:
-                    for _f in ("turn_id", "llm_start_ms", "response_text", "asr_turn_id"):
+                    for _f in (
+                        "turn_id",
+                        "llm_start_ms",
+                        "response_text",
+                        "asr_turn_id",
+                        "input_tokens",
+                        "output_tokens",
+                        "reasoning_tokens",
+                        "cached_tokens",
+                    ):
                         _t.pop(_f, None)
 
                 _asr_turns = (output["latency_dict"]["transcriber_latencies"] or {}).get("turn_latencies", [])

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4259,7 +4259,7 @@ class TaskManager(BaseManager):
 
                 _interrupted_ids = self.interruption_manager.interrupted_transcriber_turn_ids
                 for _turn in self.transcriber_latencies.turn_latencies:
-                    _tid = _turn.get("turn_id") or _turn.get("sequence_id")
+                    _tid = _turn.get("turn_id")
                     _turn["was_interrupted"] = _tid in _interrupted_ids if _tid is not None else False
                     if _turn.get("asr_start_epoch_ms") is not None:
                         _turn["asr_start_ms"] = round(_turn.pop("asr_start_epoch_ms") - _call_start_ms, 2)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3033,6 +3033,10 @@ class TaskManager(BaseManager):
                         fc_latency_dict = latency.model_dump()
                         fc_latency_dict["turn_id"] = meta_info.get("turn_id")
                         fc_latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
+                        _t = self.tools.get("transcriber")
+                        if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
+                            _t = _t.transcribers.get(_t.active_label, _t)
+                        fc_latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
                         prev = self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                         if prev and prev.get("sequence_id") == fc_latency_dict.get("sequence_id"):
                             self.llm_latencies.turn_latencies[-1] = fc_latency_dict
@@ -3058,6 +3062,10 @@ class TaskManager(BaseManager):
                     latency_dict = latency.model_dump()
                     latency_dict["turn_id"] = meta_info.get("turn_id")
                     latency_dict["llm_start_ms"] = round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2) if meta_info.get("llm_start_time") else None
+                    _t = self.tools.get("transcriber")
+                    if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
+                        _t = _t.transcribers.get(_t.active_label, _t)
+                    latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
                     previous_latency_item = (
                         self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                     )
@@ -4929,7 +4937,7 @@ class TaskManager(BaseManager):
                     "user_bot_latencies": copy.deepcopy(output["latency_dict"]["user_bot_latencies"]),
                     "mark_tracking": output["latency_dict"]["mark_tracking"],
                     "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2) if self.hangup_triggered_at else None,
-                    "hangup_detail": str(self.hangup_detail) if self.hangup_detail else None,
+                    "hangup_detail": self.hangup_detail.value if self.hangup_detail else None,
                     "voicemail_detected": self.voicemail_handler.detected,
                 }
 
@@ -4937,7 +4945,7 @@ class TaskManager(BaseManager):
                 # progression_data (deep-copied above) keeps the full enriched versions.
                 _llm_turns = (output["latency_dict"]["llm_latencies"] or {}).get("turn_latencies", [])
                 for _t in _llm_turns:
-                    for _f in ("turn_id", "llm_start_ms", "response_text"):
+                    for _f in ("turn_id", "llm_start_ms", "response_text", "asr_turn_id"):
                         _t.pop(_f, None)
 
                 _asr_turns = (output["latency_dict"]["transcriber_latencies"] or {}).get("turn_latencies", [])

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1726,6 +1726,13 @@ class TaskManager(BaseManager):
     def final_chunk_played_observer(self, is_final_chunk_played):
         logger.info(f"Updating last_transmitted_timestamp")
         self.last_transmitted_timestamp = time.time()
+        # Record actual audio playback end (mark ACK from provider) for agent_end_ms tracking.
+        input_handler = self.tools.get("input")
+        if input_handler is not None:
+            seq_id = getattr(input_handler, "last_final_chunk_sequence_id", None)
+            ts = getattr(input_handler, "last_final_chunk_played_ts", None)
+            if seq_id is not None and ts is not None:
+                self.interruption_manager.on_agent_audio_fully_played(seq_id, ts)
 
     async def agent_hangup_observer(self, is_agent_hangup):
         logger.info(f"agent_hangup_observer triggered with is_agent_hangup = {is_agent_hangup}")
@@ -4296,6 +4303,9 @@ class TaskManager(BaseManager):
                         "agent_start_ms": round(e["agent_start_s"] * 1000 - _call_start_ms, 2),
                         "agent_end_ms": self._agent_end_timestamps.get(e["sequence_id"]),
                         "latency_ms": e["latency_ms"],
+                        # agent_end_ms: actual playback end from provider mark ACK (more accurate
+                        # than ElevenLabs stream end). Present only when the final mark was ACKed.
+                        **({"agent_end_ms": round(e["agent_end_s"] * 1000 - _call_start_ms, 2)} if e.get("agent_end_s") is not None else {}),
                     }
                     for e in self.interruption_manager.user_bot_latencies
                 ]

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3129,12 +3129,16 @@ class TaskManager(BaseManager):
                         fc_latency_dict["output_tokens"] = actual_output_tokens
                         fc_latency_dict["reasoning_tokens"] = actual_reasoning_tokens
                         fc_latency_dict["cached_tokens"] = actual_cached_tokens
+                        textual_response = data.textual_response if hasattr(data, "textual_response") else None
+                        if textual_response:
+                            fc_latency_dict["response_text"] = textual_response.strip()
                         prev = self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                         if prev and prev.get("sequence_id") == fc_latency_dict.get("sequence_id"):
                             self.llm_latencies.turn_latencies[-1] = fc_latency_dict
                         else:
                             self.llm_latencies.turn_latencies.append(fc_latency_dict)
-                    textual_response = data.textual_response if hasattr(data, "textual_response") else None
+                    else:
+                        textual_response = None
                     if textual_response:  # intentionally omitting tool_calls, which will be filled later if the tool_call flow completed (requirement from OpenAI)
                         self.__store_into_history(
                             meta_info,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -601,6 +601,39 @@ class TaskManager(BaseManager):
         return redacted_headers
 
     @staticmethod
+    def _stamp_llm_latency_dict(
+        self,
+        latency_dict: dict,
+        meta_info: dict,
+        actual_input_tokens,
+        actual_output_tokens,
+        actual_reasoning_tokens,
+        actual_cached_tokens,
+        response_text: str | None = None,
+    ) -> None:
+        """Stamp observability fields onto an LLM turn latency dict.
+
+        Called from both the function-call and regular-text branches of
+        __do_llm_generation so the two paths stay in sync automatically.
+        """
+        latency_dict["turn_id"] = meta_info.get("turn_id")
+        latency_dict["llm_start_ms"] = (
+            round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2)
+            if meta_info.get("llm_start_time")
+            else None
+        )
+        _t = self.tools.get("transcriber")
+        if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
+            _t = _t.transcribers.get(_t.active_label, _t)
+        latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
+        latency_dict["model"] = self.llm_config.get("model") if self.llm_config else None
+        latency_dict["input_tokens"] = actual_input_tokens
+        latency_dict["output_tokens"] = actual_output_tokens
+        latency_dict["reasoning_tokens"] = actual_reasoning_tokens
+        latency_dict["cached_tokens"] = actual_cached_tokens
+        if response_text:
+            latency_dict["response_text"] = response_text.strip()
+
     def _extract_api_call_runtime_args(resp):
         excluded_keys = {"model_response", "textual_response"}
         return {key: copy.deepcopy(value) for key, value in resp.items() if key not in excluded_keys}
@@ -3116,24 +3149,16 @@ class TaskManager(BaseManager):
                     # Stamp total_stream_duration_ms before early return — function call chunk carries the final latency
                     if latency:
                         fc_latency_dict = latency.model_dump()
-                        fc_latency_dict["turn_id"] = meta_info.get("turn_id")
-                        fc_latency_dict["llm_start_ms"] = (
-                            round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2)
-                            if meta_info.get("llm_start_time")
-                            else None
-                        )
-                        _t = self.tools.get("transcriber")
-                        if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
-                            _t = _t.transcribers.get(_t.active_label, _t)
-                        fc_latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
-                        fc_latency_dict["model"] = self.llm_config.get("model") if self.llm_config else None
-                        fc_latency_dict["input_tokens"] = actual_input_tokens
-                        fc_latency_dict["output_tokens"] = actual_output_tokens
-                        fc_latency_dict["reasoning_tokens"] = actual_reasoning_tokens
-                        fc_latency_dict["cached_tokens"] = actual_cached_tokens
                         textual_response = data.textual_response if hasattr(data, "textual_response") else None
-                        if textual_response:
-                            fc_latency_dict["response_text"] = textual_response.strip()
+                        self._stamp_llm_latency_dict(
+                            fc_latency_dict,
+                            meta_info,
+                            actual_input_tokens,
+                            actual_output_tokens,
+                            actual_reasoning_tokens,
+                            actual_cached_tokens,
+                            response_text=textual_response,
+                        )
                         prev = self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                         if prev and prev.get("sequence_id") == fc_latency_dict.get("sequence_id"):
                             self.llm_latencies.turn_latencies[-1] = fc_latency_dict
@@ -3158,21 +3183,14 @@ class TaskManager(BaseManager):
 
                 if latency:
                     latency_dict = latency.model_dump()
-                    latency_dict["turn_id"] = meta_info.get("turn_id")
-                    latency_dict["llm_start_ms"] = (
-                        round(meta_info.get("llm_start_time", 0) * 1000 - self.conversation_start_init_ts, 2)
-                        if meta_info.get("llm_start_time")
-                        else None
+                    self._stamp_llm_latency_dict(
+                        latency_dict,
+                        meta_info,
+                        actual_input_tokens,
+                        actual_output_tokens,
+                        actual_reasoning_tokens,
+                        actual_cached_tokens,
                     )
-                    _t = self.tools.get("transcriber")
-                    if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
-                        _t = _t.transcribers.get(_t.active_label, _t)
-                    latency_dict["asr_turn_id"] = getattr(_t, "turn_counter", None)
-                    latency_dict["model"] = self.llm_config.get("model") if self.llm_config else None
-                    latency_dict["input_tokens"] = actual_input_tokens
-                    latency_dict["output_tokens"] = actual_output_tokens
-                    latency_dict["reasoning_tokens"] = actual_reasoning_tokens
-                    latency_dict["cached_tokens"] = actual_cached_tokens
                     previous_latency_item = (
                         self.llm_latencies.turn_latencies[-1] if self.llm_latencies.turn_latencies else None
                     )
@@ -3827,7 +3845,12 @@ class TaskManager(BaseManager):
                                 )
                                 # on_agent_interrupted_user MUST come before reset_utterance_end_time
                                 # so it can still read the previous turn's utterance_end_time.
-                                self.interruption_manager.on_agent_interrupted_user()
+                                _t = self.tools.get("transcriber")
+                                if hasattr(_t, "transcribers") and hasattr(_t, "active_label"):
+                                    _t = _t.transcribers.get(_t.active_label, _t)
+                                self.interruption_manager.on_agent_interrupted_user(
+                                    asr_turn_id=getattr(_t, "current_turn_id", None)
+                                )
                                 self.interruption_manager.reset_utterance_end_time()
                                 await self.__cleanup_downstream_tasks()
                         elif (

--- a/bolna/agent_manager/voicemail_handler.py
+++ b/bolna/agent_manager/voicemail_handler.py
@@ -24,6 +24,7 @@ class VoicemailHandler:
             self.enabled = False
         self.detected: bool = False
         self.check_task: Optional[asyncio.Task] = None
+        self.check_count: int = 0
         self.detection_start_time: Optional[float] = None
         self.last_check_time: Optional[float] = None
         self.check_interval: float = config.get("voicemail_check_interval", 7.0)
@@ -88,6 +89,7 @@ class VoicemailHandler:
         )
 
         try:
+            self.check_count += 1
             self.check_task = asyncio.create_task(self._background_check(transcriber_message, meta_info, is_final))
         except Exception as e:
             logger.error(f"Error starting voicemail check background task: {e}")

--- a/bolna/agent_types/contextual_conversational_agent.py
+++ b/bolna/agent_types/contextual_conversational_agent.py
@@ -20,7 +20,7 @@ class StreamingContextualAgent(BaseAgent):
         self.voicemail_llm = OpenAiLLM(model=os.getenv("VOICEMAIL_DETECTION_LLM", "gpt-4.1-mini"))
         self.history = [{"content": ""}]
 
-    async def check_for_completion(self, messages, check_for_completion_prompt):
+    async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):
         try:
             prompt = [
                 {"role": "system", "content": check_for_completion_prompt},
@@ -29,7 +29,7 @@ class StreamingContextualAgent(BaseAgent):
 
             start_time = time.time()
             response, metadata = await self.conversation_completion_llm.generate(
-                prompt, request_json=True, ret_metadata=True
+                prompt, request_json=True, ret_metadata=True, meta_info=meta_info
             )
             latency_ms = (time.time() - start_time) * 1000
 

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -203,7 +203,7 @@ class GraphAgent(BaseAgent):
                 self.routing_model = os.getenv("DEFAULT_ROUTING_MODEL_OPENAI", "gpt-4.1-mini")
             logger.info(f"Routing initialized with OpenAI ({self.routing_model})")
 
-    async def check_for_completion(self, messages, check_for_completion_prompt):
+    async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):
         """Check if the conversation should end. Returns (hangup_dict, metadata)."""
         try:
             prompt = [
@@ -213,7 +213,7 @@ class GraphAgent(BaseAgent):
 
             start_time = time.time()
             response, metadata = await self.conversation_completion_llm.generate(
-                prompt, request_json=True, ret_metadata=True
+                prompt, request_json=True, ret_metadata=True, meta_info=meta_info
             )
             latency_ms = (time.time() - start_time) * 1000
 

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -124,7 +124,7 @@ class KnowledgeBaseAgent(BaseAgent):
             "used_sources": used_sources,
         }
 
-    async def check_for_completion(self, messages, check_for_completion_prompt):
+    async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):
         """Check if the conversation should end (used for auto-hangup feature)."""
         try:
             prompt = [
@@ -133,7 +133,7 @@ class KnowledgeBaseAgent(BaseAgent):
             ]
             start_time = time.time()
             response, metadata = await self.conversation_completion_llm.generate(
-                prompt, request_json=True, ret_metadata=True
+                prompt, request_json=True, ret_metadata=True, meta_info=meta_info
             )
             latency_ms = (time.time() - start_time) * 1000
 

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -35,6 +35,7 @@ class DefaultInputHandler:
         self.queue = queue
         self.conversation_recording = conversation_recording
         self.is_welcome_message_played = is_welcome_message_played
+        self.welcome_message_played_ts = None
         # This variable stores the response which has been heard by the user
         self.response_heard_by_user = ""
         self.response_heard_by_turn = {}
@@ -212,6 +213,7 @@ class DefaultInputHandler:
                 logger.info("Received mark event for agent_welcome_message")
                 self.audio_chunks_received = 0
                 self.is_welcome_message_played = True
+                self.welcome_message_played_ts = time.time() * 1000
 
             elif message_type == "agent_hangup":
                 logger.info(f"Agent hangup has been triggered")

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import time
 import uuid
+from typing import Optional
 from starlette.websockets import WebSocketDisconnect
 
 from dotenv import load_dotenv
@@ -47,6 +48,11 @@ class DefaultInputHandler:
         self.plivo_latency_samples = []
         self.calculated_plivo_latency = 0.25
         self.max_latency_samples = 10
+        # Tracks the sequence_id and wall-clock time of the most recently fully-played
+        # agent audio chunk (is_final_chunk mark ACK). Read by task_manager to populate
+        # agent_end_ms in user_bot_latencies.
+        self.last_final_chunk_sequence_id: Optional[int] = None
+        self.last_final_chunk_played_ts: Optional[float] = None
 
     def get_calculated_plivo_latency(self):
         return self.calculated_plivo_latency
@@ -144,6 +150,11 @@ class DefaultInputHandler:
             self.response_heard_by_user += mark_event_meta_data_obj.get("text_synthesized") or ""
 
         if mark_event_meta_data_obj.get("is_final_chunk"):
+            # Record which sequence finished playing and when — task_manager reads these
+            # to populate agent_end_ms in user_bot_latencies (actual playback end, not stream end).
+            self.last_final_chunk_sequence_id = mark_event_meta_data_obj.get("sequence_id")
+            self.last_final_chunk_played_ts = time.time()
+
             if message_type != "is_user_online_message":
                 self.observable_variables["final_chunk_played_observable"].value = not self.observable_variables[
                     "final_chunk_played_observable"

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -278,9 +278,19 @@ class AzureLLM(OpenAICompatibleLLM):
         if accumulator and accumulator.final_tool_calls:
             api_call_payload = accumulator.build_api_payload(model_args, meta_info, answer)
             if api_call_payload:
-                yield LLMStreamChunk(
+                fc_chunk = LLMStreamChunk(
                     data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True
                 )
+                if stream_usage:
+                    fc_chunk.input_tokens = getattr(stream_usage, "prompt_tokens", None)
+                    fc_chunk.output_tokens = getattr(stream_usage, "completion_tokens", None)
+                    _d = getattr(stream_usage, "completion_tokens_details", None)
+                    if _d:
+                        fc_chunk.reasoning_tokens = getattr(_d, "reasoning_tokens", None)
+                    _pd = getattr(stream_usage, "prompt_tokens_details", None)
+                    if _pd:
+                        fc_chunk.cached_tokens = getattr(_pd, "cached_tokens", None)
+                yield fc_chunk
 
         # Extract actual token counts from stream usage
         usage_kwargs = {}

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -402,6 +402,8 @@ class GeminiLLM(BaseLLM):
                                 is_cached=False,
                                 run_id=self.run_id,
                             )
+                            if latency_data and latency_data.total_stream_duration_ms is None:
+                                latency_data.total_stream_duration_ms = now_ms() - start_time
                             yield LLMStreamChunk(
                                 data=payload, end_of_stream=False, latency=latency_data, is_function_call=True
                             )
@@ -429,7 +431,7 @@ class GeminiLLM(BaseLLM):
         finally:
             self.started_streaming = False
 
-        if latency_data:
+        if latency_data and latency_data.total_stream_duration_ms is None:
             latency_data.total_stream_duration_ms = now_ms() - start_time
 
         reasoning_content = "\n".join(accumulated_thought_parts) if accumulated_thought_parts else None

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -103,6 +103,10 @@ class LiteLLM(BaseLLM):
                     is_cached=False,
                     run_id=self.run_id,
                 )
+            if isinstance(meta_info, dict):
+                meta_info.setdefault("_non_fatal_errors", []).append(
+                    {"error_type": "content_policy_violation", "error": error_message, "model": self.model}
+                )
             return
         except AuthenticationError as e:
             logger.error(f"LiteLLM authentication failed: Invalid or expired API key - {e}")
@@ -204,6 +208,10 @@ class LiteLLM(BaseLLM):
                     direction=LogDirection.WARNING,
                     is_cached=False,
                     run_id=self.run_id,
+                )
+            if isinstance(meta_info, dict):
+                meta_info.setdefault("_non_fatal_errors", []).append(
+                    {"error_type": "content_policy_violation", "error": error_message, "model": self.model}
                 )
             # Don't re-raise - allow graceful degradation for content policy violations
         except AuthenticationError as e:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -548,7 +548,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         self.started_streaming = False
 
-    async def _generate_responses(self, messages, request_json=False, ret_metadata=False):
+    async def _generate_responses(self, messages, request_json=False, ret_metadata=False, meta_info=None):
         instructions, input_items = self._build_responses_input(messages)
 
         create_kwargs = {
@@ -623,7 +623,11 @@ class OpenAICompatibleLLM(BaseLLM):
         except Exception as e:
             if self.previous_response_id and self._is_stale_response_error(e):
                 logger.warning(f"Stale previous_response_id, retrying with full history: {e}")
+                if isinstance(meta_info, dict):
+                    meta_info.setdefault("_non_fatal_errors", []).append(
+                        {"error_type": "stale_response_id", "error": str(e), "model": self.model}
+                    )
                 self.previous_response_id = None
-                return await self._generate_responses(messages, request_json, ret_metadata)
+                return await self._generate_responses(messages, request_json, ret_metadata, meta_info)
             logger.error(f"Responses API error: {e}")
             raise

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -407,6 +407,10 @@ class OpenAICompatibleLLM(BaseLLM):
         except Exception as e:
             if self.previous_response_id and self._is_stale_response_error(e):
                 logger.warning(f"Stale previous_response_id, retrying with full history: {e}")
+                if isinstance(meta_info, dict):
+                    meta_info.setdefault("_non_fatal_errors", []).append(
+                        {"error_type": "stale_response_id", "error": str(e), "model": self.model}
+                    )
                 self.previous_response_id = None
                 async for chunk in self._generate_stream_responses(
                     messages, synthesize, request_json, meta_info, tool_choice

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -524,6 +524,15 @@ class OpenAICompatibleLLM(BaseLLM):
             latency_data,
         )
         if fc_chunk:
+            if response_usage:
+                fc_chunk.input_tokens = getattr(response_usage, "input_tokens", None)
+                fc_chunk.output_tokens = getattr(response_usage, "output_tokens", None)
+                _od = getattr(response_usage, "output_tokens_details", None)
+                if _od:
+                    fc_chunk.reasoning_tokens = getattr(_od, "reasoning_tokens", None)
+                _id = getattr(response_usage, "input_tokens_details", None)
+                if _id:
+                    fc_chunk.cached_tokens = getattr(_id, "cached_tokens", None)
             yield fc_chunk
 
         usage_kwargs = {}

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -426,6 +426,13 @@ class OpenAICompatibleLLM(BaseLLM):
             if event.type == ResponseStreamEvent.CREATED:
                 self.previous_response_id = event.response.id
                 service_tier = getattr(event.response, "service_tier", None)
+                if latency_data is None:
+                    latency_data = LatencyData(
+                        sequence_id=meta_info.get("sequence_id") if meta_info else None,
+                        connection_latency_ms=round(now - start_time, 2),
+                    )
+                else:
+                    latency_data.connection_latency_ms = round(now - start_time, 2)
                 continue
 
             if event.type == ResponseStreamEvent.FAILED:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -402,9 +402,19 @@ class OpenAiLLM(OpenAICompatibleLLM):
         if accumulator and accumulator.final_tool_calls:
             api_call_payload = accumulator.build_api_payload(model_args, meta_info, answer)
             if api_call_payload:
-                yield LLMStreamChunk(
+                fc_chunk = LLMStreamChunk(
                     data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True
                 )
+                if stream_usage:
+                    fc_chunk.input_tokens = getattr(stream_usage, "prompt_tokens", None)
+                    fc_chunk.output_tokens = getattr(stream_usage, "completion_tokens", None)
+                    _d = getattr(stream_usage, "completion_tokens_details", None)
+                    if _d:
+                        fc_chunk.reasoning_tokens = getattr(_d, "reasoning_tokens", None)
+                    _pd = getattr(stream_usage, "prompt_tokens_details", None)
+                    if _pd:
+                        fc_chunk.cached_tokens = getattr(_pd, "cached_tokens", None)
+                yield fc_chunk
 
         usage_kwargs = {}
         if stream_usage:
@@ -652,6 +662,15 @@ class OpenAiLLM(OpenAICompatibleLLM):
             latency_data,
         )
         if fc_chunk:
+            if response_usage and isinstance(response_usage, dict):
+                fc_chunk.input_tokens = response_usage.get("input_tokens")
+                fc_chunk.output_tokens = response_usage.get("output_tokens")
+                _od = response_usage.get("output_tokens_details") or {}
+                if _od.get("reasoning_tokens"):
+                    fc_chunk.reasoning_tokens = _od["reasoning_tokens"]
+                _id = response_usage.get("input_tokens_details") or {}
+                if _id.get("cached_tokens"):
+                    fc_chunk.cached_tokens = _id["cached_tokens"]
             yield fc_chunk
 
         usage_kwargs = {}

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -291,8 +291,12 @@ class OpenAiLLM(OpenAICompatibleLLM):
             logger.error(f"OpenAI unexpected error: {e}")
             raise
 
+        _connection_latency_ms: Optional[float] = None
         async for chunk in completion_stream:
             now = now_ms()
+            # First chunk = TCP+TLS+HTTP headers received, before any content or token.
+            if _connection_latency_ms is None:
+                _connection_latency_ms = round(now - start_time, 2)
             if hasattr(chunk, "service_tier") and chunk.service_tier:
                 service_tier = chunk.service_tier
                 if latency_data:
@@ -311,6 +315,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     sequence_id=meta_info.get("sequence_id") if meta_info else None,
                     first_token_latency_ms=first_token_time - start_time,
                     total_stream_duration_ms=None,
+                    connection_latency_ms=_connection_latency_ms,
                     service_tier=service_tier,
                     llm_host=self.llm_host,
                 )
@@ -547,6 +552,13 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     resp = evt.get("response", {})
                     self.previous_response_id = resp.get("id")
                     ws_service_tier = resp.get("service_tier")
+                    if latency_data is None:
+                        latency_data = LatencyData(
+                            sequence_id=meta_info.get("sequence_id") if meta_info else None,
+                            connection_latency_ms=round(now - start_time, 2),
+                        )
+                    else:
+                        latency_data.connection_latency_ms = round(now - start_time, 2)
                     continue
 
                 if evt_type == ResponseStreamEvent.FAILED:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -424,9 +424,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self.started_streaming = False
 
-    async def generate(self, messages, request_json=False, ret_metadata=False):
+    async def generate(self, messages, request_json=False, ret_metadata=False, meta_info=None):
         if self.use_responses_api:
-            return await self._generate_responses(messages, request_json, ret_metadata)
+            return await self._generate_responses(messages, request_json, ret_metadata, meta_info)
         return await self._generate_chat(messages, request_json, ret_metadata)
 
     async def _generate_chat(self, messages, request_json=False, ret_metadata=False):

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -16,6 +16,7 @@ class LatencyData(BaseModel):
     sequence_id: Optional[int] = None
     first_token_latency_ms: Optional[float] = None
     total_stream_duration_ms: Optional[float] = None
+    connection_latency_ms: Optional[float] = None
     service_tier: Optional[str] = None
     llm_host: Optional[str] = None
 

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -65,6 +65,8 @@ class PixaSynthesizer(BaseSynthesizer):
         self.connection_error = None
         self.current_turn_start_time = None
         self.current_turn_id = None
+        self.current_sequence_id = None
+        self.current_tts_start_ms = None
         self.current_text = ""
 
         self.api_host = os.environ.get("PIXA_TTS_HOST", "hindi.heypixa.ai")
@@ -304,7 +306,8 @@ class PixaSynthesizer(BaseSynthesizer):
                             self.turn_latencies.append(
                                 {
                                     "turn_id": self.current_turn_id,
-                                    "sequence_id": self.current_turn_id,
+                                    "sequence_id": self.current_sequence_id,
+                                    "tts_start_ms": self.current_tts_start_ms,
                                     "first_result_latency_ms": round(
                                         (self.meta_info.get("synthesizer_latency", 0)) * 1000
                                     ),
@@ -313,6 +316,8 @@ class PixaSynthesizer(BaseSynthesizer):
                             )
                             self.current_turn_start_time = None
                             self.current_turn_id = None
+                            self.current_sequence_id = None
+                            self.current_tts_start_ms = None
                     except Exception:
                         pass
 
@@ -410,6 +415,8 @@ class PixaSynthesizer(BaseSynthesizer):
             try:
                 self.current_turn_start_time = time.perf_counter()
                 self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
+                self.current_sequence_id = meta_info.get("sequence_id") or self.current_turn_id
+                self.current_tts_start_ms = meta_info.get("tts_start_ms")
             except Exception:
                 pass
 

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -414,8 +414,8 @@ class PixaSynthesizer(BaseSynthesizer):
 
             try:
                 self.current_turn_start_time = time.perf_counter()
-                self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
-                self.current_sequence_id = meta_info.get("sequence_id") or self.current_turn_id
+                self.current_turn_id = meta_info.get("turn_id") if meta_info.get("turn_id") is not None else meta_info.get("sequence_id")
+                self.current_sequence_id = meta_info.get("sequence_id") if meta_info.get("sequence_id") is not None else self.current_turn_id
                 self.current_tts_start_ms = meta_info.get("tts_start_ms")
             except Exception:
                 pass

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -414,8 +414,8 @@ class PixaSynthesizer(BaseSynthesizer):
 
             try:
                 self.current_turn_start_time = time.perf_counter()
-                self.current_turn_id = meta_info.get("turn_id") if meta_info.get("turn_id") is not None else meta_info.get("sequence_id")
-                self.current_sequence_id = meta_info.get("sequence_id") if meta_info.get("sequence_id") is not None else self.current_turn_id
+                self.current_turn_id = meta_info.get("turn_id")
+                self.current_sequence_id = meta_info.get("sequence_id")
                 self.current_tts_start_ms = meta_info.get("tts_start_ms")
             except Exception:
                 pass

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -175,8 +175,8 @@ class StreamSynthesizer(BaseSynthesizer):
             self.ws_send_time = None
             self.current_turn_ttfb = None
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
-        self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
-        self.current_sequence_id = meta_info.get("sequence_id") or self.current_turn_id
+        self.current_turn_id = meta_info.get("turn_id") if meta_info.get("turn_id") is not None else meta_info.get("sequence_id")
+        self.current_sequence_id = meta_info.get("sequence_id") if meta_info.get("sequence_id") is not None else self.current_turn_id
         self.current_tts_start_ms = meta_info.get("tts_start_ms")
 
     def _on_push(self, meta_info, text):

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -62,6 +62,7 @@ class StreamSynthesizer(BaseSynthesizer):
         self.current_tts_start_ms = None
         self.current_turn_ttfb = None
         self.ws_send_time = None
+        self.current_sequence_chars = 0
 
     # ------------------------------------------------------------------
     # Subclass hooks (override these)
@@ -155,6 +156,7 @@ class StreamSynthesizer(BaseSynthesizer):
         text = message.get("data")
         self.current_text = text
         self.synthesized_characters += len(text) if text else 0
+        self.current_sequence_chars += len(text) if text else 0
         end_of_llm_stream = meta_info.get("end_of_llm_stream", False)
         self.meta_info = copy.deepcopy(meta_info)
         meta_info["text"] = text
@@ -268,6 +270,7 @@ class StreamSynthesizer(BaseSynthesizer):
                         "tts_start_ms": self.current_tts_start_ms,
                         "first_result_latency_ms": round((self.current_turn_ttfb or 0) * 1000),
                         "total_stream_duration_ms": round(total_stream_duration * 1000),
+                        "characters": self.current_sequence_chars,
                     }
                 )
                 self.current_turn_start_time = None
@@ -276,6 +279,7 @@ class StreamSynthesizer(BaseSynthesizer):
                 self.current_tts_start_ms = None
                 self.ws_send_time = None
                 self.current_turn_ttfb = None
+                self.current_sequence_chars = 0
         except Exception:
             pass
 

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -58,6 +58,8 @@ class StreamSynthesizer(BaseSynthesizer):
         # Turn-level latency tracking
         self.current_turn_start_time = None
         self.current_turn_id = None
+        self.current_sequence_id = None
+        self.current_tts_start_ms = None
         self.current_turn_ttfb = None
         self.ws_send_time = None
 
@@ -174,6 +176,8 @@ class StreamSynthesizer(BaseSynthesizer):
             self.current_turn_ttfb = None
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
         self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
+        self.current_sequence_id = meta_info.get("sequence_id") or self.current_turn_id
+        self.current_tts_start_ms = meta_info.get("tts_start_ms")
 
     def _on_push(self, meta_info, text):
         """Provider-specific hook called during push before sender is created."""
@@ -260,13 +264,16 @@ class StreamSynthesizer(BaseSynthesizer):
                 self.turn_latencies.append(
                     {
                         "turn_id": self.current_turn_id,
-                        "sequence_id": self.current_turn_id,
+                        "sequence_id": self.current_sequence_id,
+                        "tts_start_ms": self.current_tts_start_ms,
                         "first_result_latency_ms": round((self.current_turn_ttfb or 0) * 1000),
                         "total_stream_duration_ms": round(total_stream_duration * 1000),
                     }
                 )
                 self.current_turn_start_time = None
                 self.current_turn_id = None
+                self.current_sequence_id = None
+                self.current_tts_start_ms = None
                 self.ws_send_time = None
                 self.current_turn_ttfb = None
         except Exception:

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -175,8 +175,8 @@ class StreamSynthesizer(BaseSynthesizer):
             self.ws_send_time = None
             self.current_turn_ttfb = None
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
-        self.current_turn_id = meta_info.get("turn_id") if meta_info.get("turn_id") is not None else meta_info.get("sequence_id")
-        self.current_sequence_id = meta_info.get("sequence_id") if meta_info.get("sequence_id") is not None else self.current_turn_id
+        self.current_turn_id = meta_info.get("turn_id")
+        self.current_sequence_id = meta_info.get("sequence_id")
         self.current_tts_start_ms = meta_info.get("tts_start_ms")
 
     def _on_push(self, meta_info, text):

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -176,10 +176,13 @@ class StreamSynthesizer(BaseSynthesizer):
             self.current_turn_start_time = time.perf_counter()
             self.ws_send_time = None
             self.current_turn_ttfb = None
+            # Anchor tts_start_ms to the first push — re-pushes of speculative responses
+            # (e.g. after a tool call confirms the eager response) would overwrite this
+            # to a later timestamp, making tts_start appear after agent_speech_start.
+            self.current_tts_start_ms = meta_info.get("tts_start_ms")
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
         self.current_turn_id = meta_info.get("turn_id")
         self.current_sequence_id = meta_info.get("sequence_id")
-        self.current_tts_start_ms = meta_info.get("tts_start_ms")
 
     def _on_push(self, meta_info, text):
         """Provider-specific hook called during push before sender is created."""

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -77,6 +77,7 @@ class AssemblyAITranscriber(BaseTranscriber):
         self.current_turn_id = None
         self.current_turn_interim_details = []
         self.connection_error = None
+        self._turn_start_epoch_ms = None
 
     def get_assemblyai_ws_url(self):
         """Get the AssemblyAI WebSocket URL with appropriate parameters"""
@@ -315,6 +316,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                         try:
                             if not self.current_turn_start_time:
                                 self.current_turn_start_time = time.perf_counter()
+                                self._turn_start_epoch_ms = timestamp_ms()
                                 meta = self.meta_info or {}
                                 self.current_turn_id = meta.get("turn_id") or meta.get("request_id")
                         except Exception:
@@ -396,6 +398,7 @@ class AssemblyAITranscriber(BaseTranscriber):
 
                             if self.current_turn_start_time is None:
                                 self.current_turn_start_time = time.perf_counter()
+                                self._turn_start_epoch_ms = timestamp_ms()
                                 self.current_turn_id = self.generate_request_id()
                                 self.current_turn_interim_details = []
                                 if "transcriber_first_result_latency" in (self.meta_info or {}):
@@ -430,12 +433,14 @@ class AssemblyAITranscriber(BaseTranscriber):
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
+                                        "asr_start_epoch_ms": self._turn_start_epoch_ms,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "final_transcript": transcript,
                                     }
                                     self.turn_latencies.append(turn_info)
 
                                     self.current_turn_start_time = None
+                                    self._turn_start_epoch_ms = None
                                     self.current_turn_id = None
                                     self.current_turn_interim_details = []
                             except Exception as e:
@@ -446,6 +451,7 @@ class AssemblyAITranscriber(BaseTranscriber):
 
                             if self.current_turn_start_time is None:
                                 self.current_turn_start_time = time.perf_counter()
+                                self._turn_start_epoch_ms = timestamp_ms()
                                 self.current_turn_id = self.generate_request_id()
                                 self.current_turn_interim_details = []
                                 if "transcriber_first_result_latency" in (self.meta_info or {}):

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -75,6 +75,7 @@ class AssemblyAITranscriber(BaseTranscriber):
         self.connection_authenticated = False
         self.current_turn_start_time = None
         self.current_turn_id = None
+        self.turn_counter = 0
         self.current_turn_interim_details = []
         self.connection_error = None
         self._turn_start_epoch_ms = None
@@ -399,7 +400,8 @@ class AssemblyAITranscriber(BaseTranscriber):
                             if self.current_turn_start_time is None:
                                 self.current_turn_start_time = time.perf_counter()
                                 self._turn_start_epoch_ms = timestamp_ms()
-                                self.current_turn_id = self.generate_request_id()
+                                self.turn_counter += 1
+                                self.current_turn_id = self.turn_counter
                                 self.current_turn_interim_details = []
                                 if "transcriber_first_result_latency" in (self.meta_info or {}):
                                     del self.meta_info["transcriber_first_result_latency"]
@@ -452,7 +454,8 @@ class AssemblyAITranscriber(BaseTranscriber):
                             if self.current_turn_start_time is None:
                                 self.current_turn_start_time = time.perf_counter()
                                 self._turn_start_epoch_ms = timestamp_ms()
-                                self.current_turn_id = self.generate_request_id()
+                                self.turn_counter += 1
+                                self.current_turn_id = self.turn_counter
                                 self.current_turn_interim_details = []
                                 if "transcriber_first_result_latency" in (self.meta_info or {}):
                                     del self.meta_info["transcriber_first_result_latency"]

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -430,6 +430,8 @@ class AssemblyAITranscriber(BaseTranscriber):
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
+                                        "asr_finalized_epoch_ms": timestamp_ms(),
+                                        "final_transcript": transcript,
                                     }
                                     self.turn_latencies.append(turn_info)
 

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -290,6 +290,7 @@ class AzureTranscriber(BaseTranscriber):
                 self.current_turn_start_time = None
                 self._turn_start_epoch_ms = None
                 self.current_turn_id = None
+                self._turn_start_epoch_ms = None
             except Exception as e:
                 logger.error(f"Error tracking turn latencies: {e}")
 

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -48,6 +48,7 @@ class AzureTranscriber(BaseTranscriber):
         self.current_turn_id = None
         self.speech_start_time = None
         self._turn_start_epoch_ms = None
+        self.turn_counter = 0
 
         if self.audio_provider in ("twilio", "exotel", "plivo"):
             self.encoding = "mulaw" if self.audio_provider in ("twilio",) else "linear16"
@@ -220,6 +221,7 @@ class AzureTranscriber(BaseTranscriber):
             }
             self.current_turn_interim_details.append(interim_detail)
             if self._turn_start_epoch_ms is None:
+                self.turn_counter += 1
                 self._turn_start_epoch_ms = timestamp_ms()
 
             data = {"type": "interim_transcript_received", "content": evt.result.text.strip()}

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -275,6 +275,8 @@ class AzureTranscriber(BaseTranscriber):
                     "interim_details": self.current_turn_interim_details,
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": evt.result.text.strip(),
                 }
                 self.turn_latencies.append(turn_info)
 

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -47,6 +47,7 @@ class AzureTranscriber(BaseTranscriber):
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.speech_start_time = None
+        self._turn_start_epoch_ms = None
 
         if self.audio_provider in ("twilio", "exotel", "plivo"):
             self.encoding = "mulaw" if self.audio_provider in ("twilio",) else "linear16"
@@ -218,6 +219,8 @@ class AzureTranscriber(BaseTranscriber):
                 "duration_seconds": duration_seconds,
             }
             self.current_turn_interim_details.append(interim_detail)
+            if self._turn_start_epoch_ms is None:
+                self._turn_start_epoch_ms = timestamp_ms()
 
             data = {"type": "interim_transcript_received", "content": evt.result.text.strip()}
             try:
@@ -275,6 +278,7 @@ class AzureTranscriber(BaseTranscriber):
                     "interim_details": self.current_turn_interim_details,
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
+                    "asr_start_epoch_ms": self._turn_start_epoch_ms,
                     "asr_finalized_epoch_ms": timestamp_ms(),
                     "final_transcript": evt.result.text.strip(),
                 }
@@ -282,6 +286,7 @@ class AzureTranscriber(BaseTranscriber):
 
                 self.current_turn_interim_details = []
                 self.current_turn_start_time = None
+                self._turn_start_epoch_ms = None
                 self.current_turn_id = None
             except Exception as e:
                 logger.error(f"Error tracking turn latencies: {e}")

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -364,6 +364,7 @@ class DeepgramTranscriber(BaseTranscriber):
                 {
                     "turn_id": self.current_turn_id,
                     "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                     "asr_finalized_epoch_ms": timestamp_ms(),
                     "interim_details": self.current_turn_interim_details,
                     "first_interim_to_final_ms": first_interim_to_final_ms,
@@ -756,7 +757,8 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.turn_latencies.append(
                                 {
                                     "turn_id": self.current_turn_id,
-                                    "asr_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                     "asr_finalized_epoch_ms": timestamp_ms(),
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
@@ -917,6 +919,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
                                         "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "final_transcript": transcript,
                                     }

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -479,7 +479,7 @@ class DeepgramTranscriber(BaseTranscriber):
 
                 if msg["type"] == "SpeechStarted":
                     logger.info("Received SpeechStarted event from deepgram")
-                    if self.current_turn_id is None:
+                    if not isinstance(self.current_turn_id, int):
                         self.turn_counter += 1
                         self.current_turn_id = self.turn_counter
                     self.speech_start_time = timestamp_ms()

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -588,9 +588,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                 )
                                 pass
                             self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
-                            last_word_end_wall = self._compute_last_word_end_wall(msg)
-                            if last_word_end_wall is not None:
-                                self.meta_info["user_stop_ts_wall"] = last_word_end_wall
+                            self.meta_info["user_stop_ts_wall"] = self._compute_last_word_end_wall(msg)
                             yield create_ws_data_packet(data, self.meta_info)
 
                 elif msg["type"] == "UtteranceEnd":

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -363,16 +363,14 @@ class DeepgramTranscriber(BaseTranscriber):
             self.turn_latencies.append(
                 {
                     "turn_id": self.current_turn_id,
-                    "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_start_epoch_ms": self.current_turn_start_time,
                     "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                     "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": transcript_to_send,
                     "interim_details": self.current_turn_interim_details,
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
                     "force_finalized": True,
-                    "asr_start_epoch_ms": self.current_turn_start_time,
-                    "asr_finalized_epoch_ms": timestamp_ms(),
-                    "final_transcript": transcript_to_send,
                 }
             )
         except Exception as e:
@@ -705,16 +703,13 @@ class DeepgramTranscriber(BaseTranscriber):
                                 self.turn_latencies.append(
                                     {
                                         "turn_id": self.current_turn_id,
-                                        "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_start_epoch_ms": self.current_turn_start_time,
                                         "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
-                                        "final_transcript": self.final_transcript,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
+                                        "final_transcript": self.final_transcript,
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
-                                        "asr_start_epoch_ms": self.current_turn_start_time,
-                                        "asr_finalized_epoch_ms": timestamp_ms(),
-                                        "final_transcript": self.final_transcript,
                                     }
                                 )
 
@@ -733,6 +728,8 @@ class DeepgramTranscriber(BaseTranscriber):
                                 )
                                 pass
                             self.meta_info["user_stop_offset_ms"] = self.endpointing_ms
+                            # Always assign (even None) to clear any stale value from a previous turn.
+                            # None is safe: interruption_manager guards on it before use.
                             self.meta_info["user_stop_ts_wall"] = self._compute_last_word_end_wall(msg)
                             yield create_ws_data_packet(data, self.meta_info)
 
@@ -763,15 +760,13 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.turn_latencies.append(
                                 {
                                     "turn_id": self.current_turn_id,
-                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_start_epoch_ms": self.current_turn_start_time,
                                     "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                     "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": self.final_transcript,
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
                                     "last_interim_to_final_ms": last_interim_to_final_ms,
-                                    "asr_start_epoch_ms": self.current_turn_start_time,
-                                    "asr_finalized_epoch_ms": timestamp_ms(),
-                                    "final_transcript": self.final_transcript,
                                 }
                             )
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -241,6 +241,8 @@ class DeepgramTranscriber(BaseTranscriber):
                 {
                     "turn_id": self.current_turn_id,
                     "sequence_id": self.current_turn_id,
+                    "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
                     "interim_details": self.current_turn_interim_details,
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
@@ -547,6 +549,8 @@ class DeepgramTranscriber(BaseTranscriber):
                                     {
                                         "turn_id": self.current_turn_id,
                                         "sequence_id": self.current_turn_id,
+                                        "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_finalized_epoch_ms": timestamp_ms(),
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -93,6 +93,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.connection_authenticated = False
         self.speech_start_time = None
         self.speech_end_time = None
+        self._turn_first_speech_epoch_ms = None  # epoch ms of first SpeechStarted per turn
         self.current_turn_interim_details = []
         self.audio_frame_timestamps = []  # List of (frame_start, frame_end, send_timestamp)
         self.turn_counter = 0
@@ -208,6 +209,7 @@ class DeepgramTranscriber(BaseTranscriber):
         """Reset turn state variables after finalizing a transcript"""
         self.speech_start_time = None
         self.speech_end_time = None
+        self._turn_first_speech_epoch_ms = None
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -482,7 +484,8 @@ class DeepgramTranscriber(BaseTranscriber):
                     if not isinstance(self.current_turn_id, int):
                         self.turn_counter += 1
                         self.current_turn_id = self.turn_counter
-                        self.speech_start_time = timestamp_ms()
+                        self._turn_first_speech_epoch_ms = timestamp_ms()
+                    self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
 
@@ -548,7 +551,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                 self.turn_latencies.append(
                                     {
                                         "turn_id": self.current_turn_id,
-                                        "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
@@ -559,6 +562,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                 # Complete turn reset
                                 self.speech_start_time = None
                                 self.speech_end_time = None
+                                self._turn_first_speech_epoch_ms = None
                                 self.current_turn_interim_details = []
                                 self.current_turn_start_time = None
                                 self.current_turn_id = None
@@ -595,7 +599,7 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.turn_latencies.append(
                                 {
                                     "turn_id": self.current_turn_id,
-                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                     "asr_finalized_epoch_ms": timestamp_ms(),
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
@@ -606,6 +610,7 @@ class DeepgramTranscriber(BaseTranscriber):
                             # Complete turn reset
                             self.speech_start_time = None
                             self.speech_end_time = None
+                            self._turn_first_speech_epoch_ms = None
                             self.current_turn_interim_details = []
                             self.current_turn_start_time = None
                             self.current_turn_id = None
@@ -627,6 +632,7 @@ class DeepgramTranscriber(BaseTranscriber):
                         )
                         self.speech_start_time = None
                         self.speech_end_time = None
+                        self._turn_first_speech_epoch_ms = None
                         self.current_turn_interim_details = []
                         self.current_turn_start_time = None
                         self.current_turn_id = None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -94,6 +94,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.speech_start_time = None
         self.speech_end_time = None
         self._turn_first_speech_epoch_ms = None  # epoch ms of first SpeechStarted per turn
+        self._turn_pending = False  # True after SpeechStarted until first real interim confirms speech
         self.current_turn_interim_details = []
         self.audio_frame_timestamps = []  # List of (frame_start, frame_end, send_timestamp)
         self.turn_counter = 0
@@ -210,6 +211,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.speech_start_time = None
         self.speech_end_time = None
         self._turn_first_speech_epoch_ms = None
+        self._turn_pending = False
         self.last_interim_time = None
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
@@ -482,9 +484,8 @@ class DeepgramTranscriber(BaseTranscriber):
                 if msg["type"] == "SpeechStarted":
                     logger.info("Received SpeechStarted event from deepgram")
                     if not isinstance(self.current_turn_id, int):
-                        self.turn_counter += 1
-                        self.current_turn_id = self.turn_counter
                         self._turn_first_speech_epoch_ms = timestamp_ms()
+                        self._turn_pending = True  # counter incremented on first real interim
                     self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
@@ -498,6 +499,11 @@ class DeepgramTranscriber(BaseTranscriber):
                     deepgram_request_id = msg.get("metadata", {}).get("request_id")
 
                     if transcript.strip():
+                        if self._turn_pending:
+                            self.turn_counter += 1
+                            self.current_turn_id = self.turn_counter
+                            self._turn_pending = False
+                            logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                         # Calculate latency using end position (start + duration) for cumulative transcripts
                         self.__set_transcription_cursor(msg)
                         audio_position_end = self.transcription_cursor
@@ -553,6 +559,7 @@ class DeepgramTranscriber(BaseTranscriber):
                                         "turn_id": self.current_turn_id,
                                         "asr_start_epoch_ms": self.speech_start_time,
                                         "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                                        "final_transcript": self.final_transcript,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
@@ -634,6 +641,7 @@ class DeepgramTranscriber(BaseTranscriber):
                         self.speech_start_time = None
                         self.speech_end_time = None
                         self._turn_first_speech_epoch_ms = None
+                        self._turn_pending = False
                         self.current_turn_interim_details = []
                         self.current_turn_start_time = None
                         self.current_turn_id = None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -479,8 +479,9 @@ class DeepgramTranscriber(BaseTranscriber):
 
                 if msg["type"] == "SpeechStarted":
                     logger.info("Received SpeechStarted event from deepgram")
-                    self.turn_counter += 1
-                    self.current_turn_id = self.turn_counter
+                    if self.current_turn_id is None:
+                        self.turn_counter += 1
+                        self.current_turn_id = self.turn_counter
                     self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -482,7 +482,7 @@ class DeepgramTranscriber(BaseTranscriber):
                     if not isinstance(self.current_turn_id, int):
                         self.turn_counter += 1
                         self.current_turn_id = self.turn_counter
-                    self.speech_start_time = timestamp_ms()
+                        self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -250,6 +250,9 @@ class DeepgramTranscriber(BaseTranscriber):
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
                     "force_finalized": True,
+                    "asr_start_epoch_ms": self.current_turn_start_time,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": transcript_to_send,
                 }
             )
         except Exception as e:
@@ -564,6 +567,9 @@ class DeepgramTranscriber(BaseTranscriber):
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
+                                        "asr_start_epoch_ms": self.current_turn_start_time,
+                                        "asr_finalized_epoch_ms": timestamp_ms(),
+                                        "final_transcript": self.final_transcript,
                                     }
                                 )
 
@@ -612,6 +618,9 @@ class DeepgramTranscriber(BaseTranscriber):
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
                                     "last_interim_to_final_ms": last_interim_to_final_ms,
+                                    "asr_start_epoch_ms": self.current_turn_start_time,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": self.final_transcript,
                                 }
                             )
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -551,7 +551,8 @@ class DeepgramTranscriber(BaseTranscriber):
                                 self.turn_latencies.append(
                                     {
                                         "turn_id": self.current_turn_id,
-                                        "asr_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                                        "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -240,7 +240,6 @@ class DeepgramTranscriber(BaseTranscriber):
             self.turn_latencies.append(
                 {
                     "turn_id": self.current_turn_id,
-                    "sequence_id": self.current_turn_id,
                     "asr_start_epoch_ms": self.speech_start_time,
                     "asr_finalized_epoch_ms": timestamp_ms(),
                     "interim_details": self.current_turn_interim_details,
@@ -548,7 +547,6 @@ class DeepgramTranscriber(BaseTranscriber):
                                 self.turn_latencies.append(
                                     {
                                         "turn_id": self.current_turn_id,
-                                        "sequence_id": self.current_turn_id,
                                         "asr_start_epoch_ms": self.speech_start_time,
                                         "asr_finalized_epoch_ms": timestamp_ms(),
                                         "interim_details": self.current_turn_interim_details,
@@ -596,7 +594,8 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.turn_latencies.append(
                                 {
                                     "turn_id": self.current_turn_id,
-                                    "sequence_id": self.current_turn_id,
+                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
                                     "last_interim_to_final_ms": last_interim_to_final_ms,

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -631,6 +631,12 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.current_turn_id = self.turn_counter
                             self._turn_pending = False
                             logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
+                        elif self.current_turn_id is None:
+                            # SpeechStarted was suppressed (e.g. Deepgram VAD inhibited during
+                            # agent audio playback) but real speech arrived — still assign a turn_id.
+                            self.turn_counter += 1
+                            self.current_turn_id = self.turn_counter
+                            logger.info(f"Turn id assigned without SpeechStarted: {self.current_turn_id}")
                         # Calculate latency using end position (start + duration) for cumulative transcripts
                         self.__set_transcription_cursor(msg)
                         audio_position_end = self.transcription_cursor

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -211,6 +211,9 @@ class ElevenLabsTranscriber(BaseTranscriber):
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
                     "force_finalized": True,
+                    "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": transcript_to_send,
                 }
             )
         except Exception as e:
@@ -447,6 +450,9 @@ class ElevenLabsTranscriber(BaseTranscriber):
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
                                     "last_interim_to_final_ms": last_interim_to_final_ms,
+                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": transcript,
                                 }
                             )
 
@@ -496,6 +502,9 @@ class ElevenLabsTranscriber(BaseTranscriber):
                                     "last_interim_to_final_ms": last_interim_to_final_ms,
                                     "words": words,
                                     "detected_language": detected_language,
+                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": transcript,
                                 }
                             )
 

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -355,6 +355,9 @@ class GladiaTranscriber(BaseTranscriber):
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
                     "force_finalized": True,
+                    "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": transcript_to_send,
                 }
             )
         except Exception as e:
@@ -617,6 +620,9 @@ class GladiaTranscriber(BaseTranscriber):
                                         "interim_details": self.current_turn_interim_details,
                                         "first_interim_to_final_ms": first_interim_to_final_ms,
                                         "last_interim_to_final_ms": last_interim_to_final_ms,
+                                        "asr_start_epoch_ms": self.speech_start_time,
+                                        "asr_finalized_epoch_ms": timestamp_ms(),
+                                        "final_transcript": self.final_transcript,
                                     }
                                 )
                             except Exception as e:

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -84,6 +84,7 @@ class GoogleTranscriber(BaseTranscriber):
         self.turn_latencies = []
         self.current_turn_start_time = None
         self.current_turn_id = None
+        self._turn_start_epoch_ms = None
 
         # Request tracking
         self.meta_info = None
@@ -201,6 +202,7 @@ class GoogleTranscriber(BaseTranscriber):
                         self.meta_info["transcriber_start_time"] = time.perf_counter()
                         # start turn-level tracking
                         self.current_turn_start_time = self.meta_info["transcriber_start_time"]
+                        self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_id = (
                             self.meta_info.get("turn_id") or self.meta_info.get("request_id") or self._request_id
                         )
@@ -268,6 +270,7 @@ class GoogleTranscriber(BaseTranscriber):
                     "sequence_id": self.current_turn_id,
                     "first_result_latency_ms": first_ms,
                     "total_stream_duration_ms": int(round(total_s * 1000)),
+                    "asr_start_epoch_ms": self._turn_start_epoch_ms,
                     "asr_finalized_epoch_ms": timestamp_ms(),
                 }
                 if final_transcript:
@@ -280,6 +283,7 @@ class GoogleTranscriber(BaseTranscriber):
                     pass
                 # reset turn tracking
                 self.current_turn_start_time = None
+                self._turn_start_epoch_ms = None
                 self.current_turn_id = None
         except Exception:
             logger.exception("Error appending turn latency")

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -10,7 +10,7 @@ from google.cloud import speech_v1p1beta1 as speech
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
-from bolna.helpers.utils import create_ws_data_packet
+from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
 logger = configure_logger(__name__)
@@ -254,7 +254,7 @@ class GoogleTranscriber(BaseTranscriber):
                 except Exception:
                     logger.exception("Non-bytes chunk received in google audio generator; dropping")
 
-    def _append_turn_latency(self):
+    def _append_turn_latency(self, final_transcript=None):
         """
         Add a turn latency entry compatible with the Deepgram 'turn_latencies' entries.
         Called when a final transcript arrives (end-of-turn semantics).
@@ -263,14 +263,16 @@ class GoogleTranscriber(BaseTranscriber):
             if self.current_turn_id and self.current_turn_start_time:
                 first_ms = int(round((self.meta_info.get("transcriber_first_result_latency", 0)) * 1000))
                 total_s = (time.perf_counter() - self.current_turn_start_time) if self.current_turn_start_time else 0
-                self.turn_latencies.append(
-                    {
-                        "turn_id": self.current_turn_id,
-                        "sequence_id": self.current_turn_id,
-                        "first_result_latency_ms": first_ms,
-                        "total_stream_duration_ms": int(round(total_s * 1000)),
-                    }
-                )
+                entry = {
+                    "turn_id": self.current_turn_id,
+                    "sequence_id": self.current_turn_id,
+                    "first_result_latency_ms": first_ms,
+                    "total_stream_duration_ms": int(round(total_s * 1000)),
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                }
+                if final_transcript:
+                    entry["final_transcript"] = final_transcript
+                self.turn_latencies.append(entry)
                 # also expose on meta_info for immediate consumption
                 try:
                     self.meta_info["turn_latencies"] = self.turn_latencies
@@ -367,7 +369,7 @@ class GoogleTranscriber(BaseTranscriber):
                                 pass
 
                             # append to turn_latencies (A)
-                            self._append_turn_latency()
+                            self._append_turn_latency(transcript)
 
                             data = {"type": "transcript", "content": transcript}
                             self._enqueue_output(data, meta=self.meta_info)

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -84,6 +84,7 @@ class GoogleTranscriber(BaseTranscriber):
         self.turn_latencies = []
         self.current_turn_start_time = None
         self.current_turn_id = None
+        self.turn_counter = 0
         self._turn_start_epoch_ms = None
 
         # Request tracking
@@ -203,9 +204,8 @@ class GoogleTranscriber(BaseTranscriber):
                         # start turn-level tracking
                         self.current_turn_start_time = self.meta_info["transcriber_start_time"]
                         self._turn_start_epoch_ms = timestamp_ms()
-                        self.current_turn_id = (
-                            self.meta_info.get("turn_id") or self.meta_info.get("request_id") or self._request_id
-                        )
+                        self.turn_counter += 1
+                        self.current_turn_id = self.turn_counter
                     except Exception:
                         pass
 

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -82,6 +82,7 @@ class OpenAITranscriber(BaseTranscriber):
         self.current_turn_start_time = None
         self.turn_counter = 0
         self.current_turn_interim_details = []
+        self._turn_start_epoch_ms = None
         # Saved at commit time so the receiver can still identify the turn after
         # _reset_turn_state() clears current_turn_id (e.g. utterance timeout race).
         self._last_committed_turn_id: Optional[str] = None
@@ -151,6 +152,7 @@ class OpenAITranscriber(BaseTranscriber):
             return
         self.current_turn_interim_details = []
         self.current_turn_start_time = None
+        self._turn_start_epoch_ms = None
         self.current_turn_id = None
         self.is_transcript_sent_for_processing = True
         self._turn_committed = False
@@ -335,6 +337,7 @@ class OpenAITranscriber(BaseTranscriber):
                         self.turn_counter += 1
                         self.current_turn_id = f"turn_{self.turn_counter}"
                         self.current_turn_start_time = time.perf_counter()
+                        self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []
                         self.is_transcript_sent_for_processing = False
                         logger.info(f"Speech detected, starting turn {self.current_turn_id}")
@@ -432,6 +435,7 @@ class OpenAITranscriber(BaseTranscriber):
                                     "total_stream_duration_ms": round(
                                         (self.meta_info.get("transcriber_total_stream_duration") or 0) * 1000
                                     ),
+                                    "asr_start_epoch_ms": self._turn_start_epoch_ms,
                                     "asr_finalized_epoch_ms": timestamp_ms(),
                                     "final_transcript": transcript,
                                 }

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -20,7 +20,7 @@ from bolna.constants import (
 )
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
-from bolna.helpers.utils import create_ws_data_packet
+from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
 logger = configure_logger(__name__)
@@ -432,6 +432,8 @@ class OpenAITranscriber(BaseTranscriber):
                                     "total_stream_duration_ms": round(
                                         (self.meta_info.get("transcriber_total_stream_duration") or 0) * 1000
                                     ),
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": transcript,
                                 }
                             )
                             self._reset_turn_state()

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -315,6 +315,9 @@ class PixaTranscriber(BaseTranscriber):
                                             "sequence_id": self.current_turn_id,
                                             "first_result_latency_ms": self.turn_first_result_latency,
                                             "total_stream_duration_ms": total_duration_ms,
+                                            "asr_start_epoch_ms": self.current_turn_start_time,
+                                            "asr_finalized_epoch_ms": timestamp_ms(),
+                                            "final_transcript": self.final_transcript,
                                         }
                                         self.turn_latencies.append(turn_info)
                                         self.meta_info["turn_latencies"] = self.turn_latencies
@@ -403,6 +406,9 @@ class PixaTranscriber(BaseTranscriber):
                 "first_result_latency_ms": self.turn_first_result_latency,
                 "total_stream_duration_ms": total_duration_ms,
                 "force_finalized": True,
+                "asr_start_epoch_ms": self.current_turn_start_time,
+                "asr_finalized_epoch_ms": timestamp_ms(),
+                "final_transcript": transcript_to_send,
             }
             self.turn_latencies.append(turn_info)
             self.meta_info["turn_latencies"] = self.turn_latencies

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -81,6 +81,7 @@ class SarvamTranscriber(BaseTranscriber):
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.turn_latencies = []
+        self._turn_start_epoch_ms = None
         self.first_result_latency_ms = None
         self.total_stream_duration_ms = None
         self.last_vocal_frame_timestamp = None
@@ -380,6 +381,7 @@ class SarvamTranscriber(BaseTranscriber):
                         if vad.get("signal_type") == "START_SPEECH":
                             logger.debug("Sarvam VAD: speech started")
                             self.current_turn_start_time = time.perf_counter()
+                            self._turn_start_epoch_ms = timestamp_ms()
                             self.turn_counter += 1
                             self.current_turn_id = f"turn_{self.turn_counter}"
                             self.turn_first_result_latency = None
@@ -403,6 +405,7 @@ class SarvamTranscriber(BaseTranscriber):
                                     "sequence_id": self.current_turn_id,
                                     "first_result_latency_ms": self.turn_first_result_latency,
                                     "total_stream_duration_ms": total_stream_duration_ms,
+                                    "asr_start_epoch_ms": self._turn_start_epoch_ms,
                                     "asr_finalized_epoch_ms": timestamp_ms(),
                                     "final_transcript": self.final_transcript or None,
                                 }
@@ -411,6 +414,7 @@ class SarvamTranscriber(BaseTranscriber):
 
                                 # Reset turn tracking
                                 self.current_turn_start_time = None
+                                self._turn_start_epoch_ms = None
                                 self.current_turn_id = None
 
                             if self.final_transcript:

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -20,7 +20,7 @@ from typing import Optional
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
-from bolna.helpers.utils import create_ws_data_packet
+from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
 load_dotenv()
 logger = configure_logger(__name__)
@@ -403,6 +403,8 @@ class SarvamTranscriber(BaseTranscriber):
                                     "sequence_id": self.current_turn_id,
                                     "first_result_latency_ms": self.turn_first_result_latency,
                                     "total_stream_duration_ms": total_stream_duration_ms,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": self.final_transcript or None,
                                 }
                                 self.turn_latencies.append(turn_info)
                                 self.meta_info["turn_latencies"] = self.turn_latencies

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -294,6 +294,9 @@ class SmallestTranscriber(BaseTranscriber):
                     "first_interim_to_final_ms": first_interim_to_final_ms,
                     "last_interim_to_final_ms": last_interim_to_final_ms,
                     "force_finalized": True,
+                    "asr_start_epoch_ms": self.speech_start_time,
+                    "asr_finalized_epoch_ms": timestamp_ms(),
+                    "final_transcript": transcript_to_send,
                 }
             )
         except Exception as e:
@@ -598,6 +601,9 @@ class SmallestTranscriber(BaseTranscriber):
                                     "interim_details": self.current_turn_interim_details,
                                     "first_interim_to_final_ms": first_interim_to_final_ms,
                                     "last_interim_to_final_ms": last_interim_to_final_ms,
+                                    "asr_start_epoch_ms": self.speech_start_time,
+                                    "asr_finalized_epoch_ms": timestamp_ms(),
+                                    "final_transcript": self.final_transcript,
                                 }
                             )
                         except Exception as e:

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -390,8 +390,18 @@ class TranscriberPool:
             logger.info(f"TranscriberPool: transcriber '{label}' connection dropped, reconnecting")
             await target.run()
 
+        # Carry turn_counter forward so the incoming transcriber continues
+        # the turn sequence rather than restarting from 0. The next speech
+        # event on the new transcriber will increment the counter normally.
+        old_transcriber = self.transcribers[old]
+        inherited_turn_counter = getattr(old_transcriber, "turn_counter", 0)
+        if hasattr(target, "turn_counter"):
+            target.turn_counter = inherited_turn_counter
+        if hasattr(target, "current_turn_id") and getattr(old_transcriber, "current_turn_id", None) is not None:
+            target.current_turn_id = old_transcriber.current_turn_id
+
         self.active_label = label
-        logger.info(f"TranscriberPool: switched {old} -> {label}")
+        logger.info(f"TranscriberPool: switched {old} -> {label} (inherited turn_counter={inherited_turn_counter})")
 
     async def toggle_connection(self):
         """Stop all transcriber connections."""

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -91,6 +91,10 @@ class TranscriberPool:
         # function_tool_api_call_details / call_interruption_stats.
         self.lid_detection_events: list[dict] = []
 
+        # Counts how many times a standby transcriber was reconnected mid-call
+        # (e.g. provider inactivity timeout on a transcriber that never received audio).
+        self.reconnect_count: int = 0
+
         # Debounce state
         self._lid_pending_lang: Optional[str] = None
         self._lid_pending_count: int = 0
@@ -389,6 +393,7 @@ class TranscriberPool:
         if transcription_task is not None and transcription_task.done():
             logger.info(f"TranscriberPool: transcriber '{label}' connection dropped, reconnecting")
             await target.run()
+            self.reconnect_count += 1
 
         # Carry turn_counter forward so the incoming transcriber continues
         # the turn sequence rather than restarting from 0. The next speech

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.40"
+version = "0.10.41"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.37"
+version = "0.10.38"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.42"
+version = "0.10.43"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.41"
+version = "0.10.42"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.29"
+version = "0.10.30"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.38"
+version = "0.10.39"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Captures user_start_ms, asr_start/finalized_ms, llm_start_ms, tts_start_ms, agent_end_ms, call_start_epoch_ms and turn_id across transcriber, LLM, and synthesizer so the progression endpoint can reconstruct the full call timeline.