### PR TITLE
feat: preserve Responses API chain on interruption + cache hit rate fixes

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.58"
+__version__ = "0.10.59"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.73"
+__version__ = "0.10.74"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -786,6 +786,22 @@ class TaskManager(BaseManager):
         except Exception as e:
             logger.debug(f"Failed to invalidate response chain: {e}")
 
+    def _set_interruption_hint(self, heard_text):
+        try:
+            llm_agent = self.tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.set_interruption_hint(heard_text)
+        except Exception as e:
+            logger.debug(f"Failed to set interruption hint: {e}")
+
+    def _cancel_in_flight_llm_response(self):
+        try:
+            llm_agent = self.tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.cancel_in_flight_response()
+        except Exception as e:
+            logger.debug(f"cancel_in_flight_response failed: {e}")
+
     def _inject_language_instruction(self, messages: list) -> list:
         """Inject language instruction into messages based on detected language."""
         lang = self.language_detector.dominant_language
@@ -1860,7 +1876,7 @@ class TaskManager(BaseManager):
                 self.conversation_history.sync_interim_turn_after_interruption(
                     target_turn_id, response_heard, self.update_transcript_for_interruption
                 )
-            self._invalidate_response_chain()
+            self._set_interruption_hint(response_heard)
 
         except Exception as e:
             logger.error(f"sync_history failed: {e}")
@@ -1872,6 +1888,7 @@ class TaskManager(BaseManager):
         current_ts = time.time()
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
+        self._cancel_in_flight_llm_response()
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
@@ -3676,7 +3693,6 @@ class TaskManager(BaseManager):
             # For precise transcripting we need to reconcile that in-flight turn
             # before appending the next user utterance, otherwise the full stored
             # assistant text can leak into history even when only part of it was heard.
-            self._invalidate_response_chain()
             original_message = transcriber_message
             transcriber_message = self.conversation_history.pop_and_merge_user(transcriber_message)
             if transcriber_message != original_message:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3688,11 +3688,6 @@ class TaskManager(BaseManager):
                 has_pending_sequences,
                 has_pending_generation,
             )
-            # Once audio starts sending, response_in_pipeline flips to False even
-            # though the assistant turn may still be actively playing to the user.
-            # For precise transcripting we need to reconcile that in-flight turn
-            # before appending the next user utterance, otherwise the full stored
-            # assistant text can leak into history even when only part of it was heard.
             original_message = transcriber_message
             transcriber_message = self.conversation_history.pop_and_merge_user(transcriber_message)
             if transcriber_message != original_message:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3671,11 +3671,6 @@ class TaskManager(BaseManager):
                 has_pending_sequences,
                 has_pending_generation,
             )
-            # Once audio starts sending, response_in_pipeline flips to False even
-            # though the assistant turn may still be actively playing to the user.
-            # For precise transcripting we need to reconcile that in-flight turn
-            # before appending the next user utterance, otherwise the full stored
-            # assistant text can leak into history even when only part of it was heard.
             original_message = transcriber_message
             transcriber_message = self.conversation_history.pop_and_merge_user(transcriber_message)
             if transcriber_message != original_message:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -783,6 +783,22 @@ class TaskManager(BaseManager):
         except Exception as e:
             logger.debug(f"Failed to invalidate response chain: {e}")
 
+    def _set_interruption_hint(self, heard_text):
+        try:
+            llm_agent = self.tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.set_interruption_hint(heard_text)
+        except Exception as e:
+            logger.debug(f"Failed to set interruption hint: {e}")
+
+    def _cancel_in_flight_llm_response(self):
+        try:
+            llm_agent = self.tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.cancel_in_flight_response()
+        except Exception as e:
+            logger.debug(f"cancel_in_flight_response failed: {e}")
+
     def _inject_language_instruction(self, messages: list) -> list:
         """Inject language instruction into messages based on detected language."""
         lang = self.language_detector.dominant_language
@@ -1853,7 +1869,7 @@ class TaskManager(BaseManager):
                 self.conversation_history.sync_interim_turn_after_interruption(
                     target_turn_id, response_heard, self.update_transcript_for_interruption
                 )
-            self._invalidate_response_chain()
+            self._set_interruption_hint(response_heard)
 
         except Exception as e:
             logger.error(f"sync_history failed: {e}")
@@ -1865,6 +1881,7 @@ class TaskManager(BaseManager):
         current_ts = time.time()
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
+        self._cancel_in_flight_llm_response()
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
@@ -3659,7 +3676,6 @@ class TaskManager(BaseManager):
             # For precise transcripting we need to reconcile that in-flight turn
             # before appending the next user utterance, otherwise the full stored
             # assistant text can leak into history even when only part of it was heard.
-            self._invalidate_response_chain()
             original_message = transcriber_message
             transcriber_message = self.conversation_history.pop_and_merge_user(transcriber_message)
             if transcriber_message != original_message:

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -122,7 +122,6 @@ class AzureLLM(OpenAICompatibleLLM):
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
-            "user": f"{self.run_id}#{meta_info.get('turn_id', '')}" if meta_info else self.run_id,
         }
 
         if not self.model.startswith(GPT5_MODEL_PREFIX):

--- a/bolna/llms/llm.py
+++ b/bolna/llms/llm.py
@@ -24,6 +24,14 @@ class BaseLLM:
         """
         pass
 
+    def set_interruption_hint(self, heard_text):
+        """Record what the user heard before barge-in. Consumed on next request."""
+        pass
+
+    def cancel_in_flight_response(self):
+        """Best-effort cancel of the in-flight response without resetting chain state."""
+        pass
+
     async def close(self):
         """Release resources (HTTP clients, WebSocket connections, etc.).
 

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -37,14 +37,24 @@ class ChatToolDefinition(BaseModel):
 class MessageFormatAdapter:
     @staticmethod
     def chat_to_responses_input(messages: list[dict]) -> tuple[str, list[dict]]:
-        """Chat Completions messages -> (instructions, Responses API input items)."""
+        """Chat Completions messages -> (instructions, Responses API input items).
+
+        System is emitted as a role=system input item, not as `instructions`,
+        because the instructions field breaks prompt-cache hashing.
+        """
         instructions = ""
         input_items = []
 
         parsed = [ChatMessage(**msg) for msg in messages]
         for msg in parsed:
             if msg.role == ChatRole.SYSTEM:
-                instructions = msg.content or ""
+                input_items.append(
+                    {
+                        "type": ResponseItemType.MESSAGE,
+                        "role": ChatRole.SYSTEM,
+                        "content": msg.content or "",
+                    }
+                )
 
             elif msg.role == ChatRole.USER:
                 input_items.append(

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -360,7 +360,6 @@ class OpenAICompatibleLLM(BaseLLM):
             "truncation": "auto",
             "max_output_tokens": self.max_tokens,
             "temperature": self.temperature,
-            "user": f"{self.run_id}#{meta_info['turn_id']}" if meta_info else None,
         }
 
         if stream is not None:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -222,17 +222,7 @@ class OpenAICompatibleLLM(BaseLLM):
         self._interruption_hint = "" if heard_text is None else heard_text
 
     def _extract_new_input(self, messages):
-        """Extract only new items since last server response.
-
-        The server already has all context up to its last output. We only
-        need to send:
-        - New user messages (after the last assistant message)
-        - Function call outputs (tool results)
-        """
-        instructions = ""
-        if messages and messages[0].get("role") == ChatRole.SYSTEM:
-            instructions = messages[0].get("content", "")
-
+        """Send only items after the last assistant; prior context (including system) lives on the chain."""
         last_assistant_idx = -1
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].get("role") == ChatRole.ASSISTANT:
@@ -241,11 +231,11 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if last_assistant_idx < 0:
             _, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
-            return instructions, input_items
+            return "", input_items
 
         new_messages = messages[last_assistant_idx + 1 :]
         _, input_items = MessageFormatAdapter.chat_to_responses_input(new_messages)
-        return instructions, input_items
+        return "", input_items
 
     @staticmethod
     def _is_stale_response_error(error):
@@ -349,12 +339,11 @@ class OpenAICompatibleLLM(BaseLLM):
         self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None
     ):
         """Build create kwargs common to both HTTP SSE and WebSocket streaming paths."""
