### PR TITLE
feat: global + node-level knowledge base for graph agents

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.99"
+__version__ = "0.10.100"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -69,6 +69,7 @@ class GraphAgent(BaseAgent):
         self._silence_repeats = 0
         self._event_triggered_generation = False
         self.rag_configs = self.initialize_rag_configs()
+        self.global_rag_config = self._initialize_global_rag_config()
         self.rag_server_url = os.getenv("RAG_SERVER_URL", "http://localhost:8000")
 
         # Cache transition tools per node for faster routing (bounded to prevent unbounded growth)
@@ -137,46 +138,78 @@ class GraphAgent(BaseAgent):
             logger.error(f"Failed to create LLM: {e}, falling back to default OpenAiLLM")
             return OpenAiLLM(model=self.llm_model or "gpt-4o-mini", llm_key=self.llm_key or os.getenv("OPENAI_API_KEY"))
 
+    @staticmethod
+    def _extract_rag_collections(rag_config: Dict) -> List[str]:
+        """Extract collection/vector IDs from a rag_config dict, supporting all known formats."""
+        collections = []
+        legacy_pc = rag_config.get("provider_config") if isinstance(rag_config.get("provider_config"), dict) else {}
+        provider_config = (rag_config.get("vector_store") or {}).get("provider_config") or {}
+        # Prefer the first location that actually carries a vector id; a present-but-empty
+        # field (e.g. top-level "vector_ids": []) must not shadow a valid vector_store.
+        if isinstance(rag_config.get("vector_ids"), list) and rag_config["vector_ids"]:
+            collections.extend(rag_config["vector_ids"])
+        elif rag_config.get("vector_id"):
+            collections.append(rag_config["vector_id"])
+        elif legacy_pc.get("vector_id"):
+            collections.append(legacy_pc["vector_id"])
+        elif isinstance(provider_config.get("vector_ids"), list) and provider_config["vector_ids"]:
+            collections.extend(provider_config["vector_ids"])
+        elif provider_config.get("vector_id"):
+            collections.append(provider_config["vector_id"])
+        return [c for c in collections if c]
+
+    @staticmethod
+    def _extract_similarity_top_k(rag_config: Dict, default: int = 10) -> int:
+        provider_config = (rag_config.get("vector_store") or {}).get("provider_config") or {}
+        return rag_config.get("similarity_top_k") or provider_config.get("similarity_top_k") or default
+
     def initialize_rag_configs(self) -> Dict[str, Dict]:
         """Initialize RAG configurations for each node."""
         rag_configs = {}
         for node in self.config.get("nodes", []):
             rag_config = node.get("rag_config")
-            if rag_config:
-                # Extract collection/vector IDs
-                collections = []
-                # Legacy: direct vector_id on rag_config
-                if "vector_id" in rag_config:
-                    collections.append(rag_config["vector_id"])
-                # Legacy: rag_config.provider_config.vector_id
-                elif (
-                    "provider_config" in rag_config
-                    and isinstance(rag_config.get("provider_config"), dict)
-                    and "vector_id" in rag_config["provider_config"]
-                ):
-                    collections.append(rag_config["provider_config"]["vector_id"])
-                # New: rag_config.vector_store.provider_config.vector_id
-                else:
-                    try:
-                        vector_store = rag_config.get("vector_store") or {}
-                        provider_config = vector_store.get("provider_config") or {}
-                        vs_vector_id = provider_config.get("vector_id")
-                        if vs_vector_id:
-                            collections.append(vs_vector_id)
-                    except Exception:
-                        pass
+            if not rag_config:
+                continue
 
-                rag_configs[node["id"]] = {
-                    "collections": collections,
-                    "similarity_top_k": rag_config.get("similarity_top_k", 10),
-                    "temperature": rag_config.get("temperature", 0.7),
-                    "model": rag_config.get("model", "gpt-4o"),
-                    "max_tokens": rag_config.get("max_tokens", 150),
-                }
+            collections = self._extract_rag_collections(rag_config)
+            # Nodes without resolvable collections fall back to the global rag_config
+            if not collections:
+                continue
 
