### PR TITLE
Add blocking Bandit SAST gate (catches the exec/eval class)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [master, main]
 
+permissions:
+  contents: read
+
 jobs:
   bandit:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,26 @@
+name: Security
+
+on:
+  pull_request:
+    branches: [master, main]
+  push:
+    branches: [master, main]
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.13'
+
+      - name: Install bandit
+        run: python -m pip install --upgrade pip 'bandit==1.9.4'
+
+      # Fails the build on medium+ severity, high-confidence findings (exec/eval/compile,
+      # pickle, yaml.load, etc.). Low-severity style noise is intentionally not gated.
+      - name: Bandit SAST
+        run: bandit -r bolna --severity-level medium --confidence-level high

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,10 @@ repos:
     hooks:
       - id: requirements-txt-fixer
         files: ^requirements\.txt$
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.9.4
+    hooks:
+      - id: bandit
+        args: ["--severity-level", "medium", "--confidence-level", "high"]
+        exclude: ^(tests|build|examples|local_setup)/

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.106"
+__version__ = "0.10.107"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -228,7 +228,8 @@ async def get_raw_audio_bytes(
 
 
 def get_md5_hash(text):
-    return hashlib.md5(text.encode()).hexdigest()
+    # Non-security hash (cache keys / ids); usedforsecurity=False documents that and clears bandit B324.
+    return hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()
 
 
 def is_valid_md5(hash_string):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.106"
+version = "0.10.107"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Adds a blocking Bandit SAST gate (CI workflow + pre-commit hook) that fails on medium-or-higher severity, high-confidence findings: the `exec`/`eval`/`compile`, `pickle`, and `yaml.load` classes. Low-severity style noise (asserts, try/except/pass) is intentionally not gated.

This is the control that would have caught the recent `compile()`+`exec()` RCE. The codebase is clean at this threshold today (the only such finding was a cache-key MD5, now marked `usedforsecurity=False`), so the first run is green and only newly introduced dangerous code fails.
