### PR TITLE
Add host allowlist to the outbound URL SSRF guard

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.101"
+__version__ = "0.10.102"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -1,6 +1,7 @@
 import asyncio
 import ipaddress
 import json
+import os
 import socket
 from urllib.parse import quote, urlsplit
 
@@ -13,6 +14,12 @@ from bolna.helpers.utils import convert_to_request_log, format_error_message
 logger = configure_logger(__name__)
 
 ALLOWED_URL_SCHEMES = ("http", "https")
+
+# Hosts in BOLNA_TOOL_URL_HOST_ALLOWLIST (comma-separated) bypass the SSRF block,
+# for deployments that legitimately call an internal endpoint from a tool.
+_ALLOWLISTED_HOSTS = frozenset(
+    h.strip().lower() for h in os.getenv("BOLNA_TOOL_URL_HOST_ALLOWLIST", "").split(",") if h.strip()
+)
 
 
 class SSRFError(ValueError):
@@ -62,6 +69,9 @@ async def validate_outbound_url(url):
     host = parsed.hostname
     if not host:
         raise SSRFError("Request URL has no host")
+
+    if host.lower() in _ALLOWLISTED_HOSTS:
+        return
 
     try:
         port = parsed.port

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.101"
+version = "0.10.102"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The SSRF guard added in #804 blocks any tool URL that resolves to a private address. Some deployments legitimately call an internal endpoint (for example an internal load balancer) from a tool, which the guard now blocks with no way to permit it.

This adds `BOLNA_TOOL_URL_HOST_ALLOWLIST`: a comma-separated list of trusted hostnames that bypass the block, matched case-insensitively against the URL host. It is empty by default, so behavior is unchanged unless an operator sets it. Cloud metadata, loopback, and every other private range stay blocked for non-allowlisted hosts.
