### PR TITLE
fix: only flush elevenlabs tts on end_of_llm_stream

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.59"
+__version__ = "0.10.60"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -148,12 +148,11 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             if end_of_llm_stream:
                 self.last_text_sent = True
                 self.context_id = str(uuid.uuid4())
-
-            try:
-                await self.websocket.send(json.dumps({"text": "", "flush": True}))
-            except Exception as e:
-                logger.info(f"Error sending end-of-stream signal: {e}")
-                self.connection_error = str(e)
+                try:
+                    await self.websocket.send(json.dumps({"text": "", "flush": True}))
+                except Exception as e:
+                    logger.info(f"Error sending end-of-stream signal: {e}")
+                    self.connection_error = str(e)
 
         except asyncio.CancelledError:
             logger.info("Sender task was cancelled.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.59"
+version = "0.10.60"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The ElevenLabs sender unconditionally sends `{"text": "", "flush": True}` at the end of every invocation. When the LLM streams a response in multiple chunks, `_push_stream` spawns a fresh sender task per chunk without awaiting the previous one, so two senders race on the same WebSocket. The first sender's flush causes ElevenLabs to render whatever is currently buffered and emit `isFinal`, the receiver yields `b"\x00"` (EOS), and anything the second sender writes after that point is silently dropped.

Production incident `run_id=32d3ea14-501a-4d5b-8cba-75b01d1fd8ec` turn 3: the LLM produced a 308-char response in two chunks 21ms apart; ElevenLabs rendered only the first 122 chars ("...comfort and style, perfect") before isFinal closed the context. The agent went silent mid-sentence and the call ended via `INACTIVITY_TIMEOUT` 19 seconds later.