### PR TITLE
fixed the last 4 char issue

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.86"
+__version__ = "0.10.87"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3844,6 +3844,13 @@ class TaskManager(BaseManager):
 
                     # Handling of transcriber events
                     if message["data"] == "speech_started":
+                        # VAD proof the user is acoustically active even though no transcript
+                        # exists yet (Deepgram can fire SpeechStarted with dg_turn=None and never
+                        # commit a turn). Refresh the user-silence timer so the is_user_online
+                        # probe / inactivity hangup don't fire mid-utterance — the probe's own
+                        # audio then gates the user's transcript as a false interruption
+                        # (call 8f6c45d4: probe fired 1s into user's reply, ate "नया नया").
+                        self.time_since_last_spoken_human_word = time.time()
                         if not self.tools["input"].welcome_message_played() and self.discard_pre_welcome_utterance:
                             self._speech_started_before_welcome = True
                         if self.tools["input"].welcome_message_played():

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -148,9 +148,7 @@ async def trigger_api(
                         "Only 'application/json' and 'application/x-www-form-urlencoded' are supported."
                     )
             else:
-                raise ValueError(
-                    f"Unsupported HTTP method: {method!r}. Only 'GET' and 'POST' are supported."
-                )
+                raise ValueError(f"Unsupported HTTP method: {method!r}. Only 'GET' and 'POST' are supported.")
 
             if response is not None:
                 logger.info(f"Final URL: {response.url}")

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -235,7 +235,9 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         response_text = "".join(response_chars)
                         last_four = " ".join(response_text.split(" ")[-4:]).replace('"', "").strip()
                         current_norm = self.normalize_text(self.current_text.strip()).replace('"', "").strip()
-                        logger.info(f"Last four char - {last_four} | current text - {current_norm}")
+                        # current_text now holds the full accumulated turn (can be ~2KB) and this
+                        # fires per alignment message — log only the tail the endswith compares.
+                        logger.info(f"Last four char - {last_four} | current text tail - {current_norm[-80:]}")
 
                         # Skip punctuation-only chunks (e.g. ".", ",") that match trivially.
                         has_alnum = any(c.isalnum() for c in last_four)

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -154,15 +154,23 @@ class StreamSynthesizer(BaseSynthesizer):
     async def _push_stream(self, message):
         meta_info = message.get("meta_info")
         text = message.get("data")
-        self.current_text = text
         self.synthesized_characters += len(text) if text else 0
         self.current_sequence_chars += len(text) if text else 0
         end_of_llm_stream = meta_info.get("end_of_llm_stream", False)
         self.meta_info = copy.deepcopy(meta_info)
         meta_info["text"] = text
 
-        # Stamp turn start on first push of a new turn
+        # Stamp turn start on first push of a new turn (also resets current_text)
         self._stamp_turn_start(meta_info)
+
+        # Accumulate the full turn text, not just the last chunk: the ElevenLabs
+        # end-of-turn check compares the alignment tail against current_text via
+        # endswith — if current_text held only the final chunk and that chunk is
+        # shorter than the 4-word tail, the match can never succeed, the turn never
+        # closes, and audio_playing stays stuck True (call b8982c6f seq=8: final
+        # chunk was the single word "रहेगा?").
+        if text:
+            self.current_text += text
 
         # Provider-specific pre-push hook (e.g. update context_id)
         self._on_push(meta_info, text)
@@ -186,6 +194,8 @@ class StreamSynthesizer(BaseSynthesizer):
             self.current_turn_start_time = time.perf_counter()
             self.ws_send_time = None
             self.current_turn_ttfb = None
+            # New turn — start accumulating this turn's text from scratch
+            self.current_text = ""
             # Anchor tts_start_ms to the first push — re-pushes of speculative responses
             # (e.g. after a tool call confirms the eager response) would overwrite this
             # to a later timestamp, making tts_start appear after agent_speech_start.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.86"
+version = "0.10.87"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
 Issue 1 — Turn can never close when the final LLM chunk is < 4 words (call b8982c6f)

  Symptom: Agent asked its closing question, customer answered "ok" — transcribed fine, then dropped as a false interruption 4 seconds after agent audio had actually finished. No agent response, no "are
  you still there?" probe, no silence hangup. 13s dead air → customer hung up.

  Root cause: On the ElevenLabs multi-stream endpoint we flush at turn end (never close_context), so isFinal never arrives on normal turns — the only end-of-turn mechanism is the tail-match in the
  receiver:

  # elevenlabs_synthesizer.py — runs per alignment message after last_text_sent
  if current_text.endswith(last_4_words_of_alignment):
      yield b"\x00"   # end_of_synthesizer_stream

  But _push_stream overwrote current_text with each LLM chunk:

  self.current_text = text   # holds only the LAST chunk

  When the LLM's final chunk happened to be a single word ("रहेगा?"), the alignment tail spanned the chunk boundary ("ये ठीक रहेगा?") — the haystack was shorter than the needle, so endswith could mathematically
  never─match.─No─EOS─→─final=True─mark─never─sent─to─Plivo─→─on_agent_audio_fully_played─never─fired─→─audio_playing stuck True for the rest of the call,─which─simultaneously─(a)─dropped─all─user────────
  transcripts via the false-interruption gate and (b) disabled the probe/silence-hangup loop (both gate on is_audio_being_played_to_user()).

  General rule: any turn whose final LLM chunk was shorter than 4 words could never close. Earlier turns survived by luck (final chunks ≥ 4 words). This is the second production incident from this root
  cause (first: 875583b8, 2026-05-18 — that fix never landed on master).

  Fix (stream_synthesizer.py):
  - _push_stream: accumulate — self.current_text += text (was overwrite)
  - _stamp_turn_start: reset current_text = "" in its new-turn block, which runs before the accumulation, so each turn starts clean

  The endswith tail now always exists inside current_text, regardless of how the LLM chunked the response.

  ---
  Issue 2 — "Are you still there?" probe fires mid-utterance and eats the user's reply (call 8f6c45d4)

  Symptom: Customer was answering the agent's question; 1 second into their reply the probe ("Hey, can you hear me?") fired and started playing. The reply finalized 99ms after probe audio began →
  audio_playing=True → dropped as a false interruption. Customer got talked over, then silence → hung up.

  Root cause: Deepgram fires SpeechStarted (VAD) the moment it detects voice — often seconds before committing a transcript, sometimes never committing one (dg_turn=None). But the user-silence timer
  (time_since_last_spoken_human_word) was only refreshed by processed transcripts, so the __check_for_completion loop was blind to VAD activity and believed the user silent while they were audibly
  mid-utterance. Same blind spot also caused premature inactivity hangups in calls 0eb1e8f2/4c07d4f5 (call cut while the user was actively answering — 5–8 uncommitted speech_started events, final response
  lost).

  Fix (task_manager.py, _listen_transcriber speech_started branch):

  self.time_since_last_spoken_human_word = time.time()

  Mirrors the existing unconditional stamp in the interim-transcript branch. All consumers of this timer — the probe trigger, the inactivity hangup, repeat-after-silence, and the stall backstop — now hold
  while the user is acoustically active, even before any transcript exists.

  Trade-off (known, accepted): transcript-less VAD events (background noise, hold music) also defer the inactivity hangup — same exposure as already existed for noise-induced interim transcripts (same
  timer). call_terminate remains the hard bound.

  ---
  Also in this PR

  - Log volume guard (elevenlabs_synthesizer.py): the Last four char - … | current text - … log fires per alignment message; with accumulation it would have emitted the full turn (~2KB) each time. Now
  logs only current_norm[-80:] — the tail the endswith actually compares.
