### PR TITLE
feat: typed input variables for graph-agent expression routing

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.109"
+__version__ = "0.10.110"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -51,6 +51,7 @@ class GraphAgent(BaseAgent):
         self.agent_information = self.config.get("agent_information")
         self.current_node_id = self.config.get("current_node_id")
         self.context_data = self.config.get("context_data") or {}
+        self.variable_types = self.config.get("variable_types") or {}
         self.llm_model = self.config.get("model")
 
         # Get credentials from config (injected by task_manager) or fall back to env vars
@@ -412,9 +413,9 @@ class GraphAgent(BaseAgent):
         """Return (first matching deterministic edge or None, per-edge evaluation traces)."""
         evaluations = []
         for edge in edges:
-            is_match = evaluate_edge_expression(edge, self.context_data)
+            is_match = evaluate_edge_expression(edge, self.context_data, self.variable_types)
             evaluations.append(
-                f"-> {edge.get('to_node_id')}: {describe_edge_expression(edge, self.context_data)} | matched={is_match}"
+                f"-> {edge.get('to_node_id')}: {describe_edge_expression(edge, self.context_data, self.variable_types)} | matched={is_match}"
             )
             if is_match:
                 return edge, evaluations

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -261,6 +261,12 @@ class ExpressionLogic(str, Enum):
     OR = "or"
 
 
+class VariableType(str, Enum):
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+
+
 class EdgeConditionType(str, Enum):
     LLM = "llm"
     EXPRESSION = "expression"

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -5,9 +5,12 @@ context_data for instant routing decisions.
 """
 
 import operator as op
-from typing import Any
+from typing import Any, Optional
 
-from bolna.enums import ExpressionOperator, ExpressionLogic, EdgeConditionType
+from bolna.enums import ExpressionOperator, ExpressionLogic, EdgeConditionType, VariableType
+from bolna.helpers.logger_config import configure_logger
+
+logger = configure_logger(__name__)
 
 _MISSING = object()
 
@@ -32,10 +35,81 @@ def resolve_variable(context_data: dict, path: str) -> Any:
     return current
 
 
-def _coerce_for_comparison(actual: Any, expected: Any):
-    """Coerce actual/expected to comparable types (e.g. string "3" vs int 3)."""
+_TRUE_TOKENS = {"true", "1", "yes"}
+_FALSE_TOKENS = {"false", "0", "no"}
+_BOOL_TOKENS = _TRUE_TOKENS | _FALSE_TOKENS
+
+
+def _is_bool_like(value: Any) -> bool:
+    """True for a bool or a string that names one, so inference only treats genuine
+    booleans as boolean and leaves numbers/other strings to numeric comparison."""
+    return isinstance(value, bool) or (isinstance(value, str) and value.strip().lower() in _BOOL_TOKENS)
+
+
+def _to_bool(value: Any) -> bool:
+    """Coerce a value to bool. Raises ValueError on an unrecognized string."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _TRUE_TOKENS:
+            return True
+        if token in _FALSE_TOKENS:
+            return False
+    raise ValueError(f"cannot coerce {value!r} to boolean")
+
+
+def _coerce_value(value: Any, declared_type: VariableType) -> Any:
+    """Coerce a single value into a declared type. Raises on failure."""
+    if declared_type == VariableType.STRING:
+        return str(value)
+    if declared_type == VariableType.NUMBER:
+        return float(value)
+    if declared_type == VariableType.BOOLEAN:
+        return _to_bool(value)
+    raise ValueError(f"unsupported variable type: {declared_type!r}")
+
+
+def _resolve_declared_type(variable: str, variable_types: Optional[dict]) -> Optional[VariableType]:
+    """Resolve a variable's declared type. Keys match the condition's variable path
+    exactly. An unrecognized type name falls back to inference with a warning.
+    """
+    if not variable_types:
+        return None
+    raw = variable_types.get(variable)
+    if raw is None:
+        return None
+    try:
+        return VariableType(raw)
+    except ValueError:
+        logger.warning(f"Unknown variable type {raw!r} for {variable!r}; falling back to inference")
+        return None
+
+
+def _coerce_operands(actual: Any, expected: Any, operator: str, declared_type: Optional[VariableType]):
+    """Bring actual/expected into the same domain before the operator runs.
+
+    A declared type coerces both operands (list elements too, for membership) into that
+    type, so every operator compares in the declared domain. Without one, only scalar
+    comparisons get inference coercion (same type as-is, a boolean literal vs a
+    boolean-like value -> boolean, else numeric); membership/substring keep raw values.
+    """
+    if declared_type is not None:
+        actual = _coerce_value(actual, declared_type)
+        if isinstance(expected, list):
+            expected = [_coerce_value(item, declared_type) for item in expected]
+        elif expected is not None:
+            expected = _coerce_value(expected, declared_type)
+        return actual, expected
+
+    if operator not in _COMPARISON_OPS:
+        return actual, expected
     if type(actual) is type(expected):
         return actual, expected
