### PR TITLE
fix: defer barge-ins while a tool call is in flight to prevent duplicate execution

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.114"
+__version__ = "0.10.115"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4484,9 +4484,7 @@ class TaskManager(BaseManager):
                         # Starting a new turn here cancels the in-flight tool call before its result is
                         # recorded, so the LLM re-emits the same tool and the side effect runs twice.
                         if self.function_call_in_flight:
-                            logger.info(
-                                f"Tool call in flight; deferring barge-in transcript {transcript_content!r}"
-                            )
+                            logger.info(f"Tool call in flight; deferring barge-in transcript {transcript_content!r}")
                             self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
                             continue
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4481,6 +4481,15 @@ class TaskManager(BaseManager):
                             self._speech_started_before_welcome = False
                             continue
 
+                        # Starting a new turn here cancels the in-flight tool call before its result is
+                        # recorded, so the LLM re-emits the same tool and the side effect runs twice.
+                        if self.function_call_in_flight:
+                            logger.info(
+                                f"Tool call in flight; deferring barge-in transcript {transcript_content!r}"
+                            )
+                            self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
+                            continue
+
                         _meta = message.get("meta_info") or {}
                         self.interruption_manager.on_user_speech_ended(
                             stop_offset_ms=_meta.get("user_stop_offset_ms", 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.114"
+version = "0.10.115"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem
When the LLM emits an API tool call, `__execute_function_call` fires the HTTP request and records the tool call and its result into conversation history only after the request returns. That execution runs on `llm_task`. If the user speaks (barge-in) while the request is in flight, `_listen_transcriber` starts a new turn, which cancels `llm_task` before the result is recorded. The tool call and result never land in history, so on the next turn the LLM has no memory it called the tool and re-emits the identical call. The side effect runs twice.

Observed on a voice-order agent: an `add_items` request fired, the caller said "okay" while it was still processing, the turn was cancelled before recording, and the LLM re-issued the same `add_items` with identical arguments, adding every item to the order twice.

## Fix
Defer barge-in transcripts while a tool call is in flight. In `_listen_transcriber`, when `function_call_in_flight` is set, ignore the incoming final transcript instead of starting a competing turn, so the in-flight action finishes, records its result, and its follow-up response speaks. The guard sits before the eager/normal turn-entry split so both paths are covered. This mirrors the existing guards on the transfer-call and language-switch paths, which already refuse to truncate an in-flight tool call.

## Follow-up
Speculative (eager EOT) generation can fire a tool on its own and then be reverted, repeating the same class of duplicate. That path needs its own guard and eager-specific tests, handled in a separate PR.
