### PR TITLE
feat: per-node tool scope for graph agents (end_call via hangup toggle)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.108"
+__version__ = "0.10.109"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -51,7 +51,6 @@ from bolna.enums import (
     NodeType,
     ChatRole,
     ToolScope,
-    LLMProvider,
 )
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
@@ -579,14 +578,6 @@ class TaskManager(BaseManager):
                         )
                 self.check_for_completion_llm = os.getenv("CHECK_FOR_COMPLETION_LLM")
 
-                # Explicit end_call_scope wins over the A/B experiment for graph agents.
-                end_call_scope = self.conversation_config.get("end_call_scope")
-                if end_call_scope is not None and end_call_scope not in (
-                    ToolScope.GLOBAL.value,
-                    ToolScope.NODE.value,
-                ):
-                    logger.warning(f"Ignoring invalid end_call_scope '{end_call_scope}'")
-                    end_call_scope = None
                 cancellation_prompt = self.conversation_config.get("call_cancellation_prompt")
                 end_call_description = (
                     (
@@ -597,33 +588,27 @@ class TaskManager(BaseManager):
                     else None
                 )
 
-                if self.__is_graph_agent() and end_call_scope:
-                    scope = ToolScope(end_call_scope)
+                # Graph agents: end_call tool scope follows the hangup toggle. With hangup_after_LLMCall
+                # OFF, end_call is restricted to nodes that opt in via function_call="end_call" (dormant
+                # if none do); with it ON, the experiment block below injects end_call globally.
+                if self.__is_graph_agent() and not self.use_llm_to_determine_hangup:
                     llm_config = self.task_config["tools_config"]["llm_agent"].get("llm_config", {}) or {}
-                    graph_nodes = llm_config.get("nodes", []) or []
                     end_call_nodes = [
                         n.get("id")
-                        for n in graph_nodes
+                        for n in (llm_config.get("nodes") or [])
                         if n.get("function_call") == END_CALL_FUNCTION_PREFIX and n.get("id")
                     ]
-                    self.kwargs["api_tools"] = _inject_end_call_tool(
-                        self.kwargs.get("api_tools"),
-                        scope=scope,
-                        nodes=end_call_nodes,
-                        description=end_call_description,
-                    )
-                    if scope == ToolScope.NODE and not end_call_nodes:
-                        logger.warning(
-                            "end_call_scope=node but no node declares function_call=end_call; end_call will be dormant"
+                    if end_call_nodes:
+                        self.kwargs["api_tools"] = _inject_end_call_tool(
+                            self.kwargs.get("api_tools"),
+                            scope=ToolScope.NODE,
+                            nodes=end_call_nodes,
+                            description=end_call_description,
                         )
-                    if llm_config.get("provider") == LLMProvider.GOOGLE.value:
-                        logger.warning(
-                            "Gemini does not enforce per-node tool scoping; end_call stays visible on all nodes"
-                        )
-                    logger.info(f"end_call tool injected for graph agent with scope={scope.value}")
+                        logger.info(f"end_call tool injected node-scoped on nodes={end_call_nodes}")
 
-                # A/B experiment: end_call tool as primary hangup, hangup_after_LLMCall as shadow.
-                elif (
+                # A/B experiment: end_call tool as primary (global) hangup, hangup_after_LLMCall as shadow.
+                if (
                     self.conversation_config.get("end_call_tool_mode") == "primary_with_shadow_hangup"
                     and self.use_llm_to_determine_hangup
                     and cancellation_prompt

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -43,7 +43,16 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
-from bolna.enums import TelephonyProvider, LogComponent, LogDirection, HangupReason, NodeType, ChatRole
+from bolna.enums import (
+    TelephonyProvider,
+    LogComponent,
+    LogDirection,
+    HangupReason,
+    NodeType,
+    ChatRole,
+    ToolScope,
+    LLMProvider,
+)
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
@@ -83,6 +92,28 @@ from .models import ComponentLatencies
 from .voicemail_handler import VoicemailHandler
 
 logger = configure_logger(__name__)
+
+
+def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
+    """Add the internal end_call tool (with scope/nodes) to api_tools; no-op if already present."""
+    if api_tools is None:
+        api_tools = {"tools": [], "tools_params": {}}
+    if END_CALL_FUNCTION_PREFIX in api_tools.get("tools_params", {}):
+        return api_tools  # already injected by the experiment path or a prior call
+    tool_def = copy.deepcopy(END_CALL_TOOL_DEFINITION)
+    if description:
+        tool_def["function"]["description"] = description
+    tools_list = api_tools.get("tools", [])
+    if isinstance(tools_list, str):
+        tools_list = json.loads(tools_list)
+    tools_list.append(tool_def)
+    api_tools["tools"] = tools_list
+    api_tools.setdefault("tools_params", {})[END_CALL_FUNCTION_PREFIX] = {
+        "pre_call_message": None,
+        "scope": scope.value if scope else None,
+        "nodes": list(nodes or []),
+    }
+    return api_tools
 
 
 def build_lid_decision_record(
@@ -548,29 +579,61 @@ class TaskManager(BaseManager):
                         )
                 self.check_for_completion_llm = os.getenv("CHECK_FOR_COMPLETION_LLM")
 
+                # Explicit end_call_scope wins over the A/B experiment for graph agents.
+                end_call_scope = self.conversation_config.get("end_call_scope")
+                if end_call_scope is not None and end_call_scope not in (
+                    ToolScope.GLOBAL.value,
+                    ToolScope.NODE.value,
+                ):
+                    logger.warning(f"Ignoring invalid end_call_scope '{end_call_scope}'")
+                    end_call_scope = None
+                cancellation_prompt = self.conversation_config.get("call_cancellation_prompt")
+                end_call_description = (
+                    (
+                        f"End the current call. Always say your goodbye message before calling this function.\n"
+                        f"Criteria for when to end: {cancellation_prompt}"
+                    )
+                    if cancellation_prompt
+                    else None
+                )
+
+                if self.__is_graph_agent() and end_call_scope:
+                    scope = ToolScope(end_call_scope)
+                    llm_config = self.task_config["tools_config"]["llm_agent"].get("llm_config", {}) or {}
+                    graph_nodes = llm_config.get("nodes", []) or []
+                    end_call_nodes = [
+                        n.get("id")
+                        for n in graph_nodes
+                        if n.get("function_call") == END_CALL_FUNCTION_PREFIX and n.get("id")
+                    ]
+                    self.kwargs["api_tools"] = _inject_end_call_tool(
+                        self.kwargs.get("api_tools"),
+                        scope=scope,
+                        nodes=end_call_nodes,
+                        description=end_call_description,
+                    )
+                    if scope == ToolScope.NODE and not end_call_nodes:
+                        logger.warning(
+                            "end_call_scope=node but no node declares function_call=end_call; end_call will be dormant"
+                        )
+                    if llm_config.get("provider") == LLMProvider.GOOGLE.value:
+                        logger.warning(
+                            "Gemini does not enforce per-node tool scoping; end_call stays visible on all nodes"
+                        )
+                    logger.info(f"end_call tool injected for graph agent with scope={scope.value}")
+
                 # A/B experiment: end_call tool as primary hangup, hangup_after_LLMCall as shadow.
-                if (
+                elif (
                     self.conversation_config.get("end_call_tool_mode") == "primary_with_shadow_hangup"
                     and self.use_llm_to_determine_hangup
-                    and self.conversation_config.get("call_cancellation_prompt")
+                    and cancellation_prompt
                 ):
-                    api_tools = self.kwargs.get("api_tools")
-                    if api_tools is None:
-                        api_tools = {"tools": [], "tools_params": {}}
-                        self.kwargs["api_tools"] = api_tools
-                    if END_CALL_FUNCTION_PREFIX not in api_tools.get("tools_params", {}):
-                        tool_def = copy.deepcopy(END_CALL_TOOL_DEFINITION)
-                        cancellation_criteria = self.conversation_config["call_cancellation_prompt"]
-                        tool_def["function"]["description"] = (
-                            f"End the current call. Always say your goodbye message before calling this function.\n"
-                            f"Criteria for when to end: {cancellation_criteria}"
-                        )
-                        tools_list = api_tools.get("tools", [])
-                        if isinstance(tools_list, str):
-                            tools_list = json.loads(tools_list)
-                        tools_list.append(tool_def)
-                        api_tools["tools"] = tools_list
-                        api_tools["tools_params"][END_CALL_FUNCTION_PREFIX] = {"pre_call_message": None}
+                    self.kwargs["api_tools"] = _inject_end_call_tool(
+                        self.kwargs.get("api_tools"),
+                        scope=ToolScope.GLOBAL,
+                        nodes=[],
+                        description=end_call_description,
+                    )
                     self.end_call_experiment = {
                         "end_call_invoked": False,
                         "end_call_reason": None,

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -20,7 +20,7 @@ from bolna.helpers.utils import (
     get_md5_hash,
 )
 from bolna.helpers.expression_evaluator import evaluate_edge_expression, describe_edge_expression
-from bolna.enums import EdgeConditionType, NodeType
+from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
@@ -758,6 +758,41 @@ class GraphAgent(BaseAgent):
         logger.info(f"Node '{self.current_node_id}' forcing specific function: {fn}")
         return {"type": "function", "function": {"name": fn}}
 
+    def _tools_for_node(self, node: Optional[dict], forced_name: Optional[str] = None) -> Optional[List[dict]]:
+        """Tools visible on this node (global + node-scoped + forced), or None to use the full set.
+
+        forced_name is the tool the resolved tool_choice forces this turn (or None); a forced tool
+        must stay visible for the tool_choice to be valid, but only when the force actually survives.
+        """
+        if not self.llm or not getattr(self.llm, "trigger_function_call", False):
+            return None
+        raw = getattr(self.llm, "tools", None)
+        if not raw:
+            return None
+        full = json.loads(raw) if isinstance(raw, str) else raw
+        if not full:
+            return None
+
+        api_params = getattr(self.llm, "api_params", {}) or {}
+        node_id = node.get("id") if node else None
+        forced = forced_name
+
+        subset = []
+        for tool in full:
+            name = tool.get("function", {}).get("name")
+            params = api_params.get(name, {}) or {}
+            if name == forced:
+                subset.append(tool)  # must stay visible so the forced tool_choice is valid
+            elif params.get("scope") == ToolScope.NODE.value:
+                if node_id is not None and node_id in (params.get("nodes") or []):
+                    subset.append(tool)
+            else:
+                subset.append(tool)
+
+        if len(subset) == len(full):
+            return None  # nothing filtered -> let generate_stream use self.tools
+        return subset
+
     def _missing_forced_function_vars(self, node: dict, fn: str) -> List[str]:
         tools = getattr(self.llm, "tools", None) or []
         if isinstance(tools, str):
@@ -904,8 +939,10 @@ class GraphAgent(BaseAgent):
                 )
                 yield {"messages": messages}
                 tool_choice = self._get_tool_choice_for_node(history=message)
+                forced_name = tool_choice["function"]["name"] if tool_choice else None
+                node_tools = self._tools_for_node(current_node, forced_name)
                 async for chunk in self.llm.generate_stream(
-                    messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
+                    messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice, tools=node_tools
                 ):
                     yield chunk
                 return
@@ -981,8 +1018,10 @@ class GraphAgent(BaseAgent):
             messages = await self._build_messages(message, meta_info=meta_info)
             yield {"messages": messages}
             tool_choice = self._get_tool_choice_for_node(history=message)
+            forced_name = tool_choice["function"]["name"] if tool_choice else None
+            node_tools = self._tools_for_node(current_node, forced_name)
             async for chunk in self.llm.generate_stream(
-                messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice
+                messages, synthesize=synthesize, meta_info=meta_info, tool_choice=tool_choice, tools=node_tools
             ):
                 yield chunk
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -273,6 +273,13 @@ class NodeType(str, Enum):
     STATIC = "static"
 
 
+class ToolScope(str, Enum):
+    """Where a graph-agent tool is exposed: GLOBAL (every node) or NODE (only its listed nodes)."""
+
+    GLOBAL = "global"
+    NODE = "node"
+
+
 class UsageSource(str, Enum):
     """Indicates whether token counts came from the API or text estimation."""
 

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -132,8 +132,7 @@ class AzureLLM(OpenAICompatibleLLM):
             model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:
-            _tools = tools if tools is not None else self.tools
-            _tools = json.loads(_tools) if isinstance(_tools, str) else _tools
+            _tools = self._parse_tools(tools)
             if _tools:  # omit tools when none are visible this turn (an empty array is a 400)
                 model_args["tools"] = _tools
                 model_args["tool_choice"] = tool_choice or "auto"

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -99,18 +99,22 @@ class AzureLLM(OpenAICompatibleLLM):
     def _responses_client(self):
         return getattr(self, "_responses_api_client", self.async_client)
 
-    async def generate_stream(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
+    async def generate_stream(
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
+    ):
         if self.use_responses_api:
             async for chunk in self._generate_stream_responses(
-                messages, synthesize, request_json, meta_info, tool_choice
+                messages, synthesize, request_json, meta_info, tool_choice, tools
             ):
                 yield chunk
         else:
-            async for chunk in self._generate_stream_chat(messages, synthesize, request_json, meta_info, tool_choice):
+            async for chunk in self._generate_stream_chat(
+                messages, synthesize, request_json, meta_info, tool_choice, tools
+            ):
                 yield chunk
 
     async def _generate_stream_chat(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
         if not messages or len(messages) == 0:
             raise Exception("No messages provided")
@@ -128,9 +132,12 @@ class AzureLLM(OpenAICompatibleLLM):
             model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:
-            model_args["tools"] = json.loads(self.tools) if isinstance(self.tools, str) else self.tools
-            model_args["tool_choice"] = tool_choice or "auto"
-            model_args["parallel_tool_calls"] = False
+            _tools = tools if tools is not None else self.tools
+            _tools = json.loads(_tools) if isinstance(_tools, str) else _tools
+            if _tools:  # omit tools when none are visible this turn (an empty array is a 400)
+                model_args["tools"] = _tools
+                model_args["tool_choice"] = tool_choice or "auto"
+                model_args["parallel_tool_calls"] = False
 
         answer, buffer = "", ""
         tools = model_args.get("tools", [])

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -238,8 +238,9 @@ class GeminiLLM(BaseLLM):
         return config
 
     async def generate_stream(
-        self, messages, synthesize=True, meta_info=None, tool_choice=None
+        self, messages, synthesize=True, meta_info=None, tool_choice=None, tools=None
     ) -> AsyncIterable[LLMStreamChunk]:
+        # tools= accepted for interface parity; per-node scoping is not wired for Gemini.
         system_instruction, history = self._prepare_history(messages)
         config = self._build_config(system_instruction)
 

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -59,7 +59,7 @@ class LiteLLM(BaseLLM):
             self.trigger_function_call = False
         self.run_id = kwargs.get("run_id", None)
 
-    async def generate_stream(self, messages, synthesize=True, meta_info=None, tool_choice=None):
+    async def generate_stream(self, messages, synthesize=True, meta_info=None, tool_choice=None, tools=None):
         if not messages or len(messages) == 0:
             raise Exception("No messages provided")
 
@@ -72,9 +72,12 @@ class LiteLLM(BaseLLM):
         model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:
-            model_args["tools"] = json.loads(self.tools) if isinstance(self.tools, str) else self.tools
-            model_args["tool_choice"] = tool_choice or "auto"
-            model_args["parallel_tool_calls"] = False
+            _tools = tools if tools is not None else self.tools
+            _tools = json.loads(_tools) if isinstance(_tools, str) else _tools
+            if _tools:  # omit tools when none are visible this turn (an empty array is a 400)
+                model_args["tools"] = _tools
+                model_args["tool_choice"] = tool_choice or "auto"
+                model_args["parallel_tool_calls"] = False
 
         tools = model_args.get("tools", [])
         accumulator = None

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -116,6 +116,14 @@ class OpenAICompatibleLLM(BaseLLM):
             logger.warning(f"Text tool call rescue: '{func_name}' not in api_params, falling back to TTS")
             return None
 
+        # Respect per-call tool visibility (node scoping): only rescue a tool offered this turn.
+        offered = model_args.get("tools") or []
+        if isinstance(offered, str):
+            offered = json.loads(offered)
+        if not any(t.get("function", {}).get("name") == func_name for t in offered):
+            logger.warning(f"Text tool call rescue: '{func_name}' not offered this turn, falling back to TTS")
+            return None
+
         func_conf = self.api_params[func_name]
         method = func_conf.get("method")
 
@@ -141,8 +149,7 @@ class OpenAICompatibleLLM(BaseLLM):
         )
 
         # Mirror ToolCallAccumulator.build_api_payload: validate required keys against the tool spec
-        tools_list = json.loads(self.tools) if isinstance(self.tools, str) else (self.tools or [])
-        tool_spec = next((t for t in tools_list if t.get("function", {}).get("name") == func_name), None)
+        tool_spec = next((t for t in offered if t.get("function", {}).get("name") == func_name), None)
 
         try:
             parsed_args = json.loads(args_str)
@@ -249,11 +256,12 @@ class OpenAICompatibleLLM(BaseLLM):
         """
         return isinstance(error, BadRequestError)
 
-    def _parse_tools(self):
-        """Parse tools from string or list format."""
+    def _parse_tools(self, tools=None):
+        """Parse tools from string or list format. ``tools`` overrides ``self.tools`` when given."""
         if not self.trigger_function_call:
             return []
-        return json.loads(self.tools) if isinstance(self.tools, str) else self.tools
+        src = tools if tools is not None else self.tools
+        return json.loads(src) if isinstance(src, str) else src
 
     def invalidate_response_chain(self):
         self.previous_response_id = None
@@ -336,11 +344,11 @@ class OpenAICompatibleLLM(BaseLLM):
         return LLMStreamChunk(data=api_call_payload, end_of_stream=False, latency=latency_data, is_function_call=True)
 
     def _build_responses_create_kwargs(
-        self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None
+        self, messages, meta_info, request_json, tool_choice, *, store=True, stream=None, tools=None
     ):
         """Build create kwargs common to both HTTP SSE and WebSocket streaming paths."""
         _, input_items = self._build_responses_input(messages)
-        responses_tools = MessageFormatAdapter.chat_tools_to_responses_tools(self._parse_tools())
+        responses_tools = MessageFormatAdapter.chat_tools_to_responses_tools(self._parse_tools(tools))
 
         create_kwargs = {
             "model": self.model,
@@ -389,13 +397,13 @@ class OpenAICompatibleLLM(BaseLLM):
         return create_kwargs, responses_tools
 
     async def _generate_stream_responses(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
         if not messages:
             raise ValueError("No messages provided")
 
         create_kwargs, responses_tools = self._build_responses_create_kwargs(
-            messages, meta_info, request_json, tool_choice, store=True, stream=True
+            messages, meta_info, request_json, tool_choice, store=True, stream=True, tools=tools
         )
 
         answer, buffer = "", ""
@@ -424,7 +432,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     )
                 self.previous_response_id = None
                 async for chunk in self._generate_stream_responses(
-                    messages, synthesize, request_json, meta_info, tool_choice
+                    messages, synthesize, request_json, meta_info, tool_choice, tools
                 ):
                     yield chunk
                 return

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -207,24 +207,28 @@ class OpenAiLLM(OpenAICompatibleLLM):
             self._ws_transport = OpenAIWSConnection(api_key=api_key)
             self._ws_transport.start_connect()
 
-    async def generate_stream(self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None):
+    async def generate_stream(
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
+    ):
         if self.use_responses_api:
             if self._ws_transport:
                 async for chunk in self._generate_stream_ws_responses(
-                    messages, synthesize, request_json, meta_info, tool_choice
+                    messages, synthesize, request_json, meta_info, tool_choice, tools
                 ):
                     yield chunk
             else:
                 async for chunk in self._generate_stream_responses(
-                    messages, synthesize, request_json, meta_info, tool_choice
+                    messages, synthesize, request_json, meta_info, tool_choice, tools
                 ):
                     yield chunk
         else:
-            async for chunk in self._generate_stream_chat(messages, synthesize, request_json, meta_info, tool_choice):
+            async for chunk in self._generate_stream_chat(
+                messages, synthesize, request_json, meta_info, tool_choice, tools
+            ):
                 yield chunk
 
     async def _generate_stream_chat(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
         if not messages or len(messages) == 0:
             raise Exception("No messages provided")
@@ -242,9 +246,12 @@ class OpenAiLLM(OpenAICompatibleLLM):
             model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:
-            model_args["tools"] = json.loads(self.tools) if isinstance(self.tools, str) else self.tools
-            model_args["tool_choice"] = tool_choice or "auto"
-            model_args["parallel_tool_calls"] = False
+            _tools = tools if tools is not None else self.tools
+            _tools = json.loads(_tools) if isinstance(_tools, str) else _tools
+            if _tools:  # omit tools when none are visible this turn (an empty array is a 400)
+                model_args["tools"] = _tools
+                model_args["tool_choice"] = tool_choice or "auto"
+                model_args["parallel_tool_calls"] = False
 
         answer, buffer = "", ""
         tools = model_args.get("tools", [])
@@ -492,7 +499,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             return {"type": "text"}
 
     async def _generate_stream_ws_responses(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
         """Stream via persistent WebSocket — same interface as _generate_stream_responses."""
         if not messages:
@@ -501,7 +508,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         # store=True activates server-side prompt-cache (cached_tokens in usage)
         # on top of the WS connection-local cache. Storage is free per OpenAI.
         create_params, responses_tools = self._build_responses_create_kwargs(
-            messages, meta_info, request_json, tool_choice, store=True
+            messages, meta_info, request_json, tool_choice, store=True, tools=tools
         )
 
         # WS endpoint silently closes on float temperature — coerce to int

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -246,8 +246,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:
-            _tools = tools if tools is not None else self.tools
-            _tools = json.loads(_tools) if isinstance(_tools, str) else _tools
+            _tools = self._parse_tools(tools)
             if _tools:  # omit tools when none are visible this turn (an empty array is a 400)
                 model_args["tools"] = _tools
                 model_args["tool_choice"] = tool_choice or "auto"

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -1,6 +1,8 @@
-from typing import Any, Optional, Union
+from typing import Any, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
+
+from bolna.enums import ToolScope
 
 
 class APIParams(BaseModel):
@@ -12,6 +14,9 @@ class APIParams(BaseModel):
     pre_call_message: Optional[Union[str, dict]] = None
     pre_call_webhook_url: Optional[str] = None
     pre_call_webhook_param: Optional[Union[str, dict]] = None
+    # Graph-agent tool scope; None == GLOBAL. NODE limits visibility to ``nodes``.
+    scope: Optional[ToolScope] = None
+    nodes: Optional[List[str]] = None
 
 
 class LatencyData(BaseModel):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -13,7 +13,6 @@ from .enums import (
     ExpressionLogic,
     EdgeConditionType,
     NodeType,
-    ToolScope,
 )
 from .constants import MODEL_REASONING_EFFORT_MAP
 
@@ -554,8 +553,6 @@ class ConversationConfig(BaseModel):
     voicemail_detection_duration: Optional[float] = 30.0  # Time window in seconds
     voicemail_check_interval: Optional[float] = 7.0  # Min time between interim checks
     voicemail_min_transcript_length: Optional[int] = 7  # Min words for interim check
-    # Graph agents: end_call tool scope. None == no injection (legacy/experiment path).
-    end_call_scope: Optional[ToolScope] = None
 
     @field_validator("hangup_after_silence", mode="before")
     def set_hangup_after_silence(cls, v):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -13,6 +13,7 @@ from .enums import (
     ExpressionLogic,
     EdgeConditionType,
     NodeType,
+    ToolScope,
 )
 from .constants import MODEL_REASONING_EFFORT_MAP
 
@@ -553,6 +554,8 @@ class ConversationConfig(BaseModel):
     voicemail_detection_duration: Optional[float] = 30.0  # Time window in seconds
     voicemail_check_interval: Optional[float] = 7.0  # Min time between interim checks
     voicemail_min_transcript_length: Optional[int] = 7  # Min words for interim check
+    # Graph agents: end_call tool scope. None == no injection (legacy/experiment path).
+    end_call_scope: Optional[ToolScope] = None
 
     @field_validator("hangup_after_silence", mode="before")
     def set_hangup_after_silence(cls, v):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.108"
+version = "0.10.109"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_tool_scope.py
+++ b/tests/tests/test_tool_scope.py
@@ -1,0 +1,333 @@
+"""Tests for tool scope (GLOBAL vs NODE) in graph agents and the end_call injection.
+
+Covers:
+* GraphAgent._tools_for_node resolution: global tools visible everywhere, node-scoped tools
+  only on their nodes, the forced tool always visible, and the escalation-node bug
+  (end_call must be ABSENT on intermediate nodes when NODE-scoped) -> fixed.
+* The per-call tools= override reaching the LLM request (openai chat + litellm), and tools=None
+  leaving behavior unchanged. The responses path is covered via _parse_tools.
+* _inject_end_call_tool: global vs node scope, description override, dedup, str tools list.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.agent_manager.task_manager import _inject_end_call_tool
+from bolna.enums import ToolScope
+from bolna.constants import END_CALL_TOOL_DEFINITION
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool(name):
+    return {
+        "type": "function",
+        "function": {"name": name, "description": name, "parameters": {"type": "object", "properties": {}}},
+    }
+
+
+def _make_graph_agent(nodes, current_node_id="n1"):
+    cfg = {
+        "agent_information": "t",
+        "model": "gpt-4o-mini",
+        "current_node_id": current_node_id,
+        "nodes": nodes,
+    }
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=MagicMock()),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": MagicMock(return_value=MagicMock())}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        agent = GraphAgent(cfg)
+    return agent
+
+
+class _StubLLM:
+    """Minimal stand-in for the response LLM that _tools_for_node reads."""
+
+    def __init__(self, tools, api_params):
+        self.trigger_function_call = True
+        self.tools = tools
+        self.api_params = api_params
+
+
+def _names(subset):
+    return None if subset is None else [t["function"]["name"] for t in subset]
+
+
+# ---------------------------------------------------------------------------
+# _tools_for_node
+# ---------------------------------------------------------------------------
+
+
+def test_global_tools_present_on_every_node():
+    nodes = [{"id": "n1", "edges": []}, {"id": "n2", "edges": []}]
+    agent = _make_graph_agent(nodes)
+    agent.llm = _StubLLM([_tool("a"), _tool("b")], {"a": {}, "b": {"scope": "global"}})
+    # All global -> nothing filtered -> None (LLM uses self.tools) on every node.
+    assert agent._tools_for_node(agent.get_node_by_id("n1")) is None
+    assert agent._tools_for_node(agent.get_node_by_id("n2")) is None
+
+
+def test_node_scoped_tool_visible_only_on_its_nodes():
+    nodes = [{"id": "n1", "edges": []}, {"id": "n2", "edges": []}]
+    agent = _make_graph_agent(nodes)
+    agent.llm = _StubLLM(
+        [_tool("g1"), _tool("g2"), _tool("search")],
+        {"g1": {}, "g2": {}, "search": {"scope": "node", "nodes": ["n2"]}},
+    )
+    assert _names(agent._tools_for_node(agent.get_node_by_id("n1"))) == ["g1", "g2"]
+    assert agent._tools_for_node(agent.get_node_by_id("n2")) is None  # all visible -> fallback
+
+
+def test_node_scoped_tool_with_empty_nodes_is_visible_nowhere():
+    nodes = [{"id": "n1", "edges": []}]
+    agent = _make_graph_agent(nodes)
+    agent.llm = _StubLLM([_tool("g"), _tool("orphan")], {"g": {}, "orphan": {"scope": "node", "nodes": []}})
+    assert _names(agent._tools_for_node(agent.get_node_by_id("n1"))) == ["g"]
+
+
+def test_end_call_node_scoped_absent_on_intermediate_present_and_forced_on_terminal():
+    """The production bug: NODE-scoped end_call must be unreachable on an intermediate node."""
+    nodes = [
+        {"id": "escalation", "node_type": "llm", "prompt": "p", "edges": []},
+        {"id": "goodbye", "node_type": "llm", "prompt": "bye", "function_call": "end_call", "edges": []},
+    ]
+    agent = _make_graph_agent(nodes, current_node_id="escalation")
+    agent.llm = _StubLLM(
+        [_tool("transfer"), END_CALL_TOOL_DEFINITION],
+        {"transfer": {}, "end_call": {"pre_call_message": None, "scope": "node", "nodes": ["goodbye"]}},
+    )
+    # Intermediate node: end_call is NOT offered -> the model cannot end the call here.
+    assert _names(agent._tools_for_node(agent.get_node_by_id("escalation"))) == ["transfer"]
+    # Terminal node: end_call is visible (nothing filtered -> None fallback to self.tools).
+    assert agent._tools_for_node(agent.get_node_by_id("goodbye")) is None
+    # And it is forced there, with the forced tool guaranteed present in the per-call list.
+    agent.current_node_id = "goodbye"
+    assert agent._get_tool_choice_for_node(history=[]) == {"type": "function", "function": {"name": "end_call"}}
+    # Execution invariant: api_params keeps end_call regardless of node (so the call can run).
+    assert "end_call" in agent.llm.api_params
+
+
+def test_end_call_global_present_on_intermediate_node():
+    """GLOBAL scope reproduces the original behavior: end_call offered everywhere."""
+    nodes = [
+        {"id": "escalation", "edges": []},
+        {"id": "goodbye", "function_call": "end_call", "edges": []},
+    ]
+    agent = _make_graph_agent(nodes, current_node_id="escalation")
+    agent.llm = _StubLLM(
+        [_tool("transfer"), END_CALL_TOOL_DEFINITION, _tool("node_only")],
+        {"transfer": {}, "end_call": {"scope": "global"}, "node_only": {"scope": "node", "nodes": ["goodbye"]}},
+    )
+    # On the intermediate node node_only is filtered but the GLOBAL end_call remains offered.
+    assert _names(agent._tools_for_node(agent.get_node_by_id("escalation"))) == ["transfer", "end_call"]
+
+
+def test_forced_name_keeps_tool_visible_only_while_force_survives():
+    """A forced tool stays visible even if scoped elsewhere; when the force is dropped it is hidden."""
+    nodes = [{"id": "x", "function_call": "T", "edges": []}]
+    agent = _make_graph_agent(nodes, current_node_id="x")
+    # G global, T+S both scoped to 'other'; S (a third tool) keeps the subset != full so it's inspectable.
+    agent.llm = _StubLLM(
+        [_tool("G"), _tool("T"), _tool("S")],
+        {"G": {}, "T": {"scope": "node", "nodes": ["other"]}, "S": {"scope": "node", "nodes": ["other"]}},
+    )
+    x = agent.get_node_by_id("x")
+    # force survives -> T visible despite being scoped to 'other'; S still hidden.
+    assert _names(agent._tools_for_node(x, "T")) == ["G", "T"]
+    # force dropped (forced_name None) -> T hidden (scoped to 'other', not 'x').
+    assert _names(agent._tools_for_node(x, None)) == ["G"]
+
+
+def test_tools_for_node_handles_str_tools_and_no_function_calling():
+    nodes = [{"id": "n1", "edges": []}]
+    agent = _make_graph_agent(nodes)
+    # str tools list with a node-scoped tool absent here.
+    agent.llm = _StubLLM(
+        json.dumps([_tool("g"), _tool("s")]), {"g": {}, "s": {"scope": "node", "nodes": ["other"]}}
+    )
+    assert _names(agent._tools_for_node(agent.get_node_by_id("n1"))) == ["g"]
+    # trigger_function_call False -> no override.
+    agent.llm.trigger_function_call = False
+    assert agent._tools_for_node(agent.get_node_by_id("n1")) is None
+
+
+# ---------------------------------------------------------------------------
+# Per-call tools= override at the LLM layer
+# ---------------------------------------------------------------------------
+
+
+class _Sentinel(Exception):
+    pass
+
+
+def _make_openai_llm():
+    from bolna.llms.openai_llm import OpenAiLLM
+
+    return OpenAiLLM(
+        model="gpt-4o-mini",
+        llm_key="sk-dummy",
+        api_tools={"tools": [_tool("a"), _tool("b")], "tools_params": {"a": {}, "b": {}}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_openai_tools_override_reaches_request():
+    llm = _make_openai_llm()
+    captured = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        raise _Sentinel()
+
+    llm.async_client.chat.completions.create = fake_create
+    only = [_tool("a")]
+    with pytest.raises(_Sentinel):
+        async for _ in llm._generate_stream_chat([{"role": "user", "content": "hi"}], tools=only):
+            pass
+    assert captured["tools"] == only
+
+
+@pytest.mark.asyncio
+async def test_openai_tools_none_uses_self_tools():
+    llm = _make_openai_llm()
+    captured = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        raise _Sentinel()
+
+    llm.async_client.chat.completions.create = fake_create
+    with pytest.raises(_Sentinel):
+        async for _ in llm._generate_stream_chat([{"role": "user", "content": "hi"}]):
+            pass
+    assert captured["tools"] == llm.tools
+
+
+@pytest.mark.asyncio
+async def test_openai_empty_tools_omits_tools_and_tool_choice():
+    """An empty per-call tools list (all tools scoped away) must omit tools entirely, not send []."""
+    llm = _make_openai_llm()
+    captured = {}
+
+    async def fake_create(**kwargs):
+        captured.update(kwargs)
+        raise _Sentinel()
+
+    llm.async_client.chat.completions.create = fake_create
+    with pytest.raises(_Sentinel):
+        async for _ in llm._generate_stream_chat([{"role": "user", "content": "hi"}], tools=[]):
+            pass
+    assert "tools" not in captured
+    assert "tool_choice" not in captured
+
+
+def test_openai_base_parse_tools_override():
+    llm = _make_openai_llm()
+    only = [_tool("a")]
+    assert llm._parse_tools(only) == only  # responses path uses the override
+    assert llm._parse_tools(None) == llm.tools  # back-compat
+    assert llm._parse_tools() == llm.tools
+
+
+def _make_openai_llm_with_end_call():
+    from bolna.llms.openai_llm import OpenAiLLM
+
+    return OpenAiLLM(
+        model="gpt-4o-mini",
+        llm_key="sk-dummy",
+        api_tools={
+            "tools": [_tool("transfer"), END_CALL_TOOL_DEFINITION],
+            "tools_params": {
+                "transfer": {},
+                "end_call": {"pre_call_message": None, "scope": "node", "nodes": ["goodbye"]},
+            },
+        },
+    )
+
+
+def test_text_rescue_blocked_when_tool_not_offered_this_turn():
+    """A text-emitted end_call must NOT execute on a node where it is not offered (node scoping)."""
+    llm = _make_openai_llm_with_end_call()
+    model_args = {"tools": [_tool("transfer")]}  # end_call hidden this turn
+    with patch.object(llm, "_parse_text_tool_call", return_value=("end_call", '{"reason": "x"}')):
+        chunk = llm._try_rescue_text_tool_call("end_call(...)", model_args, {}, "bye", None)
+    assert chunk is None
+
+
+def test_text_rescue_executes_when_tool_offered():
+    llm = _make_openai_llm_with_end_call()
+    model_args = {"tools": [END_CALL_TOOL_DEFINITION]}
+    with patch.object(llm, "_parse_text_tool_call", return_value=("end_call", '{"reason": "x"}')):
+        chunk = llm._try_rescue_text_tool_call("end_call(...)", model_args, {}, "bye", None)
+    assert chunk is not None and chunk.is_function_call
+
+
+@pytest.mark.asyncio
+async def test_litellm_tools_override_reaches_request():
+    from bolna.llms.litellm import LiteLLM
+
+    llm = LiteLLM(
+        model="gpt-4o-mini",
+        api_tools={"tools": [_tool("a"), _tool("b")], "tools_params": {"a": {}, "b": {}}},
+    )
+    captured = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.update(kwargs)
+        raise _Sentinel()
+
+    only = [_tool("b")]
+    with patch("bolna.llms.litellm.acompletion", fake_acompletion):
+        with pytest.raises(_Sentinel):
+            async for _ in llm.generate_stream([{"role": "user", "content": "hi"}], tools=only):
+                pass
+    assert captured["tools"] == only
+
+
+# ---------------------------------------------------------------------------
+# _inject_end_call_tool
+# ---------------------------------------------------------------------------
+
+
+def test_inject_end_call_node_scope():
+    at = _inject_end_call_tool(None, scope=ToolScope.NODE, nodes=["goodbye", "wrong_person_closing"])
+    assert at["tools_params"]["end_call"] == {
+        "pre_call_message": None,
+        "scope": "node",
+        "nodes": ["goodbye", "wrong_person_closing"],
+    }
+    assert at["tools"][0]["function"]["name"] == "end_call"
+
+
+def test_inject_end_call_global_scope_with_description_and_existing_tool():
+    at = {
+        "tools": [_tool("x")],
+        "tools_params": {"x": {}},
+    }
+    at = _inject_end_call_tool(at, scope=ToolScope.GLOBAL, nodes=[], description="custom end desc")
+    assert at["tools_params"]["end_call"]["scope"] == "global"
+    assert at["tools_params"]["end_call"]["nodes"] == []
+    end_call_def = next(t for t in at["tools"] if t["function"]["name"] == "end_call")
+    assert end_call_def["function"]["description"] == "custom end desc"
+    assert len(at["tools"]) == 2
+
+
+def test_inject_end_call_is_idempotent():
+    at = _inject_end_call_tool(None, scope=ToolScope.GLOBAL, nodes=[])
+    before = len(at["tools"])
+    at = _inject_end_call_tool(at, scope=ToolScope.NODE, nodes=["z"])  # second call is a no-op
+    assert len(at["tools"]) == before
+    assert at["tools_params"]["end_call"]["scope"] == "global"  # original scope preserved
+
+
+def test_inject_end_call_handles_str_tools_list():
+    at = _inject_end_call_tool({"tools": "[]", "tools_params": {}}, scope=ToolScope.GLOBAL, nodes=[])
+    assert isinstance(at["tools"], list)
+    assert at["tools"][0]["function"]["name"] == "end_call"

--- a/tests/tests/test_tool_scope.py
+++ b/tests/tests/test_tool_scope.py
@@ -149,9 +149,7 @@ def test_tools_for_node_handles_str_tools_and_no_function_calling():
     nodes = [{"id": "n1", "edges": []}]
     agent = _make_graph_agent(nodes)
     # str tools list with a node-scoped tool absent here.
-    agent.llm = _StubLLM(
-        json.dumps([_tool("g"), _tool("s")]), {"g": {}, "s": {"scope": "node", "nodes": ["other"]}}
-    )
+    agent.llm = _StubLLM(json.dumps([_tool("g"), _tool("s")]), {"g": {}, "s": {"scope": "node", "nodes": ["other"]}})
     assert _names(agent._tools_for_node(agent.get_node_by_id("n1"))) == ["g"]
     # trigger_function_call False -> no override.
     agent.llm.trigger_function_call = False


### PR DESCRIPTION
Adds per-node tool scoping for graph agents. A tool can be GLOBAL (visible on every LLM node, the default) or NODE (visible only on listed nodes) via `scope`/`nodes` on its `tools_params` entry. The model-visible tool list is filtered per turn; the execution map (`tools_params`) stays global so a visible tool still runs. When a node's per-call tool list is empty, tools are omitted entirely (an empty array is a 400).

The internal `end_call` tool is the first consumer, and its scope follows the existing `hangup_after_LLMCall` toggle (no new config field):
* `hangup_after_LLMCall` ON -> end_call is GLOBAL (end anywhere the model judges complete). This is what the existing A/B experiment already does.
* `hangup_after_LLMCall` OFF -> end_call is NODE-scoped to nodes that set `function_call: "end_call"` (and dormant if none do), so the model cannot end the call from an intermediate node.

Backward compatible: scope defaults to global, the per-call `tools=` override defaults to None (= `self.tools`), and OFF agents with no `function_call: end_call` nodes get no end_call (today's behavior). Custom function tools scope the same way via `scope`/`nodes`.