### PR TITLE
fix: keep strong references to fire-and-forget asyncio tasks

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -76,6 +76,7 @@ from bolna.helpers.utils import (
     format_error_message,
     enrich_context_with_time_variables,
 )
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.helpers.logger_config import configure_logger
 from ..helpers.mark_event_meta_data import MarkEventMetaData
 from ..helpers.observable_variable import ObservableVariable
@@ -4623,7 +4624,10 @@ class TaskManager(BaseManager):
             return
         snapshot = dict(meta_info)
         self._last_turn_meta_info = snapshot
-        asyncio.create_task(self.handle_language_switch(transcriber_message, snapshot, spawn_language=self.language))
+        create_tracked_task(
+            self.handle_language_switch(transcriber_message, snapshot, spawn_language=self.language),
+            name="language-switch-decision",
+        )
 
     async def handle_language_switch(
         self,

--- a/bolna/helpers/async_utils.py
+++ b/bolna/helpers/async_utils.py
@@ -1,0 +1,71 @@
+"""Helpers for safely scheduling fire-and-forget asyncio tasks.
+
+``asyncio.create_task`` only stores a *weak* reference to the task it returns.
+If the caller discards that reference (a fire-and-forget call such as
+``asyncio.create_task(do_something())``), the task can be garbage-collected
+before it finishes. That surfaces as the warning
+
+    Task was destroyed but it is pending!
+
+and the scheduled work is silently dropped. See the asyncio docs:
+https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task
+
+``create_tracked_task`` keeps a strong reference to every task it schedules
+until the task completes, then drops it via a done callback. It is a drop-in
+replacement for ``asyncio.create_task`` at fire-and-forget call sites.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+from bolna.helpers.logger_config import configure_logger
+
+logger = configure_logger(__name__)
+
+# Strong references to in-flight fire-and-forget tasks. The event loop only
+# holds a weak reference, so without this set the tasks can be collected
+# mid-execution. Tasks remove themselves once done (see ``_on_task_done``).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _on_task_done(task: asyncio.Task) -> None:
+    """Drop the strong reference and surface unexpected failures.
+
+    Calling ``task.exception()`` here also retrieves the result, which prevents
+    asyncio's "Task exception was never retrieved" noise for fire-and-forget
+    tasks that raise.
+    """
+    _background_tasks.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(f"Background task {task.get_name()!r} failed: {exc!r}")
+
+
+def create_tracked_task(coro: Coroutine[Any, Any, Any], *, name: str | None = None) -> asyncio.Task:
+    """Schedule ``coro`` and keep a strong reference until it finishes.
+
+    Use this instead of ``asyncio.create_task`` whenever the returned task would
+    otherwise be discarded, so the task cannot be garbage-collected while still
+    pending. Must be called from within a running event loop.
+
+    Args:
+        coro: The coroutine to run.
+        name: Optional task name, surfaced in logs and tracebacks.
+
+    Returns:
+        The scheduled ``asyncio.Task`` (callers may ignore it).
+    """
+    task = asyncio.create_task(coro, name=name)
+    _background_tasks.add(task)
+    task.add_done_callback(_on_task_done)
+    return task
+
+
+def pending_task_count() -> int:
+    """Return the number of tracked tasks still in flight (handy in tests)."""
+    return len(_background_tasks)

--- a/bolna/helpers/observable_variable.py
+++ b/bolna/helpers/observable_variable.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -37,9 +38,12 @@ class ObservableVariable:
         for observer in self._observers:
             if inspect.iscoroutinefunction(observer):
                 try:
-                    # If an event loop is already running, schedule the async observer
-                    loop = asyncio.get_running_loop()
-                    loop.create_task(observer(new_value))
+                    # If an event loop is already running, schedule the async observer.
+                    # get_running_loop() raises RuntimeError (handled below) when there
+                    # is none; create_tracked_task keeps a strong ref so the observer
+                    # isn't garbage-collected before it runs.
+                    asyncio.get_running_loop()
+                    create_tracked_task(observer(new_value))
                 except RuntimeError:
                     # No running loop; run the async function in a temporary event loop
                     asyncio.run(observer(new_value))

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -22,6 +22,7 @@ from enum import Enum
 from dotenv import load_dotenv
 from pydantic import create_model
 from .logger_config import configure_logger
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.constants import PREPROCESS_DIR, PRE_FUNCTION_CALL_MESSAGE, TRANSFERING_CALL_FILLER, END_CALL_FUNCTION_PREFIX
 from bolna.enums import LogComponent, LogDirection, UsageSource
 from bolna.prompts import DATE_PROMPT
@@ -818,7 +819,7 @@ def convert_to_request_log(
                 )
                 log["llm_metadata"] = llm_metadata
     log["engine"] = engine
-    asyncio.create_task(write_request_logs(log, run_id))
+    create_tracked_task(write_request_logs(log, run_id), name="write-request-logs")
 
 
 async def process_task_cancellation(asyncio_task, task_name):

--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -6,6 +6,7 @@ import json
 from starlette.websockets import WebSocketDisconnect
 from dotenv import load_dotenv
 from bolna.helpers.utils import create_ws_data_packet
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -67,7 +68,7 @@ class TelephonyInputHandler(DefaultInputHandler):
         logger.info("stopping handler")
         self.running = False
         # Fire and forget disconnect_stream - don't block the disconnection flow
-        asyncio.create_task(self._safe_disconnect_stream())
+        create_tracked_task(self._safe_disconnect_stream(), name="telephony-disconnect-stream")
         logger.info("sleeping for 2 seconds so that whatever needs to pass is passed")
         await asyncio.sleep(2)
         try:

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -9,6 +9,7 @@ import wave
 
 from dotenv import load_dotenv
 
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.helpers.logger_config import configure_logger
 
 from .base import LIDBackend
@@ -274,7 +275,7 @@ class SarvamLID(LIDBackend):
                             logger.info(
                                 f"SarvamLID: detected {lang!r} (short={short!r}, duration={audio_duration:.2f}s, conf={conf:.2f})"
                             )
-                            asyncio.create_task(self.on_language(short, conf))
+                            create_tracked_task(self.on_language(short, conf), name="sarvam-lid-on-language")
                 except Exception as e:
                     logger.error(f"SarvamLID receiver parse error: {e}")
         except asyncio.CancelledError:
@@ -296,7 +297,7 @@ class SarvamLID(LIDBackend):
             return
         self._reconnecting = True
         logger.error(f"SarvamLID: socket dead ({source}) — detector mute, attempting reconnect")
-        asyncio.create_task(self._reconnect())
+        create_tracked_task(self._reconnect(), name="sarvam-lid-reconnect")
 
     async def _reconnect(self):
         try:

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -27,6 +27,7 @@ import traceback
 import audioop
 from collections import deque
 from bolna.output_handlers.telephony import TelephonyOutputHandler
+from bolna.helpers.async_utils import create_tracked_task
 from bolna.helpers.logger_config import configure_logger
 from dotenv import load_dotenv
 
@@ -466,7 +467,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
     def set_hangup_sent(self):
         super().set_hangup_sent()
         try:
-            asyncio.create_task(self.send_hangup())
+            create_tracked_task(self.send_hangup(), name="sip-trunk-send-hangup")
         except Exception as e:
             logger.error(f"sip-trunk send_hangup: {e}")
 

--- a/tests/tests/test_async_utils.py
+++ b/tests/tests/test_async_utils.py
@@ -1,0 +1,127 @@
+"""Unit tests for bolna.helpers.async_utils.create_tracked_task.
+
+These pin the fix for "Task was destroyed but it is pending!" (issue #462):
+fire-and-forget tasks must keep a strong reference until they finish so the
+garbage collector can't drop them mid-execution.
+"""
+
+import asyncio
+import gc
+import logging
+
+import pytest
+
+from bolna.helpers.async_utils import create_tracked_task, pending_task_count
+
+
+@pytest.mark.asyncio
+async def test_runs_coroutine_and_returns_task():
+    result = {}
+
+    async def work():
+        result["ran"] = True
+        return 42
+
+    task = create_tracked_task(work())
+    assert isinstance(task, asyncio.Task)
+    assert await task == 42
+    assert result["ran"] is True
+
+
+@pytest.mark.asyncio
+async def test_tracked_while_pending_then_dropped_when_done():
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def work():
+        started.set()
+        await release.wait()
+
+    before = pending_task_count()
+    task = create_tracked_task(work())
+
+    await started.wait()
+    # While the task is pending, the helper holds a strong reference to it.
+    assert pending_task_count() == before + 1
+    assert task in _tracked_set()
+
+    release.set()
+    await task
+    # The done callback runs on the next loop iteration; let it fire.
+    await asyncio.sleep(0)
+    assert pending_task_count() == before
+    assert task not in _tracked_set()
+
+
+@pytest.mark.asyncio
+async def test_survives_garbage_collection_while_pending():
+    """The core regression: a fire-and-forget task whose return value is
+    discarded must still complete even if a GC pass runs while it is pending."""
+    done = asyncio.Event()
+
+    async def work():
+        await asyncio.sleep(0.02)
+        done.set()
+
+    # Discard the returned task entirely — the only strong reference now lives
+    # inside the helper's set, exactly the fire-and-forget shape from issue #462.
+    create_tracked_task(work())
+
+    # A GC pass here would collect an untracked task and raise
+    # "Task was destroyed but it is pending!".
+    gc.collect()
+
+    await asyncio.wait_for(done.wait(), timeout=1.0)
+    assert done.is_set()
+
+
+@pytest.mark.asyncio
+async def test_task_name_is_propagated():
+    async def work():
+        return None
+
+    task = create_tracked_task(work(), name="my-task")
+    assert task.get_name() == "my-task"
+    await task
+
+
+@pytest.mark.asyncio
+async def test_exception_is_logged_and_reference_dropped(caplog):
+    async def boom():
+        raise ValueError("kaboom")
+
+    before = pending_task_count()
+    with caplog.at_level(logging.ERROR, logger="bolna.helpers.async_utils"):
+        task = create_tracked_task(boom(), name="boom-task")
+        with pytest.raises(ValueError, match="kaboom"):
+            await task
+        # Let the done callback run so it logs and drops the reference.
+        await asyncio.sleep(0)
+
+    assert pending_task_count() == before
+    assert any("boom-task" in rec.message and "kaboom" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_task_is_not_logged_as_error(caplog):
+    async def work():
+        await asyncio.sleep(10)
+
+    before = pending_task_count()
+    with caplog.at_level(logging.ERROR, logger="bolna.helpers.async_utils"):
+        task = create_tracked_task(work(), name="cancel-me")
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await asyncio.sleep(0)
+
+    assert pending_task_count() == before
+    assert not any("cancel-me" in rec.message for rec in caplog.records)
+
+
+def _tracked_set():
+    """Access the helper's internal set for white-box assertions."""
+    from bolna.helpers import async_utils
+
+    return async_utils._background_tasks


### PR DESCRIPTION
asyncio.create_task only stores a weak reference to the task it returns. Fire-and-forget call sites that discard the returned task let the garbage collector reclaim it mid-execution, which surfaces as 'Task was destroyed but it is pending' and silently drops the scheduled work (issue #462, ~130 events/day in Sentry).

Add bolna.helpers.async_utils.create_tracked_task, a drop-in replacement for asyncio.create_task that holds a strong reference until the task finishes (then drops it via a done callback) and logs unexpected failures. This generalizes the strong-reference pattern already used inline for the pre-call webhook in task_manager.

Route the genuinely fire-and-forget call sites through the helper:
- helpers/utils.py: write_request_logs
- helpers/observable_variable.py: async observer notification
- agent_manager/task_manager.py: language-switch decision
- lid/sarvam.py: on_language + reconnect
- input_handlers/telephony.py: disconnect-stream on stop
- output_handlers/.../sip_trunk.py: send_hangup

Call sites that already store the task on self or await it are unchanged.

Closes #462