### PR TITLE
fix: drain stale synthesizer text_queue on new turn

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.66"
+__version__ = "0.10.67"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -173,6 +173,16 @@ class StreamSynthesizer(BaseSynthesizer):
     def _stamp_turn_start(self, meta_info):
         """Only stamp on the first push of a new turn (don't re-stamp on subsequent chunks)."""
         if self.current_turn_start_time is None:
+            # Drop leftover entries from a previous turn so this turn's first audio
+            # chunk doesn't pop a stale entry and inherit a dead sequence_id (which
+            # __listen_synthesizer would then filter out). Keep same-seq entries —
+            # they belong to this turn (sequence_ids are monotonic; only -1 repeats).
+            new_seq = meta_info.get("sequence_id")
+            if self.text_queue and any(m.get("sequence_id") != new_seq for m in self.text_queue):
+                kept = deque(m for m in self.text_queue if m.get("sequence_id") == new_seq)
+                dropped = len(self.text_queue) - len(kept)
+                self.text_queue = kept
+                logger.info(f"Dropped {dropped} stale text_queue entries on new turn start (seq={new_seq})")
             self.current_turn_start_time = time.perf_counter()
             self.ws_send_time = None
             self.current_turn_ttfb = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.66"
+version = "0.10.67"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
On back-to-back `switch_language` calls the agent went silent and the call dropped.

**Cause:** the synthesizer's `text_queue` holds one meta_info per text push, and the receiver pops one per yielded audio chunk. Providers don't return audio chunks 1:1 with pushes (ElevenLabs' alignment-based end-of-stream can fire before the queue drains), so a prior turn can leave a stale meta_info entry behind. The next turn's first audio chunk then pops that stale entry and inherits its (already-retired) `sequence_id`, so `__listen_synthesizer` filters the audio out.

This is cosmetic on a normal multi-chunk reply (only the first chunk is lost), but fatal for a switch handoff: the handoff line is a single short chunk, and `__execute_function_call` blocks on its mark ack before performing the switch. Dropped audio means no ack, the wait hangs, the switch never runs, and the agent is silent until the caller hangs up.

**Fix:** at the start of a new turn, drop `text_queue` entries belonging to a previous turn. Filtered by `sequence_id` (monotonic, only `-1` repeats) so same-turn entries are preserved, which keeps the premature-end-of-stream continuation path safe.