### PR TITLE
sip-trunk: fix control-frame parsing and DTMF, harden output handler

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.67"
+__version__ = "0.10.68"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.69"
+__version__ = "0.10.70"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -6,6 +6,7 @@ Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 
 import asyncio
 import json
+import os
 import traceback
 from bolna.input_handlers.telephony import TelephonyInputHandler
 from bolna.helpers.utils import create_ws_data_packet
@@ -18,6 +19,18 @@ load_dotenv()
 
 # Asterisk ulaw: 160 bytes per 20ms frame
 ASTERISK_ULAW_OPTIMAL_FRAME_SIZE = 160
+
+# Forward inbound audio to the transcriber in ~80ms batches — enough context for
+# stable Deepgram transcripts without adding noticeable latency.
+AUDIO_BATCH_MS = 80
+
+# How long to wait after sending HANGUP before closing the WebSocket, giving Asterisk
+# time to act on it. Overridable via env.
+HANGUP_SETTLE_S = float(os.environ.get("SIP_HANGUP_SETTLE_S", "0.5"))
+
+# Submit accumulated DTMF digits after this much inter-digit silence (reset on each
+# keypress), or immediately when '#' is pressed. Overridable via env.
+DTMF_INTERDIGIT_TIMEOUT_S = float(os.environ.get("SIP_DTMF_INTERDIGIT_TIMEOUT_S", "3"))
 
 
 def _parse_asterisk_control_message(text: str) -> dict:
@@ -33,14 +46,16 @@ def _parse_asterisk_control_message(text: str) -> dict:
         if isinstance(obj, dict):
             result = obj
     except (json.JSONDecodeError, TypeError):
-        for part in text.split():
+        tokens = text.split()
+        for part in tokens:
             if ":" in part:
                 k, v = part.split(":", 1)
                 result[k.strip().lower()] = v.strip()
-        if " " in text:
-            first = text.split()[0]
-            if first not in result:
-                result["event"] = first
+        # The first whitespace-delimited token is the event name (e.g. "MEDIA_START",
+        # "DTMF_END digit:5"). Bare single-token frames like "MEDIA_XOFF"/"MEDIA_XON"/
+        # "QUEUE_DRAINED" have no space — guarding on `" " in text` dropped them entirely.
+        if tokens and ":" not in tokens[0] and "event" not in result:
+            result["event"] = tokens[0]
 
     event = (result.get("event") or result.get("command") or "").upper().replace(" ", "_")
     if event:
@@ -82,6 +97,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         self.connection_id = None
         self.ptime = 20
         self._pending_stream_sid = None  # promoted to stream_sid on first audio frame
+        self._dtmf_timer_task = None  # inter-digit timeout for DTMF accumulation
 
         input_config = self._get_input_config()
         self._expected_format = (input_config.get("audio_format") or input_config.get("format") or "ulaw").lower()
@@ -107,6 +123,16 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             pass
         return {}
 
+    def _audio_meta(self) -> dict:
+        """meta_info attached to each batch of inbound audio forwarded to the transcriber."""
+        return {
+            "io": self.io_provider,
+            "call_sid": self.call_sid,
+            "stream_sid": self.stream_sid,
+            "sequence": (self.input_types or {}).get("audio", 0),
+            "format": self._expected_format,
+        }
+
     async def disconnect_stream(self):
         """Send HANGUP to Asterisk so the channel and WebSocket close."""
         try:
@@ -121,8 +147,9 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         """Stop and disconnect; Asterisk closes quickly after HANGUP."""
         logger.info(f"Stopping sip-trunk handler for channel {self.channel_id}")
         self.running = False
+        self._cancel_dtmf_timer()
         await self.disconnect_stream()
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(HANGUP_SETTLE_S)
         try:
             await self.websocket.close()
         except Exception as e:
@@ -168,10 +195,10 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         self._initialize_from_media_start(packet)
 
     async def _listen(self):
-        """Receive TEXT (control) and BINARY (ulaw). Forward audio in ~80ms batches for balance of latency and transcript accuracy."""
+        """Receive TEXT (control) and BINARY (ulaw). Forward audio in ~AUDIO_BATCH_MS batches
+        for a balance of latency and transcript accuracy."""
         buffer = []
