### PR TITLE
Add SSRF guard for user-controlled outbound URLs

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.98"
+__version__ = "0.10.99"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -31,7 +31,12 @@ from bolna.constants import (
     GPT5_4_MODEL_PREFIX,
     STALL_HANGUP_FLOOR_S,
 )
-from bolna.helpers.function_calling_helpers import trigger_api, computed_api_response, prepare_api_request
+from bolna.helpers.function_calling_helpers import (
+    trigger_api,
+    computed_api_response,
+    prepare_api_request,
+    validate_outbound_url,
+)
 from bolna.helpers.conversation_history import ConversationHistory
 from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
@@ -795,6 +800,10 @@ class TaskManager(BaseManager):
 
         async def send():
             try:
+                # ``target_url`` is user-controlled only on the direct fallback path;
+                # the dispatch URL is operator-set env config and may be internal.
+                if not dispatch_url:
+                    await validate_outbound_url(target_url)
                 convert_to_request_log(
                     str(payload),
                     meta_info,
@@ -804,7 +813,9 @@ class TaskManager(BaseManager):
                     run_id=self.run_id,
                 )
                 async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=10)) as session:
-                    async with session.post(target_url, json=payload) as response:
+                    # allow_redirects=False: a redirect hop is not re-validated and would
+                    # reopen the SSRF path past the pre-flight check above.
+                    async with session.post(target_url, json=payload, allow_redirects=False) as response:
                         response_text = await response.text()
                         logger.info(f"pre_call_webhook response ({response.status}): {response_text}")
                         convert_to_request_log(

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -48,10 +48,13 @@ async def validate_outbound_url(url):
     rebind-after-check window remains; closing it fully needs connect-time
     pinning, which we can layer on later.)
     """
-    if not url or not isinstance(url, str):
+    if not isinstance(url, str):
+        raise SSRFError("Missing or invalid request URL")
+    url = url.strip()
+    if not url:
         raise SSRFError("Missing or invalid request URL")
 
-    parsed = urlsplit(url.strip())
+    parsed = urlsplit(url)
     scheme = parsed.scheme.lower()
     if scheme not in ALLOWED_URL_SCHEMES:
         raise SSRFError(f"Blocked URL scheme {scheme!r}; only http/https are allowed")
@@ -67,7 +70,9 @@ async def validate_outbound_url(url):
 
     loop = asyncio.get_running_loop()
     try:
-        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        infos = await asyncio.wait_for(loop.getaddrinfo(host, port, type=socket.SOCK_STREAM), timeout=5)
+    except asyncio.TimeoutError:
+        raise SSRFError(f"DNS resolution for host {host!r} timed out")
     except socket.gaierror as exc:
         raise SSRFError(f"Could not resolve host {host!r}: {exc}")
 

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -1,6 +1,8 @@
 import asyncio
+import ipaddress
 import json
-from urllib.parse import quote
+import socket
+from urllib.parse import quote, urlsplit
 
 import aiohttp
 from yarl import URL
@@ -9,6 +11,74 @@ from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log, format_error_message
 
 logger = configure_logger(__name__)
+
+ALLOWED_URL_SCHEMES = ("http", "https")
+
+
+class SSRFError(ValueError):
+    """Raised when an outbound request targets a non-public address."""
+
+
+def _is_disallowed_ip(ip):
+    """True if ``ip`` (an ``ipaddress`` object) is not safe to connect to."""
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+    # ``is_global`` is the authoritative "publicly routable" check; the explicit
+    # flags are belt-and-suspenders across Python/ipaddress versions.
+    return (
+        not ip.is_global
+        or ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local  # 169.254.0.0/16 (AWS/GCP metadata) and fe80::/10
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+async def validate_outbound_url(url):
+    """SSRF guard for user-supplied URLs.
+
+    Rejects non-http(s) schemes and any host that resolves to a non-public
+    address (loopback, RFC-1918, link-local incl. the 169.254.169.254 cloud
+    metadata endpoint, reserved, etc.). Raises ``SSRFError`` on a blocked URL.
+
+    Resolution happens here rather than only checking the literal string so that
+    a hostname pointing at an internal address is also rejected. (A short
+    rebind-after-check window remains; closing it fully needs connect-time
+    pinning, which we can layer on later.)
+    """
+    if not url or not isinstance(url, str):
+        raise SSRFError("Missing or invalid request URL")
+
+    parsed = urlsplit(url.strip())
+    scheme = parsed.scheme.lower()
+    if scheme not in ALLOWED_URL_SCHEMES:
+        raise SSRFError(f"Blocked URL scheme {scheme!r}; only http/https are allowed")
+
+    host = parsed.hostname
+    if not host:
+        raise SSRFError("Request URL has no host")
+
+    try:
+        port = parsed.port
+    except ValueError:
+        port = None
+
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+    except socket.gaierror as exc:
+        raise SSRFError(f"Could not resolve host {host!r}: {exc}")
+
+    for info in infos:
+        addr = info[4][0]
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            raise SSRFError(f"Could not validate resolved address {addr!r} for host {host!r}")
+        if _is_disallowed_ip(ip):
+            raise SSRFError(f"Blocked request to non-public address {addr} (resolved from {host})")
 
 
 def _contains_var_markers(obj):
@@ -130,6 +200,7 @@ async def trigger_api(
     url, method, param, api_token, headers_data, meta_info, run_id, return_response_metadata=False, **kwargs
 ):
     try:
+        await validate_outbound_url(url)
         prepared_request = prepare_api_request(param, api_token, headers_data, **kwargs)
         request_body = prepared_request["request_body"]
         api_params = prepared_request["api_params"]
@@ -150,16 +221,20 @@ async def trigger_api(
             if method.lower() == "get":
                 get_url = build_get_url(url, api_params)
                 logger.info(f"Sending request {request_body}, {get_url}, {headers}")
-                async with session.get(get_url, headers=headers) as response:
+                # allow_redirects=False: the URL is validated pre-flight, but a redirect
+                # hop is not re-validated and would reopen the SSRF path (e.g. 302 -> IMDS).
+                async with session.get(get_url, headers=headers, allow_redirects=False) as response:
                     response_text = await response.text()
             elif method.lower() == "post":
                 logger.info(f"Sending request {api_params}, {url}, {headers}")
                 if content_type == "json":
-                    async with session.post(url, json=api_params, headers=headers) as response:
+                    async with session.post(url, json=api_params, headers=headers, allow_redirects=False) as response:
                         response_text = await response.text()
                 elif content_type == "form":
                     normalized_api_params = normalize_for_form(api_params)
-                    async with session.post(url, data=normalized_api_params, headers=headers) as response:
+                    async with session.post(
+                        url, data=normalized_api_params, headers=headers, allow_redirects=False
+                    ) as response:
                         response_text = await response.text()
                 else:
                     raise ValueError(
@@ -180,6 +255,27 @@ async def trigger_api(
                 }
 
             return response_text if response_text is not None else ""
+    except SSRFError as e:
+        message = f"ERROR CALLING API: blocked outbound request: {e}"
+        logger.warning(message)
+        if run_id:
+            convert_to_request_log(
+                format_error_message("function_call", url, str(e)),
+                meta_info,
+                model=None,
+                component=LogComponent.WARNING,
+                direction=LogDirection.WARNING,
+                is_cached=False,
+                run_id=run_id,
+            )
+        if return_response_metadata:
+            return {
+                "status_code": None,
+                "body": message,
+                "content_type": None,
+                "error": str(e),
+            }
+        return message
     except asyncio.TimeoutError:
         message = f"ERROR CALLING API: Request to {url} timed out after 5 seconds"
         logger.debug(message)

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -63,7 +63,7 @@ async def validate_outbound_url(url):
     try:
         port = parsed.port
     except ValueError:
-        port = None
+        raise SSRFError("Request URL has an invalid port")
 
     loop = asyncio.get_running_loop()
     try:
@@ -256,11 +256,14 @@ async def trigger_api(
 
             return response_text if response_text is not None else ""
     except SSRFError as e:
-        message = f"ERROR CALLING API: blocked outbound request: {e}"
-        logger.warning(message)
+        # Log the full reason server-side, but return a generic message: the resolved
+        # IP/host in the SSRFError text would otherwise flow back to the LLM and hand a
+        # non-blind SSRF probe the exact internal address it was trying to discover.
+        logger.warning(f"Blocked outbound request to {url}: {e}")
+        message = "ERROR CALLING API: request blocked by outbound URL policy"
         if run_id:
             convert_to_request_log(
-                format_error_message("function_call", url, str(e)),
+                format_error_message("function_call", url, "blocked by outbound URL policy"),
                 meta_info,
                 model=None,
                 component=LogComponent.WARNING,
@@ -273,7 +276,7 @@ async def trigger_api(
                 "status_code": None,
                 "body": message,
                 "content_type": None,
-                "error": str(e),
+                "error": "blocked by outbound URL policy",
             }
         return message
     except asyncio.TimeoutError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.98"
+version = "0.10.99"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_pre_call_webhook.py
+++ b/tests/tests/test_pre_call_webhook.py
@@ -74,8 +74,8 @@ class _FakeSession:
     def __init__(self, *a, **k):
         pass
 
-    def post(self, url, json=None):
-        _FakeSession.last_post = {"url": url, "json": json}
+    def post(self, url, json=None, **kwargs):
+        _FakeSession.last_post = {"url": url, "json": json, "kwargs": kwargs}
         return _FakeResponse()
 
     async def __aenter__(self):
@@ -277,7 +277,7 @@ async def test_pre_call_webhook_swallows_errors():
     me = _make_self()
 
     class _BoomSession(_FakeSession):
-        def post(self, url, json=None):
+        def post(self, url, json=None, **kwargs):
             raise RuntimeError("endpoint down")
 
     with (

--- a/tests/tests/test_pre_call_webhook.py
+++ b/tests/tests/test_pre_call_webhook.py
@@ -15,6 +15,20 @@ import pytest
 from bolna.agent_manager.task_manager import TaskManager
 
 
+@pytest.fixture(autouse=True)
+def _bypass_ssrf_validation():
+    """The fallback pre-call webhook now SSRF-validates its target via a real DNS
+    lookup. These tests exercise payload/bookkeeping logic with non-resolving
+    placeholder hosts, so stub the validator out here; the validator's own
+    behaviour is covered in test_ssrf_validation.py."""
+
+    async def _noop(url):
+        return None
+
+    with patch("bolna.agent_manager.task_manager.validate_outbound_url", _noop):
+        yield
+
+
 def _make_self():
     """Minimal stand-in exposing only the attributes fire_pre_call_webhook reads."""
     inp = MagicMock()

--- a/tests/tests/test_ssrf_validation.py
+++ b/tests/tests/test_ssrf_validation.py
@@ -1,0 +1,87 @@
+"""Tests for the SSRF guard on user-controlled outbound URLs.
+
+Covers ``validate_outbound_url`` directly: scheme/host/port rejection, non-public
+IP literals (incl. the cloud metadata endpoint), and the DNS-pointed-inward case
+where a public-looking hostname resolves to an internal address.
+"""
+
+import asyncio
+import socket
+
+import pytest
+
+from bolna.helpers.function_calling_helpers import SSRFError, validate_outbound_url
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://169.254.169.254/latest/meta-data/",  # AWS/GCP metadata (IMDS)
+        "http://127.0.0.1/",  # loopback
+        "http://10.0.0.5/internal",  # RFC-1918
+        "http://192.168.1.1/",
+        "http://172.16.0.1/",
+        "http://[::1]/",  # IPv6 loopback
+        "http://100.64.0.1/",  # CGNAT / shared address space
+        "http://0.0.0.0/",  # unspecified
+    ],
+)
+async def test_blocks_non_public_ip_literals(url):
+    with pytest.raises(SSRFError):
+        await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["ftp://host/x", "file:///etc/passwd", "gopher://h:70/"])
+async def test_blocks_non_http_schemes(url):
+    with pytest.raises(SSRFError):
+        await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["", None, "http:///nopath", "https://"])
+async def test_blocks_missing_or_invalid_url(url):
+    with pytest.raises(SSRFError):
+        await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+async def test_blocks_invalid_port():
+    # urlsplit raises ValueError on an out-of-range port; must surface as SSRFError
+    # rather than silently passing validation and failing later in aiohttp.
+    with pytest.raises(SSRFError):
+        await validate_outbound_url("http://1.1.1.1:99999/")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("url", ["http://8.8.8.8/", "https://1.1.1.1/dns"])
+async def test_allows_public_ip_literals(url):
+    # Public IP literals resolve locally (no network) and must pass unchanged so
+    # domain-less clients on public IPs keep working.
+    await validate_outbound_url(url)
+
+
+@pytest.mark.asyncio
+async def test_blocks_hostname_resolving_to_internal_ip(monkeypatch):
+    """A public-looking hostname that resolves to an internal address is blocked.
+    A string-only URL check would miss this (DNS pointed inward / rebinding)."""
+    loop = asyncio.get_running_loop()
+
+    async def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("169.254.169.254", port or 80))]
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+    with pytest.raises(SSRFError):
+        await validate_outbound_url("http://totally-public-looking.example/")
+
+
+@pytest.mark.asyncio
+async def test_allows_hostname_resolving_to_public_ip(monkeypatch):
+    loop = asyncio.get_running_loop()
+
+    async def fake_getaddrinfo(host, port, *args, **kwargs):
+        return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", port or 80))]
+
+    monkeypatch.setattr(loop, "getaddrinfo", fake_getaddrinfo)
+    await validate_outbound_url("http://example.com/")

--- a/tests/tests/test_ssrf_validation.py
+++ b/tests/tests/test_ssrf_validation.py
@@ -40,7 +40,7 @@ async def test_blocks_non_http_schemes(url):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("url", ["", None, "http:///nopath", "https://"])
+@pytest.mark.parametrize("url", ["", "   ", None, "http:///nopath", "https://"])
 async def test_blocks_missing_or_invalid_url(url):
     with pytest.raises(SSRFError):
         await validate_outbound_url(url)


### PR DESCRIPTION
API tools and pre-call webhooks fetch user-supplied URLs with no
restrictions, allowing SSRF to internal services and the cloud metadata
endpoint (169.254.169.254) -> IAM credential theft.

- validate_outbound_url(): reject non-http(s) schemes and any host that
  resolves to a non-public address (loopback/RFC-1918/link-local/metadata/
  reserved/CGNAT). Public IPs and domains pass, so domain-less clients on
  public IPs are unaffected.
- Apply in trigger_api() and the pre-call webhook (skips the operator-set
  PRE_CALL_WEBHOOK_DISPATCH_URL, which may be internal).
- allow_redirects=False on these calls so a 302 -> internal hop cannot
  bypass the pre-flight check.
