### PR TITLE
fix: fetch cached audio by md5 hash for static graph nodes

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.41"
+__version__ = "0.10.42"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4082,23 +4082,32 @@ class TaskManager(BaseManager):
                         audio_chunk = wav_bytes_to_pcm(resample(audio, format="wav", target_sample_rate=8000))
                         meta_info["format"] = "pcm"
                 else:
-                    start_time = time.perf_counter()
-                    audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None
+                    is_welcome = meta_info.get("message_category") == "agent_welcome_message"
+                    if is_welcome:
+                        audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None
+                    else:
+                        start_time = time.perf_counter()
+                        audio_chunk = await get_raw_audio_bytes(
+                            text,
+                            self.assistant_name,
+                            "pcm",
+                            local=self.is_local,
+                            assistant_id=self.assistant_id,
+                        )
+                        logger.info(f"Time to fetch preprocessed audio from S3 {time.perf_counter() - start_time}")
                     if meta_info["text"] == "":
                         audio_chunk = None
-                    logger.info(f"Time to get response from S3 {time.perf_counter() - start_time}")
                     if not self.buffered_output_queue.empty():
                         logger.info(f"Output queue was not empty and hence emptying it")
                         self.buffered_output_queue = asyncio.Queue()
                     meta_info["format"] = "pcm"
-                    if "message_category" in meta_info and meta_info["message_category"] == "agent_welcome_message":
-                        if audio_chunk is None:
-                            logger.info(f"File doesn't exist in S3. Hence we're synthesizing it from synthesizer")
-                            meta_info["cached"] = False
-                            await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
-                            return
-                        else:
-                            meta_info["is_first_chunk"] = True
+                    if audio_chunk is None:
+                        logger.info(f"Preprocessed audio not available, falling back to live synthesis")
+                        meta_info["cached"] = False
+                        await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
+                        return
+                    if is_welcome:
+                        meta_info["is_first_chunk"] = True
                 meta_info["end_of_synthesizer_stream"] = True
                 if yield_in_chunks and audio_chunk is not None:
                     i = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.41"
+version = "0.10.42"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Graph nodes with node_type=static emit an is_md5_hash=True packet whose data is the md5 hash of static_message. On telephony providers, __send_preprocessed_audio was ignoring the hash and returning self.preloaded_welcome_audio, so callers heard the welcome bytes (or noise) instead of the static node's audio. Welcome path keeps using preloaded_welcome_audio; everything else now fetches the cached PCM by hash via get_raw_audio_bytes, with a unified cache-miss fallback that synthesizes the actual text live.