### PR TITLE
docs: add Resemble Detect and Signal API tool examples

### DIFF
--- a/API.md
+++ b/API.md
@@ -82,11 +82,12 @@ Creates a new agent with specified configuration.
 }
 ```
 
-#### Resemble Detect API tool example
+#### Resemble Detect and Signal API tool example
 
 Bolna agents can call external HTTP APIs through `tools_config.api_tools`. Use
 this pattern when the caller provides a media URL that should be checked for
-synthetic speech or manipulated audio before the agent makes a trust decision.
+synthetic speech or manipulated audio, or when caller-provided text should be
+scored for fraud or scam intent before the agent makes a trust decision.
 
 Add the tool definition inside a task's `tools_config`:
 
@@ -116,6 +117,29 @@ Add the tool definition inside a task's `tools_config`:
           },
           "strict": true
         }
+      },
+      {
+        "type": "function",
+        "function": {
+          "name": "resemble_score_signal",
+          "description": "Score caller-provided text with Resemble Signal for fraud or scam intent. Use this before sharing reset codes, changing account details, initiating transfers, or acting on urgent payment requests.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Caller-provided text or transcript excerpt to score."
+              },
+              "reason": {
+                "type": "string",
+                "description": "Short reason this request should be scored."
+              }
+            },
+            "required": ["text"],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
       }
     ],
     "tools_params": {
@@ -137,6 +161,21 @@ Add the tool definition inside a task's `tools_config`:
           "callback_url": "<OPTIONAL_DETECTION_RESULT_WEBHOOK_URL>"
         },
         "pre_call_message": "I will verify that media before making a trust decision."
+      },
+      "resemble_score_signal": {
+        "url": "https://app.resemble.ai/api/v2/signal",
+        "method": "POST",
+        "api_token": "Bearer <RESEMBLE_API_KEY>",
+        "headers": {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        "param": {
+          "text": {
+            "$var": "text"
+          }
+        },
+        "pre_call_message": "I will check whether this request matches a fraud pattern before continuing."
       }
     }
   }
@@ -146,15 +185,19 @@ Add the tool definition inside a task's `tools_config`:
 Store the Resemble API key in your deployment secrets and inject it into
 `api_token` at deploy time. If you use `callback_url`, handle the completed
 Detect result in that webhook; the generic API tool executor sends one HTTP
-request and does not poll `GET /detect/{uuid}` during the call.
+request and does not poll `GET /detect/{uuid}` during the call. Signal text
+scoring returns synchronously from `POST /signal`.
 
 Suggested system prompt:
 
 ```text
 When the caller provides a media URL that affects a trust or fraud decision,
-call resemble_submit_detection before deciding. Treat the result as a risk
-signal. If the callback later reports synthetic speech, watermark evidence, or
-suspicious source tracing, follow this agent's escalation policy.
+call resemble_submit_detection before deciding. When the caller asks for a
+reset code, credential, wire transfer, urgent payment, or account change, call
+resemble_score_signal before deciding. Treat both responses as risk signals. If
+Detect reports synthetic speech, watermark evidence, or suspicious source
+tracing, or Signal returns suspicious/fraud, follow this agent's escalation
+policy.
 ```
 
 ### Edit Agent

--- a/API.md
+++ b/API.md
@@ -82,6 +82,81 @@ Creates a new agent with specified configuration.
 }
 ```
 
+#### Resemble Detect API tool example
+
+Bolna agents can call external HTTP APIs through `tools_config.api_tools`. Use
+this pattern when the caller provides a media URL that should be checked for
+synthetic speech or manipulated audio before the agent makes a trust decision.
+
+Add the tool definition inside a task's `tools_config`:
+
+```json
+{
+  "api_tools": {
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "resemble_submit_detection",
+          "description": "Submit a public HTTPS media URL to Resemble Detect for synthetic speech or manipulated media analysis. Use this when a caller provides a recording URL or another media artifact that should be verified.",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "url": {
+                "type": "string",
+                "description": "Public HTTPS URL for the audio, image, or video to analyze."
+              },
+              "reason": {
+                "type": "string",
+                "description": "Short reason this media should be verified."
+              }
+            },
+            "required": ["url"],
+            "additionalProperties": false
+          },
+          "strict": true
+        }
+      }
+    ],
+    "tools_params": {
+      "resemble_submit_detection": {
+        "url": "https://app.resemble.ai/api/v2/detect",
+        "method": "POST",
+        "api_token": "Bearer <RESEMBLE_API_KEY>",
+        "headers": {
+          "Accept": "application/json",
+          "Content-Type": "application/json"
+        },
+        "param": {
+          "url": {
+            "$var": "url"
+          },
+          "intelligence": true,
+          "audio_source_tracing": true,
+          "zero_retention_mode": true,
+          "callback_url": "<OPTIONAL_DETECTION_RESULT_WEBHOOK_URL>"
+        },
+        "pre_call_message": "I will verify that media before making a trust decision."
+      }
+    }
+  }
+}
+```
+
+Store the Resemble API key in your deployment secrets and inject it into
+`api_token` at deploy time. If you use `callback_url`, handle the completed
+Detect result in that webhook; the generic API tool executor sends one HTTP
+request and does not poll `GET /detect/{uuid}` during the call.
+
+Suggested system prompt:
+
+```text
+When the caller provides a media URL that affects a trust or fraud decision,
+call resemble_submit_detection before deciding. Treat the result as a risk
+signal. If the callback later reports synthetic speech, watermark evidence, or
+suspicious source tracing, follow this agent's escalation policy.
+```
+
 ### Edit Agent
 Updates an existing agent's configuration.
 


### PR DESCRIPTION
## Summary
- add API tool examples for Resemble Detect and Resemble Signal
- document when agents should call Signal before handling reset-code, credential, payment, or account-change requests
- keep the integration in Bolna's existing API-tool pattern

## Validation
- `git diff --check`