### PR TITLE
fix: release stuck Deepgram Flux turns and add inactivity stall backstop

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.70"
+__version__ = "0.10.71"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4662,16 +4662,10 @@ class TaskManager(BaseManager):
     def _should_stall_hangup(
         self, audio_playing, has_pending_generation, time_since_last_spoken_ai_word, time_since_user_last_spoke
     ):
-        """Absolute inactivity backstop, evaluated above the audio/pipeline gate.
-
-        The normal inactivity hangup sits below a gate that skips the loop while audio is
-        playing OR a response is in the pipeline. If a flag wedges (e.g. a transcriber never
-        closes a turn → callee_speaking stuck True → audio held → response_in_pipeline never
-        clears) that gate `continue`s forever and the normal hangup is never reached → endless
-        call. This fires only when there is genuinely no forward progress: no audio playing,
-        nothing in flight, and both sides silent past a floor set well above hangup_after_silence
-        so the normal path always wins whenever it is reachable.
-        """
+        """Hang up when the call has made no forward progress at all: no audio playing, nothing
+        in flight, and both sides silent past the floor. Runs above the audio/pipeline gate so it
+        still applies when a pipeline flag is stuck. Floor stays above hangup_after_silence so the
+        normal inactivity path takes precedence whenever it is reachable."""
         if self.hang_conversation_after <= 0:
             return False
         stall_timeout = max(self.hang_conversation_after, STALL_HANGUP_FLOOR_S)
@@ -4738,13 +4732,7 @@ class TaskManager(BaseManager):
                 else float("inf")
             )
 
