### PR TITLE
fix: drain in-flight hangup goodbye before terminal sync_history

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.91"
+__version__ = "0.10.92"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5218,6 +5218,11 @@ class TaskManager(BaseManager):
                         if exc is not None:
                             raise cls(str(exc), provider=provider)
 
+                # _listen_transcriber can exit (transcriber idle-closes) while a hangup
+                # goodbye is still playing in llm_task; let it drain before trimming.
+                if self.hangup_triggered and not self.conversation_ended:
+                    await self.wait_for_current_message()
+
                 has_pending_marks = len(self.mark_event_meta_data.mark_event_meta_data) > 0
                 has_response_heard = bool(self.tools["input"].response_heard_by_user)
                 if has_pending_marks or has_response_heard:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.91"
+version = "0.10.92"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_hangup_goodbye_drain_on_teardown.py
+++ b/tests/tests/test_hangup_goodbye_drain_on_teardown.py
@@ -1,0 +1,167 @@
+"""Regression: a hangup goodbye must not be cut off (and its transcript trimmed
+to a partial prefix) when the transcriber socket idle-closes mid-goodbye.
+
+Reproduces the failure where end_call generated a 7.2s goodbye, the transcriber
+connection closed ~3.4s in, _listen_transcriber broke (hangup_triggered set),
+gather() returned, and run()'s terminal sync_history trimmed the goodbye to its
+heard prefix ("...whenever you are"). The fix waits for the goodbye to drain
+before the terminal sync_history.
+"""
+
+import asyncio
+import inspect
+import time
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+
+# values from the log
+FULL_GOODBYE = (
+    "No worries at all, Sir. You can reach out whenever you are free. "
+    "Thank you so much for your time. Have a wonderful day ahead. Goodbye. "
+)
+HEARD_PREFIX = "No worries at all, Sir. You can reach out whenever you are"  # 58 chars
+GOODBYE_SENT_TS = 1779789373.8576052
+GOODBYE_DURATION = 7.20975
+TEARDOWN_TS = 1779789377.264  # ~3.4s into the goodbye
+
+
+def _content_mark(text, turn_id, response_uid, duration, sent_ts):
+    return {
+        "type": "",
+        "text_synthesized": text,
+        "turn_id": turn_id,
+        "response_uid": response_uid,
+        "duration": duration,
+        "sent_ts": sent_ts,
+        "counter": 12,
+    }
+
+
+class _InputStub:
+    last_heard_turn_id = None
+    last_heard_response_uid = None
+    response_heard_by_user = ""
+
+    def get_response_heard_for_response(self, _uid):
+        return ""
+
+    def get_response_heard_for_turn(self, _turn_id):
+        return ""
+
+    def get_current_mark_started_time(self):
+        return 0.0
+
+    def reset_response_heard_by_user(self):
+        pass
+
+
+class _MarkMetaStub:
+    def __init__(self, marks=None):
+        self.mark_event_meta_data = dict(marks or {})
+        self.mark_changed = asyncio.Event()
+
+    def get_heard_text_for_response(self, _uid):
+        return ""
+
+    def get_heard_text_for_turn(self, _turn_id):
+        return ""
+
+    def drain(self):
+        self.mark_event_meta_data.clear()
+        self.mark_changed.set()
+
+
+def _make_tm(history, marks=None):
+    tm = TaskManager.__new__(TaskManager)
+    tm.conversation_history = history
+    tm.tools = {"input": _InputStub()}
+    tm.mark_event_meta_data = _MarkMetaStub(marks)
+    tm._turn_msg_map = {}
+    tm.hangup_triggered = False
+    tm.conversation_ended = False
+    tm.hangup_mark_event_timeout = 10
+    tm._turn_audio_flushed = asyncio.Event()
+    tm._turn_audio_flushed.set()
+    return tm
+
+
+def _turn7(history):
+    return next(m for m in history.messages if m.get("turn_id") == 7)
+
+
+@pytest.mark.asyncio
+async def test_terminal_sync_history_trims_goodbye_to_heard_prefix():
+    history = ConversationHistory()
+    history.append_user("please send the review later")
+    history.append_assistant(FULL_GOODBYE.strip(), turn_id=7, response_uid="r7")
+    tm = _make_tm(history)
+
+    marks = [
+        ("pre7", {"type": "pre_mark_message", "turn_id": 7, "response_uid": "r7", "counter": 11}),
+        ("aud7", _content_mark(FULL_GOODBYE, 7, "r7", GOODBYE_DURATION, GOODBYE_SENT_TS)),
+    ]
+    await tm.sync_history(marks, interruption_processed_at=TEARDOWN_TS)
+
+    assert _turn7(history)["content"] == HEARD_PREFIX
+    assert _turn7(history)["content"] != FULL_GOODBYE.strip()
+
+
+@pytest.mark.asyncio
+async def test_draining_before_teardown_keeps_full_goodbye():
+    history = ConversationHistory()
+    history.append_assistant(FULL_GOODBYE.strip(), turn_id=7, response_uid="r7")
+    marks = {"aud7": _content_mark(FULL_GOODBYE, 7, "r7", GOODBYE_DURATION, GOODBYE_SENT_TS)}
+    tm = _make_tm(history, marks)
+    tm.hangup_triggered = True
+    tm.conversation_ended = False
+
+    async def _drain_soon():
+        await asyncio.sleep(0.05)
+        tm.mark_event_meta_data.drain()
+
+    drainer = asyncio.create_task(_drain_soon())
+
+    # run()'s terminal block, post-fix
+    start = time.monotonic()
+    if tm.hangup_triggered and not tm.conversation_ended:
+        await tm.wait_for_current_message()
+    elapsed = time.monotonic() - start
+    await drainer
+
+    assert 0.04 < elapsed < 3.0  # waited for the drain, not zero and not the full grace
+
+    has_pending = len(tm.mark_event_meta_data.mark_event_meta_data) > 0
+    if has_pending:
+        await tm.sync_history(tm.mark_event_meta_data.mark_event_meta_data.items(), time.time())
+    assert _turn7(history)["content"] == FULL_GOODBYE.strip()
+
+
+@pytest.mark.asyncio
+async def test_wait_is_bounded_when_marks_never_ack():
+    # Worst case: Plivo never acks the goodbye and conversation_ended stays False.
+    # The wait must still return via the grace deadline, never loop forever.
+    history = ConversationHistory()
+    history.append_assistant(FULL_GOODBYE.strip(), turn_id=7, response_uid="r7")
+    marks = {"aud7": _content_mark(FULL_GOODBYE, 7, "r7", 0.1, GOODBYE_SENT_TS)}
+    tm = _make_tm(history, marks)
+    tm.hangup_triggered = True
+    tm.conversation_ended = False
+    tm.hangup_mark_event_timeout = 0.2  # shrink the grace for the test
+
+    start = time.monotonic()
+    await asyncio.wait_for(tm.wait_for_current_message(), timeout=5.0)  # hard-fails if it hangs
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 2.0  # bounded by duration + grace, not endless
+    assert len(tm.mark_event_meta_data.mark_event_meta_data) > 0  # returned without the mark ever acking
+
+
+def test_run_gates_terminal_sync_on_in_flight_hangup():
+    src = inspect.getsource(TaskManager.run)
+    gate_idx = src.find("if self.hangup_triggered and not self.conversation_ended:")
+    sync_idx = src.find("await self.sync_history(self.mark_event_meta_data.mark_event_meta_data.items(), time.time())")
+    assert gate_idx != -1 and sync_idx != -1
+    assert gate_idx < sync_idx