+    if isinstance(expected, bool) and _is_bool_like(actual):
+        return _to_bool(actual), expected
     if isinstance(actual, (str, int, float)) and isinstance(expected, (str, int, float)):
         try:
             return float(actual), float(expected)
@@ -44,7 +118,9 @@ def _coerce_for_comparison(actual: Any, expected: Any):
     return actual, expected
 
 
-def evaluate_condition(condition: dict, context_data: dict) -> bool:
+def evaluate_condition(
+    condition: dict, context_data: dict, variable_types: Optional[dict] = None, log_failures: bool = True
+) -> bool:
     """Evaluate a single ExpressionCondition dict against context_data."""
     variable = condition.get("variable", "")
     operator = condition.get("operator", "")
@@ -59,14 +135,22 @@ def evaluate_condition(condition: dict, context_data: dict) -> bool:
     if actual is _MISSING:
         return False
 
+    declared_type = _resolve_declared_type(variable, variable_types)
+    try:
+        actual, expected = _coerce_operands(actual, expected, operator, declared_type)
+    except (TypeError, ValueError):
+        if log_failures and declared_type is not None:
+            logger.warning(
+                f"Expression coercion failed: {variable}={actual!r} {operator} {expected!r} as {declared_type.value}"
+            )
+        return False
+
     cmp_fn = _COMPARISON_OPS.get(operator)
     if cmp_fn:
         try:
-            coerced_actual, coerced_expected = _coerce_for_comparison(actual, expected)
-            return cmp_fn(coerced_actual, coerced_expected)
+            return cmp_fn(actual, expected)
         except TypeError:
             return False
-
     if operator == ExpressionOperator.IN:
         return actual in expected if isinstance(expected, list) else False
     if operator == ExpressionOperator.NOT_IN:
@@ -81,7 +165,7 @@ def evaluate_condition(condition: dict, context_data: dict) -> bool:
     return False
 
 
-def evaluate_expression_group(group: dict, context_data: dict) -> bool:
+def evaluate_expression_group(group: dict, context_data: dict, variable_types: Optional[dict] = None) -> bool:
     """Evaluate an AND/OR group of conditions."""
     logic = group.get("logic", ExpressionLogic.AND)
     conditions = group.get("conditions", [])
@@ -90,11 +174,11 @@ def evaluate_expression_group(group: dict, context_data: dict) -> bool:
         return False
 
     if logic == ExpressionLogic.OR:
-        return any(evaluate_condition(c, context_data) for c in conditions)
-    return all(evaluate_condition(c, context_data) for c in conditions)
+        return any(evaluate_condition(c, context_data, variable_types) for c in conditions)
+    return all(evaluate_condition(c, context_data, variable_types) for c in conditions)
 
 
-def evaluate_edge_expression(edge: dict, context_data: dict) -> bool:
+def evaluate_edge_expression(edge: dict, context_data: dict, variable_types: Optional[dict] = None) -> bool:
     """Evaluate an edge's expression. Returns True if it matches."""
     condition_type = edge.get("condition_type")
 
@@ -107,23 +191,25 @@ def evaluate_edge_expression(edge: dict, context_data: dict) -> bool:
     if not expression:
         return False
 
-    return evaluate_expression_group(expression, context_data)
+    return evaluate_expression_group(expression, context_data, variable_types)
 
 
-def describe_condition(condition: dict, context_data: dict) -> str:
+def describe_condition(condition: dict, context_data: dict, variable_types: Optional[dict] = None) -> str:
     """Trace one condition for routing logs: "variable operator value (actual=<resolved>) -> <result>"."""
     variable = condition.get("variable", "")
     operator = condition.get("operator", "")
     actual = resolve_variable(context_data, variable)
     actual_repr = "<missing>" if actual is _MISSING else repr(actual)
-    result = evaluate_condition(condition, context_data)
+    result = evaluate_condition(condition, context_data, variable_types, log_failures=False)
+    declared = _resolve_declared_type(variable, variable_types)
+    type_note = f", as {declared.value}" if declared else ""
 
     if operator in (ExpressionOperator.EXISTS, ExpressionOperator.NOT_EXISTS):
