### PR TITLE
fix: coerce null words to empty list in elevenlabs committed_transcript_with_timestamps

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.37"
+__version__ = "0.10.38"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -465,7 +465,7 @@ class ElevenLabsTranscriber(BaseTranscriber):
 
                 elif msg_type == "committed_transcript_with_timestamps":
                     transcript = msg.get("text", "")
-                    words = msg.get("words", [])
+                    words = msg.get("words") or []
                     detected_language = msg.get("language_code")
                     logger.info(f"Committed transcript with timestamps: {transcript} ({len(words)} words)")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.37"
+version = "0.10.38"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Issue

When ElevenLabs sends a `committed_transcript_with_timestamps` message with `"words": null` (happens on empty/no-speech commits), the receiver crashes with `object of type 'NoneType' has no len()` because `msg.get("words", [])` returns `None` when the key is present but null, not the default `[]`. The error fires inside the f-string log line before any downstream logic runs.

## Fix

Change `msg.get("words", [])` to `msg.get("words") or []`. Matches the existing pattern in `deepgram_transcriber.py:969`.

No behavioral change on observed traffic: the only failing case is empty transcript, where the `if transcript.strip()` guard already skips all downstream logic. Effect is just silencing the spurious ERROR log.