-        # ~80ms per batch (4 x 20ms frames) so Deepgram has enough context for stable transcripts
-        chunks_per_batch = max(2, 80 // self.ptime) if self.ptime else 4
+        chunks_per_batch = max(2, AUDIO_BATCH_MS // self.ptime) if self.ptime else 4
         message_count = 0
 
         while self.running:
@@ -197,14 +224,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
                         merged = b"".join(buffer)
                         buffer = []
                         message_count = 0
-                        meta_info = {
-                            "io": self.io_provider,
-                            "call_sid": self.call_sid,
-                            "stream_sid": self.stream_sid,
-                            "sequence": (self.input_types or {}).get("audio", 0),
-                            "format": self._expected_format,
-                        }
-                        await self.ingest_audio(merged, meta_info)
+                        await self.ingest_audio(merged, self._audio_meta())
 
                 elif "text" in message:
                     await self._handle_control_message(message["text"])
@@ -230,14 +250,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         if buffer:
             merged = b"".join(buffer)
             if merged:
-                meta_info = {
-                    "io": self.io_provider,
-                    "call_sid": self.call_sid,
-                    "stream_sid": self.stream_sid,
-                    "sequence": (self.input_types or {}).get("audio", 0),
-                    "format": self._expected_format,
-                }
-                await self.ingest_audio(merged, meta_info)
+                await self.ingest_audio(merged, self._audio_meta())
 
         ws_data_packet = create_ws_data_packet(
             data=None,
@@ -245,6 +258,33 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         )
         self.queues["transcriber"].put_nowait(ws_data_packet)
         logger.info(f"sip-trunk WebSocket closed for channel {self.channel_id}")
+
+    def _flush_dtmf(self):
+        """Enqueue the accumulated DTMF digits as one entry and clear the buffer."""
+        if self.dtmf_digits:
+            self.queues["dtmf"].put_nowait(self.dtmf_digits)
+            self.dtmf_digits = ""
+
+    def _cancel_dtmf_timer(self):
+        if self._dtmf_timer_task and not self._dtmf_timer_task.done():
+            self._dtmf_timer_task.cancel()
+        self._dtmf_timer_task = None
+
+    def _restart_dtmf_timer(self):
+        """(Re)arm the inter-digit timeout — reset on every keypress so multi-digit input
+        with short pauses still collects, then submits after DTMF_INTERDIGIT_TIMEOUT_S."""
+        self._cancel_dtmf_timer()
+        self._dtmf_timer_task = asyncio.create_task(self._dtmf_timeout())
+
+    async def _dtmf_timeout(self):
+        try:
+            await asyncio.sleep(DTMF_INTERDIGIT_TIMEOUT_S)
+        except asyncio.CancelledError:
+            return
+        self._dtmf_timer_task = None
+        if self.dtmf_digits:
+            logger.info(f"DTMF inter-digit timeout — submitting '{self.dtmf_digits}'")
+            self._flush_dtmf()
 
     async def _handle_control_message(self, text: str):
         """Handle Asterisk TEXT: MEDIA_START, DTMF_END, MEDIA_XOFF/XON, QUEUE_DRAINED, etc."""
@@ -257,7 +297,14 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         if event == "DTMF_END":
             digit = parsed.get("digit", "")
             if digit and self.is_dtmf_active:
-                self.queues["dtmf"].put_nowait(digit)
+                # Accumulate digits; submit on the '#' terminator OR after an inter-digit
+                # timeout, so callers who don't press '#' still get their input through.
+                is_complete = await self._handle_dtmf_digit(digit)
+                if is_complete:
+                    self._cancel_dtmf_timer()
+                    self._flush_dtmf()
+                elif self.dtmf_digits:
+                    self._restart_dtmf_timer()
             return
         if event == "MEDIA_XOFF":
             self._media_xoff = True

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -7,6 +7,13 @@ RTP delivery. Server-side duration tracking knows when playback ends without
 relying on QUEUE_DRAINED. FLUSH_MEDIA on interrupt. Generation counter drops
 stale audio after interruption.
 
+Asterisk has no mark echo, so playback completion is duration-based: a finish
+timer is scheduled on the final chunk (first_send + total_audio_duration + settle).
+The synthesizer emits the final audio chunk and a trailing null-byte sentinel both
+with is_final=True; both reach _schedule_finish, which is harmless because
+_response_audio_duration is reset only on a new sequence_id or on interruption
+(never on is_final) — so the second call recomputes an equivalent finish delay.
+
 Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 """
 
@@ -88,6 +95,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
         # XOFF/XON: local queue when Asterisk signals backpressure
         self._local_audio_queue: deque = deque()
+        # Serialize drains so a second MEDIA_XON can't run a drain concurrently with an
+        # in-flight one (which would interleave frames and double-count send pacing).
+        self._drain_lock = asyncio.Lock()
 
         output_config = self._get_output_config()
         self._output_format = (output_config.get("audio_format") or output_config.get("format") or "ulaw").lower()
@@ -102,6 +112,23 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         except Exception:
             pass
         return {}
+
+    # ------------------------------------------------------------------
+    # Per-response state
+    # ------------------------------------------------------------------
+
+    def _reset_response_counters(self) -> None:
+        """Reset the per-response send/duration counters and cancel any pending finish
+        timer. Shared by the new-response path (sequence_id change) and handle_interruption
+        so both reset the same set — keeping them in sync is what prevents the finish timer
+        from being computed off stale duration."""
+        self._response_first_send = 0.0
+        self._response_audio_duration = 0.0
+        self._bytes_sent = 0
+        self._pending_finish = False
+        if self._settle_task:
+            self._settle_task.cancel()
+            self._settle_task = None
 
     # ------------------------------------------------------------------
     # Playback completion — server-side duration tracking
@@ -150,8 +177,18 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self.input_handler.update_is_audio_being_played(False)
 
     # ------------------------------------------------------------------
-    # Rate limiting — prevent Asterisk frame-queue overflow
+    # Audio framing / sending
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _to_ulaw(audio_chunk: bytes, audio_format: str) -> bytes:
+        """Convert a PCM/WAV chunk to 8-bit ulaw, stripping a 44-byte RIFF header if
+        present. ulaw input is returned unchanged."""
+        if audio_format in ("pcm", "wav") or (len(audio_chunk) > 44 and audio_chunk[:4] == b"RIFF"):
+            if audio_chunk[:4] == b"RIFF":
+                audio_chunk = audio_chunk[44:]
+            audio_chunk = audioop.lin2ulaw(audio_chunk, 2)
+        return audio_chunk
 
     async def _rate_limit(self, frame_bytes: int) -> None:
         """Sleep if needed after sending frame_bytes to stay ≤ MAX_SEND_RATE_FACTOR × real-time.
@@ -168,6 +205,50 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         if elapsed < min_elapsed:
             await asyncio.sleep(min_elapsed - elapsed)
 
+    async def _send_frames(self, chunk: bytes, gen: int) -> str:
+        """Send `chunk` to Asterisk split into frames ≤ MAX_WS_FRAME_BYTES, rate-limited.
+
+        Shared by handle() and drain_local_queue(). Returns:
+          "sent"       — fully sent
+          "queue_full" — MEDIA_XOFF arrived mid-send; the unsent remainder was re-queued
+                         at the front of _local_audio_queue (preserves ordering)
+          "stale"      — a FLUSH_MEDIA/interruption bumped the generation; nothing more sent
+        """
+        offset = 0
+        while offset < len(chunk):
+            if gen != self._flush_generation:
+                return "stale"
+            if self.queue_full:
+                self._local_audio_queue.appendleft(chunk[offset:])
+                return "queue_full"
+            end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
+            if self._response_first_send == 0.0:
+                self._response_first_send = time.monotonic()
+            await self.websocket.send_bytes(chunk[offset:end])
+            await self._rate_limit(end - offset)
+            offset = end
+        return "sent"
+
+    def _register_mark(self, meta_info: dict, is_final: bool, audio_duration: float) -> None:
+        """Record per-mark metadata (same contract as Plivo/Twilio) so latency / heard-text
+        tracking works against Asterisk's duration-based playback completion."""
+        message_category = meta_info.get("message_category", "agent_response")
+        mark_id = meta_info.get("mark_id") or str(uuid.uuid4())
+        self.mark_event_meta_data.update_data(
+            mark_id,
+            {
+                "text_synthesized": meta_info.get("text_synthesized", "")
+                if meta_info.get("sequence_id") != -1
+                else "",
+                "type": message_category,
+                "is_first_chunk": meta_info.get("is_first_chunk", False),
+                "is_final_chunk": is_final,
+                "sequence_id": meta_info.get("sequence_id", 0),
+                "duration": audio_duration,
+                "sent_ts": time.time(),
+            },
+        )
+
     # ------------------------------------------------------------------
     # Interruption
     # ------------------------------------------------------------------
@@ -176,19 +257,18 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         """FLUSH_MEDIA, clear local queue, increment generation to drop stale audio."""
         logger.info("sip-trunk: handling interruption (FLUSH_MEDIA)")
         try:
-            if self._settle_task:
-                self._settle_task.cancel()
-                self._settle_task = None
-
+            self._reset_response_counters()
             self._flush_generation += 1
-            self._pending_finish = False
-            self._response_audio_duration = 0.0
-            self._response_first_send = 0.0
-            self._bytes_sent = 0
             self._current_sequence_id = None
             self._local_audio_queue.clear()
 
             await self._send_control("FLUSH_MEDIA")
+            # FLUSH_MEDIA tells Asterisk to drop its buffered audio, relieving any XOFF
+            # backpressure. Reset queue_full so the next response sends immediately instead
+            # of queuing behind stale backpressure state, and re-clear anything that raced
+            # into the queue during the FLUSH round-trip (all pre-interruption / stale).
+            self.queue_full = False
+            self._local_audio_queue.clear()
             # FLUSH_MEDIA resets Asterisk's buffering state; re-arm for next response
             self._start_buffering_sent = False
 
@@ -204,51 +284,48 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     # ------------------------------------------------------------------
 
     async def drain_local_queue(self):
-        """Send XOFF-queued audio to Asterisk (called on MEDIA_XON)."""
-        # Re-anchor the rate-limit budget to exclude the XOFF pause.
-        # During XOFF the wall clock kept running while _bytes_sent was frozen;
-        # without this, elapsed >> min_elapsed at drain start and _rate_limit
-        # returns immediately for every frame — the drain bursts at full TTS speed
-        # and immediately re-overflows Asterisk's frame queue.
-        if self._response_first_send > 0.0 and MAX_SEND_RATE_FACTOR > 0:
-            expected_elapsed = self._bytes_sent / (MAX_SEND_RATE_FACTOR * ULAW_BYTES_PER_SECOND)
-            self._response_first_send = time.monotonic() - expected_elapsed
-        gen = self._flush_generation
-        while self._local_audio_queue and not self.queue_full:
-            # Drop stale audio from before an interruption
-            if gen != self._flush_generation:
-                self._local_audio_queue.clear()
-                self._pending_finish = False
-                return
-            chunk = self._local_audio_queue.popleft()
-            if not chunk:
-                continue
-            try:
+        """Send XOFF-queued audio to Asterisk (called on MEDIA_XON).
+
+        Serialized via _drain_lock: a second MEDIA_XON waits for the in-flight drain
+        to finish (then re-scans the queue) rather than running concurrently.
+        """
+        async with self._drain_lock:
+            # Re-anchor the rate-limit budget to exclude the XOFF pause.
+            # During XOFF the wall clock kept running while _bytes_sent was frozen;
+            # without this, elapsed >> min_elapsed at drain start and _rate_limit
+            # returns immediately for every frame — the drain bursts at full TTS speed
+            # and immediately re-overflows Asterisk's frame queue.
+            if self._response_first_send > 0.0 and MAX_SEND_RATE_FACTOR > 0:
+                expected_elapsed = self._bytes_sent / (MAX_SEND_RATE_FACTOR * ULAW_BYTES_PER_SECOND)
+                self._response_first_send = time.monotonic() - expected_elapsed
+            gen = self._flush_generation
+            while self._local_audio_queue and not self.queue_full:
+                # Drop stale audio from before an interruption
+                if gen != self._flush_generation:
+                    self._local_audio_queue.clear()
+                    self._pending_finish = False
+                    return
+                chunk = self._local_audio_queue.popleft()
+                if not chunk:
+                    continue
                 if self._closed:
                     return
-                offset = 0
-                while offset < len(chunk):
-                    if gen != self._flush_generation:
-                        self._local_audio_queue.clear()
-                        self._pending_finish = False
-                        return
-                    if self.queue_full:
-                        # XOFF arrived mid-drain — put remainder back and stop
-                        self._local_audio_queue.appendleft(chunk[offset:])
-                        return
-                    end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
-                    if self._response_first_send == 0.0:
-                        self._response_first_send = time.monotonic()
-                    await self.websocket.send_bytes(chunk[offset:end])
-                    await self._rate_limit(end - offset)
-                    offset = end
-            except Exception as e:
-                logger.debug(f"sip-trunk drain send_bytes stopped: {e}")
-                return
+                try:
+                    status = await self._send_frames(chunk, gen)
+                except Exception as e:
+                    logger.debug(f"sip-trunk drain send_bytes stopped: {e}")
+                    return
+                if status == "stale":
+                    self._local_audio_queue.clear()
+                    self._pending_finish = False
+                    return
+                if status == "queue_full":
+                    # XOFF arrived mid-drain — remainder re-queued; stop until next XON.
+                    return
 
-        if not self._local_audio_queue and self._pending_finish:
-            self._pending_finish = False
-            self._schedule_finish(self._flush_generation)
+            if not self._local_audio_queue and self._pending_finish:
+                self._pending_finish = False
+                self._schedule_finish(self._flush_generation)
 
     # ------------------------------------------------------------------
     # Control helpers
@@ -269,6 +346,8 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     async def flush_media(self):
         await self._send_control("FLUSH_MEDIA")
 
+    # sip-trunk sends audio as raw binary frames and acks marks via duration tracking,
+    # so the JSON media/mark framing used by Twilio/Plivo is intentionally unused here.
     async def form_media_message(self, audio_data, audio_format="wav"):
         return None
 
@@ -283,11 +362,12 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     # ------------------------------------------------------------------
 
     async def handle(self, ws_data_packet):
+        """Send audio to Asterisk in bursts; track playback completion by accumulated
+        duration. Pipeline: convert → reset-on-new-sequence → buffer-gate → send (or
+        XOFF-queue) → register mark → schedule finish on the final chunk.
         """
-        Send audio directly to Asterisk in bursts. Asterisk's START_MEDIA_BUFFERING
-        reframes and retimes for smooth RTP. Server-side duration tracking knows
-        when playback ends.
-        """
+        if self._closed:
+            return
         try:
             audio_chunk = ws_data_packet.get("data")
             meta_info = ws_data_packet.get("meta_info") or {}
@@ -311,30 +391,19 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             if has_audio:
                 if len(audio_chunk) == 1:
                     audio_chunk += b"\x00"
-                if audio_format in ("pcm", "wav") or (len(audio_chunk) > 44 and audio_chunk[:4] == b"RIFF"):
-                    if audio_chunk[:4] == b"RIFF":
-                        audio_chunk = audio_chunk[44:]
-                    audio_chunk = audioop.lin2ulaw(audio_chunk, 2)
-                    audio_format = "ulaw"
+                audio_chunk = self._to_ulaw(audio_chunk, audio_format)
 
                 if meta_info.get("message_category") == "agent_welcome_message" and not self.welcome_message_sent_ts:
                     self.welcome_message_sent_ts = time.time() * 1000
 
-                # New response — reset duration tracking only when sequence_id
-                # actually changes.  ElevenLabs may spuriously set is_first_chunk
-                # on every chunk after the LLM stream ends, which would repeatedly
-                # reset the audio-duration accumulator and make the server think
-                # playback finishes far earlier than it actually does.
+                # New response — reset duration tracking only when sequence_id actually
+                # changes.  ElevenLabs may spuriously set is_first_chunk on every chunk
+                # after the LLM stream ends, which would repeatedly reset the audio-duration
+                # accumulator and make the server think playback finishes far too early.
                 seq_id = meta_info.get("sequence_id")
                 if seq_id is not None and seq_id != self._current_sequence_id:
                     self._current_sequence_id = seq_id
-                    self._response_first_send = 0.0
-                    self._response_audio_duration = 0.0
-                    self._bytes_sent = 0
-                    self._pending_finish = False
-                    if self._settle_task:
-                        self._settle_task.cancel()
-                        self._settle_task = None
+                    self._reset_response_counters()
 
                 # Send START_MEDIA_BUFFERING once per call (or after FLUSH_MEDIA reset)
                 if not self._start_buffering_sent:
@@ -343,58 +412,30 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     logger.info("sip-trunk: START_MEDIA_BUFFERING sent")
 
                 # Track audio duration
-                audio_duration = len(audio_chunk) / 8000.0
+                audio_duration = len(audio_chunk) / ULAW_BYTES_PER_SECOND
                 self._response_audio_duration += audio_duration
 
                 # Drop stale audio from a previous generation
                 if gen != self._flush_generation:
                     return
 
-                # Send to Asterisk in chunks ≤ MAX_WS_FRAME_BYTES (Asterisk limit: 65,500).
-                # If XOFF arrives mid-send, queue the remainder locally.
-                # Also queue if drain is still in-flight to preserve ordering.
+                # If XOFF is active or a drain is in flight, queue locally to preserve
+                # ordering; otherwise send now (re-queues the remainder on a mid-send XOFF).
                 if self.queue_full or self._local_audio_queue:
                     self._local_audio_queue.append(audio_chunk)
                 else:
-                    if self._response_first_send == 0.0:
-                        self._response_first_send = time.monotonic()
+                    if self._closed:
+                        return
                     try:
-                        if self._closed:
+                        if await self._send_frames(audio_chunk, gen) == "stale":
                             return
-                        offset = 0
-                        while offset < len(audio_chunk):
-                            if gen != self._flush_generation:
-                                return
-                            if self.queue_full:
-                                # XOFF arrived mid-send — queue remainder at front
-                                self._local_audio_queue.appendleft(audio_chunk[offset:])
-                                break
-                            end = min(offset + MAX_WS_FRAME_BYTES, len(audio_chunk))
-                            await self.websocket.send_bytes(audio_chunk[offset:end])
-                            await self._rate_limit(end - offset)
-                            offset = end
                     except Exception as e:
                         logger.debug(f"sip-trunk send_bytes stopped: {e}")
                         return
 
-            # Register mark metadata (same as Plivo/Twilio contract)
+            # Register mark metadata (same contract as Plivo/Twilio)
             if self.mark_event_meta_data:
-                message_category = meta_info.get("message_category", "agent_response")
-                mark_id = meta_info.get("mark_id") or str(uuid.uuid4())
-                self.mark_event_meta_data.update_data(
-                    mark_id,
-                    {
-                        "text_synthesized": meta_info.get("text_synthesized", "")
-                        if meta_info.get("sequence_id") != -1
-                        else "",
-                        "type": message_category,
-                        "is_first_chunk": meta_info.get("is_first_chunk", False),
-                        "is_final_chunk": is_final,
-                        "sequence_id": meta_info.get("sequence_id", 0),
-                        "duration": audio_duration,
-                        "sent_ts": time.time(),
-                    },
-                )
+                self._register_mark(meta_info, is_final, audio_duration)
 
                 if is_final:
                     if self._local_audio_queue:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.69"
+version = "0.10.70"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.67"
+version = "0.10.68"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Improvements to the sip-trunk telephony handlers.

- Input handler parses bare single-token Asterisk control frames, so MEDIA_XOFF/MEDIA_XON/QUEUE_DRAINED are honored. They were previously dropped, leaving the audio-backpressure queue unused and risking dropped frames on responses long enough to fill Asterisk's buffer.
- DTMF input accumulates digits and submits on '#' or after an inter-digit timeout (SIP_DTMF_INTERDIGIT_TIMEOUT_S, default 3s), instead of one LLM turn per keypress.
- Output handler resets backpressure state (queue_full and the local queue) on interruption so the next response sends immediately instead of stacking behind stale state. The frame-send loop is now shared between the live-send and XOFF-drain paths, drains are serialized, and a closed handler returns early.
- Module docstring aligned with actual behavior.