### PR TITLE
fix: commit late-staged assistant transcript when audio already sent

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.58"
+__version__ = "0.10.59"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -109,13 +109,7 @@ class TaskManager(BaseManager):
         self.transcriber_error_events: list[dict] = []
         self.blocked_audio_events: list[dict] = []
         self._blocked_sequences: set = set()  # dedup: only record first block per sequence
-        # Sequences whose audio passed __process_output_loop's SEND branch. Used to rescue
-        # late-staged assistant history (e.g. text+tool_call turns where the LLM stream
-        # finalizes, and thus stages, only after TTS chunks have already been sent).
         self._sent_audio_sequences: set = set()
-        # Sequences whose assistant content has already been appended to conversation_history.
-        # Guards against double-append when both SEND-time and late-stage commit fire, or when
-        # filler + main response stage under the same sequence_id.
         self._committed_assistant_sequences: set = set()
 
         self.task_config = task
@@ -3547,9 +3541,8 @@ class TaskManager(BaseManager):
             response_uid,
             len(content),
         )
-        # If audio for this sequence already passed SEND (and was not blocked), the
-        # SEND-time commit ran while _pending_assistant_history was still empty. Commit
-        # here so a later cleanup doesn't drop a message the user actually heard.
+        # Rescue commit: SEND already passed for this seq (e.g. text+tool_call turn
+        # where args stream after the spoken text), so SEND-time commit was a no-op.
         if sequence_id in self._sent_audio_sequences and sequence_id not in self._blocked_sequences:
             self._commit_staged_assistant_history(sequence_id)
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -109,6 +109,14 @@ class TaskManager(BaseManager):
         self.transcriber_error_events: list[dict] = []
         self.blocked_audio_events: list[dict] = []
         self._blocked_sequences: set = set()  # dedup: only record first block per sequence
+        # Sequences whose audio passed __process_output_loop's SEND branch. Used to rescue
+        # late-staged assistant history (e.g. text+tool_call turns where the LLM stream
+        # finalizes, and thus stages, only after TTS chunks have already been sent).
+        self._sent_audio_sequences: set = set()
+        # Sequences whose assistant content has already been appended to conversation_history.
+        # Guards against double-append when both SEND-time and late-stage commit fire, or when
+        # filler + main response stage under the same sequence_id.
+        self._committed_assistant_sequences: set = set()
 
         self.task_config = task
 
@@ -3539,12 +3547,20 @@ class TaskManager(BaseManager):
             response_uid,
             len(content),
         )
+        # If audio for this sequence already passed SEND (and was not blocked), the
+        # SEND-time commit ran while _pending_assistant_history was still empty. Commit
+        # here so a later cleanup doesn't drop a message the user actually heard.
+        if sequence_id in self._sent_audio_sequences and sequence_id not in self._blocked_sequences:
+            self._commit_staged_assistant_history(sequence_id)
 
     def _commit_staged_assistant_history(self, sequence_id):
+        if sequence_id in self._committed_assistant_sequences:
+            return
         staged = self._pending_assistant_history.pop(sequence_id, None)
         if staged is None:
             return
 
+        self._committed_assistant_sequences.add(sequence_id)
         self.conversation_history.append_assistant(
             staged["content"], turn_id=staged["turn_id"], response_uid=staged["response_uid"]
         )
@@ -4474,6 +4490,8 @@ class TaskManager(BaseManager):
 
                     if status == "SEND":
                         # Audio approved - send it
+                        if sequence_id is not None:
+                            self._sent_audio_sequences.add(sequence_id)
                         self._commit_staged_assistant_history(sequence_id)
                         self.tools["input"].update_is_audio_being_played(True)
                         self.response_in_pipeline = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.58"
+version = "0.10.59"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

The agent's goodbye line was sometimes missing from the saved transcript, even though the user heard it on the call.

## Root cause

Saving an assistant line to the transcript happens in two steps:
1. Stage the text (runs after the LLM finishes streaming).
2. Commit the staged text (runs when the audio chunk for that turn is approved for sending in `__process_output_loop`).

For a normal text-only turn, step 1 happens first, then step 2 picks it up. Works fine.

For a turn that says something AND then calls a tool in the same response (e.g. the closing line + `record_feedback_outcome`), the LLM keeps emitting tool-call arguments long after the spoken text is done. So the order flips:
1. Audio chunks for the spoken text get sent and ACKed by Plivo.
2. Commit fires during those sends, finds nothing staged yet, no-ops.
3. LLM finally finishes the tool args, stage runs.
4. The next user utterance triggers `__cleanup_downstream_tasks`, which drops everything still in the staged dict, including this line that the user actually heard.

Run `77adbac7-da07-474a-b15e-481b52927192` shows this exactly: SEND at `09:39:53.007`, stage at `:54.045`, ACK at `:58.232`, dropped at `:59.625`.

## Fix

1. Track which sequences had their audio sent in `_sent_audio_sequences`.
2. When `_stage_assistant_history` runs, if the sequence is already in `_sent_audio_sequences` and not in `_blocked_sequences`, commit right then instead of waiting for a commit that already fired.
3. Dedup commits with `_committed_assistant_sequences` so the same sequence cannot get appended twice if both the SEND-time commit and the late-stage commit would fire.

## Scope

Only the staging / commit / SEND paths in `task_manager.py` are touched. Normal text-only turns keep their existing behavior. Interrupted (BLOCK) turns keep getting dropped. Welcome message path is untouched.