-        return f"{variable} {operator} (actual={actual_repr}) -> {result}"
-    return f"{variable} {operator} {condition.get('value')!r} (actual={actual_repr}) -> {result}"
+        return f"{variable} {operator} (actual={actual_repr}{type_note}) -> {result}"
+    return f"{variable} {operator} {condition.get('value')!r} (actual={actual_repr}{type_note}) -> {result}"
 
 
-def describe_edge_expression(edge: dict, context_data: dict) -> str:
+def describe_edge_expression(edge: dict, context_data: dict, variable_types: Optional[dict] = None) -> str:
     """Trace an edge's deterministic evaluation (variable/operator/expected vs actual) for routing logs."""
     condition_type = edge.get("condition_type")
 
@@ -139,4 +225,4 @@ def describe_edge_expression(edge: dict, context_data: dict) -> str:
 
     logic = expression.get("logic") or "and"
     separator = f" {logic.upper()} "
-    return separator.join(describe_condition(c, context_data) for c in conditions)
+    return separator.join(describe_condition(c, context_data, variable_types) for c in conditions)

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -72,9 +72,12 @@ def _coerce_value(value: Any, declared_type: VariableType) -> Any:
     raise ValueError(f"unsupported variable type: {declared_type!r}")
 
 
-def _resolve_declared_type(variable: str, variable_types: Optional[dict]) -> Optional[VariableType]:
+def _resolve_declared_type(
+    variable: str, variable_types: Optional[dict], log_unknown: bool = True
+) -> Optional[VariableType]:
     """Resolve a variable's declared type. Keys match the condition's variable path
-    exactly. An unrecognized type name falls back to inference with a warning.
+    exactly. An unrecognized type name falls back to inference, warning once when
+    log_unknown (the trace/describe pass passes False to avoid duplicate warnings).
     """
     if not variable_types:
         return None
@@ -84,7 +87,8 @@ def _resolve_declared_type(variable: str, variable_types: Optional[dict]) -> Opt
     try:
         return VariableType(raw)
     except ValueError:
-        logger.warning(f"Unknown variable type {raw!r} for {variable!r}; falling back to inference")
+        if log_unknown:
+            logger.warning(f"Unknown variable type {raw!r} for {variable!r}; falling back to inference")
         return None
 
 
@@ -135,7 +139,7 @@ def evaluate_condition(
     if actual is _MISSING:
         return False
 
-    declared_type = _resolve_declared_type(variable, variable_types)
+    declared_type = _resolve_declared_type(variable, variable_types, log_unknown=log_failures)
     try:
         actual, expected = _coerce_operands(actual, expected, operator, declared_type)
     except (TypeError, ValueError):
@@ -201,7 +205,7 @@ def describe_condition(condition: dict, context_data: dict, variable_types: Opti
     actual = resolve_variable(context_data, variable)
     actual_repr = "<missing>" if actual is _MISSING else repr(actual)
     result = evaluate_condition(condition, context_data, variable_types, log_failures=False)
-    declared = _resolve_declared_type(variable, variable_types)
+    declared = _resolve_declared_type(variable, variable_types, log_unknown=False)
     type_note = f", as {declared.value}" if declared else ""
 
     if operator in (ExpressionOperator.EXISTS, ExpressionOperator.NOT_EXISTS):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -13,6 +13,7 @@ from .enums import (
     ExpressionLogic,
     EdgeConditionType,
     NodeType,
+    VariableType,
 )
 from .constants import MODEL_REASONING_EFFORT_MAP
 
@@ -404,6 +405,9 @@ class GraphAgentConfig(Llm):
     nodes: List[GraphNode]
     current_node_id: str
     context_data: Optional[dict] = None
+    # Variable path -> declared type, used to coerce expression-routing comparisons into
+    # the right domain. Keys match the condition's variable exactly (e.g. "recipient_data.age").
+    variable_types: Optional[Dict[str, VariableType]] = None
     # Global knowledge base. Nodes without their own rag_config fall back to this at retrieval time.
     rag_config: Optional[RagConfig] = None
     # Routing configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.109"
+version = "0.10.110"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_expression_routing.py
+++ b/tests/tests/test_expression_routing.py
@@ -782,3 +782,12 @@ class TestVariableTypesThreading:
             matched, _ = agent._evaluate_deterministic_edges([self._age_edge()])
         assert matched is None
         assert mock_logger.warning.call_count == 1
+
+    def test_unknown_type_warns_once_per_edge(self):
+        # an invalid declared type warns once per edge, not once per evaluate + describe resolve
+        agent = _make_agent()
+        agent.variable_types = {"recipient_data.age": "int"}  # not a valid VariableType
+        agent.context_data = {"recipient_data": {"age": "21"}}
+        with patch("bolna.helpers.expression_evaluator.logger") as mock_logger:
+            agent._evaluate_deterministic_edges([self._age_edge()])
+        assert mock_logger.warning.call_count == 1

--- a/tests/tests/test_expression_routing.py
+++ b/tests/tests/test_expression_routing.py
@@ -9,6 +9,7 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bolna.agent_types.graph_agent import GraphAgent, _DETERMINISTIC_REASONING_PREFIX
+from bolna.helpers.expression_evaluator import evaluate_condition
 
 
 # ---------------------------------------------------------------------------
@@ -232,7 +233,7 @@ class TestExpressionMatchSkipsLLM:
             # LLM should NOT have been called
             mock_thread.assert_not_called()
 
-        next_node, params, latency_ms, msgs, tools, reasoning, confidence = result
+        next_node, params, latency_ms, msgs, tools, reasoning, confidence, usage_info = result
         assert next_node == "hindi_agent"
         assert confidence == 1.0
         assert reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)
@@ -315,7 +316,7 @@ class TestFallThroughToLLM:
         with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp):
             result = await agent.decide_next_node_with_functions([{"role": "user", "content": "I want to book"}])
 