-        instructions, input_items = self._build_responses_input(messages)
+        _, input_items = self._build_responses_input(messages)
         responses_tools = MessageFormatAdapter.chat_tools_to_responses_tools(self._parse_tools())
 
         create_kwargs = {
             "model": self.model,
-            "instructions": instructions or None,
             "input": input_items,
             "store": store,
             "truncation": "auto",
@@ -589,11 +578,10 @@ class OpenAICompatibleLLM(BaseLLM):
         self.started_streaming = False
 
     async def _generate_responses(self, messages, request_json=False, ret_metadata=False, meta_info=None):
-        instructions, input_items = self._build_responses_input(messages)
+        _, input_items = self._build_responses_input(messages)
 
         create_kwargs = {
             "model": self.model,
-            "instructions": instructions or None,
             "input": input_items,
             "store": True,
             "truncation": "auto",

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -171,6 +171,7 @@ class OpenAICompatibleLLM(BaseLLM):
         self.previous_response_id = None
         self._pending_call_ids: set[str] = set()
         self.compact_threshold = compact_threshold
+        self._interruption_hint: Optional[str] = None
 
     @property
     def _responses_client(self):
@@ -184,13 +185,14 @@ class OpenAICompatibleLLM(BaseLLM):
     def _build_responses_input(self, messages):
         """Build (instructions, input_items) for Responses API.
 
-        When previous_response_id is set, only sends new items since last
-        server response. Otherwise sends the full conversation.
-
-        Tool call guard: if the previous response made function calls whose
-        outputs are not yet in the history, fall back to full context to
-        avoid 400 errors from the server.
+        With previous_response_id set, only sends items after the last
+        assistant. Falls back to full history when pending tool outputs are
+        missing. Any pending interruption hint is consumed exactly once and
+        only prepended on the chain-alive happy path.
         """
+        hint = self._interruption_hint
+        self._interruption_hint = None
+
         if self.previous_response_id:
             if self._pending_call_ids:
                 completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
@@ -198,8 +200,26 @@ class OpenAICompatibleLLM(BaseLLM):
                     logger.info("Pending tool call outputs missing, sending full context")
                     self.previous_response_id = None
                     return MessageFormatAdapter.chat_to_responses_input(messages)
-            return self._extract_new_input(messages)
+            instructions, input_items = self._extract_new_input(messages)
+            if hint is not None:
+                input_items = [self._build_interruption_hint_item(hint), *input_items]
+            return instructions, input_items
         return MessageFormatAdapter.chat_to_responses_input(messages)
+
+    @staticmethod
+    def _build_interruption_hint_item(heard_text: str) -> dict:
+        heard = (heard_text or "").strip()
+        return {
+            "type": ResponseItemType.MESSAGE,
+            "role": "developer",
+            "content": (
+                f'[Your previous response was interrupted. The user only heard: "{heard}". Adapt accordingly.]'
+            ),
+        }
+
+    def set_interruption_hint(self, heard_text: Optional[str]) -> None:
+        """Record what the user heard before barge-in. Consumed on next build."""
+        self._interruption_hint = "" if heard_text is None else heard_text
 
     def _extract_new_input(self, messages):
         """Extract only new items since last server response.
@@ -248,6 +268,7 @@ class OpenAICompatibleLLM(BaseLLM):
     def invalidate_response_chain(self):
         self.previous_response_id = None
         self._pending_call_ids = set()
+        self._interruption_hint = None
 
     def _build_function_call_chunk(
         self,
@@ -363,6 +384,8 @@ class OpenAICompatibleLLM(BaseLLM):
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
+            # Preserves reasoning across full-history fallbacks; no-op when chain is alive.
+            create_kwargs["include"] = ["reasoning.encrypted_content"]
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id
@@ -597,6 +620,7 @@ class OpenAICompatibleLLM(BaseLLM):
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
+            create_kwargs["include"] = ["reasoning.encrypted_content"]
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -171,6 +171,7 @@ class OpenAICompatibleLLM(BaseLLM):
         self.previous_response_id = None
         self._pending_call_ids: set[str] = set()
         self.compact_threshold = compact_threshold
+        self._interruption_hint: Optional[str] = None
 
     @property
     def _responses_client(self):
@@ -184,13 +185,14 @@ class OpenAICompatibleLLM(BaseLLM):
     def _build_responses_input(self, messages):
         """Build (instructions, input_items) for Responses API.
 
-        When previous_response_id is set, only sends new items since last
-        server response. Otherwise sends the full conversation.
-
-        Tool call guard: if the previous response made function calls whose
-        outputs are not yet in the history, fall back to full context to
-        avoid 400 errors from the server.
+        With previous_response_id set, only sends items after the last
+        assistant. Falls back to full history when pending tool outputs are
+        missing. Any pending interruption hint is consumed exactly once and
+        only prepended on the chain-alive happy path.
         """
+        hint = self._interruption_hint
+        self._interruption_hint = None
+
         if self.previous_response_id:
             if self._pending_call_ids:
                 completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
@@ -198,8 +200,26 @@ class OpenAICompatibleLLM(BaseLLM):
                     logger.info("Pending tool call outputs missing, sending full context")
                     self.previous_response_id = None
                     return MessageFormatAdapter.chat_to_responses_input(messages)
-            return self._extract_new_input(messages)
+            instructions, input_items = self._extract_new_input(messages)
+            if hint is not None:
+                input_items = [self._build_interruption_hint_item(hint), *input_items]
+            return instructions, input_items
         return MessageFormatAdapter.chat_to_responses_input(messages)
+
+    @staticmethod
+    def _build_interruption_hint_item(heard_text: str) -> dict:
+        heard = (heard_text or "").strip()
+        return {
+            "type": ResponseItemType.MESSAGE,
+            "role": "developer",
+            "content": (
+                f'[Your previous response was interrupted. The user only heard: "{heard}". Adapt accordingly.]'
+            ),
+        }
+
+    def set_interruption_hint(self, heard_text: Optional[str]) -> None:
+        """Record what the user heard before barge-in. Consumed on next build."""
+        self._interruption_hint = "" if heard_text is None else heard_text
 
     def _extract_new_input(self, messages):
         """Extract only new items since last server response.
@@ -248,6 +268,7 @@ class OpenAICompatibleLLM(BaseLLM):
     def invalidate_response_chain(self):
         self.previous_response_id = None
         self._pending_call_ids = set()
+        self._interruption_hint = None
 
     def _build_function_call_chunk(
         self,
@@ -363,6 +384,8 @@ class OpenAICompatibleLLM(BaseLLM):
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
+            # Preserves reasoning across full-history fallbacks; no-op when chain is alive.
+            create_kwargs["include"] = ["reasoning.encrypted_content"]
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id
@@ -595,6 +618,7 @@ class OpenAICompatibleLLM(BaseLLM):
             verbosity = self.model_args.get("verbosity")
             if verbosity:
                 create_kwargs.setdefault("text", {})["verbosity"] = verbosity
+            create_kwargs["include"] = ["reasoning.encrypted_content"]
 
         if self.previous_response_id:
             create_kwargs["previous_response_id"] = self.previous_response_id

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -222,17 +222,7 @@ class OpenAICompatibleLLM(BaseLLM):
         self._interruption_hint = "" if heard_text is None else heard_text
 
     def _extract_new_input(self, messages):
-        """Extract only new items since last server response.
-
-        The server already has all context up to its last output. We only
-        need to send:
-        - New user messages (after the last assistant message)
-        - Function call outputs (tool results)
-        """
-        instructions = ""
-        if messages and messages[0].get("role") == ChatRole.SYSTEM:
-            instructions = messages[0].get("content", "")
-
+        """Send only items after the last assistant; prior context (including system) lives on the chain."""
         last_assistant_idx = -1
         for i in range(len(messages) - 1, -1, -1):
             if messages[i].get("role") == ChatRole.ASSISTANT:
@@ -241,11 +231,11 @@ class OpenAICompatibleLLM(BaseLLM):
 
         if last_assistant_idx < 0:
             _, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
-            return instructions, input_items
+            return "", input_items
 
         new_messages = messages[last_assistant_idx + 1 :]
         _, input_items = MessageFormatAdapter.chat_to_responses_input(new_messages)
-        return instructions, input_items
+        return "", input_items
 
     @staticmethod
     def _is_stale_response_error(error):
@@ -349,12 +339,11 @@ class OpenAICompatibleLLM(BaseLLM):
         self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None
     ):
         """Build create kwargs common to both HTTP SSE and WebSocket streaming paths."""
-        instructions, input_items = self._build_responses_input(messages)
+        _, input_items = self._build_responses_input(messages)
         responses_tools = MessageFormatAdapter.chat_tools_to_responses_tools(self._parse_tools())
 
         create_kwargs = {
             "model": self.model,
-            "instructions": instructions or None,
             "input": input_items,
             "store": store,
             "truncation": "auto",
@@ -587,11 +576,10 @@ class OpenAICompatibleLLM(BaseLLM):
         self.started_streaming = False
 
     async def _generate_responses(self, messages, request_json=False, ret_metadata=False, meta_info=None):
-        instructions, input_items = self._build_responses_input(messages)
+        _, input_items = self._build_responses_input(messages)
 
         create_kwargs = {
             "model": self.model,
-            "instructions": instructions or None,
             "input": input_items,
             "store": True,
             "truncation": "auto",

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -106,21 +106,17 @@ class OpenAIWSConnection:
                     return
 
     async def cancel_response(self, response_id: str):
-        """Cancel an in-flight response. Best-effort, errors are non-critical."""
-        if self._ws is None:
+        """Best-effort cancel: signal the server to terminate the in-flight
+        response. We do not drain events here — the concurrent stream_response
+        loop is the sole recv consumer and will see the resulting terminal
+        event itself. Holding the lock would block the cancel until the
+        stream completes naturally, defeating its purpose."""
+        if self._ws is None or self._ws.state is not WSState.OPEN:
             return
         try:
             await self._ws.send(
-                json.dumps(
-                    {
-                        "type": ResponseStreamEvent.CANCEL,
-                        "response_id": response_id,
-                    }
-                )
+                json.dumps({"type": ResponseStreamEvent.CANCEL, "response_id": response_id})
             )
-            async for raw_msg in self._ws:
-                if json.loads(raw_msg).get("type") in self.TERMINAL_EVENTS:
-                    break
         except Exception:
             pass
 
@@ -707,11 +703,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self.started_streaming = False
 
-    def invalidate_response_chain(self):
-        response_id = self.previous_response_id
-        super().invalidate_response_chain()
-        if self._ws_transport and response_id:
-            asyncio.ensure_future(self._ws_transport.cancel_response(response_id))
+    def cancel_in_flight_response(self):
+        """Cancel the in-flight WS response; keeps previous_response_id alive."""
+        if self._ws_transport and self.previous_response_id:
+            asyncio.ensure_future(self._ws_transport.cancel_response(self.previous_response_id))
 
     async def close(self):
         # httpx client is shared via pool, don't close it here

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -114,9 +114,7 @@ class OpenAIWSConnection:
         if self._ws is None or self._ws.state is not WSState.OPEN:
             return
         try:
-            await self._ws.send(
-                json.dumps({"type": ResponseStreamEvent.CANCEL, "response_id": response_id})
-            )
+            await self._ws.send(json.dumps({"type": ResponseStreamEvent.CANCEL, "response_id": response_id}))
         except Exception:
             pass
 

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -237,7 +237,6 @@ class OpenAiLLM(OpenAICompatibleLLM):
             "messages": messages,
             "stream": True,
             "stream_options": {"include_usage": True},
-            "user": f"{self.run_id}#{meta_info['turn_id']}",
         }
 
         if not self.model.startswith(GPT5_MODEL_PREFIX):

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -500,9 +500,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
         if not messages:
             raise ValueError("No messages provided")
 
-        # store=False: WS previous_response_id uses connection-local cache, not server storage
+        # store=True activates server-side prompt-cache (cached_tokens in usage)
+        # on top of the WS connection-local cache. Storage is free per OpenAI.
         create_params, responses_tools = self._build_responses_create_kwargs(
-            messages, meta_info, request_json, tool_choice, store=False
+            messages, meta_info, request_json, tool_choice, store=True
         )
 
         # WS endpoint silently closes on float temperature — coerce to int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.58"
+version = "0.10.59"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.73"
+version = "0.10.74"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_responses_api.py
+++ b/tests/tests/test_responses_api.py
@@ -1,0 +1,1343 @@
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch, PropertyMock
+from openai import APIError, BadRequestError
+from bolna.llms.openai_llm import OpenAiLLM
+from bolna.llms.azure_llm import AzureLLM
+from bolna.llms.types import FunctionCallPayload
+
+
+def _make_llm(**overrides):
+    defaults = {
+        "model": "gpt-4o",
+        "max_tokens": 100,
+        "buffer_size": 40,
+        "temperature": 0.1,
+        "llm_key": "test-key",
+        "run_id": "run_123",
+    }
+    defaults.update(overrides)
+    with patch.object(OpenAiLLM, "__init__", lambda self, **kw: None):
+        llm = OpenAiLLM.__new__(OpenAiLLM)
+    llm.model = defaults["model"]
+    llm.max_tokens = defaults["max_tokens"]
+    llm.buffer_size = defaults["buffer_size"]
+    llm.temperature = defaults["temperature"]
+    llm.run_id = defaults["run_id"]
+    llm.language = "en"
+    llm.trigger_function_call = defaults.get("trigger_function_call", False)
+    llm.api_params = defaults.get("api_params", {})
+    llm.tools = defaults.get("tools", [])
+    llm.started_streaming = False
+    llm.llm_host = None
+    llm.use_responses_api = defaults.get("use_responses_api", False)
+    llm.previous_response_id = defaults.get("previous_response_id", None)
+    llm._pending_call_ids = defaults.get("_pending_call_ids", set())
+    llm.compact_threshold = defaults.get("compact_threshold", None)
+    llm._interruption_hint = defaults.get("_interruption_hint", None)
+    llm._ws_transport = None
+    llm.async_client = AsyncMock()
+    llm.model_args = {"model": llm.model, "max_tokens": llm.max_tokens, "temperature": llm.temperature}
+    return llm
+
+
+def _make_meta_info(**overrides):
+    meta = {"sequence_id": 1, "turn_id": 1}
+    meta.update(overrides)
+    return meta
+
+
+class _FakeStreamEvent:
+    def __init__(self, event_type, **kwargs):
+        self.type = event_type
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+
+
+class _FakeResponse:
+    def __init__(self, response_id):
+        self.id = response_id
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+# --- Dispatcher Tests ---
+
+
+class TestDispatcher:
+    def test_use_responses_api_false_by_default(self):
+        llm = _make_llm()
+        assert llm.use_responses_api is False
+
+    def test_use_responses_api_from_kwargs(self):
+        llm = _make_llm(use_responses_api=True)
+        assert llm.use_responses_api is True
+
+
+# --- Responses API Streaming Tests ---
+
+
+class TestResponsesAPIStreaming:
+    @pytest.mark.asyncio
+    async def test_text_streaming_yields_correct_tuples(self):
+        llm = _make_llm(use_responses_api=True)
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_001")),
+            _FakeStreamEvent("response.output_item.added", item=MagicMock(type="message", id="msg_1")),
+            _FakeStreamEvent("response.output_text.delta", delta="Hello ", item_id="msg_1"),
+            _FakeStreamEvent("response.output_text.delta", delta="world!", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_001")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Say hello"},
+        ]
+
+        chunks = []
+        async for chunk in llm.generate_stream(messages, synthesize=False, meta_info=_make_meta_info()):
+            chunks.append(chunk)
+
+        # Should have at least the final yield
+        assert len(chunks) >= 1
+        last = chunks[-1]
+        assert last.end_of_stream is True
+        assert last.is_function_call is False
+        assert "Hello world!" in last.data
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_captured(self):
+        llm = _make_llm(use_responses_api=True)
+        assert llm.previous_response_id is None
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_abc")),
+            _FakeStreamEvent("response.output_text.delta", delta="Hi", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_abc")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        assert llm.previous_response_id == "resp_abc"
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_sent_on_next_call(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_prev")
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_next")),
+            _FakeStreamEvent("response.output_text.delta", delta="Ok", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_next")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Continue"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert call_kwargs["previous_response_id"] == "resp_prev"
+
+    @pytest.mark.asyncio
+    async def test_function_call_streaming(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            trigger_function_call=True,
+            api_params={
+                "get_weather": {
+                    "url": "https://api.example.com/weather",
+                    "method": "POST",
+                    "param": None,
+                    "api_token": "token_123",
+                }
+            },
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get weather",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"city": {"type": "string"}},
+                            "required": ["city"],
+                        },
+                    },
+                }
+            ],
+        )
+
+        fc_item = MagicMock()
+        fc_item.type = "function_call"
+        fc_item.id = "fc_item_1"
+        fc_item.name = "get_weather"
+        fc_item.call_id = "call_xyz"
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_fc")),
+            _FakeStreamEvent("response.output_item.added", item=fc_item),
+            _FakeStreamEvent("response.function_call_arguments.delta", delta='{"city":', item_id="fc_item_1"),
+            _FakeStreamEvent("response.function_call_arguments.delta", delta=' "NYC"}', item_id="fc_item_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_fc")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Weather in NYC?"}],
+            synthesize=True,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        # Find the function call payload
+        fc_chunks = [c for c in chunks if c.is_function_call is True]
+        assert len(fc_chunks) == 1
+
+        payload = fc_chunks[0].data
+        assert isinstance(payload, FunctionCallPayload)
+        assert payload.called_fun == "get_weather"
+        assert payload.tool_call_id == "call_xyz"
+        assert payload.url == "https://api.example.com/weather"
+        assert payload.city == "NYC"  # parsed args merged in
+        # model_response in Chat Completions format for task_manager compat
+        assert payload.model_response[0]["function"]["name"] == "get_weather"
+        assert payload.model_response[0]["id"] == "call_xyz"
+
+    @pytest.mark.asyncio
+    async def test_latency_data_populated(self):
+        llm = _make_llm(use_responses_api=True)
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_lat")),
+            _FakeStreamEvent("response.output_text.delta", delta="Test", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_lat")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Test"}],
+            synthesize=False,
+            meta_info=_make_meta_info(sequence_id=42),
+        ):
+            chunks.append(chunk)
+
+        last = chunks[-1]
+        latency = last.latency
+        assert latency is not None
+        assert latency.sequence_id == 42
+        assert latency.first_token_latency_ms >= 0
+        assert latency.total_stream_duration_ms is not None
+
+    @pytest.mark.asyncio
+    async def test_buffer_flushing_with_synthesize(self):
+        llm = _make_llm(use_responses_api=True, buffer_size=5)
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_buf")),
+            _FakeStreamEvent("response.output_text.delta", delta="Hello there how are you today", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_buf")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=True,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        # With buffer_size=5, the 30-char text should be split into multiple chunks
+        assert len(chunks) >= 2
+
+    @pytest.mark.asyncio
+    async def test_pre_call_message_yielded(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            trigger_function_call=True,
+            api_params={
+                "book_slot": {
+                    "url": "https://api.example.com/book",
+                    "method": "POST",
+                    "param": None,
+                    "api_token": None,
+                    "pre_call_message": "Booking for you...",
+                }
+            },
+            tools=[
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "book_slot",
+                        "description": "Book a slot",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {"time": {"type": "string"}},
+                            "required": ["time"],
+                        },
+                    },
+                }
+            ],
+        )
+
+        fc_item = MagicMock()
+        fc_item.type = "function_call"
+        fc_item.id = "fc_2"
+        fc_item.name = "book_slot"
+        fc_item.call_id = "call_book"
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_pre")),
+            _FakeStreamEvent("response.output_item.added", item=fc_item),
+            _FakeStreamEvent("response.function_call_arguments.delta", delta='{"time": "3pm"}', item_id="fc_2"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_pre")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Book 3pm"}],
+            synthesize=True,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        # Should have a pre-call message chunk with function_name set
+        pre_call_chunks = [c for c in chunks if c.function_name is not None]
+        assert len(pre_call_chunks) == 1
+        assert pre_call_chunks[0].function_name == "book_slot"
+
+
+# --- Responses API Non-Streaming Tests ---
+
+
+class TestResponsesAPINonStreaming:
+    @pytest.mark.asyncio
+    async def test_generate_returns_text(self):
+        llm = _make_llm(use_responses_api=True)
+
+        mock_response = MagicMock()
+        mock_response.id = "resp_gen"
+        mock_response.output_text = "The answer is 42."
+        llm.async_client.responses.create = AsyncMock(return_value=mock_response)
+
+        result = await llm.generate(
+            [{"role": "user", "content": "What is the answer?"}],
+        )
+        assert result == "The answer is 42."
+        assert llm.previous_response_id == "resp_gen"
+
+    @pytest.mark.asyncio
+    async def test_generate_with_metadata(self):
+        llm = _make_llm(use_responses_api=True)
+
+        mock_response = MagicMock()
+        mock_response.id = "resp_meta"
+        mock_response.output_text = "Result"
+        llm.async_client.responses.create = AsyncMock(return_value=mock_response)
+
+        result, metadata = await llm.generate(
+            [{"role": "user", "content": "Test"}],
+            ret_metadata=True,
+        )
+        assert result == "Result"
+        assert "llm_host" in metadata
+
+    @pytest.mark.asyncio
+    async def test_generate_sends_previous_response_id(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_old")
+
+        mock_response = MagicMock()
+        mock_response.id = "resp_new"
+        mock_response.output_text = "Ok"
+        llm.async_client.responses.create = AsyncMock(return_value=mock_response)
+
+        await llm.generate([{"role": "user", "content": "Next"}])
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert call_kwargs["previous_response_id"] == "resp_old"
+
+
+# --- Chat Completions Fallback Tests ---
+
+
+class TestChatCompletionsFallback:
+    @pytest.mark.asyncio
+    async def test_default_uses_chat_completions(self):
+        llm = _make_llm(use_responses_api=False)
+
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "Hello"
+        mock_chunk.choices[0].delta.tool_calls = None
+        mock_chunk.service_tier = None
+
+        llm.async_client.chat.completions.create = AsyncMock(return_value=_async_iter([mock_chunk]))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) >= 1
+        # Verify chat.completions was called, not responses
+        llm.async_client.chat.completions.create.assert_called_once()
+
+
+# --- Invalidation Tests ---
+
+
+class TestInvalidation:
+    def test_invalidate_clears_previous_response_id(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_to_clear")
+        assert llm.previous_response_id == "resp_to_clear"
+        llm.invalidate_response_chain()
+        assert llm.previous_response_id is None
+
+    def test_invalidate_is_idempotent(self):
+        llm = _make_llm(use_responses_api=True)
+        llm.invalidate_response_chain()
+        llm.invalidate_response_chain()
+        assert llm.previous_response_id is None
+
+    @pytest.mark.asyncio
+    async def test_after_invalidation_no_previous_id_sent(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_stale")
+        llm.invalidate_response_chain()
+
+        mock_response = MagicMock()
+        mock_response.id = "resp_fresh"
+        mock_response.output_text = "Fresh"
+        llm.async_client.responses.create = AsyncMock(return_value=mock_response)
+
+        await llm.generate([{"role": "user", "content": "Start over"}])
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert "previous_response_id" not in call_kwargs
+
+
+# --- Task Manager Invalidation Hook Tests ---
+
+
+class TestTaskManagerInvalidationHook:
+    def test_invalidate_response_chain_called_on_pop(self):
+        """Verify _invalidate_response_chain reaches the LLM."""
+        mock_llm = MagicMock()
+        mock_llm.invalidate_response_chain = MagicMock()
+
+        mock_agent = MagicMock()
+        mock_agent.llm = mock_llm
+
+        # Simulate task_manager._invalidate_response_chain
+        tools = {"llm_agent": mock_agent}
+        try:
+            llm_agent = tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.invalidate_response_chain()
+        except Exception:
+            pass
+
+        mock_llm.invalidate_response_chain.assert_called_once()
+
+    def test_invalidation_is_non_fatal_without_llm(self):
+        """If llm_agent doesn't have llm attr, no crash."""
+        tools = {"llm_agent": MagicMock(spec=[])}
+        try:
+            llm_agent = tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.invalidate_response_chain()
+        except Exception:
+            pytest.fail("Should not raise")
+
+    def test_invalidation_is_non_fatal_without_agent(self):
+        """If no llm_agent in tools, no crash."""
+        tools = {}
+        try:
+            llm_agent = tools.get("llm_agent")
+            if llm_agent and hasattr(llm_agent, "llm"):
+                llm_agent.llm.invalidate_response_chain()
+        except Exception:
+            pytest.fail("Should not raise")
+
+
+# --- Config Propagation Tests ---
+
+
+class TestConfigPropagation:
+    def test_use_responses_api_in_llm_model(self):
+        from bolna.models import Llm
+
+        config = Llm(use_responses_api=True)
+        assert config.use_responses_api is True
+
+    def test_use_responses_api_defaults_false(self):
+        from bolna.models import Llm
+
+        config = Llm()
+        assert config.use_responses_api is False
+
+
+# --- Stale previous_response_id Fallback Tests ---
+
+
+class TestStaleResponseIdFallback:
+    @pytest.mark.asyncio
+    async def test_streaming_retries_without_previous_id_on_stale_error(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_stale")
+
+        call_count = 0
+
+        async def fake_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First call with previous_response_id fails
+                raise _bad_request("Previous response with id 'resp_stale' not found")
+            # Retry without previous_response_id succeeds
+            return _async_iter(
+                [
+                    _FakeStreamEvent("response.created", response=_FakeResponse("resp_fresh")),
+                    _FakeStreamEvent("response.output_text.delta", delta="Recovered", item_id="msg_1"),
+                    _FakeStreamEvent("response.completed", response=_FakeResponse("resp_fresh")),
+                ]
+            )
+
+        llm.async_client.responses.create = AsyncMock(side_effect=fake_create)
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hello"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert call_count == 2
+        assert llm.previous_response_id == "resp_fresh"
+        assert any("Recovered" in c.data for c in chunks if isinstance(c.data, str))
+
+    @pytest.mark.asyncio
+    async def test_streaming_raises_on_non_stale_error(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_ok")
+
+        llm.async_client.responses.create = AsyncMock(
+            side_effect=APIError(message="rate limit exceeded", request=None, body=None)
+        )
+
+        with pytest.raises(APIError):
+            async for _ in llm.generate_stream(
+                [{"role": "user", "content": "Hello"}],
+                synthesize=False,
+                meta_info=_make_meta_info(),
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_streaming_raises_without_previous_id(self):
+        """No retry when there's no previous_response_id to clear."""
+        llm = _make_llm(use_responses_api=True, previous_response_id=None)
+
+        llm.async_client.responses.create = AsyncMock(
+            side_effect=APIError(message="not found", request=None, body=None)
+        )
+
+        with pytest.raises(APIError):
+            async for _ in llm.generate_stream(
+                [{"role": "user", "content": "Hello"}],
+                synthesize=False,
+                meta_info=_make_meta_info(),
+            ):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_retries_without_previous_id_on_stale_error(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_stale")
+
+        call_count = 0
+
+        async def fake_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _bad_request("Previous response with id 'resp_stale' not found")
+            resp = MagicMock()
+            resp.id = "resp_fresh"
+            resp.output_text = "Recovered"
+            return resp
+
+        llm.async_client.responses.create = AsyncMock(side_effect=fake_create)
+
+        result = await llm.generate([{"role": "user", "content": "Hello"}])
+        assert result == "Recovered"
+        assert call_count == 2
+        assert llm.previous_response_id == "resp_fresh"
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_raises_on_non_stale_error(self):
+        llm = _make_llm(use_responses_api=True)
+
+        llm.async_client.responses.create = AsyncMock(
+            side_effect=APIError(message="authentication failed", request=None, body=None)
+        )
+
+        with pytest.raises(APIError):
+            await llm.generate([{"role": "user", "content": "Hello"}])
+
+
+# --- response.failed / response.incomplete Stream Event Tests ---
+
+
+class TestStreamFailedAndIncomplete:
+    @pytest.mark.asyncio
+    async def test_response_failed_raises_api_error(self):
+        llm = _make_llm(use_responses_api=True)
+
+        failed_response = MagicMock()
+        failed_response.id = "resp_fail"
+        failed_response.error = {"type": "server_error", "message": "Internal error"}
+        failed_response.last_error = None
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_fail")),
+            _FakeStreamEvent("response.failed", response=failed_response),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        with pytest.raises(APIError, match="Response failed"):
+            async for _ in llm.generate_stream(
+                [{"role": "user", "content": "Hi"}],
+                synthesize=False,
+                meta_info=_make_meta_info(),
+            ):
+                pass
+
+        # Should invalidate the response chain on failure
+        assert llm.previous_response_id is None
+
+    @pytest.mark.asyncio
+    async def test_response_incomplete_yields_partial(self):
+        llm = _make_llm(use_responses_api=True)
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_inc")),
+            _FakeStreamEvent("response.output_text.delta", delta="Partial ", item_id="msg_1"),
+            _FakeStreamEvent("response.output_text.delta", delta="answer", item_id="msg_1"),
+            _FakeStreamEvent("response.incomplete", response=_FakeResponse("resp_inc")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        # Should still yield whatever was received
+        assert any("Partial answer" in c.data for c in chunks if isinstance(c.data, str))
+
+    @pytest.mark.asyncio
+    async def test_response_failed_uses_last_error_fallback(self):
+        llm = _make_llm(use_responses_api=True)
+
+        failed_response = MagicMock()
+        failed_response.id = "resp_fail2"
+        failed_response.error = None
+        failed_response.last_error = {"type": "rate_limit", "message": "Too many requests"}
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_fail2")),
+            _FakeStreamEvent("response.failed", response=failed_response),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        with pytest.raises(APIError, match="Response failed"):
+            async for _ in llm.generate_stream(
+                [{"role": "user", "content": "Hi"}],
+                synthesize=False,
+                meta_info=_make_meta_info(),
+            ):
+                pass
+
+
+# --- _is_stale_response_error Tests ---
+
+
+def _bad_request(msg):
+    import httpx
+
+    resp = httpx.Response(400, request=httpx.Request("POST", "https://api.openai.com/v1/responses"))
+    return BadRequestError(message=msg, response=resp, body=None)
+
+
+class TestIsStaleResponseError:
+    def test_bad_request_is_stale(self):
+        err = _bad_request("Previous response with id 'resp_xxx' not found")
+        assert OpenAiLLM._is_stale_response_error(err) is True
+
+    def test_non_bad_request_is_not_stale(self):
+        err = APIError(message="Rate limit exceeded", request=None, body=None)
+        assert OpenAiLLM._is_stale_response_error(err) is False
+
+    def test_generic_exception_is_not_stale(self):
+        err = Exception("Something went wrong")
+        assert OpenAiLLM._is_stale_response_error(err) is False
+
+
+# --- _build_responses_input / _extract_new_input Tests ---
+
+
+class TestBuildResponsesInput:
+    """Test the incremental input logic for Responses API."""
+
+    def test_full_history_when_no_previous_response_id(self):
+        """Without previous_response_id, all messages are converted including system as input item."""
+        llm = _make_llm(use_responses_api=True, previous_response_id=None)
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        _, items = llm._build_responses_input(messages)
+        assert len(items) == 4  # system, user, assistant, user
+        assert items[0]["role"] == "system"
+        assert items[0]["content"] == "You are helpful."
+        assert items[1]["content"] == "Hello"
+        assert items[2]["content"] == "Hi there!"
+        assert items[3]["content"] == "How are you?"
+
+    def test_only_new_messages_when_previous_response_id_set(self):
+        """With previous_response_id, only messages after last assistant are sent (system is in the chain)."""
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_prev")
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+            {"role": "user", "content": "How are you?"},
+        ]
+        _, items = llm._build_responses_input(messages)
+        assert len(items) == 1
+        assert items[0]["content"] == "How are you?"
+        assert items[0]["role"] == "user"
+
+    def test_tool_results_sent_after_assistant_with_previous_id(self):
+        """Tool results after the last assistant should be included."""
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_prev")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "check order"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_order", "arguments": '{"id":"123"}'}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Order shipped"},
+            {"role": "user", "content": "thanks"},
+        ]
+        _, items = llm._build_responses_input(messages)
+        assert len(items) == 2
+        assert items[0]["type"] == "function_call_output"
+        assert items[0]["output"] == "Order shipped"
+        assert items[1]["type"] == "message"
+        assert items[1]["content"] == "thanks"
+
+    def test_fallback_to_full_when_no_assistant_with_previous_id(self):
+        """If no assistant message found, send full history including system input item."""
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_prev")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "first message"},
+        ]
+        _, items = llm._build_responses_input(messages)
+        assert len(items) == 2
+        assert items[0]["role"] == "system"
+        assert items[0]["content"] == "sys"
+        assert items[1]["content"] == "first message"
+
+    def test_system_emitted_as_input_item_not_instructions(self):
+        """System prompt is emitted as a role=system input item, not pulled into instructions."""
+        llm = _make_llm(use_responses_api=True, previous_response_id=None)
+        messages = [
+            {"role": "system", "content": "Always be polite."},
+            {"role": "user", "content": "hi"},
+        ]
+        instructions, items = llm._build_responses_input(messages)
+        assert instructions == ""
+        assert items[0]["role"] == "system"
+        assert items[0]["content"] == "Always be polite."
+
+    def test_empty_messages(self):
+        llm = _make_llm(use_responses_api=True, previous_response_id=None)
+        _, items = llm._build_responses_input([])
+        assert items == []
+
+    def test_multiple_assistant_messages_uses_last(self):
+        """With previous_response_id, only messages after the LAST assistant are new."""
+        llm = _make_llm(use_responses_api=True, previous_response_id="resp_prev")
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "reply 1"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "reply 2"},
+            {"role": "user", "content": "turn 3"},
+        ]
+        _, items = llm._build_responses_input(messages)
+        assert len(items) == 1
+        assert items[0]["content"] == "turn 3"
+
+    def test_no_system_prompt(self):
+        """Messages without a system prompt should return empty instructions."""
+        llm = _make_llm(use_responses_api=True, previous_response_id=None)
+        messages = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        instructions, items = llm._build_responses_input(messages)
+        assert instructions == ""
+        assert len(items) == 2
+
+
+# ===================================================================
+# Azure Responses API Tests
+# ===================================================================
+
+
+def _make_azure_llm(**overrides):
+    defaults = {
+        "model": "gpt-4o",
+        "max_tokens": 100,
+        "buffer_size": 40,
+        "temperature": 0.1,
+        "run_id": "run_azure_123",
+    }
+    defaults.update(overrides)
+    with patch.object(AzureLLM, "__init__", lambda self, **kw: None):
+        llm = AzureLLM.__new__(AzureLLM)
+    llm.model = defaults["model"]
+    llm.max_tokens = defaults["max_tokens"]
+    llm.buffer_size = defaults["buffer_size"]
+    llm.temperature = defaults["temperature"]
+    llm.run_id = defaults["run_id"]
+    llm.language = "en"
+    llm.trigger_function_call = defaults.get("trigger_function_call", False)
+    llm.api_params = defaults.get("api_params", {})
+    llm.tools = defaults.get("tools", [])
+    llm.started_streaming = False
+    llm.llm_host = "myazure.openai.azure.com"
+    llm.use_responses_api = defaults.get("use_responses_api", False)
+    llm.previous_response_id = defaults.get("previous_response_id", None)
+    llm._pending_call_ids = defaults.get("_pending_call_ids", set())
+    llm.compact_threshold = defaults.get("compact_threshold", None)
+    llm._interruption_hint = defaults.get("_interruption_hint", None)
+    llm.async_client = AsyncMock()  # AsyncAzureOpenAI mock (chat completions)
+    llm._responses_api_client = AsyncMock()  # AsyncOpenAI v1 mock (responses API)
+    llm.model_args = {"model": llm.model, "max_tokens": llm.max_tokens, "temperature": llm.temperature}
+    return llm
+
+
+class TestAzureResponsesAPIDefault:
+    def test_use_responses_api_false_by_default(self):
+        llm = _make_azure_llm()
+        assert llm.use_responses_api is False
+
+    def test_use_responses_api_from_kwargs(self):
+        llm = _make_azure_llm(use_responses_api=True)
+        assert llm.use_responses_api is True
+
+
+class TestAzureResponsesClientProperty:
+    def test_returns_v1_client_when_set(self):
+        llm = _make_azure_llm(use_responses_api=True)
+        assert llm._responses_client is llm._responses_api_client
+        assert llm._responses_client is not llm.async_client
+
+    def test_falls_back_to_async_client_when_no_v1(self):
+        llm = _make_azure_llm(use_responses_api=False)
+        del llm._responses_api_client
+        assert llm._responses_client is llm.async_client
+
+
+class TestAzureResponsesAPIStreaming:
+    @pytest.mark.asyncio
+    async def test_streaming_dispatches_to_responses_client(self):
+        llm = _make_azure_llm(use_responses_api=True)
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_az_001")),
+            _FakeStreamEvent("response.output_text.delta", delta="Hello from Azure!", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_az_001")),
+        ]
+        llm._responses_api_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) >= 1
+        last = chunks[-1]
+        assert last.end_of_stream is True
+        assert "Hello from Azure!" in last.data
+        # Verify v1 client was used, not Azure client
+        llm._responses_api_client.responses.create.assert_called_once()
+        llm.async_client.chat.completions.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_chaining(self):
+        llm = _make_azure_llm(use_responses_api=True)
+        assert llm.previous_response_id is None
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_az_abc")),
+            _FakeStreamEvent("response.output_text.delta", delta="Ok", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_az_abc")),
+        ]
+        llm._responses_api_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        assert llm.previous_response_id == "resp_az_abc"
+
+    @pytest.mark.asyncio
+    async def test_stale_response_retry(self):
+        llm = _make_azure_llm(use_responses_api=True, previous_response_id="resp_az_stale")
+
+        call_count = 0
+
+        async def fake_create(**kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise _bad_request("Previous response with id 'resp_az_stale' not found")
+            return _async_iter(
+                [
+                    _FakeStreamEvent("response.created", response=_FakeResponse("resp_az_fresh")),
+                    _FakeStreamEvent("response.output_text.delta", delta="Recovered", item_id="msg_1"),
+                    _FakeStreamEvent("response.completed", response=_FakeResponse("resp_az_fresh")),
+                ]
+            )
+
+        llm._responses_api_client.responses.create = AsyncMock(side_effect=fake_create)
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hello"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert call_count == 2
+        assert llm.previous_response_id == "resp_az_fresh"
+        assert any("Recovered" in c.data for c in chunks if isinstance(c.data, str))
+
+
+class TestAzureResponsesAPINonStreaming:
+    @pytest.mark.asyncio
+    async def test_non_streaming_dispatches_to_responses_client(self):
+        llm = _make_azure_llm(use_responses_api=True)
+
+        mock_response = MagicMock()
+        mock_response.id = "resp_az_gen"
+        mock_response.output_text = "Azure answer"
+        llm._responses_api_client.responses.create = AsyncMock(return_value=mock_response)
+
+        result = await llm.generate([{"role": "user", "content": "Question?"}])
+        assert result == "Azure answer"
+        assert llm.previous_response_id == "resp_az_gen"
+        llm._responses_api_client.responses.create.assert_called_once()
+        llm.async_client.chat.completions.create.assert_not_called()
+
+
+class TestAzureChatCompletionsFallback:
+    @pytest.mark.asyncio
+    async def test_chat_completions_when_responses_api_off(self):
+        llm = _make_azure_llm(use_responses_api=False)
+
+        mock_chunk = MagicMock()
+        mock_chunk.choices = [MagicMock()]
+        mock_chunk.choices[0].delta.content = "Hello from Azure chat"
+        mock_chunk.choices[0].delta.tool_calls = None
+
+        llm.async_client.chat.completions.create = AsyncMock(return_value=_async_iter([mock_chunk]))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) >= 1
+        llm.async_client.chat.completions.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_non_streaming_chat_completions_fallback(self):
+        llm = _make_azure_llm(use_responses_api=False)
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "Chat result"
+        llm.async_client.chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        result = await llm.generate([{"role": "user", "content": "Hi"}])
+        assert result == "Chat result"
+        llm.async_client.chat.completions.create.assert_called_once()
+
+
+class TestAzureInvalidation:
+    def test_invalidate_clears_previous_response_id(self):
+        llm = _make_azure_llm(use_responses_api=True, previous_response_id="resp_az_clear")
+        assert llm.previous_response_id == "resp_az_clear"
+        llm.invalidate_response_chain()
+        assert llm.previous_response_id is None
+
+    def test_invalidate_is_idempotent(self):
+        llm = _make_azure_llm(use_responses_api=True)
+        llm.invalidate_response_chain()
+        llm.invalidate_response_chain()
+        assert llm.previous_response_id is None
+
+
+# ===================================================================
+# Tool Call Guard Tests
+# ===================================================================
+
+
+class TestToolCallGuard:
+    """Verify _build_responses_input falls back to full context when tool outputs are missing."""
+
+    def test_sends_incremental_when_all_tool_outputs_present(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            previous_response_id="resp_prev",
+            _pending_call_ids={"call_1"},
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "check order"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_order", "arguments": '{"id":"123"}'}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "Order shipped"},
+            {"role": "user", "content": "thanks"},
+        ]
+        instructions, items = llm._build_responses_input(messages)
+        # Incremental: only new items after last assistant
+        assert len(items) == 2
+        assert items[0]["type"] == "function_call_output"
+        assert items[1]["content"] == "thanks"
+        # previous_response_id preserved
+        assert llm.previous_response_id == "resp_prev"
+
+    def test_falls_back_to_full_when_tool_output_missing(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            previous_response_id="resp_prev",
+            _pending_call_ids={"call_1", "call_2"},
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "check orders"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "call_1", "function": {"name": "fn_a", "arguments": "{}"}},
+                    {"id": "call_2", "function": {"name": "fn_b", "arguments": "{}"}},
+                ],
+            },
+            # Only one tool output — call_2 is missing
+            {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+        ]
+        instructions, items = llm._build_responses_input(messages)
+        # Full context: all messages converted
+        assert len(items) >= 3  # user, function_calls, tool_output
+        # previous_response_id cleared
+        assert llm.previous_response_id is None
+
+    def test_no_guard_when_no_pending_calls(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            previous_response_id="resp_prev",
+            _pending_call_ids=set(),
+        )
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "bye"},
+        ]
+        instructions, items = llm._build_responses_input(messages)
+        # Incremental: only new user message
+        assert len(items) == 1
+        assert items[0]["content"] == "bye"
+        assert llm.previous_response_id == "resp_prev"
+
+
+# ===================================================================
+# Invalidation with Pending Call IDs
+# ===================================================================
+
+
+class TestInvalidationPendingCalls:
+    def test_invalidate_clears_pending_call_ids(self):
+        llm = _make_llm(
+            use_responses_api=True,
+            previous_response_id="resp_x",
+            _pending_call_ids={"call_a", "call_b"},
+        )
+        llm.invalidate_response_chain()
+        assert llm.previous_response_id is None
+        assert llm._pending_call_ids == set()
+
+    @pytest.mark.asyncio
+    async def test_pending_call_ids_captured_on_completed(self):
+        llm = _make_llm(use_responses_api=True)
+        fc_item = MagicMock()
+        fc_item.type = "function_call"
+        fc_item.id = "fc_1"
+        fc_item.name = "my_func"
+        fc_item.call_id = "call_abc"
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_fc")),
+            _FakeStreamEvent("response.output_item.added", item=fc_item),
+            _FakeStreamEvent("response.function_call_arguments.delta", delta='{"x":1}', item_id="fc_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_fc")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "test"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        assert llm._pending_call_ids == {"call_abc"}
+
+
+# ===================================================================
+# Truncation and Compaction Parameter Tests
+# ===================================================================
+
+
+class TestCreateKwargsParameters:
+    """Verify truncation, compaction, and store are set correctly in create_kwargs."""
+
+    @pytest.mark.asyncio
+    async def test_truncation_auto_in_streaming(self):
+        llm = _make_llm(use_responses_api=True)
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_t")),
+            _FakeStreamEvent("response.output_text.delta", delta="Hi", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_t")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert call_kwargs["truncation"] == "auto"
+        assert call_kwargs["store"] is True
+
+    @pytest.mark.asyncio
+    async def test_compaction_when_threshold_set(self):
+        llm = _make_llm(use_responses_api=True, compact_threshold=20000)
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_c")),
+            _FakeStreamEvent("response.output_text.delta", delta="Ok", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_c")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert "context_management" in call_kwargs
+        assert call_kwargs["context_management"] == [{"type": "compaction", "compact_threshold": 20000}]
+
+    @pytest.mark.asyncio
+    async def test_no_compaction_when_threshold_not_set(self):
+        llm = _make_llm(use_responses_api=True, compact_threshold=None)
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_nc")),
+            _FakeStreamEvent("response.output_text.delta", delta="Ok", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_nc")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        async for _ in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            pass
+
+        call_kwargs = llm.async_client.responses.create.call_args[1]
+        assert "context_management" not in call_kwargs
+
+    def test_build_create_kwargs_store_false(self):
+        llm = _make_llm(use_responses_api=True)
+        create_kwargs, _ = llm._build_responses_create_kwargs(
+            [{"role": "user", "content": "Hi"}], _make_meta_info(), False, None, store=False
+        )
+        assert create_kwargs["store"] is False
+        assert "stream" not in create_kwargs
+
+    def test_build_create_kwargs_store_true_stream_true(self):
+        llm = _make_llm(use_responses_api=True)
+        create_kwargs, _ = llm._build_responses_create_kwargs(
+            [{"role": "user", "content": "Hi"}], _make_meta_info(), False, None, store=True, stream=True
+        )
+        assert create_kwargs["store"] is True
+        assert create_kwargs["stream"] is True
+
+
+# ===================================================================
+# Compact Threshold Config Model Tests
+# ===================================================================
+
+
+class TestCompactThresholdConfig:
+    def test_compact_threshold_in_llm_model(self):
+        from bolna.models import Llm
+
+        config = Llm(compact_threshold=25000)
+        assert config.compact_threshold == 25000
+
+    def test_compact_threshold_defaults_none(self):
+        from bolna.models import Llm
+
+        config = Llm()
+        assert config.compact_threshold is None
+
+
+# ===================================================================
+# WS Transport Routing Tests
+# ===================================================================
+
+
+class TestWSTransportRouting:
+    @pytest.mark.asyncio
+    async def test_ws_transport_used_when_set(self):
+        """When _ws_transport is set, _generate_stream_ws_responses should be called."""
+        llm = _make_llm(use_responses_api=True)
+
+        mock_ws = MagicMock()
+        ws_events = [
+            {"type": "response.created", "response": {"id": "resp_ws", "service_tier": None}},
+            {"type": "response.output_text.delta", "delta": "WS Hello", "item_id": "msg_1"},
+            {"type": "response.completed", "response": {"id": "resp_ws", "usage": None}},
+        ]
+
+        async def fake_stream(params):
+            for evt in ws_events:
+                yield evt
+
+        mock_ws.stream_response = fake_stream
+        llm._ws_transport = mock_ws
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert any("WS Hello" in c.data for c in chunks if isinstance(c.data, str))
+        # HTTP client should NOT have been called
+        llm.async_client.responses.create.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_http_sse_used_when_no_ws_transport(self):
+        llm = _make_llm(use_responses_api=True)
+        assert llm._ws_transport is None
+
+        events = [
+            _FakeStreamEvent("response.created", response=_FakeResponse("resp_http")),
+            _FakeStreamEvent("response.output_text.delta", delta="HTTP Hello", item_id="msg_1"),
+            _FakeStreamEvent("response.completed", response=_FakeResponse("resp_http")),
+        ]
+        llm.async_client.responses.create = AsyncMock(return_value=_async_iter(events))
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            [{"role": "user", "content": "Hi"}],
+            synthesize=False,
+            meta_info=_make_meta_info(),
+        ):
+            chunks.append(chunk)
+
+        assert any("HTTP Hello" in c.data for c in chunks if isinstance(c.data, str))
+        llm.async_client.responses.create.assert_called_once()
+
+
+# ===================================================================
+# OpenAIWSConnection Unit Tests
+# ===================================================================
+
+
+class TestOpenAIWSConnection:
+    def test_terminal_events_from_enum(self):
+        from bolna.llms.openai_llm import OpenAIWSConnection
+        from bolna.enums import ResponseStreamEvent
+
+        assert OpenAIWSConnection.TERMINAL_EVENTS == ResponseStreamEvent.terminal_events()
+        assert ResponseStreamEvent.COMPLETED in OpenAIWSConnection.TERMINAL_EVENTS
+        assert ResponseStreamEvent.FAILED in OpenAIWSConnection.TERMINAL_EVENTS
+        assert ResponseStreamEvent.INCOMPLETE in OpenAIWSConnection.TERMINAL_EVENTS
+        assert ResponseStreamEvent.ERROR in OpenAIWSConnection.TERMINAL_EVENTS
+
+    def test_terminal_events_matches_string_values(self):
+        from bolna.llms.openai_llm import OpenAIWSConnection
+
+        assert "response.completed" in OpenAIWSConnection.TERMINAL_EVENTS
+        assert "response.failed" in OpenAIWSConnection.TERMINAL_EVENTS
+        assert "response.incomplete" in OpenAIWSConnection.TERMINAL_EVENTS
+        assert "error" in OpenAIWSConnection.TERMINAL_EVENTS

--- a/tests/tests/test_responses_api_interruption_hint.py
+++ b/tests/tests/test_responses_api_interruption_hint.py
@@ -1,0 +1,181 @@
+import pytest
+from unittest.mock import patch, AsyncMock, MagicMock
+
+from bolna.llms.openai_llm import OpenAiLLM
+
+
+def _make_llm(**overrides):
+    defaults = {
+        "model": "gpt-4o",
+        "previous_response_id": None,
+        "_pending_call_ids": set(),
+        "_interruption_hint": None,
+    }
+    defaults.update(overrides)
+    with patch.object(OpenAiLLM, "__init__", lambda self, **kw: None):
+        llm = OpenAiLLM.__new__(OpenAiLLM)
+    llm.model = defaults["model"]
+    llm.max_tokens = 100
+    llm.buffer_size = 40
+    llm.temperature = 0.1
+    llm.run_id = "run_123"
+    llm.language = "en"
+    llm.trigger_function_call = False
+    llm.api_params = {}
+    llm.tools = []
+    llm.started_streaming = False
+    llm.llm_host = None
+    llm.use_responses_api = True
+    llm.previous_response_id = defaults["previous_response_id"]
+    llm._pending_call_ids = defaults["_pending_call_ids"]
+    llm.compact_threshold = None
+    llm._interruption_hint = defaults["_interruption_hint"]
+    llm._ws_transport = None
+    llm.async_client = AsyncMock()
+    llm.model_args = {"model": llm.model, "max_tokens": llm.max_tokens, "temperature": llm.temperature}
+    return llm
+
+
+SYSTEM_USER_ASSISTANT_USER = [
+    {"role": "system", "content": "sys"},
+    {"role": "user", "content": "hi"},
+    {"role": "assistant", "content": "hello there"},
+    {"role": "user", "content": "tell me a joke"},
+]
+
+
+class TestInterruptionHintInjection:
+    def test_barge_in_preserves_previous_response_id(self):
+        llm = _make_llm(previous_response_id="resp_prev")
+        llm.set_interruption_hint("hello th")
+
+        _, items = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
+
+        assert llm.previous_response_id == "resp_prev"
+        assert items[0]["role"] == "developer"
+        assert "hello th" in items[0]["content"]
+        assert items[1]["role"] == "user"
+        assert items[1]["content"] == "tell me a joke"
+
+    def test_hint_is_one_shot(self):
+        llm = _make_llm(previous_response_id="resp_prev")
+        llm.set_interruption_hint("partial")
+
+        _, items_first = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
+        _, items_second = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
+
+        assert items_first[0]["role"] == "developer"
+        assert items_second[0]["role"] == "user"
+        assert llm._interruption_hint is None
+
+    def test_hint_not_injected_without_chain(self):
+        llm = _make_llm(previous_response_id=None)
+        llm.set_interruption_hint("ignored")
+
+        _, items = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
+
+        assert all(item.get("role") != "developer" for item in items)
+        assert llm._interruption_hint is None
+
+    def test_hint_consumed_on_pending_tool_fallback(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "check order"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_order", "arguments": "{}"}}],
+            },
+        ]
+        llm = _make_llm(
+            previous_response_id="resp_with_tool",
+            _pending_call_ids={"call_1"},
+        )
+        llm.set_interruption_hint("let me che")
+
+        _, items = llm._build_responses_input(messages)
+
+        assert llm.previous_response_id is None
+        assert llm._interruption_hint is None
+        assert all(item.get("role") != "developer" for item in items)
+
+    def test_hint_injected_when_tool_outputs_present(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "check order"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{"id": "call_1", "function": {"name": "get_order", "arguments": "{}"}}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "shipped"},
+            {"role": "user", "content": "thanks"},
+        ]
+        llm = _make_llm(
+            previous_response_id="resp_with_tool",
+            _pending_call_ids={"call_1"},
+        )
+        llm.set_interruption_hint("your order is shi")
+
+        _, items = llm._build_responses_input(messages)
+
+        assert llm.previous_response_id == "resp_with_tool"
+        assert items[0]["role"] == "developer"
+        assert "your order is shi" in items[0]["content"]
+        types = [item.get("type") for item in items]
+        assert "function_call_output" in types
+
+    def test_invalidate_clears_hint(self):
+        llm = _make_llm(previous_response_id="resp_prev")
+        llm.set_interruption_hint("heard text")
+        assert llm._interruption_hint == "heard text"
+
+        llm.invalidate_response_chain()
+
+        assert llm._interruption_hint is None
+        assert llm.previous_response_id is None
+        assert llm._pending_call_ids == set()
+
+    def test_set_interruption_hint_with_none(self):
+        llm = _make_llm(previous_response_id="resp_prev")
+        llm.set_interruption_hint(None)
+        assert llm._interruption_hint == ""
+
+        _, items = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
+        assert items[0]["role"] == "developer"
+        assert '""' in items[0]["content"]
+
+
+class TestCancelInFlightResponse:
+    def test_cancel_in_flight_no_transport_is_noop(self):
+        llm = _make_llm(previous_response_id="resp_1")
+        llm._ws_transport = None
+        llm.cancel_in_flight_response()
+        assert llm.previous_response_id == "resp_1"
+
+    def test_cancel_in_flight_no_response_id_is_noop(self):
+        llm = _make_llm(previous_response_id=None)
+        llm._ws_transport = MagicMock()
+        llm.cancel_in_flight_response()
+        llm._ws_transport.cancel_response.assert_not_called()
+
+    def test_cancel_in_flight_does_not_invalidate_chain(self):
+        import asyncio
+
+        llm = _make_llm(previous_response_id="resp_1")
+        llm._ws_transport = MagicMock()
+        llm._ws_transport.cancel_response = AsyncMock()
+
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            llm.cancel_in_flight_response()
+            pending = asyncio.all_tasks(loop)
+            loop.run_until_complete(asyncio.gather(*pending))
+        finally:
+            loop.close()
+            asyncio.set_event_loop(None)
+
+        assert llm.previous_response_id == "resp_1"
+        assert llm._pending_call_ids == set()
+        llm._ws_transport.cancel_response.assert_called_once_with("resp_1")

