### PR TITLE
Fix/welcome message pre ack

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.56"
+__version__ = "0.10.57"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3307,15 +3307,15 @@ class TaskManager(BaseManager):
         _t_s = self.tools.get("transcriber")
         if hasattr(_t_s, "transcribers") and hasattr(_t_s, "active_label"):
             _t_s = _t_s.transcribers.get(_t_s.active_label, _t_s)
-        self.llm_latencies.turn_latencies.append({
-            "sequence_id": meta_info.get("sequence_id"),
-            "turn_id": meta_info.get("turn_id"),
-            "asr_turn_id": getattr(_t_s, "turn_counter", None),
-            "model": self.llm_config.get("model") if self.llm_config else None,
-            "llm_start_ms": round(
-                meta_info["llm_start_time"] * 1000 - self.conversation_start_init_ts, 2
-            ),
-        })
+        self.llm_latencies.turn_latencies.append(
+            {
+                "sequence_id": meta_info.get("sequence_id"),
+                "turn_id": meta_info.get("turn_id"),
+                "asr_turn_id": getattr(_t_s, "turn_counter", None),
+                "model": self.llm_config.get("model") if self.llm_config else None,
+                "llm_start_ms": round(meta_info["llm_start_time"] * 1000 - self.conversation_start_init_ts, 2),
+            }
+        )
 
         if self.turn_based_conversation:
             self.history.append({"role": "user", "content": message["data"]})

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2127,12 +2127,17 @@ class TaskManager(BaseManager):
             if first_item.get("text_synthesized") and first_item.get("is_final_chunk") is True:
                 break
 
-            pending_ends = [
-                v.get("sent_ts", 0) + v.get("duration", 0)
+            # Use time.time() + remaining audio duration rather than sent_ts + duration.
+            # sent_ts is when we buffered the chunk into Plivo, not when Plivo starts
+            # playing it. A 8s chunk sent at T=0 after 14s of preceding audio won't
+            # start playing until T=14 — so sent_ts+duration underestimates play_end by
+            # the length of all preceding queued chunks, firing the timeout too early.
+            remaining_durations = [
+                v.get("duration", 0)
                 for v in mark_events.values()
                 if v.get("type") != "pre_mark_message" and v.get("sent_ts")
             ]
-            expected_play_end = max(pending_ends) if pending_ends else time.time()
+            expected_play_end = (time.time() + sum(remaining_durations)) if remaining_durations else time.time()
             deadline = expected_play_end + self.hangup_mark_event_timeout
 
             remaining = deadline - time.time()

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -68,6 +68,7 @@ class MarkEventMetaData:
         self.heard_text_by_response = {}
         self.last_heard_turn_id = None
         self.last_heard_response_uid = None
+        self.welcome_pre_mark_id = None
 
     def update_data(self, mark_id, value):
         value["counter"] = self.counter

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -214,6 +214,10 @@ class DefaultInputHandler:
                 self.audio_chunks_received = 0
                 self.is_welcome_message_played = True
                 self.welcome_message_played_ts = time.time() * 1000
+                pre_mark_id = self.mark_event_meta_data.welcome_pre_mark_id
+                if pre_mark_id and pre_mark_id in self.mark_event_meta_data.mark_event_meta_data:
+                    self.mark_event_meta_data.fetch_data(pre_mark_id)
+                    logger.info("Cleared stale welcome pre_mark %s (never acked by Plivo)", pre_mark_id)
 
             elif message_type == "agent_hangup":
                 logger.info(f"Agent hangup has been triggered")

--- a/bolna/output_handlers/telephony.py
+++ b/bolna/output_handlers/telephony.py
@@ -65,6 +65,11 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                         }
                         mark_id = str(uuid.uuid4())
                         self.mark_event_meta_data.update_data(mark_id, pre_mark_event_meta_data)
