### PR TITLE
Resolve URL query placeholders for GET function-call tools

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.70"
+__version__ = "0.10.71"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 
 import aiohttp
+import yarl
 from bolna.helpers.logger_config import configure_logger
 from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, format_error_message
@@ -128,8 +129,18 @@ async def trigger_api(
         )
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
             if method.lower() == "get":
-                logger.info(f"Sending request {request_body}, {url}, {headers}")
-                async with session.get(url, params=api_params, headers=headers) as response:
+                # GET params may be embedded in the URL query as %(name)s placeholders; substitute
+                # them in place (targeted replace keeps literal %XX intact) and append only params
+                # not already present, so aiohttp doesn't create duplicate query keys.
+                for k, v in kwargs.items():
+                    if v is not None:
+                        url = url.replace(f"%({k})s", str(v))
+                target = yarl.URL(url, encoded=True)
+                extra = {k: v for k, v in (api_params or {}).items() if k not in target.query}
+                if extra:
+                    target = target.update_query(extra)
+                logger.info(f"Sending request {request_body}, {target}, {headers}")
+                async with session.get(target, headers=headers) as response:
                     response_text = await response.text()
             elif method.lower() == "post":
                 logger.info(f"Sending request {api_params}, {url}, {headers}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.70"
+version = "0.10.71"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
GET function-call tools that embed params in the URL query as `%(name)s` placeholders (e.g. Ozonetel IVRTransfer) left the placeholders unsubstituted in the URL and appended the resolved params separately via `params=`. aiohttp appends rather than replaces, so the request carried duplicate query keys — `ucid=%(ucid)s&...&ucid=35080402444366903`. The provider reads the first occurrence (the literal placeholder) and returns `{"status":"Error","message":"call not found"}`, while the equivalent hand-built curl succeeds. The fix substitutes `%(name)s` placeholders directly in the URL (targeted replace, so an already-encoded `appURL` survives) and appends only request_template params not already present in the URL query. GET tools with no URL query and POST are unaffected.