### PR TITLE
fix: pre-write tool_call + pending placeholder before trigger_api to prevent FC loop on barge-in

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.64"
+__version__ = "0.10.65"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2837,24 +2837,83 @@ class TaskManager(BaseManager):
             request_body=prepared_request["request_body"],
             api_params=prepared_request["api_params"],
         )
-        response = await trigger_api(
-            url=url,
-            method=method.lower(),
-            param=param,
-            api_token=api_token,
-            headers_data=headers,
-            meta_info=meta_info,
-            run_id=self.run_id,
-            return_response_metadata=True,
-            **resp,
+
+        tool_call_id = resp.get("tool_call_id", "")
+        sequence_id = meta_info.get("sequence_id")
+
+        # Best-effort commit any staged assistant for this sequence so
+        # attach_tool_calls_to_turn finds a real parent. Without this, when
+        # the audio for the FC's textual_response hasn't been approved yet,
+        # attach would fall through to its content=None placeholder branch
+        # and a later _commit_staged_assistant_history would append a second
+        # assistant for the same turn_id.
+        if (
+            turn_id is not None
+            and self._turn_msg_map.get(turn_id) is None
+            and sequence_id in self._pending_assistant_history
+        ):
+            self._commit_staged_assistant_history(sequence_id)
+
+        # Pre-write the assistant.tool_calls + a pending tool placeholder
+        # BEFORE awaiting trigger_api. If the user barges in mid-HTTP, the
+        # placeholder stays adjacent to its assistant (any new user message
+        # gets appended at the tail, after the placeholder). The cancel
+        # handler then rewrites the same row to "interrupted_by_user" so the
+        # next LLM turn sees the attempt and won't blindly re-issue the
+        # call. Without this, the tool_result lands after the new user
+        # message, _sanitize_tool_messages strips the orphaned pair, and
+        # the LLM loops the same FC indefinitely.
+        self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
+        self.conversation_history.upsert_tool_result(
+            tool_call_id,
+            json.dumps({"status": "pending", "message": "Tool call in progress"}),
         )
-        self._finalize_api_call_detail(
-            function_call_log,
-            response=response.get("body"),
-            status_code=response.get("status_code"),
-            content_type=response.get("content_type"),
-            error=response.get("error"),
-        )
+
+        response = None
+        cancelled = False
+        try:
+            response = await trigger_api(
+                url=url,
+                method=method.lower(),
+                param=param,
+                api_token=api_token,
+                headers_data=headers,
+                meta_info=meta_info,
+                run_id=self.run_id,
+                return_response_metadata=True,
+                **resp,
+            )
+        except asyncio.CancelledError:
+            cancelled = True
+            self.conversation_history.upsert_tool_result(
+                tool_call_id,
+                json.dumps(
+                    {
+                        "status": "interrupted_by_user",
+                        "message": "Tool call interrupted by user mid-flight",
+                    }
+                ),
+            )
+            self.execute_function_call_task = None
+            raise
+        finally:
+            if cancelled:
+                self._finalize_api_call_detail(
+                    function_call_log,
+                    response=None,
+                    status_code=None,
+                    content_type=None,
+                    error="user_cancelled",
+                )
+            elif response is not None:
+                self._finalize_api_call_detail(
+                    function_call_log,
+                    response=response.get("body"),
+                    status_code=response.get("status_code"),
+                    content_type=response.get("content_type"),
+                    error=response.get("error"),
+                )
+
         function_response = str(response.get("body"))
         get_res_keys, get_res_values = await computed_api_response(function_response)
 
@@ -2887,8 +2946,9 @@ class TaskManager(BaseManager):
             set_response_prompt = function_response
 
         textual_response = resp.get("textual_response", None)
-        self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
-        self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), function_response)
+        # Overwrite the pending placeholder with the real body. attach_tool_calls
+        # was already done before trigger_api, so we don't repeat it here.
+        self.conversation_history.upsert_tool_result(tool_call_id, function_response)
 
         logger.info(f"Logging function call parameters ")
         convert_to_request_log(
@@ -2900,6 +2960,18 @@ class TaskManager(BaseManager):
             is_cached=False,
             run_id=self.run_id,
         )
