### PR TITLE
fix: disable http2 on openai client to stop barge-in stream leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.76"
+__version__ = "0.10.77"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -170,7 +170,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")
 
-        http_client = get_shared_http_client(base_url=kwargs.get("base_url"), http2=True)
+        # http2=False: cancelled h2 requests leak streams until the connection pins at 100 (barge-in)
+        http_client = get_shared_http_client(base_url=kwargs.get("base_url"), http2=False)
 
         if kwargs.get("provider", "openai") == "custom":
             base_url = kwargs.get("base_url")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.76"
+version = "0.10.77"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
OpenAI calls fail in bursts with `APIConnectionError` / `LocalProtocolError('Max outbound streams is 100, 100 open')`, concentrated on high-volume tenants.

Root cause: cancelling an in-flight httpx HTTP/2 request (barge-in, interruptions, task cancellation) does not emit `RST_STREAM`, so the stream is never freed on the shared connection. Leaked streams accumulate until the connection pins at OpenAI's 100-concurrent-stream cap, after which every subsequent request on that connection fails. The shared pool keeps the connection alive long enough to fill.

Reproduced deterministically against a local HTTP/2 origin (same httpcore 1.0.9 / h2 4.3.0): 120 cancelled-mid-flight requests leak 100 streams (server sees `opened=100, reset=0`), then follow-up requests all fail with the exact error. With `http2=False` the same load passes 5/5 — HTTP/1.1 has no multiplexed streams to leak. `azure_llm` already runs `http2=False`, which is why only `openai_llm` ever logged this.