### PR TITLE
feat: Sarvam single-connection multilingual via unknown auto-detect

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.79"
+__version__ = "0.10.80"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3804,6 +3804,16 @@ class TaskManager(BaseManager):
                 TranscriberError(connection_error, provider=provider), HangupReason.TRANSCRIBER_CONNECTION_ERROR
             )
 
+    async def _maybe_update_tts_language(self, meta_info):
+        """Point a single-connection Sarvam TTS at the language ASR auto-detected; no-op otherwise."""
+        detected = (meta_info or {}).get("detected_language_code")
+        if not detected:
+            return
+        set_language = getattr(self.tools.get("synthesizer"), "set_target_language", None)
+        if set_language is None:
+            return
+        await set_language(detected)
+
     async def _listen_transcriber(self):
         temp_transcriber_message = ""
         try:
@@ -4045,6 +4055,8 @@ class TaskManager(BaseManager):
                             user_stop_ts_wall=_meta.get("user_stop_ts_wall"),
                         )
                         temp_transcriber_message = ""
+
+                        await self._maybe_update_tts_language(meta_info)
 
                         if self.output_task is None:
                             logger.info(f"Output task was none and hence starting it")

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -202,6 +202,11 @@ SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
     "bulbul:v3": 22050,  # NOTE: Documentation claims 24000, but WAV header shows 22050
 }
 
+# bulbul TTS requires a concrete target_language_code (no "unknown"/auto).
+SARVAM_TTS_SUPPORTED_LANGUAGES = {
+    "en-IN", "hi-IN", "bn-IN", "ta-IN", "te-IN", "kn-IN", "ml-IN", "mr-IN", "gu-IN", "pa-IN", "od-IN",
+}
+
 MODEL_REASONING_EFFORT_MAP = {
     "gpt-5": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
     "gpt-5-mini": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -14,7 +14,7 @@ from .stream_synthesizer import StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, get_synth_audio_format, resample, wav_bytes_to_pcm
-from bolna.constants import SARVAM_MODEL_SAMPLING_RATE_MAPPING
+from bolna.constants import SARVAM_MODEL_SAMPLING_RATE_MAPPING, SARVAM_TTS_SUPPORTED_LANGUAGES
 
 logger = configure_logger(__name__)
 
@@ -185,6 +185,38 @@ class SarvamSynthesizer(StreamSynthesizer):
     # Connection
     # ------------------------------------------------------------------
 
+    def _config_message(self):
+        return {
+            "type": "config",
+            "data": {
+                "target_language_code": self.language,
+                "speaker": self.voice_id,
+                "pitch": self.pitch,
+                "pace": self.pace,
+                "loudness": self.loudness,
+                "enable_preprocessing": self.enable_preprocessing,
+                "output_audio_codec": "wav",
+                "output_audio_bitrate": "32k",
+                "max_chunk_length": 250,
+                "min_buffer_size": self.buffer_size,
+            },
+        }
+
+    async def set_target_language(self, language):
+        """Switch TTS output language on the live socket via a fresh config message (no reconnect)."""
+        if not language or language == self.language:
+            return
+        if language not in SARVAM_TTS_SUPPORTED_LANGUAGES:
+            logger.info(f"Sarvam TTS: detected language {language!r} not supported, keeping {self.language!r}")
+            return
+        self.language = language
+        if self._is_ws_connected():
+            try:
+                await self._send_json(self._config_message())
+                logger.info(f"Sarvam TTS: switched target_language_code -> {language}")
+            except Exception as e:
+                logger.error(f"Sarvam TTS: failed to send config update for {language!r}: {e}")
+
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
@@ -196,22 +228,7 @@ class SarvamSynthesizer(StreamSynthesizer):
                 ),
                 timeout=10.0,
             )
-            bos_message = {
-                "type": "config",
-                "data": {
-                    "target_language_code": self.language,
-                    "speaker": self.voice_id,
-                    "pitch": self.pitch,
-                    "pace": self.pace,
-                    "loudness": self.loudness,
-                    "enable_preprocessing": self.enable_preprocessing,
-                    "output_audio_codec": "wav",
-                    "output_audio_bitrate": "32k",
-                    "max_chunk_length": 250,
-                    "min_buffer_size": self.buffer_size,
-                },
-            }
-            await websocket.send(json.dumps(bos_message))
+            await websocket.send(json.dumps(self._config_message()))
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -347,6 +347,13 @@ class SarvamTranscriber(BaseTranscriber):
                         if sarvam_request_id:
                             logger.info(f"Sarvam request_id: {sarvam_request_id}")
 
+                        # In auto-detect mode saaras returns the detected language per segment;
+                        # surface it so TTS can follow. Scoped to "unknown" to leave fixed-language agents alone.
+                        if self.language == "unknown":
+                            detected_language = payload.get("language_code")
+                            if detected_language and detected_language != "unknown":
+                                self.meta_info["detected_language_code"] = detected_language
+
                         if transcript and transcript.strip():
                             logger.debug(f"Sarvam transcript received: {transcript.strip()[:50]}...")
                             now_timestamp = time.time()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.79"
+version = "0.10.80"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Adds a single-connection multilingual path for Sarvam, instead of the N-connection transcriber/synthesizer pools.

How it works:
* The Sarvam transcriber, when configured with `language="unknown"`, lets saaras auto-detect the spoken language and returns it per segment. The detected `language_code` is surfaced in `meta_info` (scoped to `unknown` so fixed-language agents are untouched).
* `SarvamSynthesizer.set_target_language()` switches the TTS output language on the live socket by re-sending a `config` message. Sarvam flushes the buffer and applies the new config, so no reconnect is needed. bulbul has no auto language, so the detected language drives it.
* The task manager points TTS at the just-detected language before synthesizing each reply. It is duck-typed (only `SarvamSynthesizer` exposes `set_target_language`), so pools and other providers are skipped. A language outside bulbul's supported set leaves TTS unchanged.

Result: one STT socket (auto-detect) and one TTS socket whose language follows the caller, with no pool and no reconnect on switch.

Verified against the live Sarvam API: mid-session TTS config update renders audio in the new language, and saaras `unknown` returns language per turn.