### PR TITLE
fix: graph agent forced tool_choice + Responses API shape

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.48"
+__version__ = "0.10.49"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections import defaultdict
 import os
+import re
 import time
 from openai import OpenAI
 from dotenv import load_dotenv
@@ -40,6 +41,7 @@ load_dotenv()
 logger = configure_logger(__name__)
 
 _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
+_PROMPT_VAR_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 
 class GraphAgent(BaseAgent):
@@ -658,6 +660,11 @@ class GraphAgent(BaseAgent):
     def _get_tool_choice_for_node(self):
         """Check if current node should force a tool call.
 
+        Drops the force to None (auto) when the node's prompt references
+        recipient vars that aren't populated. Without those values the
+        LLM has nothing real to put in the function args and would either
+        hallucinate or stall, producing silent loops.
+
         Returns:
         - {"type": "function", "function": {"name": "..."}} if force_function_call is a function name string
         - "required" if force_function_call is True (LLM must call some function)
@@ -671,11 +678,36 @@ class GraphAgent(BaseAgent):
             return None
 
         fn = current_node.get("function_call")
-        if fn:
-            logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
-            return {"type": "function", "function": {"name": fn}}
+        if not fn:
+            return None
 
-        return None
+        missing = self._missing_forced_function_vars(current_node, fn)
+        if missing:
+            logger.warning(
+                f"Dropping forced function call '{fn}' on node '{self.current_node_id}': "
+                f"recipient_data missing required vars referenced in prompt: {missing}"
+            )
+            return None
+
+        logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
+        return {"type": "function", "function": {"name": fn}}
+
+    def _missing_forced_function_vars(self, node: dict, fn: str) -> List[str]:
+        tools = getattr(self.llm, "tools", None) or []
+        if isinstance(tools, str):
+            tools = json.loads(tools)
+        spec = next(
+            (t["function"] for t in tools if t.get("function", {}).get("name") == fn),
+            None,
+        )
+        required = set((spec or {}).get("parameters", {}).get("required") or [])
+        if not required:
+            return []
+
+        prompt_vars = set(_PROMPT_VAR_PATTERN.findall(node.get("prompt", "") or ""))
+        referenced = prompt_vars & required
+        recipient_data = self.context_data.get("recipient_data") or {}
+        return sorted(v for v in referenced if not recipient_data.get(v))
 
     async def _build_messages(self, history: List[dict]) -> List[dict]:
         """Build messages array: system prompt (+ optional RAG) + conversation history."""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -657,13 +657,18 @@ class GraphAgent(BaseAgent):
         example_lines = [f'  {lang.upper()}: "{text}"' for lang, text in examples.items()]
         return f"{prompt}\n\nExample responses:\n" + "\n".join(example_lines)
 
-    def _get_tool_choice_for_node(self):
+    def _get_tool_choice_for_node(self, history: Optional[List[dict]] = None):
         """Check if current node should force a tool call.
 
         Drops the force to None (auto) when the node's prompt references
         recipient vars that aren't populated. Without those values the
         LLM has nothing real to put in the function args and would either
         hallucinate or stall, producing silent loops.
+
+        Also drops the force once the tool has already been called for this
+        node visit (its result is in history). Forcing again would re-invoke
+        the same tool with the same args on every turn instead of letting
+        the LLM speak naturally about the result.
 
         Returns:
         - {"type": "function", "function": {"name": "..."}} if force_function_call is a function name string
@@ -689,6 +694,13 @@ class GraphAgent(BaseAgent):
             )
             return None
 
+        if history is not None and self._forced_function_already_called(fn, history):
+            logger.info(
+                f"Dropping forced function call '{fn}' on node '{self.current_node_id}': "
+                f"tool already invoked this node visit, letting LLM speak from the result"
+            )
+            return None
+
         logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
         return {"type": "function", "function": {"name": fn}}
 
@@ -708,6 +720,22 @@ class GraphAgent(BaseAgent):
         referenced = prompt_vars & required
         recipient_data = self.context_data.get("recipient_data") or {}
         return sorted(v for v in referenced if not recipient_data.get(v))
