### PR TITLE
fix: avoid premature end_of_synthesizer_stream on empty alignment chunks

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.36"
+__version__ = "0.10.37"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -231,9 +231,8 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         if last_four and current_norm.endswith(last_four):
                             logger.info("send end_of_synthesizer_stream")
                             yield b"\x00", ""
-                        elif (
+                        elif last_four_no_space and current_norm.replace('"', "").replace(" ", "").strip().endswith(
                             last_four_no_space
-                            and current_norm.replace('"', "").replace(" ", "").strip().endswith(last_four_no_space)
                         ):
                             logger.info("send end_of_synthesizer_stream on fallback")
                             yield b"\x00", ""

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -227,11 +227,13 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         current_norm = self.normalize_text(self.current_text.strip()).replace('"', "").strip()
                         logger.info(f"Last four char - {last_four} | current text - {current_norm}")
 
-                        if current_norm.endswith(last_four):
+                        last_four_no_space = last_four.replace(" ", "")
+                        if last_four and current_norm.endswith(last_four):
                             logger.info("send end_of_synthesizer_stream")
                             yield b"\x00", ""
                         elif (
-                            current_norm.replace('"', "").replace(" ", "").strip().endswith(last_four.replace(" ", ""))
+                            last_four_no_space
+                            and current_norm.replace('"', "").replace(" ", "").strip().endswith(last_four_no_space)
                         ):
                             logger.info("send end_of_synthesizer_stream on fallback")
                             yield b"\x00", ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.36"
+version = "0.10.37"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
**What was happening**

The ElevenLabs receiver decides "stream is ending" by checking whether the current text ends with the last few characters of the chunk just received. ElevenLabs occasionally sends mid-stream chunks where `alignment.chars` is empty (silence padding, breath frames). When that happens, the check becomes `text.endswith("")` which is always True, so we falsely declare end-of-stream. Subsequent legitimate audio chunks for the same response then get dropped as `Skipping message with sequence_id`.

User-visible effect: agent's reply gets cut off mid-sentence even though the LLM produced the full text and ElevenLabs was still streaming the tail.

**The fix**

Only treat the chunk as a possible end-of-stream signal if its characters are non-empty. Real end-of-stream is unaffected because the explicit `isFinal: True` branch above handles it directly, and the legitimate final chunk has non-empty alignment.