-                logger.info(f"Initialized RAG config for node {node['id']} with collections: {collections}")
+            rag_configs[node["id"]] = {
+                "collections": collections,
+                "similarity_top_k": self._extract_similarity_top_k(rag_config),
+            }
+
+            logger.info(f"Initialized RAG config for node {node['id']} with collections: {collections}")
 
         return rag_configs
+
+    def _initialize_global_rag_config(self) -> Dict:
+        """Initialize the agent-level RAG config (same shape as KnowledgeBaseAgent's rag_config)."""
+        rag_config = self.config.get("rag_config")
+        if not rag_config:
+            return {}
+
+        collections = []
+        used_sources = rag_config.get("used_sources")
+        if used_sources:
+            collections = [
+                source["vector_id"] for source in used_sources if isinstance(source, dict) and source.get("vector_id")
+            ]
+        if not collections:
+            collections = self._extract_rag_collections(rag_config)
+
+        if not collections:
+            logger.warning("Global rag_config present but no collections resolved")
+            return {}
+
+        logger.info(f"Initialized global RAG config with collections: {collections}")
+        return {
+            "collections": collections,
+            "similarity_top_k": self._extract_similarity_top_k(rag_config),
+            "used_sources": used_sources or [],
+        }
 
     def _init_routing_client(self):
         """Initialize routing client. Uses Groq if available, else OpenAI."""
@@ -730,7 +763,7 @@ class GraphAgent(BaseAgent):
             return False
         return any(msg.get("role") == "tool" and msg.get("tool_call_id") in call_ids_for_fn for msg in node_history)
 
-    async def _build_messages(self, history: List[dict]) -> List[dict]:
+    async def _build_messages(self, history: List[dict], meta_info: Optional[dict] = None) -> List[dict]:
         """Build messages array: system prompt (+ optional RAG) + conversation history."""
         current_node = self.get_node_by_id(self.current_node_id)
         if not current_node:
@@ -753,8 +786,8 @@ class GraphAgent(BaseAgent):
         else:
             prompt = node_prompt
 
-        # Try RAG if configured for this node
-        rag_config = self.rag_configs.get(self.current_node_id)
+        # Try RAG: node-level config wins, otherwise fall back to the global (agent-level) config
+        rag_config = self.rag_configs.get(self.current_node_id) or self.global_rag_config
         if rag_config and rag_config.get("collections"):
             try:
                 client = await RAGServiceClientSingleton.get_client(self.rag_server_url)
@@ -765,6 +798,14 @@ class GraphAgent(BaseAgent):
                     max_results=rag_config.get("similarity_top_k", 10),
                     similarity_threshold=0.0,
                 )
+                if meta_info is not None:
+                    meta_info["rag_latency"] = {
+                        "sequence_id": meta_info.get("sequence_id"),
+                        "total_query_time_ms": rag_response.total_query_time_ms,
+                        "server_processing_time_ms": rag_response.server_processing_time_ms,
+                        "collections_count": len(rag_config["collections"]),
+                        "results_count": rag_response.total_results,
+                    }
                 if rag_response.contexts:
                     rag_context = await client.format_context_for_prompt(rag_response.contexts)
                     prompt = f"{prompt}\n\nKnowledge base:\n{rag_context}\n\nUse this information naturally."
@@ -827,7 +868,7 @@ class GraphAgent(BaseAgent):
                         }
                     return
 
-                messages = await self._build_messages(message)
+                messages = await self._build_messages(message, meta_info=meta_info)
                 # Inject ephemeral event hint (NOT persisted in conversation_history)
                 event_name = self.context_data.get("_last_event", "")
                 messages.append(
@@ -911,7 +952,7 @@ class GraphAgent(BaseAgent):
                     }
                 return
 
