### PR TITLE
fix: mute transcriber input after call transfer so the transfer POST fires

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.105"
+__version__ = "0.10.106"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3805,9 +3805,6 @@ class TaskManager(BaseManager):
             self.hangup_decision_at = time.time()
 
     def _should_ignore_transcriber_input(self) -> bool:
-        # A transfer hands the call off, so further user speech must not spawn new
-        # turns; otherwise the fresh audio keeps is_audio_being_played_to_user() True
-        # and the transfer POST, which waits for audio to drain, never fires.
         return self.hangup_triggered or self._end_call_in_progress or self.has_transfer
 
     async def process_call_hangup(self):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3805,7 +3805,10 @@ class TaskManager(BaseManager):
             self.hangup_decision_at = time.time()
 
     def _should_ignore_transcriber_input(self) -> bool:
-        return self.hangup_triggered or self._end_call_in_progress
+        # A transfer hands the call off, so further user speech must not spawn new
+        # turns; otherwise the fresh audio keeps is_audio_being_played_to_user() True
+        # and the transfer POST, which waits for audio to drain, never fires.
+        return self.hangup_triggered or self._end_call_in_progress or self.has_transfer
 
     async def process_call_hangup(self):
         if self.hangup_decision_at is None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.105"
+version = "0.10.106"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_end_call_bargein_guard.py
+++ b/tests/tests/test_end_call_bargein_guard.py
@@ -22,8 +22,12 @@ import pytest
 from bolna.agent_manager.task_manager import TaskManager
 
 
-def _ignore(hangup_triggered, end_call_in_progress):
-    fake = SimpleNamespace(hangup_triggered=hangup_triggered, _end_call_in_progress=end_call_in_progress)
+def _ignore(hangup_triggered, end_call_in_progress, has_transfer=False):
+    fake = SimpleNamespace(
+        hangup_triggered=hangup_triggered,
+        _end_call_in_progress=end_call_in_progress,
+        has_transfer=has_transfer,
+    )
     return TaskManager._should_ignore_transcriber_input(fake)
 
 
@@ -53,6 +57,7 @@ def _make_tm(*, end_call_in_progress, hangup_triggered):
     tm = MagicMock()
     tm.hangup_triggered = hangup_triggered
     tm._end_call_in_progress = end_call_in_progress
+    tm.has_transfer = False
     tm.stream = True
     tm.response_in_pipeline = False
     tm.transcriber_output_queue = asyncio.Queue()


### PR DESCRIPTION
The `transfer_call` tool fires and the payload is built, but the call is never redirected. The handler logs `Sending the payload to stop the conversation ...` and then never reaches the webhook POST.

Root cause: the transfer POST waits for in-flight audio to drain before firing.

```python
while self.tools["input"].is_audio_being_played_to_user():
    await asyncio.sleep(1)
```

Nothing stops the conversation once a transfer is initiated, so the transcriber keeps feeding new user turns and each one generates fresh audio. `is_audio_being_played_to_user()` never settles to False, the loop never exits, and the POST is never sent. The call then ends by hangup with no transfer, even though a success tool result was already written to history.

Fix: include `has_transfer` in `_should_ignore_transcriber_input()`, mirroring the wind-down that `end_call` already performs. Once a transfer is initiated, further user speech is dropped, no new turns play, the in-flight transfer message drains, and the POST fires.