### PR TITLE
fix: keep __check_for_completion loop alive after silence hangup to a…

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.40"
+__version__ = "0.10.41"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4426,7 +4426,6 @@ class TaskManager(BaseManager):
                 )
                 self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
                 await self.process_call_hangup()
-                break
 
             elif (
                 time_since_last_spoken_ai_word > self.trigger_user_online_message_after

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4228,10 +4228,15 @@ class TaskManager(BaseManager):
 
                 sequence_id = message["meta_info"].get("sequence_id")
 
+                # agent_hangup audio must always reach Plivo regardless of interruption state.
+                # If callee_speaking is stuck True (e.g. Deepgram false VAD with no SpeechFinal),
+                # the WAIT loop would block the goodbye forever and the call would never end.
+                is_hangup_message = message["meta_info"].get("message_category") == "agent_hangup"
+
                 # Centralized tri-state decision loop (handles race condition + grace period)
                 should_continue_outer_loop = False
                 while True:
-                    status = self.interruption_manager.get_audio_send_status(sequence_id, len(self.history))
+                    status = "SEND" if is_hangup_message else self.interruption_manager.get_audio_send_status(sequence_id, len(self.history))
 
                     if status == "SEND":
                         # Audio approved - send it

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4431,6 +4431,7 @@ class TaskManager(BaseManager):
                 )
                 self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
                 await self.process_call_hangup()
+                break
 
             elif (
                 time_since_last_spoken_ai_word > self.trigger_user_online_message_after

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4236,7 +4236,11 @@ class TaskManager(BaseManager):
                 # Centralized tri-state decision loop (handles race condition + grace period)
                 should_continue_outer_loop = False
                 while True:
-                    status = "SEND" if is_hangup_message else self.interruption_manager.get_audio_send_status(sequence_id, len(self.history))
+                    status = (
+                        "SEND"
+                        if is_hangup_message
+                        else self.interruption_manager.get_audio_send_status(sequence_id, len(self.history))
+                    )
 
                     if status == "SEND":
                         # Audio approved - send it

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -602,6 +602,7 @@ class DeepgramTranscriber(BaseTranscriber):
                     self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
+                    self.final_transcript = ""
 
                     logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                     logger.info(

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -602,7 +602,6 @@ class DeepgramTranscriber(BaseTranscriber):
                     self.speech_start_time = timestamp_ms()
                     self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
-                    self.final_transcript = ""
 
                     logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                     logger.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.40"
+version = "0.10.41"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
…llow watchdog to fire

When silence hangup triggers, process_call_hangup() is called followed by a break that exits the loop entirely. If the goodbye audio is blocked (e.g. interruption_manager in WAIT state due to Deepgram false VAD), Plivo never receives the audio, the agent_hangup mark is never acked, and agent_hangup_observer never calls __process_end_of_conversation(). With the loop dead, the existing hangup_mark_event_timeout watchdog (lines 4381-4395) is unreachable, leaving the call alive indefinitely until Plivo's own ALLOTTED_TIMEOUT kills it.

Removing the break lets the loop continue so the watchdog can detect the unacked mark and force-end the call within hangup_mark_event_timeout (default 10s) regardless of whether the goodbye audio was delivered.