-            messages = await self._build_messages(message)
+            messages = await self._build_messages(message, meta_info=meta_info)
             yield {"messages": messages}
             tool_choice = self._get_tool_choice_for_node(history=message)
             async for chunk in self.llm.generate_stream(

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -251,15 +251,45 @@ class RerankerConfig(BaseModel):
 
 
 class LanceDBProviderConfig(BaseModel):
-    vector_id: str
+    # extra="allow" keeps call-time enrichment fields (chunk_size, overlapping) that the
+    # backend injects into provider_config before sending the config to the engine.
+    model_config = {"extra": "allow"}
+
+    vector_id: Optional[str] = None
+    vector_ids: Optional[List[str]] = None
     similarity_top_k: Optional[int] = 5
     score_threshold: Optional[float] = 0.1
     reranker: Optional[RerankerConfig] = RerankerConfig()  # Default to disabled reranker
 
+    @model_validator(mode="after")
+    def require_vector_identifier(self):
+        if not self.vector_id and not self.vector_ids:
+            raise ValueError("Either vector_id or vector_ids must be provided")
+        return self
+
 
 class VectorStore(BaseModel):
     provider: str
-    provider_config: Union[LanceDBProviderConfig, MongoDBProviderConfig]
+    provider_config: Union[LanceDBProviderConfig, MongoDBProviderConfig] = Field(union_mode="left_to_right")
+
+
+class UsedSource(BaseModel):
+    rag_id: Optional[str] = None
+    vector_id: Optional[str] = None
+    source: Optional[str] = None
+
+
+class RagConfig(BaseModel):
+    """Canonical knowledge-base config shared by the knowledgebase agent, graph agents
+    (global) and graph nodes. used_sources is populated server-side at call time.
+    """
+
+    # extra="allow" preserves server-injected enrichment keys and any node-level extras.
+    model_config = {"extra": "allow"}
+
+    vector_store: VectorStore
+    similarity_top_k: Optional[int] = None
+    used_sources: Optional[List[UsedSource]] = None
 
 
 class Llm(BaseModel):
@@ -355,15 +385,6 @@ class GraphEdge(BaseModel):
     priority: Optional[int] = None  # lower = evaluated first. Defaults: expression/unconditional=0, llm=100
 
 
-class GraphNodeRAGConfig(BaseModel):
-    """RAG configuration for Graph Agent nodes."""
-
-    vector_store: VectorStore
-    temperature: Optional[float] = 0.7
-    model: Optional[str] = "gpt-4"
-    max_tokens: Optional[int] = 150
-
-
 class GraphNode(BaseModel):
     id: str
     description: Optional[str] = None
@@ -375,7 +396,7 @@ class GraphNode(BaseModel):
     edges: List[GraphEdge] = Field(default_factory=list)
     function_call: Optional[str] = None
     completion_check: Optional[Callable[[List[dict]], bool]] = None
-    rag_config: Optional[GraphNodeRAGConfig] = None
+    rag_config: Optional[RagConfig] = None
 
 
 class GraphAgentConfig(Llm):
@@ -383,6 +404,8 @@ class GraphAgentConfig(Llm):
     nodes: List[GraphNode]
     current_node_id: str
     context_data: Optional[dict] = None
+    # Global knowledge base. Nodes without their own rag_config fall back to this at retrieval time.
+    rag_config: Optional[RagConfig] = None
     # Routing configuration
     routing_model: Optional[str] = None  # Model for routing decisions (default: same as main model)
     routing_provider: Optional[str] = None  # Provider for routing (e.g., "groq" for fast inference)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.99"
+version = "0.10.100"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Graph agents can now use a global knowledge base at `llm_config.rag_config` (the same canonical shape as the knowledgebase agent) alongside per-node `nodes[].rag_config`. A node's own `rag_config` wins for that node; nodes without one fall back to the global config. The agent always stays a `graph_agent`.

Also fixes a data-loss bug in the RAG models:

1. `LanceDBProviderConfig` required a singular `vector_id`, so a config carrying plural `vector_ids` failed that model and the `Union[LanceDBProviderConfig, MongoDBProviderConfig]` silently coerced it to the all-optional `MongoDBProviderConfig`, dropping every vector id. It now accepts `vector_id` or `vector_ids` with a validator requiring one, and `VectorStore.provider_config` uses `union_mode="left_to_right"`.
2. A shared typed `RagConfig` model now backs both the global (`GraphAgentConfig.rag_config`) and per-node (`GraphNode.rag_config`) graph configs.

The engine resolves node-level config first and falls back to the global config in `_build_messages`, and emits `rag_latency` telemetry. `similarity_top_k` is now read from `provider_config`.