### PR TITLE
fix: log underlying httpx cause on LLM connection errors

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.75"
+__version__ = "0.10.76"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -164,7 +164,7 @@ class AzureLLM(OpenAICompatibleLLM):
             logger.error(f"Azure OpenAI rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"Azure OpenAI connection error: {e}")
+            logger.error(f"Azure OpenAI connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"Azure OpenAI API error: {e}")
@@ -354,7 +354,7 @@ class AzureLLM(OpenAICompatibleLLM):
             logger.error(f"Azure OpenAI rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"Azure OpenAI connection error: {e}")
+            logger.error(f"Azure OpenAI connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"Azure OpenAI API error: {e}")

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -115,7 +115,7 @@ class LiteLLM(BaseLLM):
             logger.error(f"LiteLLM rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"LiteLLM connection error: {e}")
+            logger.error(f"LiteLLM connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"LiteLLM API error: {e}")
@@ -221,7 +221,7 @@ class LiteLLM(BaseLLM):
             logger.error(f"LiteLLM rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"LiteLLM connection error: {e}")
+            logger.error(f"LiteLLM connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"LiteLLM API error: {e}")

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -275,7 +275,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             logger.error(f"OpenAI rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"OpenAI connection error: {e}")
+            logger.error(f"OpenAI connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"OpenAI API error: {e}")
@@ -475,7 +475,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             logger.error(f"OpenAI rate limit exceeded: {e}")
             raise
         except APIConnectionError as e:
-            logger.error(f"OpenAI connection error: {e}")
+            logger.error(f"OpenAI connection error: {e} | cause: {e.__cause__!r}")
             raise
         except APIError as e:
             logger.error(f"OpenAI API error: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.75"
+version = "0.10.76"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
OpenAI/Azure/LiteLLM `APIConnectionError` always stringifies to the literal "Connection error.", so Loki can't tell apart a pool exhaustion, a connect timeout, a DNS failure, or an HTTP/2 reset. The real exception is on `__cause__`.

This appends `| cause: {e.__cause__!r}` at the six `except APIConnectionError` sites, turning "Connection error." into e.g. `PoolTimeout('')`, `ConnectError(...)`, or `RemoteProtocolError(...)` so recurrences are self-diagnosing. Logging-only, no behavior change.