--- a/tests/tests/test_task_manager_interruption_chain.py
+++ b/tests/tests/test_task_manager_interruption_chain.py
@@ -1,0 +1,199 @@
+"""TaskManager-level tests for the interruption-hint + cancel-in-flight wiring.
+
+Verifies that barge-in no longer drops the Responses API chain at the
+task_manager layer:
+  * sync_history sets the hint instead of invalidating.
+  * cleanup_before_user_append no longer invalidates the chain.
+  * __cleanup_downstream_tasks cancels the in-flight LLM response.
+"""
+
+import asyncio
+import inspect
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+
+def _make_input_tool(welcome_played=True):
+    inp = MagicMock()
+    inp.is_welcome_message_played = welcome_played
+    inp.welcome_message_played = MagicMock(side_effect=lambda: inp.is_welcome_message_played)
+    inp.io_provider = "plivo"
+    inp.is_audio_being_played_to_user = MagicMock(return_value=False)
+    inp.update_is_audio_being_played = MagicMock()
+    inp.reset_response_heard_by_user = MagicMock()
+    inp.get_call_sid = MagicMock(return_value="call-1")
+    return inp
+
+
+def _make_output_tool():
+    out = MagicMock()
+    out.handle_interruption = AsyncMock()
+    out.flush_synthesizer_stream = AsyncMock()
+    out.get_provider = MagicMock(return_value="plivo")
+    return out
+
+
+def _make_synth_tool():
+    synth = MagicMock()
+    synth.handle_interruption = AsyncMock()
+    synth.flush_synthesizer_stream = AsyncMock()
+    return synth
+
+
+def _make_llm_agent():
+    agent = MagicMock()
+    agent.llm = MagicMock()
+    agent.llm.set_interruption_hint = MagicMock()
+    agent.llm.invalidate_response_chain = MagicMock()
+    agent.llm.cancel_in_flight_response = MagicMock()
+    return agent
+
+
+def _make_history(length=2):
+    h = MagicMock()
+    h.__len__ = MagicMock(return_value=length)
+    h.is_duplicate_user = MagicMock(return_value=False)
+    h.append_user = MagicMock()
+    h.pop_unheard_responses = MagicMock()
+    h.pop_and_merge_user = MagicMock(side_effect=lambda m: m)
+    h.get_copy = MagicMock(return_value=[{"role": "system", "content": "x"}])
+    h.sync_interim = MagicMock()
+    return h
+
+
+def _make_task_manager():
+    from bolna.agent_manager.task_manager import TaskManager
+
+    tm = MagicMock()
+    tm.tools = {
+        "input": _make_input_tool(welcome_played=True),
+        "output": _make_output_tool(),
+        "synthesizer": _make_synth_tool(),
+        "llm_agent": _make_llm_agent(),
+    }
+    mem = MagicMock()
+    mem.fetch_cleared_mark_event_data = MagicMock(return_value={})
+    tm.mark_event_meta_data = mem
+    tm.conversation_history = _make_history(length=4)
+    tm.discard_pre_welcome_utterance = False
+    tm._speech_started_before_welcome = False
+    tm.generate_precise_transcript = False
+    tm.response_in_pipeline = False
+    tm.run_id = "test-run"
+    tm.llm_task = None
+    tm.eager_llm_task = None
+    tm.first_message_task = None
+    tm.output_task = None
+    tm.synthesizer_tasks = []
+    tm.buffered_output_queue = asyncio.Queue()
+    tm._turn_audio_flushed = MagicMock()
+    tm._turn_audio_flushed.set = MagicMock()
+    tm.started_transmitting_audio = True
+    tm.last_transmitted_timestamp = 0.0
+    tm.transcriber_provider = "deepgram"
+    tm.voicemail_handler = MagicMock()
+    tm.voicemail_handler.detected = False
+    tm.voicemail_handler.cancel_task = MagicMock()
+    tm.voicemail_handler.trigger_check = MagicMock()
+    tm.interruption_manager = MagicMock()
+    tm.interruption_manager.invalidate_pending_responses = MagicMock()
+    tm.interruption_manager.has_pending_responses_excluding = MagicMock(return_value=False)
+    tm.language_detector = MagicMock()
+    tm.language_detector.collect_transcript = AsyncMock()
+    tm._has_interruptible_mark_activity = MagicMock(return_value=False)
+    tm._drop_all_staged_assistant_history = MagicMock()
+    tm._retire_dropped_response = MagicMock()
+    tm._trigger_voicemail_check = MagicMock()
+    tm.execute_function_call_task = None
+    tm.task_config = {
+        "task_type": "conversation",
+        "tools_config": {
+            "transcriber": {"provider": "deepgram"},
+            "llm_agent": {"agent_flow_type": "preprocessed"},
+            "output": {"provider": "plivo", "format": "pcm"},
+        },
+    }
+    tm.__process_output_loop = AsyncMock()
+
+    tm._set_interruption_hint = TaskManager._set_interruption_hint.__get__(tm, TaskManager)
+    tm._cancel_in_flight_llm_response = TaskManager._cancel_in_flight_llm_response.__get__(tm, TaskManager)
+    tm._invalidate_response_chain = TaskManager._invalidate_response_chain.__get__(tm, TaskManager)
+    tm._TaskManager__cleanup_downstream_tasks = TaskManager._TaskManager__cleanup_downstream_tasks.__get__(
+        tm, TaskManager
+    )
+    return tm
+
+
+@pytest.fixture(autouse=True)
+def _patch_create_task(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_task", lambda coro: MagicMock())
+    yield
+
+
+class TestHelperRouting:
+    def test_set_interruption_hint_routes_to_llm(self):
+        tm = _make_task_manager()
+        tm._set_interruption_hint("the user heard this")
+        tm.tools["llm_agent"].llm.set_interruption_hint.assert_called_once_with("the user heard this")
+
+    def test_cancel_in_flight_routes_to_llm(self):
+        tm = _make_task_manager()
+        tm._cancel_in_flight_llm_response()
+        tm.tools["llm_agent"].llm.cancel_in_flight_response.assert_called_once_with()
+
+    def test_invalidate_still_routes_to_llm(self):
+        tm = _make_task_manager()
+        tm._invalidate_response_chain()
+        tm.tools["llm_agent"].llm.invalidate_response_chain.assert_called_once_with()
+
+    def test_set_interruption_hint_no_llm_agent_is_safe(self):
+        tm = _make_task_manager()
+        tm.tools.pop("llm_agent")
+        tm._set_interruption_hint("text")  # must not raise
+
+    def test_cancel_in_flight_no_llm_agent_is_safe(self):
+        tm = _make_task_manager()
+        tm.tools.pop("llm_agent")
+        tm._cancel_in_flight_llm_response()  # must not raise
+
+
+class TestCleanupDownstream:
+    @pytest.mark.asyncio
+    async def test_cleanup_cancels_in_flight_llm(self):
+        tm = _make_task_manager()
+        await tm._TaskManager__cleanup_downstream_tasks()
+        tm.tools["llm_agent"].llm.cancel_in_flight_response.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_does_not_invalidate_chain(self):
+        tm = _make_task_manager()
+        await tm._TaskManager__cleanup_downstream_tasks()
+        tm.tools["llm_agent"].llm.invalidate_response_chain.assert_not_called()
+
+
+class TestCallSites:
+    """Source-level guards: catches accidental re-introduction of the
+    barge-in invalidation we deliberately removed."""
+
+    def test_sync_history_does_not_invalidate(self):
+        from bolna.agent_manager.task_manager import TaskManager
+
+        src = inspect.getsource(TaskManager.sync_history)
+        assert "_invalidate_response_chain" not in src, (
+            "sync_history must use _set_interruption_hint instead of dropping the chain"
+        )
+        assert "_set_interruption_hint" in src
+
+    def test_handle_transcriber_output_does_not_invalidate(self):
+        from bolna.agent_manager.task_manager import TaskManager
+
+        src = inspect.getsource(TaskManager._handle_transcriber_output)
+        assert "_invalidate_response_chain" not in src, (
+            "_handle_transcriber_output must not drop the chain; sync_history already set the hint"
+        )
+
+    def test_cleanup_downstream_cancels_in_flight(self):
+        from bolna.agent_manager.task_manager import TaskManager
+
+        src = inspect.getsource(TaskManager._TaskManager__cleanup_downstream_tasks)
+        assert "_cancel_in_flight_llm_response" in src

--- a/tests/tests/test_task_manager_interruption_chain.py
+++ b/tests/tests/test_task_manager_interruption_chain.py
@@ -115,6 +115,7 @@ def _make_task_manager():
     }
     tm.__process_output_loop = AsyncMock()
 