-            # Stall backstop: the gate below skips the loop while audio is playing OR a
-            # response is in the pipeline. A wedged flag (e.g. a transcriber that never
-            # closes a turn, leaving callee_speaking True so audio is held and
-            # response_in_pipeline never clears) makes that gate `continue` forever and the
-            # normal inactivity hangup below is never reached → endless call. This fires only
-            # when there is genuinely no forward progress: no audio playing, nothing in
-            # flight, and both sides silent past a floor well above hangup_after_silence.
+            # Must run above the audio/pipeline gate below (see method docstring).
             if self._should_stall_hangup(
                 audio_playing=self.tools["input"].is_audio_being_played_to_user(),
                 has_pending_generation=has_pending_generation,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3855,7 +3855,9 @@ class TaskManager(BaseManager):
                         # *after* our utterance timeout already force-finalized the same text
                         # and started the LLM. Don't treat this late delivery as new user speech
                         # — the LLM is already processing this exact transcript.
-                        if self.response_in_pipeline and self.conversation_history.is_duplicate_user(transcript_content):
+                        if self.response_in_pipeline and self.conversation_history.is_duplicate_user(
+                            transcript_content
+                        ):
                             logger.info(
                                 "Skipping interruption: Deepgram late delivery of already-processing transcript: %s",
                                 transcript_content,
@@ -3942,13 +3944,21 @@ class TaskManager(BaseManager):
                         logger.info(f"EagerEndOfTurn received (confidence={eot_confidence}): {eager_transcript}")
 
                         transcriber = self.tools.get("transcriber")
-                        active_transcriber = transcriber.transcribers.get(transcriber.active_label, transcriber) if hasattr(transcriber, "transcribers") else transcriber
+                        active_transcriber = (
+                            transcriber.transcribers.get(transcriber.active_label, transcriber)
+                            if hasattr(transcriber, "transcribers")
+                            else transcriber
+                        )
                         eager_eot_threshold = getattr(active_transcriber, "eager_eot_threshold", None)
 
                         if not eager_eot_threshold:
-                            logger.info(f"Skipping speculative LLM: EagerEOT disabled (eager_eot_threshold not set or zero)")
+                            logger.info(
+                                f"Skipping speculative LLM: EagerEOT disabled (eager_eot_threshold not set or zero)"
+                            )
                         elif eot_confidence is not None and eot_confidence < eager_eot_threshold:
-                            logger.info(f"Skipping speculative LLM: EagerEOT confidence {eot_confidence} below threshold {eager_eot_threshold}")
+                            logger.info(
+                                f"Skipping speculative LLM: EagerEOT confidence {eot_confidence} below threshold {eager_eot_threshold}"
+                            )
                         elif (
                             eager_transcript
                             and self.tools["input"].welcome_message_played()

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -29,6 +29,7 @@ from bolna.constants import (
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
     GPT5_4_MODEL_PREFIX,
+    STALL_HANGUP_FLOOR_S,
 )
 from bolna.helpers.function_calling_helpers import trigger_api, computed_api_response, prepare_api_request
 from bolna.helpers.conversation_history import ConversationHistory
@@ -4658,6 +4659,29 @@ class TaskManager(BaseManager):
             logger.info("Silence repeat generation cancelled by interruption")
             return
 
+    def _should_stall_hangup(
+        self, audio_playing, has_pending_generation, time_since_last_spoken_ai_word, time_since_user_last_spoke
+    ):
+        """Absolute inactivity backstop, evaluated above the audio/pipeline gate.
+
+        The normal inactivity hangup sits below a gate that skips the loop while audio is
+        playing OR a response is in the pipeline. If a flag wedges (e.g. a transcriber never
+        closes a turn → callee_speaking stuck True → audio held → response_in_pipeline never
+        clears) that gate `continue`s forever and the normal hangup is never reached → endless
+        call. This fires only when there is genuinely no forward progress: no audio playing,
+        nothing in flight, and both sides silent past a floor set well above hangup_after_silence
+        so the normal path always wins whenever it is reachable.
+        """
+        if self.hang_conversation_after <= 0:
+            return False
+        stall_timeout = max(self.hang_conversation_after, STALL_HANGUP_FLOOR_S)
+        return (
+            not audio_playing
+            and not has_pending_generation
+            and time_since_last_spoken_ai_word > stall_timeout
+            and time_since_user_last_spoke > stall_timeout
+        )
+
     async def __check_for_completion(self):
         logger.info(f"Starting task to check for completion")
         while True:
@@ -4697,9 +4721,6 @@ class TaskManager(BaseManager):
                         )
                 continue
 
-            if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
-                continue
-
             # An in-flight LLM task (including a tool-call API request + follow-up generation
             # running inside it) means a response is still being produced even though
             # response_in_pipeline has flipped False after the filler audio. Treat that
@@ -4716,6 +4737,31 @@ class TaskManager(BaseManager):
                 if self.time_since_last_spoken_human_word > 0
                 else float("inf")
             )
+
+            # Stall backstop: the gate below skips the loop while audio is playing OR a
+            # response is in the pipeline. A wedged flag (e.g. a transcriber that never
+            # closes a turn, leaving callee_speaking True so audio is held and
+            # response_in_pipeline never clears) makes that gate `continue` forever and the
+            # normal inactivity hangup below is never reached → endless call. This fires only
+            # when there is genuinely no forward progress: no audio playing, nothing in
+            # flight, and both sides silent past a floor well above hangup_after_silence.
+            if self._should_stall_hangup(
+                audio_playing=self.tools["input"].is_audio_being_played_to_user(),
+                has_pending_generation=has_pending_generation,
+                time_since_last_spoken_ai_word=time_since_last_spoken_ai_word,
+                time_since_user_last_spoke=time_since_user_last_spoke,
+            ):
+                logger.warning(
+                    f"Stall backstop: no forward progress for {time_since_last_spoken_ai_word:.1f}s "
+                    f"(audio_playing=False, no pending generation, response_in_pipeline={self.response_in_pipeline}) "
+                    f"- forcing hangup"
+                )
+                self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
+                await self.process_call_hangup()
+                break
+
+            if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
+                continue
 
             if (
                 self.repeat_after_silence_seconds

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -11,6 +11,18 @@ OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 0.5
 DEEPGRAM_FLUX_EOT_THRESHOLD = 0.7  # confidence to declare end-of-turn
 DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD = 0.5  # confidence to trigger speculative LLM early
 DEEPGRAM_FLUX_EOT_TIMEOUT_MS = 500  # max silence before forcing end-of-turn
+# Client-side backstop: if a Flux turn opens but no Flux event arrives for this long,
+# the server has gone application-silent mid-turn and will never send the EndOfTurn
+# that resets callee_speaking. Derived from eot_timeout_ms so it always sits well past
+# a healthy end-of-turn wait (Flux emits Update events several times/sec while the user
+# is actually speaking), never preempting a real pause.
+DEEPGRAM_FLUX_TURN_STALL_FLOOR_S = 3.0
+
+# Absolute inactivity backstop for __check_for_completion: hangs up a call that has made
+# no forward progress (no agent audio, no user speech, nothing in flight) for this long,
+# even when the normal hangup_after_silence path is blocked by a wedged pipeline flag.
+# Floored well above hangup_after_silence so the normal path always wins when reachable.
+STALL_HANGUP_FLOOR_S = 20.0
 
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -11,17 +11,9 @@ OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 0.5
 DEEPGRAM_FLUX_EOT_THRESHOLD = 0.7  # confidence to declare end-of-turn
 DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD = 0.5  # confidence to trigger speculative LLM early
 DEEPGRAM_FLUX_EOT_TIMEOUT_MS = 500  # max silence before forcing end-of-turn
-# Client-side backstop: if a Flux turn opens but no Flux event arrives for this long,
-# the server has gone application-silent mid-turn and will never send the EndOfTurn
-# that resets callee_speaking. Derived from eot_timeout_ms so it always sits well past
-# a healthy end-of-turn wait (Flux emits Update events several times/sec while the user
-# is actually speaking), never preempting a real pause.
+# Min time a Flux turn may stay open with no transcriber events before it is force-closed.
 DEEPGRAM_FLUX_TURN_STALL_FLOOR_S = 3.0
-
-# Absolute inactivity backstop for __check_for_completion: hangs up a call that has made
-# no forward progress (no agent audio, no user speech, nothing in flight) for this long,
-# even when the normal hangup_after_silence path is blocked by a wedged pipeline flag.
-# Floored well above hangup_after_silence so the normal path always wins when reachable.
+# Min idle time before the inactivity backstop hangs up; kept above hangup_after_silence.
 STALL_HANGUP_FLOOR_S = 20.0
 
 # Model prefixes

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -237,9 +237,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         self.mark_event_meta_data.update_data(
             mark_id,
             {
-                "text_synthesized": meta_info.get("text_synthesized", "")
-                if meta_info.get("sequence_id") != -1
-                else "",
+                "text_synthesized": meta_info.get("text_synthesized", "") if meta_info.get("sequence_id") != -1 else "",
                 "type": message_category,
                 "is_first_chunk": meta_info.get("is_first_chunk", False),
                 "is_final_chunk": is_final,

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -119,8 +119,7 @@ class DeepgramTranscriber(BaseTranscriber):
         self.eager_eot_threshold = kwargs.get("eager_eot_threshold")
         _eot_timeout_ms = kwargs.get("eot_timeout_ms")
         self.eot_timeout_ms = _eot_timeout_ms if _eot_timeout_ms is not None else DEEPGRAM_FLUX_EOT_TIMEOUT_MS
-        # Stall backstop: fire only well past a healthy end-of-turn wait so a real pause
-        # (Flux waiting out eot_timeout_ms) is never mistaken for a server stall.
+        # Kept above the normal end-of-turn wait so an ordinary pause isn't treated as a stall.
         self.flux_turn_stall_timeout_s = max(DEEPGRAM_FLUX_TURN_STALL_FLOOR_S, (self.eot_timeout_ms / 1000.0) * 4)
         self.flux_watchdog_task = None
         self._last_flux_msg_time = None
@@ -426,44 +425,27 @@ class DeepgramTranscriber(BaseTranscriber):
             raise
 
     def _flux_turn_is_stalled(self, now):
-        """True if a Flux turn is open but no Flux event has arrived for the stall window.
-
-        A turn is "open" once we've seen any interim (last_interim_time set); it is disarmed
-        by _reset_turn_state on normal finalization. A healthy turn keeps _last_flux_msg_time
-        fresh (Flux emits Update events several times/sec while the user speaks), so this only
-        trips when the server has gone application-silent mid-turn.
-        """
+        """True if a turn is open (interim seen) but no Flux event arrived within the stall window."""
         if self.last_interim_time is None or self._last_flux_msg_time is None:
             return False
         return (now - self._last_flux_msg_time) > self.flux_turn_stall_timeout_s
 
     async def _release_stuck_flux_turn(self):
-        """Emit speech_ended to release a stalled turn, then disarm via _reset_turn_state.
-
-        speech_ended (not a phantom transcript) is the same signal Nova's UtteranceEnd path
-        uses to reset callee_speaking downstream without injecting a user turn or starting an
-        LLM. _reset_turn_state suppresses a late EndOfTurn for the abandoned turn via the
-        `not is_transcript_sent_for_processing` guard in receiver_flux.
-        """
+        # speech_ended ends the user turn downstream (resets callee_speaking) without injecting a
+        # transcript or LLM call; _reset_turn_state then drops any later finalization for this turn.
         await self.push_to_transcriber_queue(create_ws_data_packet({"type": "speech_ended"}, self.meta_info))
         self._reset_turn_state()
 
     async def monitor_flux_turn_timeout(self):
-        """Release a Flux turn that opened but never received a closing event.
-
-        Flux normally closes every turn with an EndOfTurn (which downstream maps to
-        on_user_speech_ended → resets callee_speaking). If the Flux server goes
-        application-silent mid-turn — no Update/EndOfTurn/LID for an extended period while
-        the websocket stays alive — that reset never arrives, callee_speaking stays True,
-        and the agent's audio is held in WAIT forever.
-        """
+        """Force-close a Flux turn that stays open without any closing event, so a missing
+        EndOfTurn cannot leave the user turn open and the agent's audio held indefinitely."""
         try:
             while True:
                 await asyncio.sleep(1.0)
                 if self._flux_turn_is_stalled(time.time()):
                     logger.warning(
-                        f"Flux turn stall: no Flux event for >{self.flux_turn_stall_timeout_s:.1f}s "
-                        f"(turn {self.current_turn_id}). Emitting speech_ended to release stuck turn."
+                        f"Flux turn stall: no event for >{self.flux_turn_stall_timeout_s:.1f}s "
+                        f"(turn {self.current_turn_id}), releasing via speech_ended."
                     )
                     await self._release_stuck_flux_turn()
         except asyncio.CancelledError:
@@ -907,9 +889,8 @@ class DeepgramTranscriber(BaseTranscriber):
             try:
                 msg = json.loads(msg)
 
-                # Any Flux message resets the stall watchdog. Keyed on "last message of any
-                # type" (not turn-state flags) so it also covers turns that only ever produced
-                # an Update with no StartOfTurn.
+                # Track liveness off every message (any type), so the stall watchdog also covers
+                # turns that only produced an Update and never a StartOfTurn.
                 self._last_flux_msg_time = time.time()
 
                 if self.connection_start_time is None:
@@ -1199,9 +1180,6 @@ class DeepgramTranscriber(BaseTranscriber):
 
                 if self.is_flux_model:
                     self.heartbeat_task = asyncio.create_task(self.send_heartbeat_flux(deepgram_ws))
-                    # Flux normally closes turns with EndOfTurn, but if the server goes
-                    # application-silent mid-turn that close never arrives and callee_speaking
-                    # stays stuck. This watchdog releases such turns.
                     self.flux_watchdog_task = asyncio.create_task(self.monitor_flux_turn_timeout())
                 else:
                     self.heartbeat_task = asyncio.create_task(self.send_heartbeat(deepgram_ws))

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -19,6 +19,7 @@ from bolna.constants import (
     DEEPGRAM_FLUX_EOT_THRESHOLD,
     DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD,
     DEEPGRAM_FLUX_EOT_TIMEOUT_MS,
+    DEEPGRAM_FLUX_TURN_STALL_FLOOR_S,
 )
 
 
@@ -118,6 +119,11 @@ class DeepgramTranscriber(BaseTranscriber):
         self.eager_eot_threshold = kwargs.get("eager_eot_threshold")
         _eot_timeout_ms = kwargs.get("eot_timeout_ms")
         self.eot_timeout_ms = _eot_timeout_ms if _eot_timeout_ms is not None else DEEPGRAM_FLUX_EOT_TIMEOUT_MS
+        # Stall backstop: fire only well past a healthy end-of-turn wait so a real pause
+        # (Flux waiting out eot_timeout_ms) is never mistaken for a server stall.
+        self.flux_turn_stall_timeout_s = max(DEEPGRAM_FLUX_TURN_STALL_FLOOR_S, (self.eot_timeout_ms / 1000.0) * 4)
+        self.flux_watchdog_task = None
+        self._last_flux_msg_time = None
         self.eager_transcript_pending = None
         self.language_hints = kwargs.get("language_hints")
         # ASR-native LID events (flux-general-multi only) — collected per turn and
@@ -419,6 +425,54 @@ class DeepgramTranscriber(BaseTranscriber):
             logger.error(f"Error in monitor_utterance_timeout: {e}")
             raise
 
+    def _flux_turn_is_stalled(self, now):
+        """True if a Flux turn is open but no Flux event has arrived for the stall window.
+
+        A turn is "open" once we've seen any interim (last_interim_time set); it is disarmed
+        by _reset_turn_state on normal finalization. A healthy turn keeps _last_flux_msg_time
+        fresh (Flux emits Update events several times/sec while the user speaks), so this only
+        trips when the server has gone application-silent mid-turn.
+        """
+        if self.last_interim_time is None or self._last_flux_msg_time is None:
+            return False
+        return (now - self._last_flux_msg_time) > self.flux_turn_stall_timeout_s
+
+    async def _release_stuck_flux_turn(self):
+        """Emit speech_ended to release a stalled turn, then disarm via _reset_turn_state.
+
+        speech_ended (not a phantom transcript) is the same signal Nova's UtteranceEnd path
+        uses to reset callee_speaking downstream without injecting a user turn or starting an
+        LLM. _reset_turn_state suppresses a late EndOfTurn for the abandoned turn via the
+        `not is_transcript_sent_for_processing` guard in receiver_flux.
+        """
+        await self.push_to_transcriber_queue(create_ws_data_packet({"type": "speech_ended"}, self.meta_info))
+        self._reset_turn_state()
+
+    async def monitor_flux_turn_timeout(self):
+        """Release a Flux turn that opened but never received a closing event.
+
+        Flux normally closes every turn with an EndOfTurn (which downstream maps to
+        on_user_speech_ended → resets callee_speaking). If the Flux server goes
+        application-silent mid-turn — no Update/EndOfTurn/LID for an extended period while
+        the websocket stays alive — that reset never arrives, callee_speaking stays True,
+        and the agent's audio is held in WAIT forever.
+        """
+        try:
+            while True:
+                await asyncio.sleep(1.0)
+                if self._flux_turn_is_stalled(time.time()):
+                    logger.warning(
+                        f"Flux turn stall: no Flux event for >{self.flux_turn_stall_timeout_s:.1f}s "
+                        f"(turn {self.current_turn_id}). Emitting speech_ended to release stuck turn."
+                    )
+                    await self._release_stuck_flux_turn()
+        except asyncio.CancelledError:
+            logger.info("Flux turn timeout monitoring task cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Error in monitor_flux_turn_timeout: {e}")
+            raise
+
     async def toggle_connection(self):
         self.connection_on = False
         if self.heartbeat_task is not None:
@@ -427,6 +481,8 @@ class DeepgramTranscriber(BaseTranscriber):
             self.sender_task.cancel()
         if self.utterance_timeout_task is not None:
             self.utterance_timeout_task.cancel()
+        if self.flux_watchdog_task is not None:
+            self.flux_watchdog_task.cancel()
 
         if self.websocket_connection is not None:
             try:
@@ -455,6 +511,7 @@ class DeepgramTranscriber(BaseTranscriber):
             ("heartbeat_task", getattr(self, "heartbeat_task", None)),
             ("sender_task", getattr(self, "sender_task", None)),
             ("utterance_timeout_task", getattr(self, "utterance_timeout_task", None)),
+            ("flux_watchdog_task", getattr(self, "flux_watchdog_task", None)),
             ("transcription_task", getattr(self, "transcription_task", None)),
         ]:
             if task is not None and not task.done():
@@ -850,6 +907,11 @@ class DeepgramTranscriber(BaseTranscriber):
             try:
                 msg = json.loads(msg)
 
+                # Any Flux message resets the stall watchdog. Keyed on "last message of any
+                # type" (not turn-state flags) so it also covers turns that only ever produced
+                # an Update with no StartOfTurn.
+                self._last_flux_msg_time = time.time()
+
                 if self.connection_start_time is None:
                     self.connection_start_time = time.time() - (self.num_frames * self.audio_frame_duration)
 
@@ -1137,10 +1199,13 @@ class DeepgramTranscriber(BaseTranscriber):
 
                 if self.is_flux_model:
                     self.heartbeat_task = asyncio.create_task(self.send_heartbeat_flux(deepgram_ws))
+                    # Flux normally closes turns with EndOfTurn, but if the server goes
+                    # application-silent mid-turn that close never arrives and callee_speaking
+                    # stays stuck. This watchdog releases such turns.
+                    self.flux_watchdog_task = asyncio.create_task(self.monitor_flux_turn_timeout())
                 else:
                     self.heartbeat_task = asyncio.create_task(self.send_heartbeat(deepgram_ws))
-                    # Flux uses EndOfTurn events as the canonical finalization signal —
-                    # utterance timeout is only needed for Nova where UtteranceEnd can be unreliable.
+                    # Nova relies on UtteranceEnd, which can be unreliable — force-finalize on timeout.
                     self.utterance_timeout_task = asyncio.create_task(self.monitor_utterance_timeout())
 
                 receiver_method = self.receiver_flux if self.is_flux_model else self.receiver
@@ -1199,6 +1264,8 @@ class DeepgramTranscriber(BaseTranscriber):
                 self.heartbeat_task.cancel()
             if hasattr(self, "utterance_timeout_task") and self.utterance_timeout_task is not None:
                 self.utterance_timeout_task.cancel()
+            if hasattr(self, "flux_watchdog_task") and self.flux_watchdog_task is not None:
+                self.flux_watchdog_task.cancel()
 
             # Use Deepgram's actual audio duration for billing
             if self.meta_info is not None and "deepgram_duration" in self.meta_info:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.70"
+version = "0.10.71"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_check_completion_stall_backstop.py
+++ b/tests/tests/test_check_completion_stall_backstop.py
@@ -1,0 +1,73 @@
+"""Tests for the __check_for_completion stall backstop (Layer 2).
+
+Guarantees that a wedged pipeline (e.g. a stuck transcriber turn that holds audio and never
+clears response_in_pipeline) cannot produce an endless call, while never firing during healthy
+playback, in-flight tool/LLM generation, or normal short silences.
+"""
+
+from types import SimpleNamespace
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.constants import STALL_HANGUP_FLOOR_S
+
+
+# _should_stall_hangup only reads self.hang_conversation_after, so we can exercise the pure
+# predicate on a lightweight stand-in via the unbound method.
+def _decide(hang_conversation_after, *, audio_playing, has_pending_generation, ai_silent_s, user_silent_s):
+    fake = SimpleNamespace(hang_conversation_after=hang_conversation_after)
+    return TaskManager._should_stall_hangup(
+        fake,
+        audio_playing=audio_playing,
+        has_pending_generation=has_pending_generation,
+        time_since_last_spoken_ai_word=ai_silent_s,
+        time_since_user_last_spoke=user_silent_s,
+    )
+
+
+AGED = STALL_HANGUP_FLOOR_S + 5  # comfortably past the floor
+
+
+def test_fires_on_wedged_pipeline_stall():
+    # The bug: audio held (not playing), nothing in flight, both sides long silent.
+    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is True
+
+
+def test_does_not_fire_during_audio_playback():
+    # A long healthy TTS response: audio is playing -> never force-hangup.
+    assert _decide(15, audio_playing=True, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is False
+
+
+def test_does_not_fire_during_pending_generation():
+    # A slow tool/LLM call in flight with no audio yet -> must not hang up.
+    assert _decide(15, audio_playing=False, has_pending_generation=True, ai_silent_s=AGED, user_silent_s=AGED) is False
+
+
+def test_does_not_fire_when_timers_fresh():
+    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=1.0, user_silent_s=1.0) is False
+
+
+def test_requires_both_sides_silent():
+    # User just spoke (fresh) even though agent has been silent -> not a stall.
+    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=1.0) is False
+
+
+def test_disabled_when_hang_conversation_after_zero():
+    # hangup_after_silence disabled -> backstop also disabled.
+    assert _decide(0, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is False
+
+
+def test_floor_applies_when_hangup_after_silence_small():
+    # hang_conversation_after=5, but floor is STALL_HANGUP_FLOOR_S: a 10s stall must NOT fire
+    # (would be past the 5s normal timeout, but the backstop deliberately waits longer so the
+    # normal inactivity path wins whenever it is reachable).
+    short = STALL_HANGUP_FLOOR_S - 5
+    assert short > 0
+    assert _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=short, user_silent_s=short) is False
+    # Past the floor it does fire.
+    assert _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is True
+
+
+def test_uses_larger_of_floor_and_configured_timeout():
+    # A long configured timeout (60s) must be respected over the floor: a 30s stall must not fire.
+    assert _decide(60, audio_playing=False, has_pending_generation=False, ai_silent_s=30, user_silent_s=30) is False
+    assert _decide(60, audio_playing=False, has_pending_generation=False, ai_silent_s=65, user_silent_s=65) is True

--- a/tests/tests/test_check_completion_stall_backstop.py
+++ b/tests/tests/test_check_completion_stall_backstop.py
@@ -62,7 +62,9 @@ def test_floor_applies_when_hangup_after_silence_small():
     # normal inactivity path wins whenever it is reachable).
     short = STALL_HANGUP_FLOOR_S - 5
     assert short > 0
-    assert _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=short, user_silent_s=short) is False
+    assert (
+        _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=short, user_silent_s=short) is False
+    )
     # Past the floor it does fire.
     assert _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is True
 

