### PR TITLE
fix: lock out barge-in during end_call actuation so hangup can't be cancelled

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.90"
+__version__ = "0.10.91"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -184,6 +184,7 @@ class TaskManager(BaseManager):
         self.switch_handoff_messages = {}
         self.agent_names = {}
         self._end_of_conversation_in_progress = False
+        self._end_call_in_progress = False
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
         self.hangup_mark_event_timeout = 10
@@ -2588,6 +2589,9 @@ class TaskManager(BaseManager):
             resp["execution_id"] = self.run_id
 
         if called_fun.startswith(END_CALL_FUNCTION_PREFIX):
+            # Lock out barge-in before the goodbye is generated, otherwise an interruption
+            # cancels the turn task and the disconnect never runs.
+            self._end_call_in_progress = True
             reason = resp.get("reason", "")
 
             if self.end_call_experiment is not None and not self.end_call_experiment["end_call_invoked"]:
@@ -3566,6 +3570,9 @@ class TaskManager(BaseManager):
         if self.hangup_decision_at is None:
             self.hangup_decision_at = time.time()
 
+    def _should_ignore_transcriber_input(self) -> bool:
+        return self.hangup_triggered or self._end_call_in_progress
+
     async def process_call_hangup(self):
         if self.hangup_decision_at is None:
             self.hangup_decision_at = time.time()
@@ -3940,7 +3947,7 @@ class TaskManager(BaseManager):
                 message = await self.transcriber_output_queue.get()
                 logger.info(f"Message from the transcriber class {message}")
 