+                        if (
+                            meta_info.get("message_category") == "agent_welcome_message"
+                            and self.mark_event_meta_data.welcome_pre_mark_id is None
+                        ):
+                            self.mark_event_meta_data.welcome_pre_mark_id = mark_id
                         logger.info(
                             "BOLNA_TRACE_TEL send_pre_mark mark_id=%s seq=%s turn=%s response_uid=%s group_uid=%s category=%s",
                             mark_id,

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -186,11 +186,13 @@ class StreamSynthesizer(BaseSynthesizer):
         self.current_sequence_id = meta_info.get("sequence_id")
         # Eager stub — captured even if turn never produces audio (e.g. TTS WS drop).
         # _record_turn_latency() upserts by sequence_id on completion, replacing this entry.
-        self._upsert_turn_latency({
-            "turn_id": self.current_turn_id,
-            "sequence_id": self.current_sequence_id,
-            "tts_start_ms": self.current_tts_start_ms,
-        })
+        self._upsert_turn_latency(
+            {
+                "turn_id": self.current_turn_id,
+                "sequence_id": self.current_sequence_id,
+                "tts_start_ms": self.current_tts_start_ms,
+            }
+        )
 
     def _on_push(self, meta_info, text):
         """Provider-specific hook called during push before sender is created."""
@@ -336,16 +338,15 @@ class StreamSynthesizer(BaseSynthesizer):
                 logger.info(f"{self.provider_name} sender task cancelled during cleanup.")
                 # Always stamp cancellation — even if sequence_id is None the event is useful
                 _t = self.task_manager_instance
-                _cancelled_at = (
-                    round(time.time() * 1000 - _t.conversation_start_init_ts, 2)
-                    if _t is not None else None
+                _cancelled_at = round(time.time() * 1000 - _t.conversation_start_init_ts, 2) if _t is not None else None
+                self._upsert_turn_latency(
+                    {
+                        "turn_id": self.current_turn_id,
+                        "sequence_id": self.current_sequence_id,
+                        "tts_start_ms": self.current_tts_start_ms,
+                        "cancelled_at_ms": _cancelled_at,
+                    }
                 )
-                self._upsert_turn_latency({
-                    "turn_id": self.current_turn_id,
-                    "sequence_id": self.current_sequence_id,
-                    "tts_start_ms": self.current_tts_start_ms,
-                    "cancelled_at_ms": _cancelled_at,
-                })
             except Exception as e:
                 logger.warning(f"Error cancelling {self.provider_name} sender task: {e}")
 

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -590,12 +590,14 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.info("Sender stream task cancelled")
             # Stamp cancellation on the open ASR stub if a turn was in progress
             if self.current_turn_id is not None:
-                self._upsert_turn_latency({
-                    "turn_id": self.current_turn_id,
-                    "asr_start_epoch_ms": self.current_turn_start_time,
-                    "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
-                    "cancelled_at_ms": timestamp_ms(),
-                })
+                self._upsert_turn_latency(
+                    {
+                        "turn_id": self.current_turn_id,
+                        "asr_start_epoch_ms": self.current_turn_start_time,
+                        "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                        "cancelled_at_ms": timestamp_ms(),
+                    }
+                )
             raise
         except Exception as e:
             logger.error("Error in sender_stream: " + str(e))
@@ -638,11 +640,13 @@ class DeepgramTranscriber(BaseTranscriber):
                             self._turn_pending = False
                             logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
                             # Eager stub — captured even if turn is never finalized (e.g. transcriber drop)
-                            self.turn_latencies.append({
-                                "turn_id": self.current_turn_id,
-                                "asr_start_epoch_ms": self.current_turn_start_time,
-                                "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
-                            })
+                            self.turn_latencies.append(
+                                {
+                                    "turn_id": self.current_turn_id,
+                                    "asr_start_epoch_ms": self.current_turn_start_time,
+                                    "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                                }
+                            )
                         elif self.current_turn_id is None:
                             # SpeechStarted was suppressed (e.g. Deepgram VAD inhibited during
                             # agent audio playback) but real speech arrived — still assign a turn_id.
@@ -650,11 +654,13 @@ class DeepgramTranscriber(BaseTranscriber):
                             self.current_turn_id = self.turn_counter
                             logger.info(f"Turn id assigned without SpeechStarted: {self.current_turn_id}")
                             # Eager stub for turns where SpeechStarted was suppressed
-                            self.turn_latencies.append({
-                                "turn_id": self.current_turn_id,
-                                "asr_start_epoch_ms": self.current_turn_start_time,
-                                "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
-                            })
+                            self.turn_latencies.append(
+                                {
+                                    "turn_id": self.current_turn_id,
+                                    "asr_start_epoch_ms": self.current_turn_start_time,
+                                    "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                                }
+                            )
                         # Calculate latency using end position (start + duration) for cumulative transcripts
                         self.__set_transcription_cursor(msg)
                         audio_position_end = self.transcription_cursor
@@ -869,11 +875,13 @@ class DeepgramTranscriber(BaseTranscriber):
                         self.is_transcript_sent_for_processing = False
                         self.final_transcript = ""
                         # Eager stub — captured even if turn is never finalized
-                        self.turn_latencies.append({
-                            "turn_id": self.current_turn_id,
-                            "asr_start_epoch_ms": self.speech_start_time,
-                            "asr_turn_start_epoch_ms": self.speech_start_time,
-                        })
+                        self.turn_latencies.append(
+                            {
+                                "turn_id": self.current_turn_id,
+                                "asr_start_epoch_ms": self.speech_start_time,
+                                "asr_turn_start_epoch_ms": self.speech_start_time,
+                            }
+                        )
                         yield create_ws_data_packet("speech_started", self.meta_info)
                         # StartOfTurn is guaranteed non-empty — use it immediately for barge-in
                         # instead of waiting for the first Update (~0.25s later)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.56"
+version = "0.10.57"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Issue:
  end_call cuts the farewell audio mid-sentence on Plivo — call disconnects before the agent finishes speaking.

  ---
  Root Cause:

  Every audio chunk sent to Plivo is wrapped with a pre-mark (sent before audio) and a post-mark (sent after audio). Plivo echoes both back as acknowledgments. wait_for_current_message uses these acks to
  know when audio has fully played before hanging up — it breaks out of the wait loop when only pre-marks remain (post-marks acked = audio done).

  The problem: Plivo silently drops the ack for the very first mark ever sent in a call (counter=0) — the welcome message pre-mark. This is a Plivo connection-setup race; every subsequent mark (counter ≥
  1) is acked normally.

  This stale seq=-1, type=pre_mark_message mark sits in mark_event_meta_data for the entire call lifetime. When end_call fires on the last turn, the break condition in wait_for_current_message is:

  if len(mark_items_list) == 1 and first_item.get("type") == "pre_mark_message":
      break

  But the list always has ≥ 2 items — the stuck welcome pre-mark plus the current turn's marks — so len == 1 never fires. The loop falls through to the timeout path (expected_play_end +
  hangup_mark_event_timeout = ~17s) and force-disconnects the call while farewell audio is still playing.
  
  
  
Fix:

  Track the welcome pre-mark ID at send time. When the welcome post-mark is acked by Plivo (confirming the welcome audio played), check if the pre-mark is still in the dict and remove it.

  - mark_event_meta_data.py — add welcome_pre_mark_id = None to __init__
  - telephony.py — after creating the welcome pre-mark, store its ID into mark_event_meta_data.welcome_pre_mark_id (guarded by is None so only the first chunk is captured)
  - default.py — when agent_welcome_message post-mark fires (is_welcome_message_played = True), pop the stored pre-mark ID from the dict if it's still present