### PR TITLE
feat: apply account/call service_tier to graph routing LLM calls

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.71"
+__version__ = "0.10.72"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3089,6 +3089,7 @@ class TaskManager(BaseManager):
                                 "output_tokens": routing_usage.get("output_tokens"),
                                 "reasoning_tokens": routing_usage.get("reasoning_tokens"),
                                 "cached_tokens": routing_usage.get("cached_tokens"),
+                                "service_tier": routing_usage.get("service_tier"),
                             }
                         )
 

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -81,6 +81,7 @@ class GraphAgent(BaseAgent):
         self.routing_instructions = self.config.get("routing_instructions")  # Custom routing instructions
         self.routing_reasoning_effort = self.config.get("routing_reasoning_effort")
         self.routing_max_tokens = self.config.get("routing_max_tokens")
+        self.service_tier = self.config.get("service_tier")
         logger.info(
             f"GraphAgent routing_instructions loaded: {bool(self.routing_instructions)} (length: {len(self.routing_instructions) if self.routing_instructions else 0})"
         )
@@ -520,6 +521,10 @@ class GraphAgent(BaseAgent):
                 routing_kwargs["max_tokens"] = self.routing_max_tokens or 250
                 routing_kwargs["temperature"] = 0.0
 
+            # Groq uses a different service_tier vocabulary, so only forward it to OpenAI routing
+            if self.routing_provider == "openai" and self.service_tier:
+                routing_kwargs["service_tier"] = self.service_tier
+
             response = await asyncio.to_thread(self.routing_client.chat.completions.create, **routing_kwargs)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
@@ -535,6 +540,7 @@ class GraphAgent(BaseAgent):
                     "cached_tokens": response.usage.prompt_tokens_details.cached_tokens
                     if response.usage.prompt_tokens_details
                     else None,
+                    "service_tier": getattr(response, "service_tier", None),
                 }
 
             # Extract the function call

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.71"
+version = "0.10.72"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Graph routing makes a separate OpenAI call that ignored the account/call `service_tier`, so it ran on `default` while the response LLM ran on `priority`. This forwards the existing `service_tier` to the routing call (OpenAI only, since Groq uses a different vocabulary) and records the served tier in `routing_latencies.turn_latencies[].service_tier`.