### PR TITLE
fix: arm watchdog to clear stuck response_in_pipeline flag

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.51"
+__version__ = "0.10.52"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -264,6 +264,8 @@ class TaskManager(BaseManager):
         self.consider_next_transcript_after = time.time()
         self.llm_response_generated = False
         self.response_in_pipeline = False
+        self._pipeline_guard_task = None
+        self._pipeline_guard_deadline_sec = 10.0
         self._response_turn_id = 0
         self._turn_msg_map = {}  # turn_id → assistant message dict ref in _messages
         self._pending_assistant_history = {}  # sequence_id -> {content, turn_id, response_uid}
@@ -1880,6 +1882,9 @@ class TaskManager(BaseManager):
         self.interruption_manager.invalidate_pending_responses()
         self._drop_all_staged_assistant_history("cleanup_downstream_tasks")
         self.response_in_pipeline = False
+        if self._pipeline_guard_task is not None and not self._pipeline_guard_task.done():
+            self._pipeline_guard_task.cancel()
+            self._pipeline_guard_task = None
         await self.tools["synthesizer"].flush_synthesizer_stream()
 
         # Stop the output loop first so that we do not transmit anything else
@@ -1992,6 +1997,48 @@ class TaskManager(BaseManager):
             meta_info = message["meta_info"]
             sequence = meta_info.get("sequence", 0)
         return sequence, meta_info
+
+    def _set_response_in_pipeline(self, sequence_id):
+        """Mark a new response as in-flight and arm a watchdog.
+
+        Some LLM/TTS failure modes (empty stream, synth wedge, httpx stall)
+        never emit audio, so the flag is never cleared by the SEND or
+        BLOCK-with-EOS paths in __process_output_loop and remains stuck True.
+        The guard armed here clears the flag after a deadline if no audio
+        flowed and the sequence is still current.
+        """
+        self.response_in_pipeline = True
+        prev = getattr(self, "_pipeline_guard_task", None)
+        if prev is not None and not prev.done():
+            prev.cancel()
+        self._pipeline_guard_task = None
+        if sequence_id is None:
+            logger.warning("pipeline_guard not armed: sequence_id is None")
+            return
+        self._pipeline_guard_task = asyncio.create_task(
+            self._guard_response_in_pipeline(sequence_id)
+        )
+
+    async def _guard_response_in_pipeline(self, sequence_id):
+        deadline_sec = self._pipeline_guard_deadline_sec
+        try:
+            await asyncio.sleep(deadline_sec)
+        except asyncio.CancelledError:
+            return
+        if self.hangup_triggered or self.conversation_ended:
+            return
+        if not self.response_in_pipeline:
+            return
+        if not self.interruption_manager.is_valid_sequence(sequence_id):
+            return
+        if self.tools["input"].is_audio_being_played_to_user():
+            return
+        logger.warning(
+            "Pipeline guard cleared response_in_pipeline after %.1fs with no audio | sequence_id=%s",
+            deadline_sec,
+            sequence_id,
+        )
+        self.response_in_pipeline = False
 
     def _is_extraction_task(self):
         return self.task_config["task_type"] == "extraction"
@@ -2279,7 +2326,7 @@ class TaskManager(BaseManager):
                 "message_category": "event_proactive",
             }
         )
-        self.response_in_pipeline = True
+        self._set_response_in_pipeline(meta_info["sequence_id"])
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet("", meta_info)))
         self.llm_task = task
         try:
@@ -3691,7 +3738,7 @@ class TaskManager(BaseManager):
             # interruption path, the new seq_id would otherwise never be added
             # back to sequence_ids, causing all audio to be BLOCKed permanently.
             self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
-            self.response_in_pipeline = True
+            self._set_response_in_pipeline(meta_info["sequence_id"])
             self.llm_task = asyncio.create_task(self._run_llm_task(transcriber_package))
 
         elif next_task == "synthesizer":
@@ -4000,7 +4047,7 @@ class TaskManager(BaseManager):
                                 # invalidate_pending_responses from the interruption path can remove it,
                                 # and without this call all audio from the eager task would be BLOCKed.
                                 self.interruption_manager.revalidate_sequence_id(self.eager_meta_info["sequence_id"])
-                                self.response_in_pipeline = True
+                                self._set_response_in_pipeline(self.eager_meta_info["sequence_id"])
                             self.llm_task = self.eager_llm_task
                             self.eager_llm_task = None
                             self.eager_meta_info = None
