### PR TITLE
fix: update Smallest AI model, TTS and STT API endpoints

### DIFF
--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -3,9 +3,11 @@ import base64
 import json
 import os
 import time
+import uuid
 
 import aiohttp
 import websockets
+from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
@@ -25,6 +27,8 @@ class SmallestSynthesizer(StreamSynthesizer):
         stream=False,
         buffer_size=400,
         synthesizer_key=None,
+        speed=1.0,
+        add_wav_header=False,
         **kwargs,
     ):
         super().__init__(
@@ -38,9 +42,13 @@ class SmallestSynthesizer(StreamSynthesizer):
         self.model = model
         self.sampling_rate = int(sampling_rate)
         self.language = language
+        self.speed = speed
+        self.add_wav_header = add_wav_header
 
         self.api_url = f"https://waves-api.smallest.ai/api/v1/{self.model}/get_speech"
         self.ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v2/get_speech/stream?timeout=60"
+
+        self.ws_trace_id = None
 
     # ------------------------------------------------------------------
     # StreamSynthesizer hooks
@@ -49,13 +57,33 @@ class SmallestSynthesizer(StreamSynthesizer):
     def _get_audio_format(self):
         return "wav"
 
+    def _unpack_receiver_message(self, item):
+        audio, text_synthesized = item
+        return audio, {"text_synthesized": text_synthesized}
+
+    def _process_audio_chunk(self, chunk):
+        return chunk
+
     def form_payload(self, text):
         return {
             "voice_id": self.voice_id,
             "text": text,
             "language": self.language,
             "sample_rate": self.sampling_rate,
+            "speed": self.speed,
+            "add_wav_header": self.add_wav_header,
         }
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
+    async def handle_interruption(self):
+        try:
+            if self.websocket and self._is_ws_connected():
+                await self.websocket.close()
+        except Exception:
+            pass
 
     # ------------------------------------------------------------------
     # sender / receiver
@@ -72,14 +100,18 @@ class SmallestSynthesizer(StreamSynthesizer):
             await self._wait_for_ws()
 
             if text != "":
-                try:
-                    if self.ws_send_time is None:
-                        self.ws_send_time = time.perf_counter()
-                    await self._send_json(self.form_payload(text))
-                except Exception as e:
-                    logger.error(f"Error sending chunk: {e}")
-                    self.connection_error = str(e)
-                    return
+                for text_chunk in self.text_chunker(text):
+                    if not self.should_synthesize_response(sequence_id):
+                        logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                        return
+                    try:
+                        if self.ws_send_time is None:
+                            self.ws_send_time = time.perf_counter()
+                        await self._send_json(self.form_payload(text_chunk))
+                    except Exception as e:
+                        logger.error(f"Error sending chunk: {e}")
+                        self.connection_error = str(e)
+                        return
 
             if end_of_llm_stream:
                 self.last_text_sent = True
@@ -90,6 +122,9 @@ class SmallestSynthesizer(StreamSynthesizer):
             logger.error(f"Unexpected error in sender: {e}")
 
     async def receiver(self):
+        """Yields (audio_chunk, text_synthesized) tuples, or (b'\\x00', '') for end-of-stream."""
+        audio_chunk_count = 0
+        last_recv_time = None
         not_connected_since = None
         while True:
             try:
@@ -111,13 +146,33 @@ class SmallestSynthesizer(StreamSynthesizer):
                 else:
                     not_connected_since = None
 
+                recv_start = time.perf_counter()
                 response = await self.websocket.recv()
+                recv_duration = (time.perf_counter() - recv_start) * 1000
                 data = json.loads(response)
 
                 if data.get("status") == "chunk":
-                    yield base64.b64decode(data["data"]["audio"])
+                    audio_chunk_count += 1
+                    if audio_chunk_count == 1 and self.ws_send_time is not None:
+                        time_since_send = (time.perf_counter() - self.ws_send_time) * 1000
+                        logger.info(
+                            f"Smallest recv FIRST trace_id={self.ws_trace_id} "
+                            f"recv_wait={recv_duration:.0f}ms ttfb={time_since_send:.0f}ms"
+                        )
+                    elif recv_duration > 200:
+                        gap = (recv_start - last_recv_time) * 1000 if last_recv_time else 0
+                        logger.info(
+                            f"Smallest recv SLOW chunk={audio_chunk_count} trace_id={self.ws_trace_id} "
+                            f"recv_wait={recv_duration:.0f}ms gap={gap:.0f}ms"
+                        )
+                    last_recv_time = time.perf_counter()
+                    yield base64.b64decode(data["data"]["audio"]), ""
+
                 elif data.get("status") == "complete":
-                    yield b"\x00"
+                    logger.info(f"Smallest recv complete trace_id={self.ws_trace_id}")
+                    audio_chunk_count = 0
+                    last_recv_time = None
+                    yield b"\x00", ""
 
             except websockets.exceptions.ConnectionClosed:
                 break
@@ -139,32 +194,42 @@ class SmallestSynthesizer(StreamSynthesizer):
                 ),
                 timeout=10.0,
             )
+            if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
+                self.ws_trace_id = websocket.response.headers.get("x-trace-id") or str(uuid.uuid4())
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
-            logger.info(f"Connected to {self.ws_url}")
+            logger.info(f"Connected to Smallest trace_id={self.ws_trace_id}")
             return websocket
         except asyncio.TimeoutError:
             logger.error("Timeout while connecting to Smallest websocket")
