### PR TITLE
fix: send GET function-call URLs verbatim instead of re-encoding params

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.86"
+__version__ = "0.10.87"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -1,7 +1,9 @@
 import asyncio
 import json
+from urllib.parse import quote
 
 import aiohttp
+from yarl import URL
 from bolna.helpers.logger_config import configure_logger
 from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, format_error_message
@@ -108,6 +110,24 @@ def prepare_api_request(param, api_token, headers_data, **kwargs):
     }
 
 
+def build_get_url(url, api_params):
+    """Assemble the final GET URL, treating the base url as already in wire form.
+
+    The base url is sent verbatim (encoded=True) so a pre-encoded value such as a nested
+    callback URL (e.g. an Ozonetel appURL) keeps its %3F/%3A/%2F instead of being decoded
+    to a literal ?/:/ that receivers truncate at. Param values are percent-encoded once and
+    appended, so plain values are unchanged and any param that is itself a URL is encoded
+    correctly rather than left with a query-splitting literal '?'.
+    """
+    final_url = url
+    if api_params:
+        sep = "&" if "?" in url else "?"
+        final_url = url + sep + "&".join(
+            f"{quote(str(k), safe='')}={quote(str(v), safe='')}" for k, v in api_params.items()
+        )
+    return URL(final_url, encoded=True)
+
+
 async def trigger_api(
     url, method, param, api_token, headers_data, meta_info, run_id, return_response_metadata=False, **kwargs
 ):
@@ -130,8 +150,9 @@ async def trigger_api(
             response = None
             response_text = None
             if method.lower() == "get":
-                logger.info(f"Sending request {api_params}, {url}, {headers}")
-                async with session.get(url, params=api_params, headers=headers) as response:
+                get_url = build_get_url(url, api_params)
+                logger.info(f"Sending request {request_body}, {get_url}, {headers}")
+                async with session.get(get_url, headers=headers) as response:
                     response_text = await response.text()
             elif method.lower() == "post":
                 logger.info(f"Sending request {api_params}, {url}, {headers}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.86"
+version = "0.10.87"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
GET function-call tools whose URL or params are already in wire form — most commonly a percent-encoded nested URL such as an Ozonetel `appURL` — were corrupted before sending. The GET branch of `trigger_api` used `session.get(url, params=api_params)`, where yarl re-quotes the URL: it leaves `?`/`:`/`/` literal inside a nested URL value (and decodes a pre-encoded one), so the receiver truncates the nested query at the literal `?` and the callback never resolves. The same request via curl works because curl sends the bytes verbatim.

The GET branch now builds the URL through `build_get_url`: the base URL is sent verbatim (`encoded=True`) and each param value is percent-encoded exactly once with `quote(safe="")`, then appended. Plain values are unchanged, a param that is itself a URL is encoded correctly rather than left with a query-splitting literal `?`, and the wire request is byte-identical to the working curl. POST paths are untouched.

Scoped to the GET path only. An audit of all live GET function-call tools (2,635 across 1,703 agents) found 2,027 byte-identical under this change and the rest decode-equivalent (`:`/`/` → `%3A`/`%2F`, mostly Cal.com); no currently-working tool regresses.