### PR TITLE
added the fixed for agent nothing saying before hangup

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.63"
+__version__ = "0.10.64"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4127,6 +4127,8 @@ class TaskManager(BaseManager):
             copied_meta_info["is_final_chunk_of_entire_response"] = True
 
         self.buffered_output_queue.put_nowait(create_ws_data_packet(chunk, copied_meta_info))
+        if self.output_task is None or self.output_task.done():
+            self.output_task = asyncio.create_task(self.__process_output_loop())
 
     def is_sequence_id_in_current_ids(self, sequence_id):
         """Check if sequence_id is valid. Delegates to InterruptionManager."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.63"
+version = "0.10.64"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Issue

  When the user interrupts the agent mid-speech, __cleanup_downstream_tasks cancels output_task and sets it to None. This is correct — it stops the current audio.

  But when end_call fires shortly after, the followup goodbye (seq=5) gets synthesized through ElevenLabs, and __enqueue_chunk puts the audio into buffered_output_queue. However, output_task is still None
   — nobody restarted it. The buffer fills up but nothing reads from it and sends to VoBiz. No marks are created, wait_for_current_message sees current_list: [], times out, and the call disconnects
  silently without the user ever hearing the goodbye.

  In this specific call: user interrupted at 14:26:12.926 → output_task cancelled. end_call fired at 14:26:13.930 → goodbye synthesized at 14:26:14.727 → ElevenLabs returned audio → __listen_synthesizer
  said "Processing" → audio enqueued → silence → disconnect at 14:26:17.728.

  ---
  Fix

  In __enqueue_chunk — the single place all audio enters the buffer — restart the output loop if it's not running:

  self.buffered_output_queue.put_nowait(create_ws_data_packet(chunk, copied_meta_info))
  if self.output_task is None or self.output_task.done():
      self.output_task = asyncio.create_task(self.__process_output_loop())