+
+        # Defense-in-depth: if the user barged in right after trigger_api
+        # returned (but before this point), the sequence is invalidated and
+        # the new user turn already has its own LLM stream running. Don't
+        # spawn a stale followup that races it.
+        if not self.interruption_manager.is_valid_sequence(sequence_id):
+            logger.info(
+                "Skipping followup LLM generation: sequence_id=%s invalidated by user interruption",
+                sequence_id,
+            )
+            self.execute_function_call_task = None
+            return
 
         messages = self.conversation_history.get_copy()
         convert_to_request_log(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2841,12 +2841,8 @@ class TaskManager(BaseManager):
         tool_call_id = resp.get("tool_call_id", "")
         sequence_id = meta_info.get("sequence_id")
 
-        # Best-effort commit any staged assistant for this sequence so
-        # attach_tool_calls_to_turn finds a real parent. Without this, when
-        # the audio for the FC's textual_response hasn't been approved yet,
-        # attach would fall through to its content=None placeholder branch
-        # and a later _commit_staged_assistant_history would append a second
-        # assistant for the same turn_id.
+        # Commit staged assistant first so attach finds a real parent instead
+        # of appending a content=None placeholder that would later duplicate.
         if (
             turn_id is not None
             and self._turn_msg_map.get(turn_id) is None
@@ -2854,20 +2850,9 @@ class TaskManager(BaseManager):
         ):
             self._commit_staged_assistant_history(sequence_id)
 
-        # Pre-write the assistant.tool_calls + a pending tool placeholder
-        # BEFORE awaiting trigger_api. If the user barges in mid-HTTP, the
-        # placeholder stays adjacent to its assistant (any new user message
-        # gets appended at the tail, after the placeholder). The cancel
-        # handler then rewrites the same row to "interrupted_by_user" so the
-        # next LLM turn sees the attempt and won't blindly re-issue the
-        # call. Without this, the tool_result lands after the new user
-        # message, _sanitize_tool_messages strips the orphaned pair, and
-        # the LLM loops the same FC indefinitely.
+        # Pre-write tool_calls + pending tool placeholder BEFORE trigger_api so
+        # barge-in mid-HTTP keeps the assistant/tool pair adjacent through sanitize.
         self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
-        # Only write a pending placeholder when we have a real tool_call_id to
-        # key the upsert on. Empty ids can't be disambiguated from each other,
-        # so two empty-id rows would both end up stripped by sanitize. In that
-        # legacy path we keep the old append-after-trigger_api semantics.
         if tool_call_id:
             self.conversation_history.upsert_tool_result(
                 tool_call_id,
@@ -2952,10 +2937,6 @@ class TaskManager(BaseManager):
             set_response_prompt = function_response
 
         textual_response = resp.get("textual_response", None)
-        # Overwrite the pending placeholder with the real body. attach_tool_calls
-        # was already done before trigger_api, so we don't repeat it here. For
-        # the empty-id legacy path no placeholder was written, so this still
-        # writes the single tool message (matching old append semantics).
         self.conversation_history.upsert_tool_result(tool_call_id, function_response)
 
         logger.info(f"Logging function call parameters ")
@@ -2969,15 +2950,14 @@ class TaskManager(BaseManager):
             run_id=self.run_id,
         )
 
-        # Defense-in-depth: if the user barged in right after trigger_api
-        # returned (but before this point), the sequence is invalidated and
-        # the new user turn already has its own LLM stream running. Don't
-        # spawn a stale followup that races it.
+        # Skip followup if the user barged in after trigger_api returned;
+        # the new user turn already has its own LLM stream running.
         if not self.interruption_manager.is_valid_sequence(sequence_id):
             logger.info(
                 "Skipping followup LLM generation: sequence_id=%s invalidated by user interruption",
                 sequence_id,
             )
+            self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
             self.execute_function_call_task = None
             return
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2864,10 +2864,15 @@ class TaskManager(BaseManager):
         # message, _sanitize_tool_messages strips the orphaned pair, and
         # the LLM loops the same FC indefinitely.
         self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
-        self.conversation_history.upsert_tool_result(
-            tool_call_id,
-            json.dumps({"status": "pending", "message": "Tool call in progress"}),
-        )
+        # Only write a pending placeholder when we have a real tool_call_id to
+        # key the upsert on. Empty ids can't be disambiguated from each other,
+        # so two empty-id rows would both end up stripped by sanitize. In that
+        # legacy path we keep the old append-after-trigger_api semantics.
+        if tool_call_id:
+            self.conversation_history.upsert_tool_result(
+                tool_call_id,
+                json.dumps({"status": "pending", "message": "Tool call in progress"}),
+            )
 
         response = None
         cancelled = False
@@ -2885,15 +2890,16 @@ class TaskManager(BaseManager):
             )
         except asyncio.CancelledError:
             cancelled = True
