### PR TITLE
fix: reliable ElevenLabs end-of-stream via close_context

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.86"
+__version__ = "0.10.87"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -148,9 +148,7 @@ async def trigger_api(
                         "Only 'application/json' and 'application/x-www-form-urlencoded' are supported."
                     )
             else:
-                raise ValueError(
-                    f"Unsupported HTTP method: {method!r}. Only 'GET' and 'POST' are supported."
-                )
+                raise ValueError(f"Unsupported HTTP method: {method!r}. Only 'GET' and 'POST' are supported.")
 
             if response is not None:
                 logger.info(f"Final URL: {response.url}")

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -67,11 +67,12 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         )
         self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
 
-        # One context per conversation segment, rotated only on interruption so
-        # the interrupted turn's frames can be dropped without leaking contexts
-        # (ElevenLabs caps a connection at 5 concurrent contexts).
+        # One context per turn: closed at end_of_llm_stream and on interruption, so each
+        # turn gets a fresh context_id. Closing frees the slot, staying well under
+        # ElevenLabs' 5-concurrent-context cap.
         self.context_id = None
         self.context_ids_to_ignore = set()
+        self._eos_context_id = None  # context the last end-of-stream was emitted for
         self.ws_send_time = None
         self.ws_trace_id = None
         self.current_turn_ttfb = None
@@ -157,6 +158,12 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 self.last_text_sent = True
                 try:
                     await self.websocket.send(json.dumps({"text": "", "context_id": self.context_id, "flush": True}))
+                    # Closing the context makes ElevenLabs emit isFinal, which the receiver uses
+                    # as end-of-stream. The context's remaining frames are still delivered. The
+                    # next turn opens a fresh context; voice_settings carry over from the connection BOS.
+                    if self.context_id:
+                        await self.websocket.send(json.dumps({"context_id": self.context_id, "close_context": True}))
+                        self.context_id = None
                 except Exception as e:
                     logger.info(f"Error sending end-of-stream signal: {e}")
                     self.connection_error = str(e)
@@ -196,7 +203,8 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 recv_duration = (time.perf_counter() - recv_start) * 1000
                 data = json.loads(response)
 
-                if data.get("contextId") in self.context_ids_to_ignore:
+                ctx = data.get("contextId")
+                if ctx in self.context_ids_to_ignore:
                     continue
 
                 if "audio" in data and data["audio"] and self.ws_send_time is not None:
@@ -223,11 +231,12 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         text_spoken = ""
                     yield chunk, text_spoken
 
+                emit_eos = False
                 if "isFinal" in data and data["isFinal"]:
                     logger.info(f"WS recv isFinal trace_id={self.ws_trace_id}")
                     audio_chunk_count = 0
                     last_recv_time = None
-                    yield b"\x00", ""
+                    emit_eos = True
 
                 elif self.last_text_sent:
                     try:
@@ -245,12 +254,18 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                         current_cmp = re.sub(r"\s+", "", current_norm)
                         if last_four_cmp and has_alnum and current_cmp.endswith(last_four_cmp):
                             logger.info("send end_of_synthesizer_stream")
-                            yield b"\x00", ""
+                            emit_eos = True
                     except Exception as e:
                         logger.error(f"Error getting chars from response - {e}")
-                        yield b"\x00", ""
+                        emit_eos = True
                 else:
                     logger.info("No audio data in the response")
