### PR TITLE
fix: bump aiohttp to >=3.10.11 for google-genai DNS error compatibility

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.54"
+__version__ = "0.10.55"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.54"
+version = "0.10.55"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiobotocore==2.9.0
 aiofiles==23.2.1
-aiohttp>=3.9.2,<3.10.0
+aiohttp>=3.10.11,<4.0.0
 azure-cognitiveservices-speech==1.38.0
 fastapi==0.108.0
 google-cloud-speech==2.25.0


### PR DESCRIPTION
google-genai references `aiohttp.ClientConnectorDNSError` (added in 3.10.10) in its DNS retry path. Our `<3.10.0` cap surfaces it as `AttributeError: module aiohttp has no attribute ClientConnectorDNSError` on real DNS hiccups, masking the underlying network error and breaking the SDK's internal retry.