### PR TITLE
fix: use configured provider for check_for_completion LLM (Groq via litellm)

### DIFF
--- a/bolna/agent_types/contextual_conversational_agent.py
+++ b/bolna/agent_types/contextual_conversational_agent.py
@@ -16,9 +16,29 @@ class StreamingContextualAgent(BaseAgent):
     def __init__(self, llm):
         super().__init__()
         self.llm = llm
-        self.conversation_completion_llm = OpenAiLLM(model=os.getenv("CHECK_FOR_COMPLETION_LLM", llm.model))
+        self.conversation_completion_llm = self._build_completion_llm(llm)
         self.voicemail_llm = OpenAiLLM(model=os.getenv("VOICEMAIL_DETECTION_LLM", "gpt-4.1-mini"))
         self.history = [{"content": ""}]
+
+    @staticmethod
+    def _build_completion_llm(llm):
+        """Build the hangup/completion-check LLM using the SAME provider as the main LLM.
+
+        Hard-coding OpenAiLLM here sent non-OpenAI credentials (e.g. a Groq key routed
+        through LiteLLM) to the OpenAI API, so check_for_completion failed with a 401 and
+        the agent never replied (bolna-ai/bolna#224, #742). We rebuild with the main LLM's
+        provider class and carry over its resolved credentials so the right endpoint is hit.
+        """
+        completion_model = os.getenv("CHECK_FOR_COMPLETION_LLM", llm.model)
+        kwargs = {"model": completion_model}
+        # Carry over credentials that the main LLM resolved (LiteLLM stores these).
+        if getattr(llm, "api_key", None):
+            kwargs["llm_key"] = llm.api_key
+        if getattr(llm, "api_base", None):
+            kwargs["base_url"] = llm.api_base
+        if getattr(llm, "api_version", None):
+            kwargs["api_version"] = llm.api_version
+        return type(llm)(**kwargs)
 
     async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):
         try:

--- a/tests/tests/test_contextual_agent_completion_provider.py
+++ b/tests/tests/test_contextual_agent_completion_provider.py
@@ -1,0 +1,79 @@
+"""Tests for provider selection of the check_for_completion / hangup-detection LLM.
+
+Regression for bolna-ai/bolna#224 and #742: when an agent is configured with a
+non-OpenAI provider routed through LiteLLM (e.g. Groq), StreamingContextualAgent
+must build its conversation_completion_llm with the SAME provider as the main LLM.
+Previously it hard-coded OpenAiLLM, so a Groq key (gsk_...) was sent to the OpenAI
+API and check_for_completion failed with a 401, and the agent never replied.
+"""
+
+from unittest.mock import patch
+
+from bolna.agent_types.contextual_conversational_agent import StreamingContextualAgent
+from bolna.llms import OpenAiLLM, LiteLLM
+
+
+def _stub_init(record):
+    """Return an __init__ that records its kwargs instead of doing real work."""
+
+    def _init(self, **kwargs):
+        record.append(kwargs)
+
+    return _init
+
+
+def _make_litellm_stub(model="groq/llama-3.3-70b-versatile"):
+    """A lightweight LiteLLM instance (Groq routed via litellm) without network/keys."""
+    with patch.object(LiteLLM, "__init__", lambda self, **kw: None):
+        llm = LiteLLM.__new__(LiteLLM)
+    llm.model = model
+    llm.api_key = "gsk_test_groq_key"
+    llm.api_base = None
+    llm.api_version = None
+    return llm
+
+
+def _build_agent(main_llm, litellm_calls, openai_calls):
+    """Construct the agent with both provider __init__s stubbed out (no network/keys)."""
+    with (
+        patch.object(LiteLLM, "__init__", _stub_init(litellm_calls)),
+        patch.object(OpenAiLLM, "__init__", _stub_init(openai_calls)),
+    ):
+        return StreamingContextualAgent(main_llm)
+
+
+def test_completion_llm_uses_same_provider_and_credentials_as_main_llm():
+    main_llm = _make_litellm_stub()
+
+    litellm_calls, openai_calls = [], []
+    agent = _build_agent(main_llm, litellm_calls, openai_calls)
+
+    # The completion LLM must be built with the main LLM's provider class (LiteLLM),
+    # NOT a hard-coded OpenAiLLM, so the Groq key is not sent to the OpenAI API.
+    assert isinstance(agent.conversation_completion_llm, LiteLLM)
+    completion_calls = [c for c in litellm_calls if c.get("model") == "groq/llama-3.3-70b-versatile"]
+    assert completion_calls, "completion LLM should be built via the LiteLLM (Groq) provider"
+    # And it must carry over the provider key that the main LLM resolved.
+    assert completion_calls[0]["llm_key"] == "gsk_test_groq_key"
+
+
+def test_completion_llm_stays_openai_for_openai_agent():
+    with patch.object(OpenAiLLM, "__init__", lambda self, **kw: None):
+        main_llm = OpenAiLLM.__new__(OpenAiLLM)
+    main_llm.model = "gpt-4o-mini"
+
+    litellm_calls, openai_calls = [], []
+    agent = _build_agent(main_llm, litellm_calls, openai_calls)
+
+    assert isinstance(agent.conversation_completion_llm, OpenAiLLM)
+    assert any(c.get("model") == "gpt-4o-mini" for c in openai_calls)
+
+
+def test_completion_model_env_override_is_respected(monkeypatch):
+    monkeypatch.setenv("CHECK_FOR_COMPLETION_LLM", "groq/llama-3.1-8b-instant")
+    main_llm = _make_litellm_stub()
+
+    litellm_calls, openai_calls = [], []
+    _build_agent(main_llm, litellm_calls, openai_calls)
+
+    assert any(c.get("model") == "groq/llama-3.1-8b-instant" for c in litellm_calls)


