### PR TITLE
fix: scope ElevenLabs synthesizer frames by context_id to stop barge-in audio leak

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.84"
+__version__ = "0.10.85"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -204,7 +204,17 @@ SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
 
 # bulbul TTS requires a concrete target_language_code (no "unknown"/auto).
 SARVAM_TTS_SUPPORTED_LANGUAGES = {
-    "en-IN", "hi-IN", "bn-IN", "ta-IN", "te-IN", "kn-IN", "ml-IN", "mr-IN", "gu-IN", "pa-IN", "od-IN",
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "ta-IN",
+    "te-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "gu-IN",
+    "pa-IN",
+    "od-IN",
 }
 
 MODEL_REASONING_EFFORT_MAP = {

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -128,7 +128,7 @@ async def trigger_api(
         )
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
             if method.lower() == "get":
-                logger.info(f"Sending request {request_body}, {url}, {headers}")
+                logger.info(f"Sending request {api_params}, {url}, {headers}")
                 async with session.get(url, params=api_params, headers=headers) as response:
                     response_text = await response.text()
             elif method.lower() == "post":
@@ -140,6 +140,9 @@ async def trigger_api(
                     normalized_api_params = normalize_for_form(api_params)
                     async with session.post(url, data=normalized_api_params, headers=headers) as response:
                         response_text = await response.text()
+
+            if response:
+                logger.info(f"Final URL: {response.url}")
 
             if return_response_metadata:
                 return {

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -97,6 +97,9 @@ class CartesiaSynthesizer(StreamSynthesizer):
                 logger.info(f"handle_interruption: {interrupt_message}")
                 await self.websocket.send(json.dumps(interrupt_message))
                 self.context_id = None
+                # The interrupted context's end-of-stream is now dropped, so the
+                # next turn must be re-detected as new to clear stale queue entries.
+                self.current_turn_start_time = None
         except Exception as e:
             logger.error(f"Error in handle_interruption: {e}")
 

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -123,6 +123,9 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 interrupt_message = {"context_id": self.context_id, "close_context": True}
                 await self.websocket.send(json.dumps(interrupt_message))
                 self.context_id = None
+                # The interrupted context's end-of-stream is now dropped, so the
+                # next turn must be re-detected as new to clear stale queue entries.
+                self.current_turn_start_time = None
         except Exception:
             pass
 

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -67,7 +67,11 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         )
         self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
 
+        # Per-turn context_id so frames from an interrupted turn can be dropped.
         self.context_id = None
+        self.turn_id = 0
+        self.sequence_id = 0
+        self.context_ids_to_ignore = set()
         self.ws_send_time = None
         self.ws_trace_id = None
         self.current_turn_ttfb = None
@@ -92,7 +96,14 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
 
     def _on_push(self, meta_info, text):
         if not self.context_id:
-            self.context_id = str(uuid.uuid4())
+            self._update_context(meta_info)
+        elif self.turn_id != meta_info.get("turn_id", 0) or self.sequence_id != meta_info.get("sequence_id", 0):
+            self._update_context(meta_info)
+
+    def _update_context(self, meta_info):
+        self.context_id = str(uuid.uuid4())
+        self.turn_id = meta_info.get("turn_id", 0)
+        self.sequence_id = meta_info.get("sequence_id", 0)
 
     # ------------------------------------------------------------------
     # Format helper
@@ -108,9 +119,10 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
     async def handle_interruption(self):
         try:
             if self.context_id:
+                self.context_ids_to_ignore.add(self.context_id)
                 interrupt_message = {"context_id": self.context_id, "close_context": True}
-                self.context_id = str(uuid.uuid4())
                 await self.websocket.send(json.dumps(interrupt_message))
+                self.context_id = None
         except Exception:
             pass
 
@@ -139,7 +151,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         if self.ws_send_time is None:
                             self.ws_send_time = time.perf_counter()
                             logger.info(f"WS send trace_id={self.ws_trace_id} first_text_sent")
-                        await self.websocket.send(json.dumps({"text": text_chunk}))
+                        await self.websocket.send(json.dumps({"text": text_chunk, "context_id": self.context_id}))
                     except Exception as e:
                         logger.info(f"Error sending chunk: {e}")
                         self.connection_error = str(e)
@@ -147,9 +159,8 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
 
             if end_of_llm_stream:
                 self.last_text_sent = True
-                self.context_id = str(uuid.uuid4())
                 try:
-                    await self.websocket.send(json.dumps({"text": "", "flush": True}))
+                    await self.websocket.send(json.dumps({"text": "", "context_id": self.context_id, "flush": True}))
                 except Exception as e:
                     logger.info(f"Error sending end-of-stream signal: {e}")
                     self.connection_error = str(e)
@@ -188,6 +199,9 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 response = await self.websocket.recv()
                 recv_duration = (time.perf_counter() - recv_start) * 1000
                 data = json.loads(response)
+
+                if data.get("contextId") in self.context_ids_to_ignore:
+                    continue
 
                 if "audio" in data and data["audio"] and self.ws_send_time is not None:
                     audio_chunk_count += 1

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -67,10 +67,10 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         )
         self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
 
-        # Per-turn context_id so frames from an interrupted turn can be dropped.
+        # One context per conversation segment, rotated only on interruption so
+        # the interrupted turn's frames can be dropped without leaking contexts
+        # (ElevenLabs caps a connection at 5 concurrent contexts).
         self.context_id = None
-        self.turn_id = 0
-        self.sequence_id = 0
         self.context_ids_to_ignore = set()
         self.ws_send_time = None
         self.ws_trace_id = None
@@ -96,14 +96,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
 
     def _on_push(self, meta_info, text):
         if not self.context_id:
-            self._update_context(meta_info)
-        elif self.turn_id != meta_info.get("turn_id", 0) or self.sequence_id != meta_info.get("sequence_id", 0):
-            self._update_context(meta_info)
-
-    def _update_context(self, meta_info):
-        self.context_id = str(uuid.uuid4())
-        self.turn_id = meta_info.get("turn_id", 0)
-        self.sequence_id = meta_info.get("sequence_id", 0)
+            self.context_id = str(uuid.uuid4())
 
     # ------------------------------------------------------------------
     # Format helper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.84"
+version = "0.10.85"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
ElevenLabs `multi-stream-input` multiplexes turns on a single socket, but the synthesizer never tagged `text`/`flush` messages with a `context_id`, so `close_context` on a barge-in was a no-op. The interrupted turn keeps streaming and emits a trailing `isFinal` that gets mis-paired with the next turn via the FIFO `text_queue` pop, with two failure modes:

* the stale `isFinal` is attributed to the **new** sequence, retiring it early and cutting the agent off mid-sentence;
* the stale `isFinal` is attributed to the **old** sequence and the new turn never receives its own end-of-stream, so `is_audio_being_played` stays `True` and every subsequent short utterance is dropped as a false interruption (agent goes permanently mute).

The fix tags each conversation segment with a `context_id` and drops frames from cancelled contexts:

1. mint one `context_id` for the segment (`_on_push`), reused across normal turns;
2. send it on every `text` and `flush`;
3. on interruption, add the live context to `context_ids_to_ignore`, `close_context`, null it, and reset `current_turn_start_time` (so the next turn is re-detected as new and stale `text_queue` entries are cleared);
4. drop frames whose `contextId` is in the ignore set in the receiver.

The context is rotated **only on interruption**, not per turn. ElevenLabs caps a connection at 5 concurrent contexts and we set `inactivity_timeout=170`, so a new context per turn would accumulate and get the connection dropped mid-call (lost audio, silence). Reuse keeps at most ~2 contexts open. Frame-to-turn mapping is unchanged: it is done by `sequence_id`/`text_queue` in the base generate loop, and `contextId` is used only to drop interrupted-context frames, so reuse is functionally identical to per-turn tagging for normal turns.

Cartesia gets the same `current_turn_start_time` reset on interruption. Its per-turn context rotation is left as-is: Cartesia auto-closes contexts ~5s after generation, so it does not accumulate.

Validated against the live ElevenLabs API: a single named context accepts six consecutive `text`->`flush` turns and returns audio each time (no rotation, one context); a barge-in drops the interrupted context's trailing frames while the new context streams its own audio and end-of-stream.