### PR TITLE
fix: only flush sarvam tts on end_of_llm_stream

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.45"
+__version__ = "0.10.46"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -125,12 +125,11 @@ class SarvamSynthesizer(StreamSynthesizer):
 
             if end_of_llm_stream:
                 self.last_text_sent = True
-
-            try:
-                await self._send_json({"type": "flush"})
-            except Exception as e:
-                logger.info(f"Error sending end-of-stream signal: {e}")
-                self.connection_error = str(e)
+                try:
+                    await self._send_json({"type": "flush"})
+                except Exception as e:
+                    logger.info(f"Error sending end-of-stream signal: {e}")
+                    self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.45"
+version = "0.10.46"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Sarvam streaming TTS was cutting audio after ~2s with no user interruption.

`sender()` flushed after every text segment, and Sarvam emits `event_type=final` per flush. The receiver yields `b"\x00"` on every `final`, which sets `end_of_synthesizer_stream=True` and retires the sequence_id. Subsequent audio chunks for the same turn got dropped as `Skipping message with sequence_id`.

Fix: only flush when `end_of_llm_stream=True`. Mid-stream chunking falls back to Sarvam's `min_buffer_size` (40 for `en`), matching the doc's intended usage. One flush per turn, one `final`, one `b"\x00"`.