### PR DESCRIPTION
## Summary

Fixes #224 and #742.

When an agent is configured with a non-OpenAI provider routed through **litellm** (e.g. **Groq**), the agent never replies and the logs show a 401 in `check_for_completion`:

```
ERROR  {contextual_conversational_agent} [check_for_completion] check_for_completion exception:
Error code: 401 - {'error': {'message': 'Incorrect API key provided: gsk_YPb8****...
You can find your API key at https://platform.openai.com/account/api-keys.', ...}}
```

### Root cause

`StreamingContextualAgent.__init__` built its hangup/completion-check LLM by **hard-coding `OpenAiLLM`**:

```python
self.conversation_completion_llm = OpenAiLLM(model=os.getenv("CHECK_FOR_COMPLETION_LLM", llm.model))
```

This ignores the configured provider. The main `self.llm` is a `LiteLLM` instance (Groq), but the completion LLM is an `OpenAiLLM`, so the Groq key (`gsk_...`) is sent to the OpenAI API and fails with a 401. `check_for_completion` then swallows the exception and the turn never produces a reply.

### Fix

Build `conversation_completion_llm` with the **same provider class** as the main LLM (`type(llm)`) and carry over the credentials the main LLM already resolved (`api_key` / `api_base` / `api_version`), so the completion check hits the correct endpoint. The OpenAI path is unchanged. The `CHECK_FOR_COMPLETION_LLM` env override is still respected.

## Testing

Added `tests/tests/test_contextual_agent_completion_provider.py` (no live keys — provider construction is mocked).

Confirmed RED on `master` (before the fix):

```
tests/tests/test_contextual_agent_completion_provider.py::test_completion_llm_uses_same_provider_and_credentials_as_main_llm FAILED
>       assert isinstance(agent.conversation_completion_llm, LiteLLM)
E       assert False
2 failed, 1 passed
```

GREEN with the fix:

```
tests/tests/test_contextual_agent_completion_provider.py::test_completion_llm_uses_same_provider_and_credentials_as_main_llm PASSED
tests/tests/test_contextual_agent_completion_provider.py::test_completion_llm_stays_openai_for_openai_agent PASSED
tests/tests/test_contextual_agent_completion_provider.py::test_completion_model_env_override_is_respected PASSED
3 passed
```

`ruff check` and `ruff format --check` pass on the changed files. The surrounding agent/task-manager test suites (89 tests) pass; the only failures in the full run are pre-existing and unrelated (`test_event_injection_e2e.py`, `test_expression_routing.py`), failing identically on `master` without this change.

## Notes

This was developed with AI assistance and reviewed/verified by me.