### PR TITLE
fix: skip control marks when selecting sync_history trim target

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.67"
+__version__ = "0.10.68"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -24,6 +24,7 @@ from bolna.constants import (
     DEFAULT_TIMEZONE,
     LANGUAGE_NAMES,
     LLM_DEFAULT_CONFIGS,
+    NON_EVIDENCE_MARK_TYPES,
     SWITCH_LANGUAGE_TOOL_DEFINITION,
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
@@ -1597,6 +1598,8 @@ class TaskManager(BaseManager):
         latest_turn_id = None
         latest_counter = -1
         for _, mark_data in mark_events_data:
+            if mark_data.get("type") in NON_EVIDENCE_MARK_TYPES:
+                continue
             turn_id = mark_data.get("turn_id")
             if turn_id is None:
                 continue
@@ -1611,6 +1614,8 @@ class TaskManager(BaseManager):
         latest_response_uid = None
         latest_counter = -1
         for _, mark_data in mark_events_data:
+            if mark_data.get("type") in NON_EVIDENCE_MARK_TYPES:
+                continue
             response_uid = mark_data.get("response_uid")
             if response_uid is None:
                 continue

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -168,6 +168,9 @@ SWITCH_LANGUAGE_TOOL_DEFINITION = {
     },
 }
 
+# Control marks carry no playback evidence and must not be used as a trim target.
+NON_EVIDENCE_MARK_TYPES = ("pre_mark_message", "backchanneling")
+
 END_CALL_FUNCTION_PREFIX = "end_call"
 
 END_CALL_TOOL_DEFINITION = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.67"
+version = "0.10.68"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_sync_history_control_marks.py
+++ b/tests/tests/test_sync_history_control_marks.py
@@ -1,0 +1,103 @@
+"""Regression tests: a leftover control mark (pre-mark/backchanneling) must not
+become the sync_history trim target. A fully-played turn whose pre-mark lingered
+unacked was being removed from the transcript as 'unheard' after a language
+switch, causing the agent to repeat the vanished reply."""
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+
+
+def _mark(mark_type="", turn_id=None, response_uid=None, counter=0, duration=0.0):
+    return {
+        "type": mark_type,
+        "turn_id": turn_id,
+        "response_uid": response_uid,
+        "counter": counter,
+        "duration": duration,
+    }
+
+
+class TestLatestFromMarksSkipsControlMarks:
+    def test_pre_mark_only_yields_no_target(self):
+        marks = [("m0", _mark("pre_mark_message", turn_id=5, response_uid="r5", counter=0))]
+        assert TaskManager._get_latest_turn_id_from_marks(marks) is None
+        assert TaskManager._get_latest_response_uid_from_marks(marks) is None
+
+    def test_backchanneling_only_yields_no_target(self):
+        marks = [("m0", _mark("backchanneling", turn_id=5, response_uid="r5", counter=0))]
+        assert TaskManager._get_latest_turn_id_from_marks(marks) is None
+        assert TaskManager._get_latest_response_uid_from_marks(marks) is None
+
+    def test_audio_mark_is_a_valid_target(self):
+        marks = [
+            ("m0", _mark("pre_mark_message", turn_id=5, response_uid="r5", counter=0)),
+            ("m1", _mark("", turn_id=5, response_uid="r5", counter=1)),
+        ]
+        assert TaskManager._get_latest_turn_id_from_marks(marks) == 5
+        assert TaskManager._get_latest_response_uid_from_marks(marks) == "r5"
+
+    def test_audio_mark_wins_over_later_pre_mark(self):
+        marks = [
+            ("m0", _mark("", turn_id=4, response_uid="r4", counter=10)),
+            ("m1", _mark("pre_mark_message", turn_id=5, response_uid="r5", counter=14)),
+        ]
+        assert TaskManager._get_latest_turn_id_from_marks(marks) == 4
+        assert TaskManager._get_latest_response_uid_from_marks(marks) == "r4"
+
+
+class _InputStub:
+    last_heard_turn_id = None
+    last_heard_response_uid = None
+    response_heard_by_user = ""
+
+    def get_response_heard_for_response(self, _uid):
+        return ""
+
+    def get_response_heard_for_turn(self, _turn_id):
+        return ""
+
+    def get_current_mark_started_time(self):
+        return 0.0
+
+
+class _MarkMetaStub:
+    def get_heard_text_for_response(self, _uid):
+        return ""
+
+    def get_heard_text_for_turn(self, _turn_id):
+        return ""
+
+
+def _make_task_manager(history):
+    tm = TaskManager.__new__(TaskManager)
+    tm.conversation_history = history
+    tm.tools = {"input": _InputStub()}
+    tm.mark_event_meta_data = _MarkMetaStub()
+    tm._turn_msg_map = {}
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_lingering_pre_mark_keeps_played_turn():
+    history = ConversationHistory()
+    history.append_user("switch to hindi please")
+    history.append_assistant("agent reply in hindi", turn_id=5, response_uid="r5")
+    tm = _make_task_manager(history)
+
+    leftover = [("m0", _mark("pre_mark_message", turn_id=5, response_uid="r5", counter=0))]
+    await tm.sync_history(leftover, interruption_processed_at=1000.0)
+
+    assert any(m.get("content") == "agent reply in hindi" for m in history.messages)
+
+
+@pytest.mark.asyncio
+async def test_no_marks_keeps_played_turn():
+    history = ConversationHistory()
+    history.append_assistant("agent reply", turn_id=5, response_uid="r5")
+    tm = _make_task_manager(history)
+
+    await tm.sync_history([], interruption_processed_at=1000.0)
+
+    assert any(m.get("content") == "agent reply" for m in history.messages)


### PR DESCRIPTION
## Problem

After a language switch, the agent's first reply was spoken and committed to the transcript, then silently removed from it a few turns later. Because the reply was dropped from `conversation_history`, the LLM no longer saw that it had asked the question and repeated itself on the next turn.

Root cause: a turn's first `pre_mark_message` occasionally lingers unacked. On the next user interruption, `sync_history` picks the trim target via `_get_latest_turn_id_from_marks` / `_get_latest_response_uid_from_marks`, which read `turn_id`/`response_uid` off *any* mark, including that leftover pre-mark. The pre-mark carries no playback info and is skipped in every heard-text estimation path, so `response_heard` stays empty and the fully-played turn gets trimmed as "unheard" and removed. A turn with no leftover marks instead takes the safe blind-fallback branch and is preserved, which is why this only bit the post-switch turns.

## Fix

Skip `pre_mark_message` and `backchanneling` marks in both target-selection helpers, mirroring the skip already used in the heard-text estimation loops. A lone leftover control mark now yields no target, so the turn falls through to the existing blind-fallback guard and is preserved. Real interruptions are unaffected because they leave audio post-marks carrying the same `turn_id`.

The mark types are centralized in `constants.NON_EVIDENCE_MARK_TYPES`.