-        next_node, params, latency_ms, msgs, tools, reasoning, confidence = result
+        next_node, params, latency_ms, msgs, tools, reasoning, confidence, usage_info = result
         assert next_node == "booking"
         assert confidence == 0.9
         assert not reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)
@@ -676,3 +677,108 @@ class TestRoutingInfoType:
 
         routing_info = chunks[0].get("routing_info")
         assert routing_info["routing_type"] == "llm"
+
+
+class TestTypedCoercion:
+    """variable_types coerces expression comparisons into the right domain."""
+
+    def test_number_avoids_lexicographic(self):
+        # declared number -> numeric comparison: 9 > 10 is False
+        cond = {"variable": "recipient_data.age", "operator": "gt", "value": 10}
+        ctx = {"recipient_data": {"age": "9"}}
+        assert not evaluate_condition(cond, ctx, {"recipient_data.age": "number"})
+
+    def test_string_string_lexicographic_is_the_bug_typing_fixes(self):
+        # both sides strings compare lexicographically ("9" > "10" is True); declaring number corrects it
+        cond = {"variable": "recipient_data.age", "operator": "gt", "value": "10"}
+        ctx = {"recipient_data": {"age": "9"}}
+        assert evaluate_condition(cond, ctx)
+        assert not evaluate_condition(cond, ctx, {"recipient_data.age": "number"})
+
+    def test_resolution_is_exact_path(self):
+        # keys match the condition's variable exactly; a leaf-only key does not apply
+        cond = {"variable": "recipient_data.age", "operator": "gt", "value": "100"}
+        ctx = {"recipient_data": {"age": "9"}}
+        assert not evaluate_condition(cond, ctx, {"recipient_data.age": "number"})  # 9 > 100 numeric -> False
+        assert evaluate_condition(cond, ctx, {"age": "number"})  # leaf key ignored -> "9" > "100" lexically -> True
+
+    def test_boolean_string_tokens(self):
+        cond = {"variable": "is_member", "operator": "eq", "value": True}
+        assert evaluate_condition(cond, {"is_member": "true"}, {"is_member": "boolean"})
+        assert not evaluate_condition(cond, {"is_member": "false"}, {"is_member": "boolean"})
+
+    def test_string_match(self):
+        cond = {"variable": "plan", "operator": "eq", "value": "premium"}
+        assert evaluate_condition(cond, {"plan": "premium"}, {"plan": "string"})
+
+    def test_uncoercible_fails_closed(self):
+        cond = {"variable": "age", "operator": "gt", "value": 10}
+        assert not evaluate_condition(cond, {"age": "abc"}, {"age": "number"})
+
+    def test_inference_bool_fix_without_declaration(self):
+        cond = {"variable": "is_member", "operator": "eq", "value": True}
+        assert evaluate_condition(cond, {"is_member": "true"})
+
+    def test_inference_numeric_cross_preserved(self):
+        cond = {"variable": "age", "operator": "gte", "value": 18}
+        assert evaluate_condition(cond, {"age": "21"})
+
+    def test_inference_bool_literal_does_not_hijack_numbers(self):
+        # a bool literal must not change numeric/string comparisons for non-bool-like actuals
+        assert evaluate_condition({"variable": "x", "operator": "gt", "value": True}, {"x": 5})  # 5.0 > 1.0
+        assert not evaluate_condition({"variable": "x", "operator": "eq", "value": True}, {"x": 5})  # 5 != True
+        assert evaluate_condition({"variable": "x", "operator": "neq", "value": False}, {"x": "hello"})
+
+    def test_invalid_declared_type_falls_back_to_inference(self):
+        cond = {"variable": "age", "operator": "gt", "value": "10"}
+        with patch("bolna.helpers.expression_evaluator.logger") as mock_logger:
+            result = evaluate_condition(cond, {"age": "9"}, {"age": "int"})
+        assert result  # inference path: "9" > "10" lexically
+        assert mock_logger.warning.call_count == 1  # unknown type warned, then ignored
+
+    def test_neq_and_lt_with_declared_number(self):
+        assert evaluate_condition({"variable": "age", "operator": "lt", "value": 18}, {"age": "16"}, {"age": "number"})
+        assert evaluate_condition({"variable": "age", "operator": "neq", "value": 18}, {"age": "16"}, {"age": "number"})
+
+    def test_membership_coerces_declared_type(self):
+        # a declared type coerces the value and the list elements: "21" -> 21.0 in [18.0, 21.0, 25.0]
+        cond = {"variable": "age", "operator": "in", "value": [18, 21, 25]}
+        assert evaluate_condition(cond, {"age": "21"}, {"age": "number"})
+        assert not evaluate_condition(cond, {"age": "20"}, {"age": "number"})
+
+
+class TestVariableTypesThreading:
+    """self.variable_types flows from the agent into deterministic evaluation."""
+
+    def _age_edge(self):
+        return {
+            "to_node_id": "adult",
+            "condition_type": "expression",
+            "expression": {
+                "logic": "and",
+                "conditions": [{"variable": "recipient_data.age", "operator": "gte", "value": 18}],
+            },
+        }
+
+    def test_threaded_through_deterministic_edges(self):
+        agent = _make_agent()
+        agent.variable_types = {"recipient_data.age": "number"}
+        edge = self._age_edge()
+
+        agent.context_data = {"recipient_data": {"age": "16"}}
+        matched, _ = agent._evaluate_deterministic_edges([edge])
+        assert matched is None  # 16 >= 18 is False
+
+        agent.context_data = {"recipient_data": {"age": "21"}}
+        matched, _ = agent._evaluate_deterministic_edges([edge])
+        assert matched is edge  # 21 >= 18 is True
+
+    def test_coercion_failure_warns_once_per_edge(self):
+        # the evaluate + describe passes must not double-log the coercion warning
+        agent = _make_agent()
+        agent.variable_types = {"recipient_data.age": "number"}
+        agent.context_data = {"recipient_data": {"age": "abc"}}
+        with patch("bolna.helpers.expression_evaluator.logger") as mock_logger:
+            matched, _ = agent._evaluate_deterministic_edges([self._age_edge()])
+        assert matched is None
+        assert mock_logger.warning.call_count == 1


### PR DESCRIPTION
Expression-based routing compares a runtime variable against a literal, but input variables arrive untyped (strings from CSV/telephony, JSON-typed from the API). Comparisons can therefore run in the wrong domain: `"9" > "10"` is True lexically but `9 > 10` is False numerically, and string `"true"` never matches a boolean literal, so an edge can silently mis-route a live call.

This adds a `variable_types` map on the graph agent config (`name -> string | number | boolean`) so the evaluator coerces both sides into the declared domain before comparing, with literal inference as the fallback for undeclared values.

## Behavior

* A declared type coerces both operands (and list elements for `in`/`not_in`) into that type, applied uniformly across `eq`/`neq`/`gt`/`gte`/`lt`/`lte`/`in`/`not_in`/`contains`.
* Keys match the condition's variable path exactly (e.g. `recipient_data.age`).
* Undeclared variables fall back to inference, so existing configs are unchanged.
* A coercion that fails on a declared variable logs a warning and the condition evaluates False (fail-closed).
* Prompt rendering is untouched; values still render as their original strings.

## Usage

Types are declared once on the graph agent config; the call payload keeps sending plain variables.

```json
"variable_types": { "recipient_data.age": "number", "recipient_data.is_member": "boolean" }
```