-            self.conversation_history.upsert_tool_result(
-                tool_call_id,
-                json.dumps(
-                    {
-                        "status": "interrupted_by_user",
-                        "message": "Tool call interrupted by user mid-flight",
-                    }
-                ),
-            )
+            if tool_call_id:
+                self.conversation_history.upsert_tool_result(
+                    tool_call_id,
+                    json.dumps(
+                        {
+                            "status": "interrupted_by_user",
+                            "message": "Tool call interrupted by user mid-flight",
+                        }
+                    ),
+                )
             self.execute_function_call_task = None
             raise
         finally:
@@ -2947,7 +2953,9 @@ class TaskManager(BaseManager):
 
         textual_response = resp.get("textual_response", None)
         # Overwrite the pending placeholder with the real body. attach_tool_calls
-        # was already done before trigger_api, so we don't repeat it here.
+        # was already done before trigger_api, so we don't repeat it here. For
+        # the empty-id legacy path no placeholder was written, so this still
+        # writes the single tool message (matching old append semantics).
         self.conversation_history.upsert_tool_result(tool_call_id, function_response)
 
         logger.info(f"Logging function call parameters ")

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -79,17 +79,7 @@ class ConversationHistory:
         )
 
     def upsert_tool_result(self, tool_call_id: str, content: str):
-        """Update an existing tool message with this id, or append a new one.
-
-        Used by the function-call path to pre-write a "pending" placeholder
-        adjacent to its assistant.tool_calls before the API call is awaited,
-        then overwrite the same row with the real body (or an
-        "interrupted_by_user" marker on cancellation). Keeping the rewrite
-        in place preserves the assistant/tool adjacency that
-        _sanitize_tool_messages enforces, so a user barge-in mid-trigger_api
-        no longer leaves an orphaned tool record that gets stripped and
-        causes the LLM to re-issue the same call on the next turn.
-        """
+        """Update existing tool message with this id, or append a new one."""
         if not tool_call_id:
             logger.warning("upsert_tool_result called with empty tool_call_id; falling back to append")
             self.append_tool_result(tool_call_id, content)

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -78,6 +78,29 @@ class ConversationHistory:
             }
         )
 
