### PR TITLE
fix: graph agent forced tool_choice (Responses shape, missing vars, force-once)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.50"
+__version__ = "0.10.51"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -657,18 +657,11 @@ class GraphAgent(BaseAgent):
         example_lines = [f'  {lang.upper()}: "{text}"' for lang, text in examples.items()]
         return f"{prompt}\n\nExample responses:\n" + "\n".join(example_lines)
 
-    def _get_tool_choice_for_node(self):
-        """Check if current node should force a tool call.
+    def _get_tool_choice_for_node(self, history: Optional[List[dict]] = None):
+        """Return forced tool_choice for the current node, or None if not forced.
 
-        Drops the force to None (auto) when the node's prompt references
-        recipient vars that aren't populated. Without those values the
-        LLM has nothing real to put in the function args and would either
-        hallucinate or stall, producing silent loops.
-
-        Returns:
-        - {"type": "function", "function": {"name": "..."}} if force_function_call is a function name string
-        - "required" if force_function_call is True (LLM must call some function)
-        - None otherwise (defaults to "auto")
+        Drops the force when required prompt vars aren't in recipient_data,
+        or when the tool has already been called this node visit.
         """
         if not self.llm or not getattr(self.llm, "trigger_function_call", False):
             return None
@@ -686,6 +679,13 @@ class GraphAgent(BaseAgent):
             logger.warning(
                 f"Dropping forced function call '{fn}' on node '{self.current_node_id}': "
                 f"recipient_data missing required vars referenced in prompt: {missing}"
+            )
+            return None
+
+        if history is not None and self._forced_function_already_called(fn, history):
+            logger.info(
+                f"Dropping forced function call '{fn}' on node '{self.current_node_id}': "
+                f"tool already invoked this node visit, letting LLM speak from the result"
             )
             return None
 
@@ -708,6 +708,22 @@ class GraphAgent(BaseAgent):
         referenced = prompt_vars & required
         recipient_data = self.context_data.get("recipient_data") or {}
         return sorted(v for v in referenced if not recipient_data.get(v))
+
+    def _forced_function_already_called(self, fn: str, history: List[dict]) -> bool:
+        node_history = history[self.current_node_entry_index :] if self.current_node_entry_index < len(history) else []
+        call_ids_for_fn = {
+            tc.get("id")
+            for msg in node_history
+            if msg.get("role") == "assistant" and msg.get("tool_calls")
+            for tc in msg["tool_calls"]
+            if tc.get("function", {}).get("name") == fn
+        }
+        if not call_ids_for_fn:
+            return False
+        return any(
+            msg.get("role") == "tool" and msg.get("tool_call_id") in call_ids_for_fn
+            for msg in node_history
+        )
 
     async def _build_messages(self, history: List[dict]) -> List[dict]:
         """Build messages array: system prompt (+ optional RAG) + conversation history."""
@@ -816,7 +832,7 @@ class GraphAgent(BaseAgent):
                     }
                 )
                 yield {"messages": messages}
-                tool_choice = self._get_tool_choice_for_node()
+                tool_choice = self._get_tool_choice_for_node(history=message)
                 async for chunk in self.llm.generate_stream(
                     messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
                 ):
@@ -891,7 +907,7 @@ class GraphAgent(BaseAgent):
 
             messages = await self._build_messages(message)
             yield {"messages": messages}
-            tool_choice = self._get_tool_choice_for_node()
+            tool_choice = self._get_tool_choice_for_node(history=message)
             async for chunk in self.llm.generate_stream(
                 messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
             ):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -1,6 +1,7 @@
 import asyncio
 from collections import defaultdict
 import os
+import re
 import time
 from openai import OpenAI
 from dotenv import load_dotenv
@@ -40,6 +41,7 @@ load_dotenv()
 logger = configure_logger(__name__)
 
 _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
+_PROMPT_VAR_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 
 class GraphAgent(BaseAgent):
@@ -658,6 +660,11 @@ class GraphAgent(BaseAgent):
     def _get_tool_choice_for_node(self):
         """Check if current node should force a tool call.
 
+        Drops the force to None (auto) when the node's prompt references
+        recipient vars that aren't populated. Without those values the
+        LLM has nothing real to put in the function args and would either
+        hallucinate or stall, producing silent loops.
+
         Returns:
         - {"type": "function", "function": {"name": "..."}} if force_function_call is a function name string
         - "required" if force_function_call is True (LLM must call some function)
@@ -671,11 +678,36 @@ class GraphAgent(BaseAgent):
             return None
 
         fn = current_node.get("function_call")
-        if fn:
-            logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
-            return {"type": "function", "function": {"name": fn}}
+        if not fn:
+            return None
 
