### PR TITLE
feat: log deterministic graph routing requests with expression trace

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.100"
+__version__ = "0.10.101"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3365,6 +3365,18 @@ class TaskManager(BaseManager):
                             direction=LogDirection.REQUEST,
                             run_id=self.run_id,
                         )
+                    elif routing_info.get("routing_type") == "deterministic":
+                        expression_trace = (
+                            routing_info.get("routing_expression") or routing_info.get("reasoning") or "matched"
+                        )
+                        convert_to_request_log(
+                            message=f"Deterministic routing on node '{routing_info.get('previous_node', '?')}'\n{expression_trace}",
+                            meta_info=meta_info,
+                            model="deterministic",
+                            component=LogComponent.GRAPH_ROUTING,
+                            direction=LogDirection.REQUEST,
+                            run_id=self.run_id,
+                        )
 
                     # Build routing response data
                     if routing_info.get("transitioned"):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -19,7 +19,7 @@ from bolna.helpers.utils import (
     DictWithMissing,
     get_md5_hash,
 )
-from bolna.helpers.expression_evaluator import evaluate_edge_expression
+from bolna.helpers.expression_evaluator import evaluate_edge_expression, describe_edge_expression
 from bolna.enums import EdgeConditionType, NodeType
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
@@ -68,6 +68,7 @@ class GraphAgent(BaseAgent):
         self.current_node_entry_index = 0
         self._silence_repeats = 0
         self._event_triggered_generation = False
+        self._last_deterministic_eval = None
         self.rag_configs = self.initialize_rag_configs()
         self.global_rag_config = self._initialize_global_rag_config()
         self.rag_server_url = os.getenv("RAG_SERVER_URL", "http://localhost:8000")
@@ -396,12 +397,17 @@ class GraphAgent(BaseAgent):
         llm.sort(key=lambda e: e["priority"] if e.get("priority") is not None else 100)
         return deterministic, llm
 
-    def _evaluate_deterministic_edges(self, edges: list) -> Optional[dict]:
-        """Return first matching deterministic edge, or None."""
+    def _evaluate_deterministic_edges(self, edges: list) -> Tuple[Optional[dict], List[str]]:
+        """Return (first matching deterministic edge or None, per-edge evaluation traces)."""
+        evaluations = []
         for edge in edges:
-            if evaluate_edge_expression(edge, self.context_data):
-                return edge
-        return None
+            is_match = evaluate_edge_expression(edge, self.context_data)
+            evaluations.append(
+                f"-> {edge.get('to_node_id')}: {describe_edge_expression(edge, self.context_data)} | matched={is_match}"
+            )
+            if is_match:
+                return edge, evaluations
+        return None, evaluations
 
     def process_event(self, event: dict) -> dict:
         """Process an external event. Merges properties into context_data
@@ -635,6 +641,7 @@ class GraphAgent(BaseAgent):
     ]:
         """Two-phase routing: deterministic expressions first, then LLM fallback."""
         start_time = time.perf_counter()
+        self._last_deterministic_eval = None
 
         current_node = self.get_node_by_id(self.current_node_id)
         if not current_node:
@@ -664,15 +671,23 @@ class GraphAgent(BaseAgent):
 
         # Phase 1: deterministic (0ms)
         if deterministic_edges:
-            matched_edge = self._evaluate_deterministic_edges(deterministic_edges)
+            matched_edge, det_evaluations = self._evaluate_deterministic_edges(deterministic_edges)
+            self._last_deterministic_eval = "; ".join(det_evaluations)
             if matched_edge:
                 latency_ms = (time.perf_counter() - start_time) * 1000
                 ct = matched_edge.get("condition_type", EdgeConditionType.EXPRESSION)
                 reasoning = f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{matched_edge.get('condition', ct)}"
                 logger.info(
-                    f"Routing decision (deterministic): -> {matched_edge['to_node_id']} | {reasoning} (latency: {latency_ms:.1f}ms)"
+                    f"Routing decision (deterministic) on node '{self.current_node_id}': "
+                    f"-> {matched_edge['to_node_id']} | {self._last_deterministic_eval} (latency: {latency_ms:.1f}ms)"
                 )
                 return matched_edge["to_node_id"], None, latency_ms, None, None, reasoning, 1.0, None
+
+            logger.info(
+                f"No deterministic edge matched on node '{self.current_node_id}' "
+                f"({'falling back to LLM routing' if llm_edges else 'staying on node'}): "
+                f"{self._last_deterministic_eval}"
+            )
 
         # Phase 2: LLM
         if llm_edges:
@@ -934,6 +949,7 @@ class GraphAgent(BaseAgent):
                     "routing_messages": routing_messages,
                     "routing_tools": routing_tools,
                     "reasoning": reasoning,
+                    "routing_expression": self._last_deterministic_eval,
                     "confidence": confidence,
                     "routing_usage": routing_usage,
                     "node_type": node_type,

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -108,3 +108,35 @@ def evaluate_edge_expression(edge: dict, context_data: dict) -> bool:
         return False
 
     return evaluate_expression_group(expression, context_data)
+
+
+def describe_condition(condition: dict, context_data: dict) -> str:
+    """Trace one condition for routing logs: "variable operator value (actual=<resolved>) -> <result>"."""
+    variable = condition.get("variable", "")
+    operator = condition.get("operator", "")
+    actual = resolve_variable(context_data, variable)
+    actual_repr = "<missing>" if actual is _MISSING else repr(actual)
+    result = evaluate_condition(condition, context_data)
+
+    if operator in (ExpressionOperator.EXISTS, ExpressionOperator.NOT_EXISTS):
+        return f"{variable} {operator} (actual={actual_repr}) -> {result}"
+    return f"{variable} {operator} {condition.get('value')!r} (actual={actual_repr}) -> {result}"
+
+
+def describe_edge_expression(edge: dict, context_data: dict) -> str:
+    """Trace an edge's deterministic evaluation (variable/operator/expected vs actual) for routing logs."""
+    condition_type = edge.get("condition_type")
+
+    if condition_type == EdgeConditionType.UNCONDITIONAL:
+        return "unconditional"
+    if condition_type != EdgeConditionType.EXPRESSION:
+        return f"{condition_type} (non-deterministic)"
+
+    expression = edge.get("expression") or {}
+    conditions = expression.get("conditions", [])
+    if not conditions:
+        return "expression (no conditions)"
+
+    logic = expression.get("logic") or "and"
+    separator = f" {logic.upper()} "
+    return separator.join(describe_condition(c, context_data) for c in conditions)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.100"
+version = "0.10.101"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Deterministic (expression/unconditional) graph-agent routing produced no `graph_routing` request log and never surfaced which expression was evaluated or the resolved value, so these routing decisions were effectively invisible when debugging.

What changed:
1. Emit a `graph_routing` REQUEST log for deterministic routing. The request log previously gated on `routing_messages`, which only LLM routing populates, so deterministic turns logged no request at all.
2. Add per-edge evaluation traces via two pure helpers in `expression_evaluator.py` (`describe_condition`, `describe_edge_expression`): `variable operator expected (actual=<resolved>) -> result | matched=`. Surfaced on `routing_info.routing_expression`.
3. Keep the routing RESPONSE log compact, matching the LLM routing response shape; the evaluation detail lives on the request side.

Example request log for an expression edge:
```
Deterministic routing on node 'verify_otp'
-> account_locked: recipient_data.attempts gte 3 (actual=3) -> True AND recipient_data.verified eq False (actual=False) -> True | matched=True
```