+    def upsert_tool_result(self, tool_call_id: str, content: str):
+        """Update an existing tool message with this id, or append a new one.
+
+        Used by the function-call path to pre-write a "pending" placeholder
+        adjacent to its assistant.tool_calls before the API call is awaited,
+        then overwrite the same row with the real body (or an
+        "interrupted_by_user" marker on cancellation). Keeping the rewrite
+        in place preserves the assistant/tool adjacency that
+        _sanitize_tool_messages enforces, so a user barge-in mid-trigger_api
+        no longer leaves an orphaned tool record that gets stripped and
+        causes the LLM to re-issue the same call on the next turn.
+        """
+        if not tool_call_id:
+            logger.warning("upsert_tool_result called with empty tool_call_id; falling back to append")
+            self.append_tool_result(tool_call_id, content)
+            return
+        for i in range(len(self._messages) - 1, -1, -1):
+            m = self._messages[i]
+            if m.get("role") == ChatRole.TOOL and m.get("tool_call_id") == tool_call_id:
+                m["content"] = content
+                return
+        self.append_tool_result(tool_call_id, content)
+
     def attach_tool_calls_to_last_response(self, tool_calls: list):
         if self._messages and self._messages[-1].get("role") == ChatRole.ASSISTANT:
             self._messages[-1]["tool_calls"] = tool_calls

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.64"
+version = "0.10.65"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_function_call_cancellation.py
+++ b/tests/tests/test_function_call_cancellation.py
@@ -1,0 +1,251 @@
+"""Tests for the cancellation + history-record behavior of __execute_function_call.
+
+These cover the production bug where user interruption mid-trigger_api would
+leave no trace of the attempted tool call in conversation history, causing the
+LLM to re-emit the same call indefinitely on subsequent turns.
+
+The fix records the tool_call attempt BEFORE awaiting trigger_api with a
+pending placeholder, overwrites with the real body on success, or with an
+"interrupted_by_user" marker on CancelledError.
+"""
+
+import asyncio
+import copy
+import json
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+
+
+def _build_task_manager_mock(conversation_history: ConversationHistory) -> MagicMock:
+    """Build a TaskManager-shaped mock that uses a real ConversationHistory."""
+    tm = MagicMock()
+    tm.conversation_ended = False
+    tm.hangup_triggered = False
+    tm.run_id = "run-test"
+    tm.check_if_user_online = True
+    tm.context_data = None
+    tm.conversation_history = conversation_history
+    tm.conversation_config = {}
+    tm.llm_config = {"model": "gpt-4o"}
+    tm.generate_precise_transcript = False
+    tm.tools = {"output": MagicMock(), "llm_agent": MagicMock()}
+    tm.execute_function_call_task = None
+    tm._TaskManager__is_graph_agent = MagicMock(return_value=False)
+    tm.wait_for_current_message = AsyncMock()
+    tm._commit_staged_assistant_history = MagicMock()
+    tm._spawn_followup_meta_info = MagicMock(return_value={"sequence_id": 2, "turn_id": 2})
+    tm._start_api_call_detail = MagicMock(return_value={})
+    tm._finalize_api_call_detail = MagicMock()
+    tm._extract_api_call_runtime_args = MagicMock(return_value={})
+    # Name-mangled private method must be set explicitly because MagicMock
+    # auto-attributes return MagicMock instances that cannot be awaited.
+    tm._TaskManager__do_llm_generation = AsyncMock()
+    return tm
+
+
+class TestFunctionCallCancellation:
+    @pytest.mark.asyncio
+    async def test_history_has_pending_placeholder_before_trigger_api(self):
+        """attach_tool_calls + append_tool_result(pending) run BEFORE trigger_api.
+
+        This is the key invariant: if anything later raises CancelledError,
+        history already has the assistant.tool_calls and a tool message.
+        """
+        ch = ConversationHistory()
+        ch.append_user("track my order")
+        ch.append_assistant("एक मिनट दीजिए", turn_id=1)
+
+        tm = _build_task_manager_mock(ch)
+
+        observed_history_at_trigger_api: list = []
+
+        async def slow_trigger_api(**kwargs):
+            # Snapshot history at the moment trigger_api starts so we can
+            # confirm the placeholder was already written. Deep-copy
+            # because the tool message gets mutated in place after this
+            # function returns.
+            observed_history_at_trigger_api.extend(copy.deepcopy(ch.messages))
+            return {"body": '{"order": "shipped"}', "status_code": 200, "content_type": "application/json"}
+
+        model_response = [{"id": "call_X", "function": {"name": "advanced_track_order"}}]
+
+        with patch("bolna.agent_manager.task_manager.trigger_api", side_effect=slow_trigger_api):
+            with patch(
+                "bolna.agent_manager.task_manager.computed_api_response",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ):
+                with patch(
+                    "bolna.agent_manager.task_manager.TaskManager._TaskManager__do_llm_generation",
+                    new_callable=AsyncMock,
+                ):
+                    with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+                        with patch("bolna.agent_manager.task_manager.format_messages", return_value=""):
+                            await TaskManager._TaskManager__execute_function_call(
+                                tm,
+                                url="https://api.example.com/tools",
+                                method="post",
+                                param=None,
+                                api_token=None,
+                                headers=None,
+                                model_args={},
+                                meta_info={"sequence_id": 1, "turn_id": 1, "bypass_synth": False},
+                                next_step=None,
+                                called_fun="advanced_track_order",
+                                model_response=model_response,
+                                tool_call_id="call_X",
+                                textual_response=None,
+                            )
+
+        # At the moment trigger_api was entered, history must already contain
+        # the assistant.tool_calls + a tool message (pending placeholder).
+        assistant_with_tool_calls = [
+            m for m in observed_history_at_trigger_api if m.get("role") == "assistant" and m.get("tool_calls")
+        ]
+        tool_messages = [m for m in observed_history_at_trigger_api if m.get("role") == "tool"]
+        assert len(assistant_with_tool_calls) == 1, "Assistant.tool_calls must be set before trigger_api"
+        assert assistant_with_tool_calls[0]["tool_calls"][0]["id"] == "call_X"
+        assert len(tool_messages) == 1, "A pending tool placeholder must exist before trigger_api"
+        assert tool_messages[0]["tool_call_id"] == "call_X"
+        assert "pending" in tool_messages[0]["content"]
+
+        # After success, the placeholder should have been overwritten with
+        # the real response body, not still "pending".
+        final_tools = [m for m in ch.messages if m.get("role") == "tool"]
+        assert len(final_tools) == 1
+        assert "pending" not in final_tools[0]["content"]
+        assert "shipped" in final_tools[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_cancellation_mid_trigger_api_marks_tool_as_interrupted(self):
+        """When CancelledError lands inside trigger_api, the pending tool
+        placeholder is converted to an 'interrupted_by_user' marker so the
+        LLM next turn sees the attempt happened."""
+        ch = ConversationHistory()
+        ch.append_user("track my order")
+        ch.append_assistant("एक मिनट दीजिए", turn_id=1)
+
+        tm = _build_task_manager_mock(ch)
+
+        # trigger_api blocks long enough for us to cancel it mid-flight.
+        async def hanging_trigger_api(**kwargs):
+            await asyncio.sleep(10)
+            return {"body": "never reached"}
+
+        model_response = [{"id": "call_Y", "function": {"name": "advanced_track_order"}}]
+
+        with patch("bolna.agent_manager.task_manager.trigger_api", side_effect=hanging_trigger_api):
+            with patch(
+                "bolna.agent_manager.task_manager.computed_api_response",
+                new_callable=AsyncMock,
+                return_value=([], []),
+            ):
+                with patch(
+                    "bolna.agent_manager.task_manager.TaskManager._TaskManager__do_llm_generation",
+                    new_callable=AsyncMock,
+                ):
+                    with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+                        task = asyncio.create_task(
+                            TaskManager._TaskManager__execute_function_call(
+                                tm,
+                                url="https://api.example.com/tools",
+                                method="post",
+                                param=None,
+                                api_token=None,
+                                headers=None,
+                                model_args={},
+                                meta_info={"sequence_id": 1, "turn_id": 1, "bypass_synth": False},
+                                next_step=None,
+                                called_fun="advanced_track_order",
+                                model_response=model_response,
+                                tool_call_id="call_Y",
+                                textual_response=None,
+                            )
+                        )
+
+                        # Wait for the task to enter the hanging trigger_api,
+                        # then cancel — simulating the user interruption.
+                        await asyncio.sleep(0.05)
+                        task.cancel()
+                        with pytest.raises(asyncio.CancelledError):
+                            await task
+
+        # History must show the cancellation as a tool message, not vanish.
+        tool_messages = [m for m in ch.messages if m.get("role") == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["tool_call_id"] == "call_Y"
+        assert "interrupted_by_user" in tool_messages[0]["content"]
+
+        # And the assistant must keep its tool_calls field so the pair stays
+        # well-formed on the next get_copy().
+        assistants_with_calls = [m for m in ch.messages if m.get("role") == "assistant" and m.get("tool_calls")]
+        assert len(assistants_with_calls) == 1
+        assert assistants_with_calls[0]["tool_calls"][0]["id"] == "call_Y"
+
+        # get_copy must keep the well-formed pair intact (no orphan removal,
+        # no synthetic insertion needed because we already have a real tool
+        # message adjacent to its parent).
+        clean = ch.get_copy()
+        roles = [m["role"] for m in clean]
+        assert "assistant" in roles and "tool" in roles
+        # Assistant with tool_calls must be immediately followed by its tool.
+        asst_idx = next(i for i, m in enumerate(clean) if m.get("role") == "assistant" and m.get("tool_calls"))
+        assert clean[asst_idx + 1]["role"] == "tool"
+        assert clean[asst_idx + 1]["tool_call_id"] == "call_Y"
+
+    @pytest.mark.asyncio
+    async def test_subsequent_llm_turn_sees_the_interrupted_attempt(self):
+        """End-to-end: after a cancelled call, the next LLM-bound history
+        copy shows the interrupted record. The LLM has evidence the call
+        happened and won't blindly re-emit."""
+        ch = ConversationHistory()
+        ch.append_user("track my order")
+        ch.append_assistant("एक मिनट दीजिए", turn_id=1)
+
+        tm = _build_task_manager_mock(ch)
+
+        async def hanging_trigger_api(**kwargs):
+            await asyncio.sleep(10)
+
+        model_response = [{"id": "call_Z", "function": {"name": "advanced_track_order"}}]
+
+        with patch("bolna.agent_manager.task_manager.trigger_api", side_effect=hanging_trigger_api):
+            with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+                task = asyncio.create_task(
+                    TaskManager._TaskManager__execute_function_call(
+                        tm,
+                        url="https://api.example.com/tools",
+                        method="post",
+                        param=None,
+                        api_token=None,
+                        headers=None,
+                        model_args={},
+                        meta_info={"sequence_id": 1, "turn_id": 1, "bypass_synth": False},
+                        next_step=None,
+                        called_fun="advanced_track_order",
+                        model_response=model_response,
+                        tool_call_id="call_Z",
+                        textual_response=None,
+                    )
+                )
+                await asyncio.sleep(0.05)
+                task.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await task
+
+        # Simulate the next user turn appending a new user message.
+        ch.append_user("हाँ कोई बात नहीं")
+        # And the LLM-bound copy
+        messages = ch.get_copy()
+        # Verify the interrupted attempt is preserved in the history sent to
+        # the next LLM invocation.
+        tool_msgs = [m for m in messages if m.get("role") == "tool"]
+        assert len(tool_msgs) == 1
+        assert "interrupted_by_user" in tool_msgs[0]["content"]
+        # The assistant.tool_calls field is preserved as well.
+        asst_msgs = [m for m in messages if m.get("role") == "assistant" and m.get("tool_calls")]
+        assert len(asst_msgs) == 1
+        assert asst_msgs[0]["tool_calls"][0]["id"] == "call_Z"


### PR DESCRIPTION
## Bug

In a production call (run_id `ef7d4e21-7d2b-48cb-b82d-80de8a5394c7`), `advanced_track_order` fired 13 times in 32 seconds after the user barged in once. The caller heard "एक मिनट दीजिए, हम आपका order ट्रैक करके देखते हैं" 8-10 times back-to-back before the agent gave up and transferred to a human.

## Cause

`__execute_function_call` runs `attach_tool_calls_to_turn` + `append_tool_result` AFTER `await trigger_api`. When the user barges in during the HTTP call, the new user message gets appended between the assistant and the tool result. `_sanitize_tool_messages` correctly enforces OpenAI's adjacency rule, strips the tool_calls and removes the orphan tool. The followup LLM then sees no record of the call attempt and re-issues it. Loop.

## Fix

1. `ConversationHistory.upsert_tool_result(tool_call_id, content)`: update an existing tool message with the matching id in place, or append a new one.
2. In `__execute_function_call`:
   * Best-effort commit any staged assistant for the FC's `sequence_id` before attaching tool_calls, so attach finds a real parent instead of creating a `content=None` placeholder duplicate.
   * Write `attach_tool_calls_to_turn` + `upsert_tool_result(pending)` BEFORE `await trigger_api` so the assistant/tool pair stays adjacent across barge-in.
   * Wrap `trigger_api` in `try / except asyncio.CancelledError`: on cancel, rewrite the placeholder to `"interrupted_by_user"` and re-raise. `_finalize_api_call_detail` moved to `finally` so the API-call telemetry still gets a row (with `error="user_cancelled"`) on cancellation.
   * On success, overwrite the placeholder with the real body via `upsert_tool_result`.
   * Defense-in-depth: skip the followup `__do_llm_generation` if `interruption_manager.is_valid_sequence(sequence_id)` is False, so a stale followup doesn't race the new user turn's LLM stream.

The 3 sibling paths (`end_call`, `transfer_call`, `language_switch`) keep using `append_tool_result` since their flows don't await a network call that can be interrupted.

## Validation

`tests/tests/test_function_call_cancellation.py` was authored as a spec for this fix and committed alongside it. All 3 tests fail on master with `AssertionError: Assistant.tool_calls must be set before trigger_api` and pass with this PR.

Before:
```
FAILED tests/tests/test_function_call_cancellation.py::TestFunctionCallCancellation::test_history_has_pending_placeholder_before_trigger_api
FAILED tests/tests/test_function_call_cancellation.py::TestFunctionCallCancellation::test_cancellation_mid_trigger_api_marks_tool_as_interrupted
FAILED tests/tests/test_function_call_cancellation.py::TestFunctionCallCancellation::test_subsequent_llm_turn_sees_the_interrupted_attempt
```

After:
```
3 passed, 2 warnings in 5.90s
```

No regressions in `test_function_call_trace.py`, `test_function_call_timeout.py`, `test_tool_call_accumulator.py`, `test_tool_call_audio_sync.py`, `test_conversation_history.py` (verified via `git stash` baseline; the 16 unchanged failures are pre-existing on master).

## Out of scope

* The dead `execute_function_call_task` cancellation machinery (initialized to None, never assigned). Fixing it requires spawning `__execute_function_call` as a separate task, which changes scheduling across the FC family.
* The 9ms double `trigger_api` on the cancelled turn (likely two concurrent LLM streams). The placeholder fix makes the duplicate harmless from a history-correctness standpoint, but the underlying duplication should be investigated separately.