### PR TITLE
feat: separate DEEPGRAM_FLUX_HOST for self-hosted Flux endpoint

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.34"
+__version__ = "0.10.35"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -245,9 +245,7 @@ class DeepgramTranscriber(BaseTranscriber):
         if self.run_id:
             dg_params["tag"] = self.run_id
 
-        websocket_api = "{}://{}/v2/listen?".format(
-            os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_flux_host
-        )
+        websocket_api = "{}://{}/v2/listen?".format(os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_flux_host)
         websocket_url = websocket_api + urlencode(dg_params, doseq=True)
         return websocket_url
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -60,6 +60,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.encoding = encoding
         self.api_key = kwargs.get("transcriber_key", os.getenv("DEEPGRAM_AUTH_TOKEN"))
         self.deepgram_host = os.getenv("DEEPGRAM_HOST", "api.deepgram.com")
+        self.deepgram_flux_host = os.getenv("DEEPGRAM_FLUX_HOST", "api.deepgram.com")
         self.transcriber_output_queue = output_queue
         self.transcription_task = None
         self.keywords = keywords
@@ -244,7 +245,9 @@ class DeepgramTranscriber(BaseTranscriber):
         if self.run_id:
             dg_params["tag"] = self.run_id
 
-        websocket_api = "{}://{}/v2/listen?".format(os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_host)
+        websocket_api = "{}://{}/v2/listen?".format(
+            os.getenv("DEEPGRAM_FLUX_HOST_PROTOCOL", "wss"), self.deepgram_flux_host
+        )
         websocket_url = websocket_api + urlencode(dg_params, doseq=True)
         return websocket_url
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -246,8 +246,7 @@ class DeepgramTranscriber(BaseTranscriber):
             dg_params["tag"] = self.run_id
 
         websocket_api = "{}://{}/v2/listen?".format(
-            os.getenv("DEEPGRAM_FLUX_HOST_PROTOCOL", os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss")),
-            self.deepgram_flux_host,
+            os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_flux_host
         )
         websocket_url = websocket_api + urlencode(dg_params, doseq=True)
         return websocket_url

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -246,7 +246,8 @@ class DeepgramTranscriber(BaseTranscriber):
             dg_params["tag"] = self.run_id
 
         websocket_api = "{}://{}/v2/listen?".format(
-            os.getenv("DEEPGRAM_FLUX_HOST_PROTOCOL", "wss"), self.deepgram_flux_host
+            os.getenv("DEEPGRAM_FLUX_HOST_PROTOCOL", os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss")),
+            self.deepgram_flux_host,
         )
         websocket_url = websocket_api + urlencode(dg_params, doseq=True)
         return websocket_url

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.34"
+version = "0.10.35"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Flux runs on a different cluster than Nova on India self-hosted, so the Flux WebSocket URL needs its own host/protocol independent of DEEPGRAM_HOST. Read DEEPGRAM_FLUX_HOST and DEEPGRAM_FLUX_HOST_PROTOCOL in _get_flux_ws_url (both default to api.deepgram.com / wss, matching prior behavior). Nova URL builder is untouched.