### PR TITLE
Log abnormal telephony websocket disconnects

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.80"
+__version__ = "0.10.81"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -159,11 +159,14 @@ class TelephonyInputHandler(DefaultInputHandler):
                     break
 
             except WebSocketDisconnect as e:
-                if e.code in (1000, 1001, 1006):
-                    pass
+                if e.code in (1000, 1001):
+                    logger.info(f"{self.io_provider} websocket closed normally: code={e.code}")
                 else:
-                    logger.error(
-                        f"WebSocket disconnected unexpectedly: code={e.code}, reason={getattr(e, 'reason', None)}"
+                    # 1006 (abnormal closure, no close frame) and any other code mean the media
+                    # stream dropped mid-call rather than ending gracefully.
+                    logger.warning(
+                        f"{self.io_provider} websocket disconnected abnormally: code={e.code}, "
+                        f"reason={getattr(e, 'reason', None)}, stream_sid={self.stream_sid}, call_sid={self.call_sid}"
                     )
 
             except Exception as e:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.80"
+version = "0.10.81"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary

`TelephonyInputHandler._listen()` swallowed WebSocket close codes 1000/1001/1006 with a bare `pass`, so abnormal mid-call media-stream drops (1006 — connection lost with no close frame) produced no log at all. This is why Vobiz "End Of XML Instructions" / 4010 stream drops (BOLNA-1216) were invisible on our side.

Now 1000/1001 log at INFO; 1006 and any other code log at WARNING with the close code, reason, and `stream_sid`/`call_sid`. `run_id` is already carried on the log context. Logging-only — control flow is unchanged. Lives in the shared base handler, so it covers all telephony providers (Twilio/Plivo/Exotel/Vobiz/sip-trunk).