### PR DESCRIPTION
## Problem

When the agent says its end_call goodbye and the transcriber socket idle-closes mid-goodbye, the call tears down before the goodbye finishes playing. `_listen_transcriber` breaks on `transcriber_connection_closed` (`hangup_triggered` is set), `await asyncio.gather(*tasks)` returns, and `run()` immediately runs the terminal `sync_history`. With no mark ACK confirming full playback, `sync_history` falls back to a time-based estimate and trims the assistant turn to the partially-heard prefix, so the transcript ends mid-sentence ("...whenever you are") while the LLM trace keeps the full goodbye.

## Root cause

The conversation lifetime is bound only to `_listen_transcriber` via `gather(*tasks)`. The hangup goodbye and its `wait_for_current_message` (with the 10s `hangup_mark_event_timeout` grace) run in `llm_task`, which is not gathered. A transcriber idle-close therefore races ahead of the hangup wait and tears down + trims before the goodbye drains.

## Fix

Before the terminal `sync_history`, if a hangup is in flight and the conversation has not formally ended, wait for the goodbye audio to drain, reusing the existing `wait_for_current_message` (bounded by the same grace). This keeps the stream alive so the goodbye plays fully and the transcript records the complete text.

No-op on every other path: normal end_call / LLM-prompted hangup already sets `conversation_ended` before this point, and non-hangup teardown leaves `hangup_triggered` false.