### PR TITLE
feat: forward transfer_call_reason on transfer webhook

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.44"
+__version__ = "0.10.45"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2508,6 +2508,7 @@ class TaskManager(BaseManager):
 
             call_sid = None
             call_transfer_number = None
+            transfer_call_reason = None
             payload = {
                 "call_sid": call_sid,
                 "provider": self.tools["input"].io_provider,
@@ -2531,6 +2532,9 @@ class TaskManager(BaseManager):
                     call_transfer_number = json_function_call_params["call_transfer_number"]
                     if call_transfer_number:
                         payload["call_transfer_number"] = call_transfer_number
+                    transfer_call_reason = json_function_call_params.get("transfer_call_reason")
+                    if transfer_call_reason:
+                        payload["transfer_call_reason"] = transfer_call_reason
                 except Exception as e:
                     logger.error(f"Error in __execute_function_call {e}")
 
@@ -2550,6 +2554,7 @@ class TaskManager(BaseManager):
                     "turn_id": meta_info.get("turn_id"),
                     "sequence_id": meta_info.get("sequence_id"),
                     "transfer_number": payload.get("call_transfer_number"),
+                    "transfer_call_reason": payload.get("transfer_call_reason"),
                     "provider": self.tools["input"].io_provider,
                 }
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.44"
+version = "0.10.45"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

* `__execute_function_call` extracts `transfer_call_reason` from the LLM's `transfer_call` tool args and forwards it in the POST to `/process_transfer`.
* Records the reason on the `transfer_start` progression event so it flows into `progression_data`.
* Uses `.get()` so legacy agents without the new schema field do not crash.

Companion dashboard-backend PR: https://github.com/bolna-ai/dashboard-backend/pull/2176