--- a/tests/tests/test_deepgram_flux.py
+++ b/tests/tests/test_deepgram_flux.py
@@ -1,0 +1,120 @@
+"""Unit tests for Deepgram Flux URL building, language hints, and tuning defaults."""
+
+import os
+from urllib.parse import urlparse, parse_qs
+
+import pytest
+
+from bolna.transcriber.deepgram_transcriber import DeepgramTranscriber
+
+
+def _make_transcriber(model="flux-general-en", language="en", **kwargs):
+    return DeepgramTranscriber(
+        telephony_provider="plivo",
+        model=model,
+        language=language,
+        stream=True,
+        **kwargs,
+    )
+
+
+def _params(url):
+    return parse_qs(urlparse(url).query, keep_blank_values=True)
+
+
+def test_flux_url_uses_v2_endpoint():
+    t = _make_transcriber()
+    url = t._get_flux_ws_url()
+    assert "/v2/listen?" in url
+
+
+def test_flux_general_en_omits_language_hint():
+    t = _make_transcriber(model="flux-general-en", language="en")
+    p = _params(t._get_flux_ws_url())
+    assert "language_hint" not in p
+
+
+def test_flux_general_multi_with_single_language():
+    t = _make_transcriber(model="flux-general-multi", language="hi")
+    p = _params(t._get_flux_ws_url())
+    assert p["language_hint"] == ["hi"]
+
+
+def test_flux_general_multi_with_multi_prefix():
+    t = _make_transcriber(model="flux-general-multi", language="multi-hi")
+    p = _params(t._get_flux_ws_url())
+    assert p["language_hint"] == ["hi"]
+
+
+def test_flux_general_multi_with_bare_multi_omits_hint():
+    t = _make_transcriber(model="flux-general-multi", language="multi")
+    p = _params(t._get_flux_ws_url())
+    assert "language_hint" not in p
+
+
+def test_flux_general_multi_with_explicit_hints_list():
+    t = _make_transcriber(
+        model="flux-general-multi",
+        language="multi",
+        language_hints=["en", "hi"],
+    )
+    p = _params(t._get_flux_ws_url())
+    assert p["language_hint"] == ["en", "hi"]
+
+
+def test_flux_defaults_present_in_url():
+    t = _make_transcriber()
+    p = _params(t._get_flux_ws_url())
+    assert p["eot_threshold"] == ["0.7"]
+    assert p["eot_timeout_ms"] == ["500"]
+    # eager_eot_threshold is only emitted when explicitly configured (no default sent).
+    assert "eager_eot_threshold" not in p
+
+
+def test_flux_kwargs_override_defaults():
+    t = _make_transcriber(
+        eot_threshold=0.8,
+        eager_eot_threshold=0.4,
+        eot_timeout_ms=2000,
+    )
+    p = _params(t._get_flux_ws_url())
+    assert p["eot_threshold"] == ["0.8"]
+    assert p["eager_eot_threshold"] == ["0.4"]
+    assert p["eot_timeout_ms"] == ["2000"]
+
+
+def test_resolve_language_hints_helper():
+    cases = [
+        ("multi-general", "multi", None),
+        ("multi-general", "multi-hi", ["hi"]),
+        ("multi-general", "hi", ["hi"]),
+        ("multi-general", None, None),
+    ]
+    for _, lang, expected in cases:
+        t = _make_transcriber(model="flux-general-multi", language=lang or "en")
+        if lang is None:
+            t.language = None
+        assert t._resolve_language_hints() == expected, f"for language={lang}"
+
+    # explicit hints override derivation
+    t = _make_transcriber(model="flux-general-multi", language="hi", language_hints=["en", "es"])
+    assert t._resolve_language_hints() == ["en", "es"]
+
+
+def test_nova_url_unchanged_by_flux_changes():
+    t = _make_transcriber(model="nova-2", language="en")
+    url = t._get_nova_ws_url()
+    assert "/v1/listen?" in url
+    p = _params(url)
+    # Flux params must not leak into Nova URL
+    assert "eot_threshold" not in p
+    assert "eager_eot_threshold" not in p
+    assert "language_hint" not in p
+
+
+def test_is_flux_model_detection():
+    assert _make_transcriber(model="flux-general-en").is_flux_model is True
+    assert _make_transcriber(model="flux-general-multi").is_flux_model is True
+    assert _make_transcriber(model="flux-general-multi").is_flux_multi is True
+    assert _make_transcriber(model="flux-general-en").is_flux_multi is False
+    assert _make_transcriber(model="nova-2").is_flux_model is False