+    tm.sync_history = AsyncMock()
     tm._set_interruption_hint = TaskManager._set_interruption_hint.__get__(tm, TaskManager)
     tm._cancel_in_flight_llm_response = TaskManager._cancel_in_flight_llm_response.__get__(tm, TaskManager)
     tm._invalidate_response_chain = TaskManager._invalidate_response_chain.__get__(tm, TaskManager)


### PR DESCRIPTION
## Summary

Voice barge-ins used to call `LLM.invalidate_response_chain()`, killing `previous_response_id`, the WS connection-local cache, and GPT-5 reasoning items. Two separate cache-routing bugs also dropped hit rates well below what Chat Completions was getting. This PR fixes all of them.

## What changed

1. **Chain survives barge-in.** `sync_history` now calls `llm.set_interruption_hint(heard_text)` instead of invalidating, and `__cleanup_downstream_tasks` calls `llm.cancel_in_flight_response()` to stop in-flight generation without touching `previous_response_id`. The hint is consumed exactly once on the next `_build_responses_input` and only prepended on the chain-alive happy path. `invalidate_response_chain` is reserved for hard errors (FAILED, INCOMPLETE, stale-ID 400, WS error fallback). Redundant invalidation in `_handle_transcriber_output` removed.

2. **Drop deprecated `user=` field.** Was set to `f"{run_id}#{turn_id}"` on all three call sites (Responses API, Chat Completions, Azure Chat Completions). `turn_id` changes every turn, salting OpenAI's prefix-routing hash and scattering each turn to a different inference server. Removing it restores natural cross-call cache routing. This is the primary cache hit rate fix.

3. **System message as input item, not `instructions` field.** OpenAI hashes the `instructions` field differently for cache routing than input items. Emitting the system prompt as a `{role: "system"}` input item, matching Chat Completions, restores 100% cross-call cache hits on Responses API (verified across 3 local runs). This is the second cache fix.

4. **`store=true` on the WS path.** Was `false`. Switching to `true` persists responses server-side, matches OpenAI's recommended pattern for `previous_response_id` chaining, and lets the server hydrate `previous_response_id` from persisted state when the WS connection-local cache is lost (reconnect, server eviction). Storage is free per OpenAI. This does not by itself change `cached_tokens` reporting, the real cache fixes are items 2 and 3.

5. **`include=["reasoning.encrypted_content"]` for GPT-5.** Preserves reasoning continuity across forced full-history fallbacks (pending-tool guard, stale-ID retry, server compaction evict). No-op cost when the chain is alive.

6. **WS cancel race fix.** `OpenAIWSConnection.cancel_response` no longer drains events after sending the cancel signal. The active `stream_response` is the sole recv consumer and will see the resulting terminal event itself; holding the lock would have blocked cancel until the stream finished naturally.

The hint is always consumed (even on fallback paths) so it never leaks into a future turn.