### PR TITLE
fix: prevent UnboundLocalError in trigger_api for unsupported method/content-type

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.85"
+__version__ = "0.10.86"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -127,6 +127,8 @@ async def trigger_api(
             run_id=run_id,
         )
         async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
+            response = None
+            response_text = None
             if method.lower() == "get":
                 logger.info(f"Sending request {api_params}, {url}, {headers}")
                 async with session.get(url, params=api_params, headers=headers) as response:
@@ -140,18 +142,27 @@ async def trigger_api(
                     normalized_api_params = normalize_for_form(api_params)
                     async with session.post(url, data=normalized_api_params, headers=headers) as response:
                         response_text = await response.text()
+                else:
+                    raise ValueError(
+                        f"Unsupported Content-Type for POST: {headers.get('Content-Type')!r}. "
+                        "Only 'application/json' and 'application/x-www-form-urlencoded' are supported."
+                    )
+            else:
+                raise ValueError(
+                    f"Unsupported HTTP method: {method!r}. Only 'GET' and 'POST' are supported."
+                )
 
-            if response:
+            if response is not None:
                 logger.info(f"Final URL: {response.url}")
 
             if return_response_metadata:
                 return {
                     "status_code": response.status if response is not None else None,
-                    "body": response_text,
+                    "body": response_text if response_text is not None else "",
                     "content_type": response.headers.get("Content-Type") if response is not None else None,
                 }
 
-            return response_text
+            return response_text if response_text is not None else ""
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"
         logger.debug(message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.85"
+version = "0.10.86"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

- Initialize `response` and `response_text` to `None` before the method dispatch block so they are always bound, eliminating the `UnboundLocalError: local variable 'response' referenced before assignment` crash
- Add explicit `ValueError` branches for unsupported HTTP methods (anything other than GET/POST) and unsupported POST Content-Types (anything other than `application/json` / `application/x-www-form-urlencoded`) — the existing `except Exception` handler catches these and formats them into a clear error message returned to the agent
- Replace the unreliable truthiness check `if response:` with `if response is not None:` (aiohttp's `ClientResponse.__bool__` is not guaranteed to be useful)
- Guard `response_text` reads in the return paths with `if response_text is not None else ""`

## Test plan

- [ ] Manually call `trigger_api` with `method="PUT"` and confirm the response is `"ERROR CALLING API: Please check your API: Unsupported HTTP method: 'PUT'..."` instead of a traceback
- [ ] Call with `method="POST"` and a `Content-Type: multipart/form-data` header and confirm the analogous error message
- [ ] Existing GET and POST (json/form) flows are unaffected

Issue: https://linear.app/bolna/issue/BOLNA-1344/trace-data-unavailable-for-execution-id-e5703319-a9f3-41ee-9edc 

🤖 Generated with [Claude Code](https://claude.com/claude-code)