### PR TITLE
fix: reset last_text_sent at start of each synth turn

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.39"
+__version__ = "0.10.40"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -172,6 +172,7 @@ class StreamSynthesizer(BaseSynthesizer):
             self.current_turn_start_time = time.perf_counter()
             self.ws_send_time = None
             self.current_turn_ttfb = None
+            self.last_text_sent = False
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
         self.current_turn_id = meta_info.get("turn_id") or meta_info.get("sequence_id")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.39"
+version = "0.10.40"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
`ElevenlabsSynthesizer.receiver()` emits a `\x00` end-of-stream sentinel when its alignment chars end with the last 4 chars of `current_text`, guarded by `self.last_text_sent`. That flag is set True in the sender on `end_of_llm_stream=True`, but is never reset. Once any turn completes cleanly, every subsequent turn is vulnerable: if the LLM streams in multiple chunks and ElevenLabs finishes synthesizing chunk N before chunk N+1 arrives, the receiver yields a false EOS and `task_manager` retires the sequence_id. Remaining LLM chunks then hit `is_valid_sequence` and are dropped ("N is not a valid sequence id and hence not synthesizing this").

Seen in a case, seq=6: 252 output tokens streamed across ~4s in 5 chunks, but EL finished chunk 1's audio in 1.4s. Receiver fired EOS at 06:43:47.847 (21ms before the next LLM chunk); chunks 2–5 were all discarded. Agent cut off mid-sentence and never recovered.

Fix: reset `self.last_text_sent = False` in `_stamp_turn_start` (the canonical "new turn begins" hook).