### PR TITLE
Serialize SynthesizerPool.switch to prevent duplicate receivers on one websocket

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.92"
+__version__ = "0.10.93"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/synthesizer_pool.py
+++ b/bolna/synthesizer/synthesizer_pool.py
@@ -40,6 +40,7 @@ class SynthesizerPool:
         self._gen_task = None  # current _run_generate task
         self._monitor_tasks = {}  # label -> monitor task
         self._multilingual_config = multilingual_config
+        self._switch_lock = asyncio.Lock()
 
     # ------------------------------------------------------------------
     # Properties
@@ -139,33 +140,31 @@ class SynthesizerPool:
         3. Start a new _run_generate task for the new synth.
         4. Push SENTINEL so pool.generate() returns → __listen_synthesizer re-enters.
         """
-        if label == self.active_label:
-            logger.info(f"SynthesizerPool: already active on '{label}', no-op")
-            return
+        # Serialize: concurrent switches would each start a _run_generate (dual recv on one ws).
+        async with self._switch_lock:
+            if label == self.active_label:
+                logger.info(f"SynthesizerPool: already active on '{label}', no-op")
+                return
 
-        if label not in self.synthesizers:
-            raise ValueError(f"Unknown synthesizer label '{label}'. Available: {list(self.synthesizers.keys())}")
+            if label not in self.synthesizers:
+                raise ValueError(f"Unknown synthesizer label '{label}'. Available: {list(self.synthesizers.keys())}")
 
-        old = self.active_label
+            old = self.active_label
 
-        # Cancel old generate task
-        if self._gen_task and not self._gen_task.done():
-            self._gen_task.cancel()
-            try:
-                await self._gen_task
-            except asyncio.CancelledError:
-                pass
-            logger.info(f"SynthesizerPool: cancelled generate task for '{old}'")
+            if self._gen_task and not self._gen_task.done():
+                self._gen_task.cancel()
+                try:
+                    await self._gen_task
+                except asyncio.CancelledError:
+                    pass
+                logger.info(f"SynthesizerPool: cancelled generate task for '{old}'")
 
-        self.active_label = label
+            self.active_label = label
+            self._gen_task = asyncio.create_task(self._run_generate(label))
+            logger.info(f"SynthesizerPool: started generate task for '{label}'")
 
-        # Start new generate task
-        self._gen_task = asyncio.create_task(self._run_generate(label))
-        logger.info(f"SynthesizerPool: started generate task for '{label}'")
-
-        # Push sentinel so the current generate() iteration returns
-        self._output_queue.put_nowait(_SWITCH_SENTINEL)
-        logger.info(f"SynthesizerPool: switched {old} -> {label}")
+            self._output_queue.put_nowait(_SWITCH_SENTINEL)
+            logger.info(f"SynthesizerPool: switched {old} -> {label}")
 
     # ------------------------------------------------------------------
     # Active synth info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.92"
+version = "0.10.93"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_synthesizer_pool_switch.py
+++ b/tests/tests/test_synthesizer_pool_switch.py
@@ -1,0 +1,42 @@
+"""Regression: concurrent SynthesizerPool.switch() calls for one transition must not
+start two _run_generate tasks (two receivers on one websocket -> "cannot call recv
+while another coroutine is already running recv")."""
+
+import asyncio
+
+import pytest
+
+from bolna.synthesizer.synthesizer_pool import SynthesizerPool
+
+
+class _FakeSynth:
+    def __init__(self):
+        self.active = 0
+        self.max_concurrent = 0
+        self.connection_time = 0
+
+    async def generate(self):
+        self.active += 1
+        self.max_concurrent = max(self.max_concurrent, self.active)
+        try:
+            while True:
+                await asyncio.sleep(0.005)
+                yield {"meta_info": {}, "data": b"x"}
+        finally:
+            self.active -= 1
+
+
+@pytest.mark.asyncio
+async def test_concurrent_switch_starts_single_receiver():
+    synths = {"en": _FakeSynth(), "hi": _FakeSynth()}
+    pool = SynthesizerPool(synths, "en", {})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en"))
+    await asyncio.sleep(0.02)
+
+    await asyncio.gather(pool.switch("hi"), pool.switch("hi"))
+    await asyncio.sleep(0.03)
+
+    assert synths["hi"].max_concurrent == 1
+    assert pool.active_label == "hi"
+
+    pool._gen_task.cancel()


### PR DESCRIPTION
`SynthesizerPool.switch()` isn't concurrency-safe. It cancels the active generate task (an `await`) before re-pointing `active_label`, so two concurrent `switch()` calls for the same transition both pass the `if label == active_label` guard and each start a `_run_generate`, leaving two receivers calling `recv()` on the same websocket. `websockets` then raises "cannot call recv while another coroutine is already running recv", and the duplicate receivers spin on that error, breaking TTS for the rest of the turn.

Serialize `switch()` with an `asyncio.Lock` and re-check the active label inside it, so a duplicate concurrent switch becomes a clean no-op. Affects multilingual agents during language switches; single-language agents never call `switch()`.