-                if self.hangup_triggered:
+                if self._should_ignore_transcriber_input():
                     if message["data"] == "transcriber_connection_closed":
                         logger.info(f"Transcriber connection has been closed")
                         self.transcriber_duration += (

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -122,8 +122,8 @@ def build_get_url(url, api_params):
     final_url = url
     if api_params:
         sep = "&" if "?" in url else "?"
-        final_url = url + sep + "&".join(
-            f"{quote(str(k), safe='')}={quote(str(v), safe='')}" for k, v in api_params.items()
+        final_url = (
+            url + sep + "&".join(f"{quote(str(k), safe='')}={quote(str(v), safe='')}" for k, v in api_params.items())
         )
     return URL(final_url, encoded=True)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.90"
+version = "0.10.91"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_end_call_bargein_guard.py
+++ b/tests/tests/test_end_call_bargein_guard.py
@@ -1,0 +1,52 @@
+"""Guards the end_call hangup actuation against barge-in resurrection.
+
+Reproduces the failure where the end_call tool fired and generated a goodbye,
+but a user barge-in during/after the goodbye cancelled the conversation turn
+task before the disconnect ran. hangup_triggered was never set, so the
+transcriber kept feeding new turns and the agent looped goodbyes until the
+user dropped (actual_hangup_reason stayed null in the experiment outcome).
+
+The fix: _end_call_in_progress is set the instant the end_call tool fires
+(before the goodbye is generated), and _listen_transcriber drops all user
+speech while a hangup or end_call actuation is underway, so barge-in can no
+longer cancel the in-flight hangup.
+"""
+
+import inspect
+from types import SimpleNamespace
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+def _ignore(hangup_triggered, end_call_in_progress):
+    fake = SimpleNamespace(hangup_triggered=hangup_triggered, _end_call_in_progress=end_call_in_progress)
+    return TaskManager._should_ignore_transcriber_input(fake)
+
+
+def test_ignores_input_during_end_call_actuation():
+    # end_call fired but hangup_triggered not yet set (goodbye still generating).
+    assert _ignore(hangup_triggered=False, end_call_in_progress=True) is True
+
+
+def test_ignores_input_after_hangup_locked():
+    assert _ignore(hangup_triggered=True, end_call_in_progress=False) is True
+
+
+def test_processes_input_during_normal_conversation():
+    assert _ignore(hangup_triggered=False, end_call_in_progress=False) is False
+
+
+class TestSourceGuards:
+    """Catch accidental removal of the wiring that closes the barge-in race."""
+
+    def test_end_call_branch_sets_in_progress_flag(self):
+        src = inspect.getsource(TaskManager._TaskManager__execute_function_call)
+        assert "_end_call_in_progress = True" in src, (
+            "end_call branch must set _end_call_in_progress before generating the goodbye"
+        )
+
+    def test_listen_transcriber_uses_the_guard(self):
+        src = inspect.getsource(TaskManager._listen_transcriber)
+        assert "_should_ignore_transcriber_input" in src, (
+            "_listen_transcriber must drop user speech while a hangup/end_call actuation is underway"
+        )

--- a/tests/tests/test_end_call_bargein_guard.py
+++ b/tests/tests/test_end_call_bargein_guard.py
@@ -1,19 +1,23 @@
 """Guards the end_call hangup actuation against barge-in resurrection.
 
 Reproduces the failure where the end_call tool fired and generated a goodbye,
-but a user barge-in during/after the goodbye cancelled the conversation turn
-task before the disconnect ran. hangup_triggered was never set, so the
-transcriber kept feeding new turns and the agent looped goodbyes until the
-user dropped (actual_hangup_reason stayed null in the experiment outcome).
+but a user barge-in cancelled the conversation turn task before the disconnect
+ran. hangup_triggered was never set, so the transcriber kept feeding new turns
+and the agent looped goodbyes until the user dropped (actual_hangup_reason
+stayed null in the experiment outcome).
 
 The fix: _end_call_in_progress is set the instant the end_call tool fires
-(before the goodbye is generated), and _listen_transcriber drops all user
-speech while a hangup or end_call actuation is underway, so barge-in can no
-longer cancel the in-flight hangup.
+(before the goodbye is generated), and _listen_transcriber drops user speech
+while a hangup or end_call actuation is underway, so barge-in can no longer
+cancel the in-flight hangup.
 """
 
+import asyncio
 import inspect
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from bolna.agent_manager.task_manager import TaskManager
 
@@ -34,6 +38,60 @@ def test_ignores_input_after_hangup_locked():
 
 def test_processes_input_during_normal_conversation():
     assert _ignore(hangup_triggered=False, end_call_in_progress=False) is False
+
+
+# An interim transcript that crosses the interruption threshold. In the real
+# call this is what fired "Condition for interruption hit" -> __cleanup_downstream_tasks
+# -> "Cancelling LLM Task", killing the in-flight end_call handler.
+_INTERIM_BARGEIN = {
+    "data": {"type": "interim_transcript_received", "content": "कोई order ही नहीं"},
+    "meta_info": {"io": "plivo", "sequence_id": 2},
+}
+
+
+def _make_tm(*, end_call_in_progress, hangup_triggered):
+    tm = MagicMock()
+    tm.hangup_triggered = hangup_triggered
+    tm._end_call_in_progress = end_call_in_progress
+    tm.stream = True
+    tm.response_in_pipeline = False
+    tm.transcriber_output_queue = asyncio.Queue()
+    tm.process_transcriber_request = AsyncMock(return_value=0)
+    tm._set_call_details = MagicMock()
+    tm._get_next_step = MagicMock(return_value="llm")
+    tm.tools = {"input": MagicMock(), "transcriber": MagicMock()}
+    tm.tools["input"].welcome_message_played = MagicMock(return_value=True)
+    tm.conversation_history.is_duplicate_user = MagicMock(return_value=False)
+    tm.interruption_manager.should_trigger_interruption = MagicMock(return_value=True)
+    tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
+    tm._end_call_on_component_error = AsyncMock()
+    tm.task_config = {"tools_config": {"transcriber": {"provider": "deepgram"}}}
+    tm._should_ignore_transcriber_input = TaskManager._should_ignore_transcriber_input.__get__(tm, TaskManager)
+    tm._listen_transcriber = TaskManager._listen_transcriber.__get__(tm, TaskManager)
+    return tm
+
+
+async def _drive_with_bargein(tm):
+    await tm.transcriber_output_queue.put(_INTERIM_BARGEIN)
+    try:
+        await asyncio.wait_for(tm._listen_transcriber(), timeout=0.3)
+    except asyncio.TimeoutError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_bargein_does_not_cancel_turn_during_end_call():
+    tm = _make_tm(end_call_in_progress=True, hangup_triggered=False)
+    await _drive_with_bargein(tm)
+    tm._set_call_details.assert_not_called()
+    tm._TaskManager__cleanup_downstream_tasks.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bargein_cancels_turn_during_normal_conversation():
+    tm = _make_tm(end_call_in_progress=False, hangup_triggered=False)
+    await _drive_with_bargein(tm)
+    tm._TaskManager__cleanup_downstream_tasks.assert_awaited_once()
 
 
 class TestSourceGuards:

--- a/tests/tests/test_pre_call_webhook.py
+++ b/tests/tests/test_pre_call_webhook.py
@@ -105,8 +105,17 @@ async def test_pre_call_webhook_no_template_sends_common_only():
     assert body["from_number"] == "+15551112222"
     assert body["to_number"] == "+15553334444"
     # NO LLM args / internal keys / excluded fields
-    for k in ("reason", "call_transfer_number", "model_response", "textual_response",
-              "tool_call_id", "resp", "stream_sid", "tool_name", "call_sid"):
+    for k in (
+        "reason",
+        "call_transfer_number",
+        "model_response",
+        "textual_response",
+        "tool_call_id",
+        "resp",
+        "stream_sid",
+        "tool_name",
+        "call_sid",
+    ):
         assert k not in body
 
 
@@ -122,18 +131,16 @@ async def test_pre_call_webhook_param_template_controls_body():
         patch("bolna.agent_manager.task_manager.aiohttp.ClientSession", _FakeSession),
         patch("bolna.agent_manager.task_manager.convert_to_request_log"),
     ):
-        TaskManager.fire_pre_call_webhook(
-            me, "https://hook.example/notify", "custom_task_x", resp, {}, webhook_param
-        )
+        TaskManager.fire_pre_call_webhook(me, "https://hook.example/notify", "custom_task_x", resp, {}, webhook_param)
         await asyncio.sleep(0)
         await asyncio.sleep(0)
 
     body = _FakeSession.last_post["json"]
-    assert body["who"] == "Alice"          # templated from LLM arg
-    assert body["channel"] == "voice"      # static value in template
-    assert body["execution_id"] == "exec-123"   # common fields still added
+    assert body["who"] == "Alice"  # templated from LLM arg
+    assert body["channel"] == "voice"  # static value in template
+    assert body["execution_id"] == "exec-123"  # common fields still added
     assert body["agent_id"] == "agent-1"
-    assert "reason" not in body            # not in the template → not sent
+    assert "reason" not in body  # not in the template → not sent
     assert "customer_name" not in body
 
 
@@ -156,9 +163,9 @@ async def test_pre_call_webhook_common_fields_win_over_template():
         await asyncio.sleep(0)
 
     body = _FakeSession.last_post["json"]
-    assert body["provider"] == "plivo"     # common wins over template
-    assert body["agent_id"] == "agent-1"   # common wins over template
-    assert body["note"] == "transfer me"   # templated from LLM arg
+    assert body["provider"] == "plivo"  # common wins over template
+    assert body["agent_id"] == "agent-1"  # common wins over template
+    assert body["note"] == "transfer me"  # templated from LLM arg
 
 
 @pytest.mark.asyncio
@@ -227,8 +234,8 @@ async def test_pre_call_webhook_dispatch_mode(monkeypatch):
     body = sent["json"]
     assert body["execution_id"] == "exec-123"
     assert body["webhook_url"] == "https://customer/notify"  # customer URL passed through
-    assert body["params"] == {"who": "Alice"}                # substituted template
-    assert "provider" not in body                            # common fields added by backend, not here
+    assert body["params"] == {"who": "Alice"}  # substituted template
+    assert "provider" not in body  # common fields added by backend, not here
 
 
 @pytest.mark.asyncio
@@ -278,5 +285,5 @@ def test_build_call_context_has_common_fields_only():
     assert ctx["provider"] == "plivo"
     assert ctx["from_number"] == "+15551112222"
     assert ctx["to_number"] == "+15553334444"
-    assert "stream_sid" not in ctx          # transfer-specific — removed
-    assert "call_sid" not in ctx            # excluded from customer call-event webhooks
+    assert "stream_sid" not in ctx  # transfer-specific — removed
+    assert "call_sid" not in ctx  # excluded from customer call-event webhooks


### PR DESCRIPTION
## Problem
When the `end_call` tool fires, a user barge-in during the goodbye can cancel the conversation turn task before the disconnect runs. The call then never hangs up: the agent loops its goodbye line until the user drops. The experiment outcome shows `end_call_invoked: true` but `actual_hangup_reason: null`, i.e. the disconnect block never executed.

## Root cause
The end_call handler runs inside the conversation turn task (`llm_task`). In the no-textual-response branch, `hangup_triggered` is only set *after* the goodbye LLM call returns. `_listen_transcriber` drops user speech only once `hangup_triggered` is True, so a barge-in in that window passes the guard, `_handle_transcriber_output` cancels `llm_task`, and a fresh turn is spawned. `_enter_hangup_state` / `process_call_hangup` never run, so `conversation_ended` is never set.

## Fix
1. Set `_end_call_in_progress` the instant the tool fires, before the goodbye is generated.
2. `_listen_transcriber` now drops user input whenever a hangup or end_call actuation is underway (`_should_ignore_transcriber_input`), so barge-in can no longer cancel the in-flight hangup.

The goodbye still generates because it only gates on `hangup_triggered`, which is unchanged. Scope is limited to the end_call branch; transfer, API tools, and the legacy LLM-prompted hangup are untouched. `wait_for_current_message` and `__process_end_of_conversation` have bounded timeouts, so ignoring barge-in cannot wedge the call.