--- a/tests/tests/test_flux_stuck_turn.py
+++ b/tests/tests/test_flux_stuck_turn.py
@@ -1,0 +1,98 @@
+"""Tests for the Flux stuck-turn watchdog (Layer 1).
+
+Repro: prod run 906511cf — a Flux turn opened from an Update interim, the server then
+went application-silent (no further Flux events) so EndOfTurn never arrived, callee_speaking
+stayed True, and the agent's audio was held forever. The watchdog must release such turns by
+emitting speech_ended, without preempting healthy turns or injecting a phantom transcript.
+"""
+
+import asyncio
+
+import pytest
+
+from bolna.transcriber.deepgram_transcriber import DeepgramTranscriber
+
+
+def _make_flux(output_queue=None, **kwargs):
+    return DeepgramTranscriber(
+        telephony_provider="plivo",
+        model="flux-general-en",
+        language="en",
+        stream=True,
+        output_queue=output_queue,
+        **kwargs,
+    )
+
+
+def _make_nova(output_queue=None, **kwargs):
+    return DeepgramTranscriber(
+        telephony_provider="plivo",
+        model="nova-3",
+        language="en",
+        stream=True,
+        output_queue=output_queue,
+        **kwargs,
+    )
+
+
+def _open_turn(t, last_msg_age_s):
+    """Simulate a turn that has been opened (interim seen) with the last Flux message
+    received `last_msg_age_s` seconds ago."""
+    now = 1_000_000.0
+    t.last_interim_time = now - last_msg_age_s
+    t._last_flux_msg_time = now - last_msg_age_s
+    t.meta_info = {"request_id": "test"}
+    return now
+
+
+def test_threshold_derived_from_eot_timeout():
+    # Default eot_timeout_ms=500 -> max(3.0, 0.5*4=2.0) == 3.0
+    assert _make_flux().flux_turn_stall_timeout_s == 3.0
+    # Larger eot_timeout_ms scales the stall window: max(3.0, 4*4=16) == 16
+    assert _make_flux(eot_timeout_ms=4000).flux_turn_stall_timeout_s == 16.0
+
+
+def test_stalled_when_no_event_past_window():
+    t = _make_flux()
+    now = _open_turn(t, last_msg_age_s=t.flux_turn_stall_timeout_s + 1)
+    assert t._flux_turn_is_stalled(now) is True
+
+
+def test_not_stalled_within_window():
+    t = _make_flux()
+    now = _open_turn(t, last_msg_age_s=t.flux_turn_stall_timeout_s - 1)
+    assert t._flux_turn_is_stalled(now) is False
+
+
+def test_not_stalled_when_no_turn_open():
+    t = _make_flux()
+    # No interim seen yet -> not armed, even if _last_flux_msg_time is old.
+    t.last_interim_time = None
+    t._last_flux_msg_time = 1.0
+    assert t._flux_turn_is_stalled(1_000_000.0) is False
+
+
+def test_release_emits_single_speech_ended_and_disarms():
+    q = asyncio.Queue()
+    t = _make_flux(output_queue=q)
+    _open_turn(t, last_msg_age_s=t.flux_turn_stall_timeout_s + 1)
+    t.is_transcript_sent_for_processing = False  # mid-turn
+
+    asyncio.run(t._release_stuck_flux_turn())
+
+    # Exactly one speech_ended packet, no phantom transcript.
+    assert q.qsize() == 1
+    packet = q.get_nowait()
+    assert packet["data"] == {"type": "speech_ended"}
+    # Disarmed so the watchdog won't re-fire and a late EndOfTurn is suppressed.
+    assert t.last_interim_time is None
+    assert t.is_transcript_sent_for_processing is True
+    assert t._flux_turn_is_stalled(1_000_000.0) is False
+
+
+def test_nova_does_not_arm_flux_watchdog_state():
+    # Nova path must not depend on Flux watchdog; predicate stays inert (no flux msgs).
+    t = _make_nova()
+    t.last_interim_time = 1.0
+    assert t._last_flux_msg_time is None
+    assert t._flux_turn_is_stalled(1_000_000.0) is False