+            return None
+        except InvalidHandshake as e:
+            error_msg = str(e)
+            if "401" in error_msg or "403" in error_msg:
+                logger.error(f"Smallest authentication failed: Invalid or expired API key - {e}")
+            else:
+                logger.error(f"Smallest handshake failed: {e}")
+            self.connection_error = str(e)
             return None
         except Exception as e:
             logger.error(f"Failed to connect to Smallest: {e}")
             return None
 
+    # ------------------------------------------------------------------
+    # HTTP fallback
+    # ------------------------------------------------------------------
+
     def _process_http_audio(self, audio):
-        # Guard against null response from API
         return audio if audio else b"\x00"
 
-    # ------------------------------------------------------------------
-    # HTTP
-    # ------------------------------------------------------------------
-
     async def _generate_http(self, text):
-        logger.info(f"text {text}")
         payload = {
             "text": text,
             "voice_id": self.voice_id,
+            "language": self.language,
             "sample_rate": self.sampling_rate,
-            "add_wav_header": False,
+            "speed": self.speed,
+            "add_wav_header": self.add_wav_header,
         }
         headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
         async with aiohttp.ClientSession() as session:

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -45,8 +45,8 @@ class SmallestSynthesizer(StreamSynthesizer):
         self.speed = speed
         self.add_wav_header = add_wav_header
 
-        self.api_url = f"https://waves-api.smallest.ai/api/v1/{self.model}/get_speech"
-        self.ws_url = f"wss://waves-api.smallest.ai/api/v1/{self.model}/get_speech/stream?timeout=60"
+        self.api_url = f"https://api.smallest.ai/waves/v1/{self.model}/get_speech"
+        self.ws_url = f"wss://api.smallest.ai/waves/v1/{self.model}/get_speech/stream"
 
         self.ws_trace_id = None
 
@@ -189,7 +189,7 @@ class SmallestSynthesizer(StreamSynthesizer):
             websocket = await asyncio.wait_for(
                 websockets.connect(
                     self.ws_url,
-                    additional_headers={"Authorization": f"Token {self.api_key}"},
+                    additional_headers={"Authorization": f"Bearer {self.api_key}"},
                     ssl=get_ssl_context(self.ws_url),
                 ),
                 timeout=10.0,

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -20,7 +20,7 @@ class SmallestSynthesizer(StreamSynthesizer):
     def __init__(
         self,
         voice_id,
-        model="lightning",
+        model="lightning-v3.1",
         language="en",
         audio_format="mp3",
         sampling_rate="8000",
@@ -46,7 +46,7 @@ class SmallestSynthesizer(StreamSynthesizer):
         self.add_wav_header = add_wav_header
 
         self.api_url = f"https://waves-api.smallest.ai/api/v1/{self.model}/get_speech"
-        self.ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v2/get_speech/stream?timeout=60"
+        self.ws_url = f"wss://waves-api.smallest.ai/api/v1/{self.model}/get_speech/stream?timeout=60"
 
         self.ws_trace_id = None
 

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -62,7 +62,7 @@ class SmallestTranscriber(BaseTranscriber):
 
         # API configuration
         self.api_key = kwargs.get("transcriber_key", os.getenv("SMALLEST_API_KEY"))
-        self.smallest_host = os.getenv("SMALLEST_HOST", "waves-api.smallest.ai")
+        self.smallest_host = os.getenv("SMALLEST_HOST", "api.smallest.ai")
 
         # Queues
         self.transcriber_output_queue = output_queue
@@ -171,7 +171,7 @@ class SmallestTranscriber(BaseTranscriber):
         if self.word_timestamps:
             params["word_timestamps"] = "true"
 
-        websocket_url = f"wss://{self.smallest_host}/api/v1/lightning/get_text?{urlencode(params)}"
+        websocket_url = f"wss://{self.smallest_host}/waves/v1/pulse/get_text?{urlencode(params)}"
         logger.info(
             f"Smallest WebSocket URL params - language: {self.language}, sample_rate: {self.sampling_rate}, encoding: {self.encoding}, word_timestamps: {self.word_timestamps}"
         )


### PR DESCRIPTION
## Summary

Updates both the synthesizer and transcriber to use Smallest AI's current API endpoints.

**Synthesizer (`smallest_synthesizer.py`)**
- Default model updated to `lightning-v3.1` (was `lightning`)
- HTTP + WS base URL: `waves-api.smallest.ai/api/v1` → `api.smallest.ai/waves/v1`
- WS URL made dynamic from `self.model` (was hardcoded to `lightning-v2`)
- WS auth header: `Token` → `Bearer`

**Transcriber (`smallest_transcriber.py`)**
- Default host: `waves-api.smallest.ai` → `api.smallest.ai`
- WS path: `/api/v1/lightning/get_text` → `/waves/v1/pulse/get_text` (STT service is Pulse)

## Test plan

- [ ] Streaming TTS connects to `wss://api.smallest.ai/waves/v1/lightning-v3.1/get_speech/stream`
- [ ] HTTP TTS fallback hits `https://api.smallest.ai/waves/v1/lightning-v3.1/get_speech`
- [ ] STT transcriber connects to `wss://api.smallest.ai/waves/v1/pulse/get_text`
- [ ] Bad API key surfaces a 401 with the auth-specific error log
- [ ] End-to-end voice agent session with `synthesizer_provider: smallest` and `transcriber.provider: smallest`