-        return None
+        missing = self._missing_forced_function_vars(current_node, fn)
+        if missing:
+            logger.warning(
+                f"Dropping forced function call '{fn}' on node '{self.current_node_id}': "
+                f"recipient_data missing required vars referenced in prompt: {missing}"
+            )
+            return None
+
+        logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
+        return {"type": "function", "function": {"name": fn}}
+
+    def _missing_forced_function_vars(self, node: dict, fn: str) -> List[str]:
+        tools = getattr(self.llm, "tools", None) or []
+        if isinstance(tools, str):
+            tools = json.loads(tools)
+        spec = next(
+            (t["function"] for t in tools if t.get("function", {}).get("name") == fn),
+            None,
+        )
+        required = set((spec or {}).get("parameters", {}).get("required") or [])
+        if not required:
+            return []
+
+        prompt_vars = set(_PROMPT_VAR_PATTERN.findall(node.get("prompt", "") or ""))
+        referenced = prompt_vars & required
+        recipient_data = self.context_data.get("recipient_data") or {}
+        return sorted(v for v in referenced if not recipient_data.get(v))
 
     async def _build_messages(self, history: List[dict]) -> List[dict]:
         """Build messages array: system prompt (+ optional RAG) + conversation history."""

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -106,3 +106,14 @@ class MessageFormatAdapter:
                 }
             )
         return result
+
+    @staticmethod
+    def chat_tool_choice_to_responses(tool_choice):
+        """Flatten Chat-Completions tool_choice for the Responses API.
+
+        {"type":"function","function":{"name":...}} -> {"type":"function","name":...}
+        String forms ("auto", "required", "none") and None pass through unchanged.
+        """
+        if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "function" in tool_choice:
+            return {"type": "function", "name": tool_choice["function"].get("name")}
+        return tool_choice

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -109,11 +109,7 @@ class MessageFormatAdapter:
 
     @staticmethod
     def chat_tool_choice_to_responses(tool_choice):
-        """Flatten Chat-Completions tool_choice for the Responses API.
-
-        {"type":"function","function":{"name":...}} -> {"type":"function","name":...}
-        String forms ("auto", "required", "none") and None pass through unchanged.
-        """
+        """Flatten Chat-Completions tool_choice to the Responses API shape; pass strings/None through."""
         if isinstance(tool_choice, dict) and tool_choice.get("type") == "function" and "function" in tool_choice:
             return {"type": "function", "name": tool_choice["function"].get("name")}
         return tool_choice

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -369,7 +369,10 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if responses_tools:
             create_kwargs["tools"] = responses_tools
-            create_kwargs["tool_choice"] = tool_choice or "auto"
+            tc = tool_choice or "auto"
+            if isinstance(tc, dict) and tc.get("type") == "function" and "function" in tc:
+                tc = {"type": "function", "name": tc["function"].get("name")}
+            create_kwargs["tool_choice"] = tc
             create_kwargs["parallel_tool_calls"] = False
 
         if request_json:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -369,10 +369,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if responses_tools:
             create_kwargs["tools"] = responses_tools
-            tc = tool_choice or "auto"
-            if isinstance(tc, dict) and tc.get("type") == "function" and "function" in tc:
-                tc = {"type": "function", "name": tc["function"].get("name")}
-            create_kwargs["tool_choice"] = tc
+            create_kwargs["tool_choice"] = MessageFormatAdapter.chat_tool_choice_to_responses(tool_choice or "auto")
             create_kwargs["parallel_tool_calls"] = False
 
         if request_json:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.50"
+version = "0.10.51"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Three forced-function-call defects on graph agents, all anchored in `_get_tool_choice_for_node()` and the Responses-API adapter.

1. **`tool_choice` shape mismatch.** Forced calls produced the Chat Completions shape `{"type":"function","function":{"name":...}}` but were sent through the Responses API (any GPT-5 model after the trunk auto-route patch), which rejects it as `unknown_parameter: tool_choice.function`. Added `MessageFormatAdapter.chat_tool_choice_to_responses` and call it from `_build_responses_create_kwargs`. Covers WebSocket and HTTP SSE Responses paths.

2. **Silent loop when required args can't be resolved.** If a node's `function_call` forces a tool whose required schema params are referenced in the prompt as `{var}` tokens but those vars aren't in `recipient_data`, the LLM hallucinated values, the API call failed, the stream stalled, and the agent silently looped until the inactivity timeout. New `_missing_forced_function_vars` check drops the force to auto so the LLM speaks naturally from the node prompt instead.

3. **Loop after a successful tool call.** `function_call: <name>` was forcing the tool on every LLM turn while on the node, even after the tool had returned and its result was already in conversation history. Routing decided "stay" on the next turn (no new user input), the force re-pinned, the same tool fired again with the same args. New `_forced_function_already_called` check walks the per-node-visit slice of history (from `current_node_entry_index`) looking for a `tool` role message with the function's `tool_call_id`, and drops the force once one is found. On a fresh node visit the slice updates and the force re-applies. No re-force on failure: the LLM either speaks the failure or designers model retry via an edge.