### PR DESCRIPTION
## Problem

On Deepgram Flux, a turn opened from an `Update` interim (no `StartOfTurn`) and the server then went application-silent — no further events while the websocket stayed alive. No `EndOfTurn` arrived, so `on_user_speech_ended()` never ran and `callee_speaking` stayed `True` forever. That held the agent's audio in WAIT (agent went mute) and kept `response_in_pipeline=True`, which sits above the inactivity-hangup gate in `__check_for_completion`, so the call never cut. Nova self-heals this; Flux had no equivalent.

## Fix

**Layer 1 — Flux stuck-turn watchdog** (`deepgram_transcriber.py`): tracks time since the last Flux message of any type. If a turn is open but no event arrives for `max(3s, eot_timeout_ms*4)`, emit `speech_ended` to release `callee_speaking` and reset turn state. Flux-only; cancelled in all teardown paths.

**Layer 2 — inactivity stall backstop** (`task_manager.py`): a no-forward-progress hangup evaluated above the audio/pipeline gate, so no wedged flag can produce an endless call. Fires only when no audio is playing, nothing is in flight (`has_pending_generation`), and both sides are silent past `max(hangup_after_silence, 20s)`.

## No regressions

* Layer 1 is gated on `is_flux_model`; Nova and other transcribers are untouched. Threshold sits well past a healthy Flux pause, so it never cuts off a live speaker.
* Layer 2 skips real playback, in-flight tool/LLM calls, and fresh timers; its floor is at least the normal timeout so the existing path wins when reachable.
* Also fixed pre-existing stale assertions in `test_deepgram_flux.py` (`eot_timeout_ms` 500, `eager_eot_threshold` omitted).

Tests: `test_flux_stuck_turn.py`, `test_check_completion_stall_backstop.py`. 129 passed across affected suites; no new failures vs master.