### PR TITLE
fix: send vobiz stop event before disconnect to prevent phantom stream reconnect

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.59"
+__version__ = "0.10.60"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.44"
+__version__ = "0.10.45"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony_providers/vobiz.py
+++ b/bolna/input_handlers/telephony_providers/vobiz.py
@@ -1,3 +1,4 @@
+import json
 import os
 import requests
 from requests.auth import HTTPBasicAuth
@@ -40,6 +41,15 @@ class VobizInputHandler(TelephonyInputHandler):
     async def disconnect_stream(self):
         try:
             logger.info("Disconnecting vobiz stream for call: {}".format(self.call_sid))
+
+            if self.stream_sid and self.websocket is not None:
+                try:
+                    stop_message = {"event": "stop", "streamId": self.stream_sid}
+                    await self.websocket.send_text(json.dumps(stop_message))
+                    logger.info(f"Sent vobiz stop event for stream {self.stream_sid}")
+                except Exception as stop_err:
+                    logger.info(f"Could not send vobiz stop event: {stop_err}")
+
             api_key = os.getenv("VOBIZ_API_KEY")
             api_secret = os.getenv("VOBIZ_API_SECRET")
             call_uuid = self.call_sid
@@ -58,7 +68,6 @@ class VobizInputHandler(TelephonyInputHandler):
                     )
             else:
                 logger.warning("Cannot disconnect Vobiz call: VOBIZ_AUTH_ID or call_sid missing")
-            logger.info("Disconnecting vobiz stream for call: {}".format(self.call_sid))
         except Exception as e:
             logger.info("Error deleting vobiz stream: {}".format(str(e)))
 

--- a/bolna/input_handlers/telephony_providers/vobiz.py
+++ b/bolna/input_handlers/telephony_providers/vobiz.py
@@ -60,7 +60,7 @@ class VobizInputHandler(TelephonyInputHandler):
                 if api_key and api_secret:
                     auth = HTTPBasicAuth(api_key, api_secret)
                 response = requests.delete(url, auth=auth)
-                if response.status_code == 200:
+                if response.status_code in (200, 204):
                     logger.info(f"Successfully disconnected Vobiz call: {call_uuid}")
                 else:
                     logger.warning(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.44"
+version = "0.10.45"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.59"
+version = "0.10.60"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

Vobiz `<Stream keepCallAlive="true">` can cause a phantom WebSocket reconnect on the same `run_id` after the call ends, which re-enters `process_websocket` and overwrites the transcript with empty data (see BOLNA-1083). Per [Vobiz stream events docs](https://docs.vobiz.ai/xml/stream/stream-events), send `{"event":"stop","streamId":<sid>}` over the existing WS in `disconnect_stream` before the HTTP DELETE so Vobiz tears the stream down cleanly and doesn't auto-reconnect.

Pairs with dashboard-backend PR (same branch name) which adds the empty-transcript write guard as a backstop.