@@ -4582,7 +4629,7 @@ class TaskManager(BaseManager):
                 "format": self.task_config["tools_config"]["output"].get("format", "pcm"),
             }
         )
-        self.response_in_pipeline = True
+        self._set_response_in_pipeline(meta_info["sequence_id"])
         task = asyncio.create_task(self._run_llm_task(create_ws_data_packet(injected_message, meta_info)))
         self.llm_task = task
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.51"
+version = "0.10.52"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/repro_response_in_pipeline.py
+++ b/repro_response_in_pipeline.py
@@ -1,0 +1,128 @@
+"""Reproduction script for the stuck response_in_pipeline bug.
+
+Demonstrates the bug PRE-FIX (raw `self.response_in_pipeline = True` with no
+watchdog) versus the fix POST-FIX (centralized setter that arms a watchdog).
+
+Each scenario simulates one of the three upstream failure modes seen in
+production logs:
+  * empty_llm   : the LLM stream completed with no textual content
+  * synth_wedge : the synthesizer WS hangs and never yields audio
+  * httpx_hang  : the LLM HTTP call is suspended inside the httpx pool
+
+In every scenario nothing ever clears the flag externally. PRE-FIX leaves
+the flag stuck True forever, breaking interruption handling and the
+hangup-after-silence timer. POST-FIX clears the flag within the watchdog
+deadline.
+
+Run: python repro_response_in_pipeline.py
+"""
+
+import asyncio
+import sys
+from unittest.mock import MagicMock
+
+
+class FakeInterruptionManager:
+    def __init__(self):
+        self.sequence_ids = {-1}
+        self._n = 0
+
+    def next(self):
+        self._n += 1
+        self.sequence_ids.add(self._n)
+        return self._n
+
+    def is_valid_sequence(self, sid):
+        return sid in self.sequence_ids
+
+
+class TM:
+    """Stand-in mirroring the TaskManager attributes the guard reads."""
+
+    def __init__(self, with_fix):
+        self.response_in_pipeline = False
+        self._pipeline_guard_task = None
+        self._pipeline_guard_deadline_sec = 0.5
+        self.hangup_triggered = False
+        self.conversation_ended = False
+        self.interruption_manager = FakeInterruptionManager()
+        inp = MagicMock()
+        inp.is_audio_being_played_to_user = MagicMock(return_value=False)
+        self.tools = {"input": inp}
+        self.with_fix = with_fix
+
+    def start_turn(self):
+        sid = self.interruption_manager.next()
+        if self.with_fix:
+            self._set_response_in_pipeline(sid)
+        else:
+            self.response_in_pipeline = True  # original buggy behaviour
+        return sid
+
+    def _set_response_in_pipeline(self, sid):
+        self.response_in_pipeline = True
+        prev = self._pipeline_guard_task
+        if prev is not None and not prev.done():
+            prev.cancel()
+        self._pipeline_guard_task = asyncio.create_task(self._guard(sid))
+
+    async def _guard(self, sid):
+        try:
+            await asyncio.sleep(self._pipeline_guard_deadline_sec)
+        except asyncio.CancelledError:
+            return
+        if self.hangup_triggered or self.conversation_ended:
+            return
+        if not self.response_in_pipeline:
+            return
+        if not self.interruption_manager.is_valid_sequence(sid):
+            return
+        if self.tools["input"].is_audio_being_played_to_user():
+            return
+        self.response_in_pipeline = False
+
+
+SCENARIOS = ["empty_llm", "synth_wedge", "httpx_hang"]
+
+
+async def simulate_scenario(scenario, with_fix):
+    """Drive a single scenario. None of these scenarios produce audio, so
+    nothing ever clears the flag externally."""
+    tm = TM(with_fix=with_fix)
+    tm.start_turn()
+    if scenario == "synth_wedge":
+        wedged = asyncio.create_task(asyncio.Event().wait())
+    elif scenario == "httpx_hang":
+        hung = asyncio.create_task(asyncio.Event().wait())
+        tm.llm_task = hung
+    await asyncio.sleep(1.0)
+    if scenario == "synth_wedge":
+        wedged.cancel()
+        try:
+            await wedged
+        except BaseException:
+            pass
+    elif scenario == "httpx_hang":
+        hung.cancel()
+        try:
+            await hung
+        except BaseException:
+            pass
+    return tm.response_in_pipeline
+
+
+async def run(label, with_fix):
+    print(f"\n=== {label}  (with_fix={with_fix}) ===")
+    for scenario in SCENARIOS:
+        stuck = await simulate_scenario(scenario, with_fix)
+        status = "STUCK (BUG)" if stuck else "CLEAR (OK)"
+        print(f"  scenario={scenario:<11} response_in_pipeline={stuck}  -> {status}")
+
+
+async def main():
+    await run("PRE-FIX", with_fix=False)
+    await run("POST-FIX", with_fix=True)
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/test_response_in_pipeline_guard.py
+++ b/tests/test_response_in_pipeline_guard.py
@@ -1,0 +1,203 @@
+"""Tests for the response_in_pipeline watchdog guard.
+
+Standalone script style matching tests/test_elevenlabs_eos_emission.py.
+Run: python tests/test_response_in_pipeline_guard.py
+"""
+
+import asyncio
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.agent_manager.interruption_manager import InterruptionManager
+
+
+def make_tm(deadline_sec=0.5):
+    tm = TaskManager.__new__(TaskManager)
+    tm.response_in_pipeline = False
+    tm._pipeline_guard_task = None
+    tm._pipeline_guard_deadline_sec = deadline_sec
+    tm.hangup_triggered = False
+    tm.conversation_ended = False
+    im = InterruptionManager.__new__(InterruptionManager)
+    im.sequence_ids = {-1}
+    im.curr_sequence_id = 0
+    tm.interruption_manager = im
+    input_tool = MagicMock()
+    input_tool.is_audio_being_played_to_user = MagicMock(return_value=False)
+    tm.tools = {"input": input_tool}
+    return tm
+
+
+def new_seq(tm):
+    tm.interruption_manager.curr_sequence_id += 1
+    sid = tm.interruption_manager.curr_sequence_id
+    tm.interruption_manager.sequence_ids.add(sid)
+    return sid
+
+
+async def case_a_empty_llm_stream_guard_fires():
+    tm = make_tm(deadline_sec=0.3)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    assert tm.response_in_pipeline is True
+    await asyncio.sleep(0.5)
+    assert tm.response_in_pipeline is False, "guard must have cleared the flag"
+    assert tm._pipeline_guard_task.done()
+
+
+async def case_b_synth_wedge_guard_fires():
+    tm = make_tm(deadline_sec=0.3)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    wedged = asyncio.create_task(asyncio.Event().wait())
+    try:
+        await asyncio.sleep(0.5)
+        assert tm.response_in_pipeline is False
+    finally:
+        wedged.cancel()
+        try:
+            await wedged
+        except (asyncio.CancelledError, BaseException):
+            pass
+
+
+async def case_c_llm_http_hang_guard_fires_even_when_task_suspended():
+    tm = make_tm(deadline_sec=0.3)
+    sid = new_seq(tm)
+
+    async def fake_llm_task():
+        await asyncio.Event().wait()  # never resolves
+
+    hung = asyncio.create_task(fake_llm_task())
+    tm.llm_task = hung
+    tm._set_response_in_pipeline(sid)
+    try:
+        await asyncio.sleep(0.5)
+        assert tm.response_in_pipeline is False
+        assert not hung.done(), "guard must not touch the hung llm_task"
+    finally:
+        hung.cancel()
+        try:
+            await hung
+        except (asyncio.CancelledError, BaseException):
+            pass
+
+
+async def case_d_healthy_turn_guard_no_ops():
+    tm = make_tm(deadline_sec=0.3)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    await asyncio.sleep(0.05)
+    tm.response_in_pipeline = False  # simulates SEND path clearing the flag
+    await asyncio.sleep(0.4)
+    assert tm.response_in_pipeline is False
+    assert tm._pipeline_guard_task.done()
+
+
+async def case_e_interruption_replaces_guard():
+    tm = make_tm(deadline_sec=0.3)
+    sid_a = new_seq(tm)
+    tm._set_response_in_pipeline(sid_a)
+    guard_a = tm._pipeline_guard_task
+    await asyncio.sleep(0.05)
+    # interruption flow: invalidate old, revalidate new, set flag (which arms new guard)
+    tm.interruption_manager.sequence_ids = {-1}
+    sid_b = new_seq(tm)
+    tm._set_response_in_pipeline(sid_b)
+    guard_b = tm._pipeline_guard_task
+    assert guard_a is not guard_b
+    await asyncio.sleep(0)  # let cancellation propagate
+    assert guard_a.cancelled() or guard_a.done()
+    await asyncio.sleep(0.5)
+    assert tm.response_in_pipeline is False
+    assert guard_b.done()
+
+
+async def case_f_only_latest_guard_active():
+    tm = make_tm(deadline_sec=0.5)
+    guards = []
+    for _ in range(3):
+        sid = new_seq(tm)
+        tm._set_response_in_pipeline(sid)
+        guards.append(tm._pipeline_guard_task)
+        await asyncio.sleep(0.02)
+    await asyncio.sleep(0)
+    assert all(g.cancelled() or g.done() for g in guards[:-1])
+    assert not guards[-1].done()
+    await asyncio.sleep(0.6)
+    assert tm.response_in_pipeline is False
+
+
+async def case_g_hangup_short_circuits_guard():
+    tm = make_tm(deadline_sec=0.2)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    tm.hangup_triggered = True
+    await asyncio.sleep(0.4)
+    assert tm.response_in_pipeline is True, "guard must not clear during hangup teardown"
+
+
+async def case_h_audio_playing_guard_no_ops():
+    tm = make_tm(deadline_sec=0.2)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    tm.tools["input"].is_audio_being_played_to_user = MagicMock(return_value=True)
+    await asyncio.sleep(0.4)
+    assert tm.response_in_pipeline is True
+
+
+async def case_i_invalid_sequence_guard_no_ops():
+    tm = make_tm(deadline_sec=0.2)
+    sid = new_seq(tm)
+    tm._set_response_in_pipeline(sid)
+    tm.interruption_manager.sequence_ids.discard(sid)
+    await asyncio.sleep(0.4)
+    assert tm.response_in_pipeline is True
+
+
+async def case_j_none_sequence_does_not_arm():
+    tm = make_tm(deadline_sec=0.2)
+    tm._set_response_in_pipeline(None)
+    assert tm.response_in_pipeline is True
+    assert tm._pipeline_guard_task is None
+
+
+CASES = [
+    case_a_empty_llm_stream_guard_fires,
+    case_b_synth_wedge_guard_fires,
+    case_c_llm_http_hang_guard_fires_even_when_task_suspended,
+    case_d_healthy_turn_guard_no_ops,
+    case_e_interruption_replaces_guard,
+    case_f_only_latest_guard_active,
+    case_g_hangup_short_circuits_guard,
+    case_h_audio_playing_guard_no_ops,
+    case_i_invalid_sequence_guard_no_ops,
+    case_j_none_sequence_does_not_arm,
+]
+
+
+async def main():
+    results = []
+    for case in CASES:
+        name = case.__name__
+        try:
+            await case()
+            results.append((name, "PASS", ""))
+        except AssertionError as e:
+            results.append((name, "FAIL", str(e)))
+        except Exception as e:
+            results.append((name, "ERROR", f"{type(e).__name__}: {e}"))
+    width = max(len(n) for n, _, _ in results)
+    for name, status, detail in results:
+        print(f"{name:<{width}}  {status}  {detail}")
+    failed = [r for r in results if r[1] != "PASS"]
+    print(f"\nTotal: {len(results)}, Passed: {len(results) - len(failed)}, Failed: {len(failed)}")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
## Summary
* `response_in_pipeline` was set True at the start of every LLM turn and cleared only by the SEND/BLOCK-with-EOS paths in `__process_output_loop` or by an LLM exception. Failure modes that never produce audio (empty LLM stream, synth WS wedge, httpx read stall inside the 600s pool timeout) left the flag stuck True for the rest of the call, silently breaking interruption handling and the hangup-after-silence timer.
* Centralized the four set-True sites through `_set_response_in_pipeline(sequence_id)` which arms an independent watchdog task. After a 10s deadline with no audio flowing and the sequence still valid, the watchdog clears the flag and logs a warning.
* Watchdog is cancelled on every new turn (so only the latest is armed) and on `__cleanup_downstream_tasks`. It silently no-ops if hangup or conversation end is in progress, the sequence has been invalidated, or audio is actually playing.

## Why a watchdog and not a `finally`
The httpx stall case leaves `_run_llm_task` suspended inside `await chat.completions.create()`, so a `finally`-based clear would never run. An independent task scheduled at flag-set time recovers all three failure modes uniformly.

## Follow-up
Companion change to reduce `httpx.Timeout` read from 600s to ~30s in `bolna/llms/http_client_pool.py` will be raised separately.