### PR TITLE
feat: add gpt-5 reasoning_effort and verbosity to latency telemetry

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.72"
+__version__ = "0.10.73"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3079,6 +3079,7 @@ class TaskManager(BaseManager):
                                 "routing_end_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
                                 "routing_model": routing_info.get("routing_model"),
                                 "routing_provider": routing_info.get("routing_provider"),
+                                "routing_reasoning_effort": routing_info.get("routing_reasoning_effort"),
                                 "previous_node": routing_info.get("previous_node"),
                                 "current_node": routing_info.get("current_node"),
                                 "transitioned": routing_info.get("transitioned", False),

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -525,6 +525,8 @@ class GraphAgent(BaseAgent):
             if self.routing_provider == "openai" and self.service_tier:
                 routing_kwargs["service_tier"] = self.service_tier
 
+            self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
+
             response = await asyncio.to_thread(self.routing_client.chat.completions.create, **routing_kwargs)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
@@ -885,6 +887,7 @@ class GraphAgent(BaseAgent):
                     "routing_model": self.routing_model,
                     "routing_provider": getattr(self, "routing_provider", None),
                     "routing_latency_ms": round(routing_latency_ms, 1),
+                    "routing_reasoning_effort": getattr(self, "_routing_reasoning_effort_used", None),
                     "extracted_params": extracted_params or {},
                     "node_history": list(self.node_history),
                     "routing_messages": routing_messages,

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -458,6 +458,8 @@ class OpenAICompatibleLLM(BaseLLM):
                     total_stream_duration_ms=None,
                     service_tier=service_tier,
                     llm_host=llm_host,
+                    reasoning_effort=self.model_args.get("reasoning_effort"),
+                    verbosity=self.model_args.get("verbosity"),
                 )
 
             if event.type == ResponseStreamEvent.OUTPUT_TEXT_DELTA:

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -19,6 +19,8 @@ class LatencyData(BaseModel):
     connection_latency_ms: Optional[float] = None
     service_tier: Optional[str] = None
     llm_host: Optional[str] = None
+    reasoning_effort: Optional[str] = None
+    verbosity: Optional[str] = None
 
 
 class FunctionCallPayload(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.72"
+version = "0.10.73"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
GPT-5 `reasoning_effort` and `verbosity` are sent to the OpenAI Responses API but never carried into the per-turn latency payload, so latency cannot be sliced by either in the `voiceai.llm.*` dashboards. `reasoning_effort` is a major lever on first-token latency.

This stamps both onto the latency data the same way `service_tier`/`llm_host` already flow.

1. `llms/types.py` adds `reasoning_effort` and `verbosity` to `LatencyData`.
2. `llms/openai_base.py` populates them from `self.model_args` (the exact dict sent to OpenAI, so defaults are reflected) in the first-token branch. Covers OpenAI and Azure since both subclass `OpenAICompatibleLLM`.
3. `agent_types/graph_agent.py` surfaces the effective routing `reasoning_effort` into `routing_info`.
4. `agent_manager/task_manager.py` carries it onto the routing latency turn.

Fields flow through `model_dump()` into the turn dicts automatically. The dashboard-backend side tags these onto the Datadog metrics in a companion PR.