### PR TITLE
fix: mark welcome played on interruption to prevent transcript wedge

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.35"
+__version__ = "0.10.36"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1819,6 +1819,11 @@ class TaskManager(BaseManager):
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
+        # handle_interruption clears the welcome's pending mark; its ACK would
+        # otherwise be the only signal that flips this flag.
+        if not self.tools["input"].welcome_message_played():
+            self.tools["input"].is_welcome_message_played = True
+
         if self.generate_precise_transcript:
             await self.sync_history(self.mark_event_meta_data.fetch_cleared_mark_event_data().items(), current_ts)
             self.tools["input"].reset_response_heard_by_user()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.35"
+version = "0.10.36"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Why

When the welcome message is interrupted before its final mark is ACKed by Plivo, `mark_event_meta_data.clear_data()` (called from `output.handle_interruption()`) wipes the welcome mark. That ACK is the only signal that flips `is_welcome_message_played` to `True`. With it gone, the gate in `_handle_transcriber_output`

```python
if not self.tools["input"].welcome_message_played() and (
    self.discard_pre_welcome_utterance or len(self.conversation_history) > 2
):
    return  # transcript dropped
```

silently drops every subsequent user transcript with reason `welcome_still_playing`, and the agent never replies again for the rest of the call.

Easiest real-world trigger seen in prod: the welcome TTS bleeds back into the transcriber as user speech (Deepgram emits `hello` from the welcome's first word), self-triggers the interruption, and the call wedges from there.

## Fix

After `output.handle_interruption()` in `__cleanup_downstream_tasks`, flip `is_welcome_message_played = True` if it wasn't already. The cleanup only fires when audio was actually in flight, so by definition the welcome was queued and either played or interrupted.

No-op for the four other call sites (already gated on `welcome_played=True` or running at hangup).