+
+    def _forced_function_already_called(self, fn: str, history: List[dict]) -> bool:
+        node_history = history[self.current_node_entry_index :] if self.current_node_entry_index < len(history) else []
+        call_ids_for_fn = {
+            tc.get("id")
+            for msg in node_history
+            if msg.get("role") == "assistant" and msg.get("tool_calls")
+            for tc in msg["tool_calls"]
+            if tc.get("function", {}).get("name") == fn
+        }
+        if not call_ids_for_fn:
+            return False
+        return any(
+            msg.get("role") == "tool" and msg.get("tool_call_id") in call_ids_for_fn
+            for msg in node_history
+        )
 
     async def _build_messages(self, history: List[dict]) -> List[dict]:
         """Build messages array: system prompt (+ optional RAG) + conversation history."""
@@ -816,7 +844,7 @@ class GraphAgent(BaseAgent):
                     }
                 )
                 yield {"messages": messages}
-                tool_choice = self._get_tool_choice_for_node()
+                tool_choice = self._get_tool_choice_for_node(history=message)
                 async for chunk in self.llm.generate_stream(
                     messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
                 ):
@@ -891,7 +919,7 @@ class GraphAgent(BaseAgent):
 
             messages = await self._build_messages(message)
             yield {"messages": messages}
-            tool_choice = self._get_tool_choice_for_node()
+            tool_choice = self._get_tool_choice_for_node(history=message)
             async for chunk in self.llm.generate_stream(
                 messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
             ):

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -106,3 +106,14 @@ class MessageFormatAdapter:
                 }
             )
         return result
+
+    @staticmethod
+    def chat_tool_choice_to_responses(tool_choice):
+        """Flatten Chat-Completions tool_choice for the Responses API.
+
+        {"type":"function","function":{"name":...}} -> {"type":"function","name":...}
+        String forms ("auto", "required", "none") and None pass through unchanged.
+        """
+        if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "function" in tool_choice:
+            return {"type": "function", "name": tool_choice["function"].get("name")}
+        return tool_choice

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -369,7 +369,10 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if responses_tools:
             create_kwargs["tools"] = responses_tools
-            create_kwargs["tool_choice"] = tool_choice or "auto"
+            tc = tool_choice or "auto"
+            if isinstance(tc, dict) and tc.get("type") == "function" and "function" in tc:
+                tc = {"type": "function", "name": tc["function"].get("name")}
+            create_kwargs["tool_choice"] = tc
             create_kwargs["parallel_tool_calls"] = False
 
         if request_json:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -369,10 +369,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if responses_tools:
             create_kwargs["tools"] = responses_tools
-            tc = tool_choice or "auto"
-            if isinstance(tc, dict) and tc.get("type") == "function" and "function" in tc:
-                tc = {"type": "function", "name": tc["function"].get("name")}
-            create_kwargs["tool_choice"] = tc
+            create_kwargs["tool_choice"] = MessageFormatAdapter.chat_tool_choice_to_responses(tool_choice or "auto")
             create_kwargs["parallel_tool_calls"] = False
 
         if request_json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.48"
+version = "0.10.49"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Two graph-agent forced-function-call defects, one chokepoint each.

1. **Responses API tool_choice shape (PRO-87, PRO-88).** Graph nodes with `function_call: <name>` produce a Chat-Completions shape `{"type":"function","function":{"name":...}}`, but the call routes through the Responses API (any GPT-5 model + the auto-route trunk patch), which rejects that shape with `unknown_parameter: tool_choice.function`. Translation now lives in `MessageFormatAdapter.chat_tool_choice_to_responses`, called from `_build_responses_create_kwargs` so both WS and HTTP SSE Responses paths are covered.
2. **Silent loop when forced-function args can't be filled (PRO-91).** `_get_tool_choice_for_node()` was pinning a forced tool even when the node prompt referenced `{var}` tokens that weren't present in `recipient_data` (e.g. test calls with no recipient context). LLM then hallucinated values, the API call failed, the stream stalled, conversation silently looped on the node for the full timeout window. New `_missing_forced_function_vars` check drops the force to `None` (auto) when required prompt vars are unresolvable, letting the LLM speak naturally from the node prompt instead. Per-turn cost is a small dict walk against state we already have.

Repro and regression cases verified locally against the patched source: empty `recipient_data` and partially populated cases drop the force; fully resolved cases still pin; nodes without `function_call` and LLMs with `trigger_function_call=False` are unaffected.

Closes PRO-87, PRO-88, PRO-91. Related: PRO-86 (already mitigated in trunk), PRO-92 (separate semantic question in Product Solutioning).