### PR TITLE
fixed the eos for llm true function call in welcome message

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.113"
+__version__ = "0.10.114"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -255,6 +255,9 @@ class StreamSynthesizer(BaseSynthesizer):
             if audio == b"\x00":
                 logger.info(f"{self.provider_name}: end of stream")
                 self.meta_info["end_of_synthesizer_stream"] = True
+                # eos may pop a non-final chunk's meta; carry end_of_llm_stream so is_final_chunk fires
+                if self.last_text_sent:
+                    self.meta_info["end_of_llm_stream"] = True
                 self.first_chunk_generated = False
                 self._record_turn_latency()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.113"
+version = "0.10.114"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_stream_synthesizer_eos.py
+++ b/tests/tests/test_stream_synthesizer_eos.py
@@ -1,0 +1,90 @@
+"""
+Regression tests for StreamSynthesizer._generate_ws_loop end-of-stream tagging.
+
+Bug: ElevenLabs buffers short replies into fewer audio messages than there were
+LLM pushes, so the eos sentinel (b"\\x00") pops a non-final chunk's meta_info via
+text_queue.popleft(). is_final_chunk = end_of_llm_stream AND end_of_synthesizer_stream,
+so the eos mark came out final=False and is_audio_being_played latched True (caller
+replies dropped as false interruptions). Fix: when the turn's LLM stream has ended
+(last_text_sent), stamp end_of_llm_stream on the eos packet regardless of which meta
+was popped.
+"""
+
+from collections import deque
+
+import pytest
+
+from bolna.synthesizer.stream_synthesizer import StreamSynthesizer
+
+
+class FakeStreamSynth:
+    """Minimal self for driving the real StreamSynthesizer._generate_ws_loop."""
+
+    def __init__(self, recv_items, text_metas, last_text_sent):
+        self.recv_items = recv_items  # list of (audio_bytes, extra_meta)
+        self.text_queue = deque(text_metas)
+        self.last_text_sent = last_text_sent
+        self.connection_error = None
+        self.meta_info = None
+        self.provider_name = "elevenlabs"
+        self.first_chunk_generated = False
+
+    async def receiver(self):
+        for item in self.recv_items:
+            yield item
+
+    def _unpack_receiver_message(self, raw_item):
+        return raw_item
+
+    def _compute_first_result_latency(self):
+        pass
+
+    def _get_audio_format(self):
+        return "mulaw"
+
+    def _stamp_first_chunk(self, meta_info):
+        pass
+
+    def _process_audio_chunk(self, audio):
+        return audio
+
+    def _stamp_mark_id(self, meta_info):
+        pass
+
+    def _record_turn_latency(self):
+        pass
+
+
+async def drain(fake):
+    return [pkt async for pkt in StreamSynthesizer._generate_ws_loop(fake)]
+
+
+@pytest.mark.asyncio
+async def test_eos_carries_end_of_llm_stream_when_turn_ended():
+    # 3 LLM pushes (eol on the last), but only 2 receiver yields (audio + eos):
+    # popleft gives the eos packet chunk2's meta (eol=False), stranding chunk3.
+    metas = [
+        {"sequence_id": 2, "end_of_llm_stream": False},
+        {"sequence_id": 2, "end_of_llm_stream": False},
+        {"sequence_id": 2, "end_of_llm_stream": True},
+    ]
+    recv = [(b"audio", {}), (b"\x00", {})]
+    packets = await drain(FakeStreamSynth(recv, metas, last_text_sent=True))
+
+    eos = packets[-1]
+    assert eos["data"] == b"\x00"
+    assert eos["meta_info"]["end_of_synthesizer_stream"] is True
+    assert eos["meta_info"]["end_of_llm_stream"] is True  # <- final mark now fires
+
+
+@pytest.mark.asyncio
+async def test_eos_does_not_force_end_of_llm_stream_when_turn_not_ended():
+    # Interrupted/incomplete turn: end_of_llm_stream was never sent, so the eos
+    # must NOT be forced final (no premature is_final_chunk).
+    metas = [{"sequence_id": 2, "end_of_llm_stream": False}]
+    recv = [(b"\x00", {})]
+    packets = await drain(FakeStreamSynth(recv, metas, last_text_sent=False))
+
+    eos = packets[-1]
+    assert eos["meta_info"]["end_of_synthesizer_stream"] is True
+    assert eos["meta_info"].get("end_of_llm_stream", False) is False


### PR DESCRIPTION
Issue

  On multilingual switch-language agents, the agent goes silent and stops responding after a short reply. The caller keeps talking (e.g. answering "telugu"), ASR captures it, but it's never sent to the
  LLM — logs show Ignoring transcript: ... / Continuing the loop and ignoring the transcript ... false interruption. This was reproducing on every call for the affected agent.

  Observed in calls d2b9ad62… and c8d1fd8c…: the agent plays the short "which language would you like — Hindi, English, Telugu, Tamil or Kannada?" reply, then ignores the caller for ~20s until the call
  dies.

  Root cause

  The flag is_audio_being_played_to_user (used to suppress short backchannel words from interrupting the agent mid-speech) only clears when a TTS chunk's mark is is_final_chunk, where:

  is_final_chunk = end_of_llm_stream AND end_of_synthesizer_stream

  In StreamSynthesizer._generate_ws_loop, the end-of-stream sentinel (b"\x00") takes its meta_info from text_queue.popleft() — one pop per receiver message. But ElevenLabs buffers a short reply into fewer
  audio messages than the number of LLM text pushes, so:

  - the eos sentinel binds to a non-final chunk's meta (end_of_llm_stream=False), and
  - the chunk that actually had end_of_llm_stream=True is left stranded in the queue.

  On top of that, the brittle text-match end detector (current_text.endswith(last_four)) fires eos on the first buffered recv, and the correct isFinal from close_context — which would have paired with the
  final chunk — is dropped by the once-per-context guard.

  Net result: end_of_synthesizer_stream and end_of_llm_stream land on different marks, so no mark is ever is_final_chunk → no final mark is sent/acked → is_audio_being_played latches True forever → every
  short caller reply is discarded as a "false interruption."