### PR TITLE
fix: suppress 'are you still there' and silence-repeat while LLM/tool task in flight

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.60"
+__version__ = "0.10.61"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4674,6 +4674,19 @@ class TaskManager(BaseManager):
             if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
                 continue
 
+            # An in-flight LLM task (including a tool-call API request + follow-up generation
+            # running inside it) means a response is still being produced even though
+            # response_in_pipeline has flipped False after the filler audio. Treat that
+            # window as busy so we don't synthesize "are you still there" over the
+            # upcoming follow-up response. hang_conversation_after intentionally remains
+            # ungated so a truly hung task still triggers the inactivity hangup.
+            has_pending_generation = (
+                self.llm_task is not None and not self.llm_task.done()
+            ) or (
+                self.execute_function_call_task is not None
+                and not self.execute_function_call_task.done()
+            )
+
             time_since_last_spoken_ai_word = time.time() - self.last_transmitted_timestamp
             time_since_user_last_spoke = (
                 (time.time() - self.time_since_last_spoken_human_word)
@@ -4686,6 +4699,7 @@ class TaskManager(BaseManager):
                 and time_since_last_spoken_ai_word > self.repeat_after_silence_seconds
                 and time_since_user_last_spoke > self.repeat_after_silence_seconds
                 and not self.response_in_pipeline
+                and not has_pending_generation
             ):
                 await self._inject_and_run_llm(
                     f"[silence] User was silent for {self.repeat_after_silence_seconds} seconds"
@@ -4708,6 +4722,7 @@ class TaskManager(BaseManager):
                 time_since_last_spoken_ai_word > self.trigger_user_online_message_after
                 and not self.asked_if_user_is_still_there
                 and time_since_user_last_spoke > self.trigger_user_online_message_after
+                and not has_pending_generation
             ):
                 logger.info(
                     f"Asking if the user is still there (agent silent for {time_since_last_spoken_ai_word:.2f}s, user silent for {time_since_user_last_spoke:.2f}s)"

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4680,11 +4680,8 @@ class TaskManager(BaseManager):
             # window as busy so we don't synthesize "are you still there" over the
             # upcoming follow-up response. hang_conversation_after intentionally remains
             # ungated so a truly hung task still triggers the inactivity hangup.
-            has_pending_generation = (
-                self.llm_task is not None and not self.llm_task.done()
-            ) or (
-                self.execute_function_call_task is not None
-                and not self.execute_function_call_task.done()
+            has_pending_generation = (self.llm_task is not None and not self.llm_task.done()) or (
+                self.execute_function_call_task is not None and not self.execute_function_call_task.done()
             )
 
             time_since_last_spoken_ai_word = time.time() - self.last_transmitted_timestamp

--- a/bolna/lid/elevenlabs_scribe.py
+++ b/bolna/lid/elevenlabs_scribe.py
@@ -118,25 +118,33 @@ class ElevenLabsScribeLID(LIDBackend):
                 # Byte-based accumulation means commit cadence is correct regardless of
                 # incoming chunk size (100ms from Twilio, 80ms from SIP, 100ms in tests).
                 should_commit = bytes_since_commit >= self.commit_threshold_bytes
-                await self.ws.send(json.dumps({
-                    "message_type": "input_audio_chunk",
-                    "audio_base_64": b64,
-                    "commit": should_commit,
-                    "sample_rate": self.sr,
-                    "previous_text": None,
-                }))
+                await self.ws.send(
+                    json.dumps(
+                        {
+                            "message_type": "input_audio_chunk",
+                            "audio_base_64": b64,
+                            "commit": should_commit,
+                            "sample_rate": self.sr,
+                            "previous_text": None,
+                        }
+                    )
+                )
                 if should_commit:
                     logger.debug(f"ElevenLabsScribeLID: committed segment after {bytes_since_commit} bytes")
                     bytes_since_commit = 0
 
             # Flush any pending audio — force VAD commit on whatever is buffered
             logger.info("ElevenLabsScribeLID: sending final commit flush")
-            await self.ws.send(json.dumps({
-                "message_type": "input_audio_chunk",
-                "audio_base_64": "",
-                "commit": True,
-                "sample_rate": self.sr,
-            }))
+            await self.ws.send(
+                json.dumps(
+                    {
+                        "message_type": "input_audio_chunk",
+                        "audio_base_64": "",
+                        "commit": True,
+                        "sample_rate": self.sr,
+                    }
+                )
+            )
         except asyncio.TimeoutError:
             logger.error("ElevenLabsScribeLID: timed out waiting for session_started")
             self.dead = True
@@ -166,9 +174,7 @@ class ElevenLabsScribeLID(LIDBackend):
                     elif msg_type == "committed_transcript_with_timestamps":
                         text = data.get("text", "").strip()
                         lang = data.get("language_code") or ""
-                        logger.info(
-                            f"ElevenLabsScribeLID: committed transcript text={text!r} language_code={lang!r}"
-                        )
+                        logger.info(f"ElevenLabsScribeLID: committed transcript text={text!r} language_code={lang!r}")
                         if lang:
                             # Normalise to short ISO-639-1 (e.g. "eng" → "en", "hin" → "hi")
                             short = lang[:2].lower()

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -915,15 +915,17 @@ class DeepgramTranscriber(BaseTranscriber):
 
                             if languages:
                                 logger.info(f"Flux LID Update: languages={languages} hinted={languages_hinted}")
-                                self.flux_lid_events.append({
-                                    "detected_lang": languages[0],
-                                    "all_languages": languages,
-                                    "event_type": "Update",
-                                    "turn_index": turn_index,
-                                    "transcript": transcript,
-                                    "lid_provider": "deepgram_flux",
-                                    "detected_at": time.time(),
-                                })
+                                self.flux_lid_events.append(
+                                    {
+                                        "detected_lang": languages[0],
+                                        "all_languages": languages,
+                                        "event_type": "Update",
+                                        "turn_index": turn_index,
+                                        "transcript": transcript,
+                                        "lid_provider": "deepgram_flux",
+                                        "detected_at": time.time(),
+                                    }
+                                )
 
                             data = {"type": "interim_transcript_received", "content": transcript}
                             yield create_ws_data_packet(data, self.meta_info)
@@ -931,15 +933,17 @@ class DeepgramTranscriber(BaseTranscriber):
                     elif event == "EagerEndOfTurn":
                         if languages:
                             logger.info(f"Flux LID EagerEndOfTurn: languages={languages} hinted={languages_hinted}")
-                            self.flux_lid_events.append({
-                                "detected_lang": languages[0],
-                                "all_languages": languages,
-                                "event_type": "EagerEndOfTurn",
-                                "turn_index": turn_index,
-                                "transcript": transcript,
-                                "lid_provider": "deepgram_flux",
-                                "detected_at": time.time(),
-                            })
+                            self.flux_lid_events.append(
+                                {
+                                    "detected_lang": languages[0],
+                                    "all_languages": languages,
+                                    "event_type": "EagerEndOfTurn",
+                                    "turn_index": turn_index,
+                                    "transcript": transcript,
+                                    "lid_provider": "deepgram_flux",
+                                    "detected_at": time.time(),
+                                }
+                            )
                         logger.info(f"Flux: EagerEndOfTurn (confidence={eot_confidence}, transcript={transcript!r})")
                         if transcript:
                             self.eager_transcript_pending = transcript
@@ -960,15 +964,17 @@ class DeepgramTranscriber(BaseTranscriber):
                     elif event == "EndOfTurn":
                         if languages:
                             logger.info(f"Flux LID EndOfTurn: languages={languages} hinted={languages_hinted}")
-                            self.flux_lid_events.append({
-                                "detected_lang": languages[0],
-                                "all_languages": languages,
-                                "event_type": "EndOfTurn",
-                                "turn_index": turn_index,
-                                "transcript": transcript,
-                                "lid_provider": "deepgram_flux",
-                                "detected_at": time.time(),
-                            })
+                            self.flux_lid_events.append(
+                                {
+                                    "detected_lang": languages[0],
+                                    "all_languages": languages,
+                                    "event_type": "EndOfTurn",
+                                    "turn_index": turn_index,
+                                    "transcript": transcript,
+                                    "lid_provider": "deepgram_flux",
+                                    "detected_at": time.time(),
+                                }
+                            )
                         logger.info(f"Flux: EndOfTurn (confidence={eot_confidence}) transcript={transcript!r}")
 
                         if transcript:

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -275,7 +275,9 @@ class TranscriberPool:
         synthesizer and prompt catch up.
         """
         if confidence is not None and confidence < self._LID_CONFIDENCE_THRESHOLD:
-            logger.debug(f"TranscriberPool LID: {lang} conf={f'{confidence:.2f}' if confidence is not None else 'n/a'} below threshold — suppressed")
+            logger.debug(
+                f"TranscriberPool LID: {lang} conf={f'{confidence:.2f}' if confidence is not None else 'n/a'} below threshold — suppressed"
+            )
             self._record_lid_event(lang, confidence, None, False, "low_confidence")
             return
 
@@ -286,7 +288,9 @@ class TranscriberPool:
             self._record_lid_event(lang, confidence, None, False, "unsupported_language")
             return
 
-        logger.info(f"TranscriberPool LID: {lang} conf={f'{confidence:.2f}' if confidence is not None else 'n/a'} (provider={self._lid_provider_name})")
+        logger.info(
+            f"TranscriberPool LID: {lang} conf={f'{confidence:.2f}' if confidence is not None else 'n/a'} (provider={self._lid_provider_name})"
+        )
 
         _active_cfg = self._multilingual_config.get(self.active_label, {})
         active_lang = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.60"
+version = "0.10.61"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_elevenlabs_scribe_lid.py
+++ b/tests/test_elevenlabs_scribe_lid.py
@@ -27,11 +27,12 @@ load_dotenv()
 sys.path.insert(0, ".")
 from bolna.lid.elevenlabs_scribe import ElevenLabsScribeLID
 
-CHUNK_DURATION_S = 0.100         # 100ms per chunk — matches Twilio 10×20ms batch size
+CHUNK_DURATION_S = 0.100  # 100ms per chunk — matches Twilio 10×20ms batch size
 TEST_AUDIO_PATH = "/tmp/test_elevenlabs_lid.wav"
 
 
 # ── Audio generation ──────────────────────────────────────────────────────────
+
 
 def generate_test_audio(path: str):
     """Generate mixed-language speech WAV using create_test_audio.py logic."""
@@ -64,6 +65,7 @@ def generate_test_audio(path: str):
 
 # ── WAV reader ────────────────────────────────────────────────────────────────
 
+
 def read_wav_chunks(path: str, chunk_duration_s: float):
     with wave.open(path, "rb") as wf:
         sr = wf.getframerate()
@@ -85,6 +87,7 @@ def read_wav_chunks(path: str, chunk_duration_s: float):
 
 
 # ── Main test ─────────────────────────────────────────────────────────────────
+
 
 async def run(fast: bool = False):
     print("\n=== ElevenLabs Scribe v2 Realtime LID Test ===\n")


### PR DESCRIPTION
## Bug

After the LLM emits a `pre_call_message` filler and `__execute_function_call` starts the tool API request, the silence detector in `__check_for_completion` treats the system as idle. Once `trigger_user_online_message_after` seconds (default 6) elapse with no audio and `response_in_pipeline=False`, it synthesizes "Hey, are you still there?" — interrupting the actual follow-up LLM response.

Confirmed in three production calls (Bitespeed agents). Timeline from one log:

* `30.136`: filler audio mark ACKs in, `response_in_pipeline` flips False, `last_transmitted_timestamp` updates
* `30.136`: tool API POST starts
* `36.569`: API returns (~6.4s)
* `36.570`: follow-up LLM call starts (new sequence_id)
* `37.442`: follow-up LLM POST returns
* `37.455`: `__check_for_completion` ticks → `time_since_last_spoken_ai_word=7.32s` → fires "Hey, are you still there?" which calls `handle_interruption` and kills the real follow-up audio before it ever streams

`check_if_user_online` was already reset to True at task_manager.py:2914 before the follow-up `__do_llm_generation` await, and `asked_if_user_is_still_there` was cleared by the filler's `end_of_synthesizer_stream`, so neither existing guard prevented this.

## Fix

Extend the silence-trigger gate to also check `has_pending_generation` (in-flight `llm_task` / `execute_function_call_task`). Same predicate already exists at task_manager.py:3645 for `_handle_transcriber_output`.

`hang_conversation_after` intentionally remains ungated as a safety net for a truly wedged task.