+
+                # isFinal and the text-match can both fire within one turn; emit end-of-stream
+                # only once per context.
+                if emit_eos and not (ctx is not None and ctx == self._eos_context_id):
+                    self._eos_context_id = ctx
+                    yield b"\x00", ""
 
             except websockets.exceptions.ConnectionClosed:
                 break

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.86"
+version = "0.10.87"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_elevenlabs_close_context_eos.py
+++ b/tests/test_elevenlabs_close_context_eos.py
@@ -1,0 +1,135 @@
+"""End-of-stream detection on the ElevenLabs multi-stream socket: close_context yields
+isFinal, with a text-match backstop and per-context dedup so each turn emits one EOS."""
+
+import asyncio
+import base64
+import json
+
+from websockets.exceptions import ConnectionClosed
+from websockets.protocol import State
+
+from bolna.synthesizer.elevenlabs_synthesizer import ElevenlabsSynthesizer
+
+
+def _audio_msg(ctx, text=""):
+    return json.dumps(
+        {"audio": base64.b64encode(b"\x01\x02\x03\x04").decode(), "alignment": {"chars": list(text)}, "contextId": ctx}
+    )
+
+
+def _final_msg(ctx):
+    return json.dumps({"isFinal": True, "contextId": ctx})
+
+
+class FakeWS:
+    def __init__(self, messages):
+        self._messages = list(messages)
+        self.sent = []
+        self.state = State.OPEN
+
+    async def recv(self):
+        if not self._messages:
+            raise ConnectionClosed(None, None)
+        return self._messages.pop(0)
+
+    async def send(self, data):
+        self.sent.append(json.loads(data))
+
+
+class StubTaskManager:
+    def is_sequence_id_in_current_ids(self, sequence_id):
+        return True
+
+
+def _make_synth():
+    return ElevenlabsSynthesizer(
+        voice="v", voice_id="vid", synthesizer_key="test", caching=False, task_manager_instance=StubTaskManager()
+    )
+
+
+async def _collect(gen, limit=50):
+    out = []
+    async for item in gen:
+        out.append(item)
+        if len(out) >= limit:
+            break
+    return out
+
+
+def _end_markers(items):
+    return [a for (a, _t) in items if a == b"\x00"]
+
+
+def test_boundary_cross_recovers_via_isfinal():
+    """When the final chunk ("a limited time.") is longer than the last segment ("limited
+    time."), the text-match does not fire; isFinal must still produce one end-of-stream."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.last_text_sent = True
+    synth.current_text = "limited time."
+    ctx = "ctx-boundary"
+    synth.websocket = FakeWS(
+        [
+            _audio_msg(ctx, "and lasts up to 24 hours. It comes in"),
+            _audio_msg(ctx, "for a limited time."),  # crosses the segment boundary -> text-match fails
+            _final_msg(ctx),
+        ]
+    )
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1, "boundary-crossing turn must still emit exactly one end-of-stream"
+
+
+def test_no_double_eos_when_textmatch_and_isfinal():
+    """Single-segment turn where both the text-match and isFinal fire: dedup must
+    collapse them to one end-of-stream."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.last_text_sent = True
+    synth.current_text = "hello there friend."
+    ctx = "ctx-single"
+    synth.websocket = FakeWS(
+        [
+            _audio_msg(ctx, "hello there friend."),  # text-match fires
+            _final_msg(ctx),  # isFinal fires again -> must be deduped
+        ]
+    )
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1, "text-match + isFinal on one turn must emit exactly one end-of-stream"
+
+
+def test_eos_emitted_once_per_turn_across_contexts():
+    """Dedup is per-context: a fresh context per turn must each emit its own end-of-stream."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.last_text_sent = True
+    synth.current_text = "x"
+    synth.websocket = FakeWS([_final_msg("turn-a"), _final_msg("turn-b")])
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 2, "each turn's context must emit its own end-of-stream"
+
+
+def test_sender_closes_context_and_rotates_on_end_of_stream():
+    """end_of_llm_stream flushes, closes the context, and clears context_id."""
+    synth = _make_synth()
+    synth.context_id = "ctx-live"
+    synth.websocket = FakeWS([])
+
+    asyncio.run(synth.sender("the final words", sequence_id=1, end_of_llm_stream=True))
+
+    flush = [m for m in synth.websocket.sent if m.get("flush")]
+    close = [m for m in synth.websocket.sent if m.get("close_context")]
+    assert flush and all(m.get("context_id") == "ctx-live" for m in flush)
+    assert close and all(m.get("context_id") == "ctx-live" for m in close)
+    assert synth.context_id is None, "context must be cleared so the next turn mints a fresh one"
+
+
+def test_sender_does_not_close_when_not_end_of_stream():
+    """Mid-turn pushes must not close the context."""
+    synth = _make_synth()
+    synth.context_id = "ctx-live"
+    synth.websocket = FakeWS([])
+
+    asyncio.run(synth.sender("some words", sequence_id=1, end_of_llm_stream=False))
+
+    assert not any(m.get("close_context") for m in synth.websocket.sent)
+    assert synth.context_id == "ctx-live"


### PR DESCRIPTION
## Problem
On the ElevenLabs multi-stream-input endpoint, a bare `flush` does not produce an `isFinal` message, so end-of-stream detection fell back to matching the final audio chunk's aligned text against the last pushed text segment. When the final flush of a turn is a short fragment and ElevenLabs aligns the last audio chunk across the segment boundary (last segment `"limited time."` vs final aligned chunk `"a limited time."`), the match fails. No end-of-stream is emitted, `is_audio_being_played` stays True, and the agent stops responding to short user replies for the rest of the call.

## Fix
1. On `end_of_llm_stream`, send `close_context` after the flush. `close_context` emits a reliable `isFinal`, giving the receiver a real end-of-stream signal instead of the boundary-fragile text match.
2. Dedup end-of-stream per context so `isFinal` and the text-match backstop cannot both emit (which would send a duplicate final-chunk mark).
3. Each turn now uses a fresh context. `close_context` frees the slot, so the 5 concurrent context cap is not a concern, and `voice_settings` are inherited from the connection BOS.

The text-match stays as a backstop. Verified live against the ElevenLabs API: `flush` alone yields no `isFinal`; `flush` + `close_context` yields exactly one `isFinal` with complete audio. The barge-in handling (`context_ids_to_ignore`) is untouched.
