### PR TITLE
feat: typed agent state (working memory)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.122"
+__version__ = "0.10.123"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3194,11 +3194,7 @@ class TaskManager(BaseManager):
         # write lands inside the function_call_in_flight guard, so a barge-in defers and
         # the commit is not lost or doubled.
         if called_fun == "update_state":
-            writable = {
-                path[len("state.") :]
-                for path in (self.variable_types or {})
-                if path.startswith("state.")
-            }
+            writable = {path[len("state.") :] for path in (self.variable_types or {}) if path.startswith("state.")}
             # Read the model's arguments from the tool call itself, not from **resp:
             # FunctionCallPayload field names (url, headers, ...) would otherwise shadow
             # same-named state variables.
@@ -3415,9 +3411,7 @@ class TaskManager(BaseManager):
                 if self.context_data is None:
                     self.context_data = {}
                 self.context_data.setdefault("state", {})
-                written = apply_state_assignments(
-                    self.context_data, assignments, assign_source, self.variable_types
-                )
+                written = apply_state_assignments(self.context_data, assignments, assign_source, self.variable_types)
                 if written:
                     logger.info(f"Tool {called_fun} wrote state {written}")
             else:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -39,6 +39,7 @@ from bolna.helpers.function_calling_helpers import (
     validate_outbound_url,
 )
 from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.expression_evaluator import enum_values
 from bolna.helpers.agent_state import (
     format_state_block,
     apply_state_assignments,
@@ -99,9 +100,16 @@ logger = configure_logger(__name__)
 
 
 def _state_json_type(declared) -> str:
-    """Map a declared VariableType (or its raw value) to a JSON-schema type."""
-    value = declared.value if hasattr(declared, "value") else str(declared)
-    return value if value in ("string", "number", "boolean") else "string"
+    """Map a declared variable type (bare type, value string, or spec) to a JSON-schema
+    scalar type. Enum maps to string; its allowed set is attached separately."""
+    if isinstance(declared, dict):
+        value = declared.get("type")
+    elif hasattr(declared, "type"):  # a VariableSpec instance
+        value = declared.type
+    else:
+        value = declared
+    value = value.value if hasattr(value, "value") else value
+    return value if value in ("number", "boolean") else "string"
 
 
 def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
@@ -1361,18 +1369,20 @@ class TaskManager(BaseManager):
         (otp_verified after a read-back, a computed total). Mirrors the switch_language
         injection: registered in api_tools so the accumulator keeps the call and routes
         it through __execute_function_call. No-op without writable vars."""
-        writable = {
-            path[len("state.") :]: vtype
-            for path, vtype in (self.variable_types or {}).items()
-            if path.startswith("state.")
-        }
-        if not writable:
+        writable_paths = [p for p in (self.variable_types or {}) if p.startswith("state.")]
+        if not writable_paths:
             return
         if self.kwargs.get("api_tools") is None:
             self.kwargs["api_tools"] = {"tools": [], "tools_params": {}}
         if "update_state" in self.kwargs["api_tools"].get("tools_params", {}):
             return
-        properties = {name: {"type": _state_json_type(vtype)} for name, vtype in writable.items()}
+        properties = {}
+        for path in writable_paths:
+            prop = {"type": _state_json_type(self.variable_types[path])}
+            allowed = enum_values(path, self.variable_types)
+            if allowed:
+                prop["enum"] = allowed
+            properties[path[len("state.") :]] = prop
         tool_def = {
             "type": "function",
             "function": {
@@ -1391,7 +1401,7 @@ class TaskManager(BaseManager):
         tools_list.append(tool_def)
         self.kwargs["api_tools"]["tools"] = tools_list
         self.kwargs["api_tools"].setdefault("tools_params", {})["update_state"] = {}
-        logger.info(f"Injected update_state tool (vars={list(writable)})")
+        logger.info(f"Injected update_state tool (vars={list(properties)})")
 
     def _inject_state_block(self, messages):
         """Append the pinned typed-state block as a trailing system message for non-graph

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -100,15 +100,9 @@ logger = configure_logger(__name__)
 
 
 def _state_json_type(declared) -> str:
-    """Map a declared variable type (bare type, value string, or spec) to a JSON-schema
-    scalar type. Enum maps to string; its allowed set is attached separately."""
-    if isinstance(declared, dict):
-        value = declared.get("type")
-    elif hasattr(declared, "type"):  # a VariableSpec instance
-        value = declared.type
-    else:
-        value = declared
-    value = value.value if hasattr(value, "value") else value
+    """Map a declared variable type (bare type or spec dict) to a JSON-schema scalar
+    type. Enum maps to string; its allowed set is attached separately."""
+    value = declared.get("type") if isinstance(declared, dict) else declared
     return value if value in ("number", "boolean") else "string"
 
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -39,6 +39,11 @@ from bolna.helpers.function_calling_helpers import (
     validate_outbound_url,
 )
 from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.agent_state import (
+    format_state_block,
+    apply_state_assignments,
+    apply_state_updates,
+)
 from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
@@ -91,6 +96,12 @@ from .models import ComponentLatencies
 from .voicemail_handler import VoicemailHandler
 
 logger = configure_logger(__name__)
+
+
+def _state_json_type(declared) -> str:
+    """Map a declared VariableType (or its raw value) to a JSON-schema type."""
+    value = declared.value if hasattr(declared, "value") else str(declared)
+    return value if value in ("string", "number", "boolean") else "string"
 
 
 def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
@@ -390,6 +401,9 @@ class TaskManager(BaseManager):
         self.is_local = False
         self.llm_config = None
         self.agent_type = None
+        # Typed agent state schema: dot-path -> declared type. Populated from the llm
+        # config below; empty when the agent does not use typed state.
+        self.variable_types = {}
 
         self.llm_config_map = {}
         self.llm_agent_map = {}
@@ -432,6 +446,18 @@ class TaskManager(BaseManager):
                         "provider": self.llm_agent_config["provider"],
                         "temperature": self.llm_agent_config["temperature"],
                     }
+
+                # Typed agent state schema lives on the llm_agent config (simple agents)
+                # or nested under llm_config (graph/knowledge agents).
+                self.variable_types = (
+                    (self.llm_agent_config or {}).get("variable_types")
+                    or (self.llm_agent_config or {}).get("llm_config", {}).get("variable_types")
+                    or {}
+                )
+                if self.variable_types:
+                    if self.context_data is None:
+                        self.context_data = {}
+                    self.context_data.setdefault("state", {})
 
                 if "reasoning_effort" in self.llm_agent_config:
                     self.llm_config["reasoning_effort"] = self.llm_agent_config["reasoning_effort"]
@@ -698,6 +724,8 @@ class TaskManager(BaseManager):
         self.agent_names = self.task_config.get("tools_config", {}).get("agent_names") or {}
         if not self.__language_switch_enabled():
             self.__inject_switch_language_tool()
+
+        self.__inject_update_state_tool()
 
         # # setting llm
         # llm = self.__setup_llm(self.llm_config)
@@ -1326,6 +1354,55 @@ class TaskManager(BaseManager):
         # setup call site, before this injection.)
         self.kwargs["api_tools"]["tools_params"]["switch_language"] = {}
         logger.info(f"Injected legacy switch_language tool (labels={sorted(labels)})")
+
+    def __inject_update_state_tool(self):
+        """Expose the built-in update_state tool when writable ``state.*`` variables are
+        declared, so the LLM can commit typed flags/values that no API tool produces
+        (otp_verified after a read-back, a computed total). Mirrors the switch_language
+        injection: registered in api_tools so the accumulator keeps the call and routes
+        it through __execute_function_call. No-op without writable vars."""
+        writable = {
+            path[len("state.") :]: vtype
+            for path, vtype in (self.variable_types or {}).items()
+            if path.startswith("state.")
+        }
+        if not writable:
+            return
+        if self.kwargs.get("api_tools") is None:
+            self.kwargs["api_tools"] = {"tools": [], "tools_params": {}}
+        if "update_state" in self.kwargs["api_tools"].get("tools_params", {}):
+            return
+        properties = {name: {"type": _state_json_type(vtype)} for name, vtype in writable.items()}
+        tool_def = {
+            "type": "function",
+            "function": {
+                "name": "update_state",
+                "description": (
+                    "Record internal call state. Call this the moment a tracked value becomes "
+                    "known or changes (a verification result, a computed total, a decision). "
+                    "Pass only the fields that changed. This does not speak to the user."
+                ),
+                "parameters": {"type": "object", "properties": properties, "required": []},
+            },
+        }
+        tools_list = self.kwargs["api_tools"].get("tools", [])
+        if isinstance(tools_list, str):
+            tools_list = json.loads(tools_list)
+        tools_list.append(tool_def)
+        self.kwargs["api_tools"]["tools"] = tools_list
+        self.kwargs["api_tools"].setdefault("tools_params", {})["update_state"] = {}
+        logger.info(f"Injected update_state tool (vars={list(writable)})")
+
+    def _inject_state_block(self, messages):
+        """Append the pinned typed-state block as a trailing system message for non-graph
+        agents (graph agents inject their own inside _build_messages). No-op without
+        declared variable_types."""
+        if self.agent_type == "graph_agent" or not self.variable_types:
+            return messages
+        block = format_state_block(self.context_data, self.variable_types)
+        if block:
+            return messages + [{"role": "system", "content": block}]
+        return messages
 
     def _get_voice_name_for_label(self, label):
         """Get agent name for a language label from configured agent_names."""
@@ -3108,6 +3185,51 @@ class TaskManager(BaseManager):
                         )
                 return
 
+        # Built-in update_state tool: the model commits typed flags/values into the
+        # state namespace. URL-less internal tool, handled here (not the HTTP path). The
+        # write lands inside the function_call_in_flight guard, so a barge-in defers and
+        # the commit is not lost or doubled.
+        if called_fun == "update_state":
+            writable = {
+                path[len("state.") :]
+                for path in (self.variable_types or {})
+                if path.startswith("state.")
+            }
+            # Read the model's arguments from the tool call itself, not from **resp:
+            # FunctionCallPayload field names (url, headers, ...) would otherwise shadow
+            # same-named state variables.
+            raw_args = {}
+            tool_calls = resp.get("model_response") or []
+            if tool_calls:
+                try:
+                    raw_args = json.loads(tool_calls[0]["function"]["arguments"] or "{}")
+                except (json.JSONDecodeError, KeyError, TypeError):
+                    raw_args = {}
+            updates = {name: value for name, value in raw_args.items() if name in writable}
+            dropped = [name for name in raw_args if name not in writable]
+            if dropped:
+                logger.warning(f"update_state ignoring undeclared keys: {dropped}")
+            if self.context_data is None:
+                self.context_data = {}
+            self.context_data.setdefault("state", {})
+            written = apply_state_updates(self.context_data, updates, self.variable_types)
+            logger.info(f"update_state wrote {written}")
+            function_response = json.dumps({"status": "success", "updated": written})
+
+            self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
+            self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), function_response)
+            convert_to_request_log(
+                function_response, meta_info, None, "function_call", direction="response", run_id=self.run_id
+            )
+
+            messages = self.conversation_history.get_copy()
+            followup_meta_info = self._spawn_followup_meta_info(meta_info)
+            await self.__do_llm_generation(
+                messages, followup_meta_info, next_step, should_bypass_synth=False, should_trigger_function_call=True
+            )
+            self.execute_function_call_task = None
+            return
+
         # LEGACY flow handler (flag-off): the switch_language tool injected by
         # __inject_switch_language_tool. Restored from master for the feature-flag
         # fallback path — unreachable when the LLM-driven flow is enabled (the tool
@@ -3274,6 +3396,30 @@ class TaskManager(BaseManager):
                     logger.info(f"Merged API response into context_data: {list(response_data.keys())}")
             except (json.JSONDecodeError, TypeError) as e:
                 logger.debug(f"Could not parse API response as JSON for context merge: {e}")
+
+        # Typed state assignment (write path A): map declared response fields into the
+        # state namespace, coerced to declared types. Inside the function_call_in_flight guard.
+        assignments = tool_conf.get("response_assignments")
+        if assignments:
+            try:
+                assign_source = (
+                    json.loads(function_response) if isinstance(function_response, str) else function_response
+                )
+            except (json.JSONDecodeError, TypeError):
+                assign_source = None
+            if isinstance(assign_source, dict):
+                if self.context_data is None:
+                    self.context_data = {}
+                self.context_data.setdefault("state", {})
+                written = apply_state_assignments(
+                    self.context_data, assignments, assign_source, self.variable_types
+                )
+                if written:
+                    logger.info(f"Tool {called_fun} wrote state {written}")
+            else:
+                logger.warning(
+                    f"Tool {called_fun} has response_assignments but its response is not a JSON object; no state written"
+                )
         if called_fun.startswith("check_availability_of_slots") and (
             not get_res_values or (len(get_res_values) == 1 and len(get_res_values[0]) == 0)
         ):
@@ -3393,6 +3539,10 @@ class TaskManager(BaseManager):
 
         # Inject language instruction if detection complete
         messages = self._inject_language_instruction(messages)
+
+        # Inject the pinned typed-state block for non-graph agents (graph agents add
+        # their own inside _build_messages).
+        messages = self._inject_state_block(messages)
 
         # Pass detected language to LLM for pre_call_message selection
         meta_info["detected_language"] = self.language
@@ -6488,6 +6638,10 @@ class TaskManager(BaseManager):
                     },
                     "hangup_detail": self.hangup_detail,
                     "has_transfer": self.has_transfer,
+                    # Typed agent state at call end; persisted to executions.agent_state.
+                    # Gated on variable_types so a stray "state" key merged from a tool
+                    # response never masquerades as agent state for a non-typed agent.
+                    "agent_state": ((self.context_data or {}).get("state") or None) if self.variable_types else None,
                 }
 
                 try:

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -20,6 +20,7 @@ from bolna.helpers.utils import (
     get_md5_hash,
 )
 from bolna.helpers.expression_evaluator import evaluate_edge_expression, describe_edge_expression
+from bolna.helpers.agent_state import format_state_block
 from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
@@ -916,6 +917,9 @@ class GraphAgent(BaseAgent):
         messages = [{"role": "system", "content": prompt}] + conversation
         if rag_message:
             messages.append(rag_message)
+        state_block = format_state_block(self.context_data, self.variable_types)
+        if state_block:
+            messages.append({"role": "system", "content": state_block})
         return messages
 
     async def generate(self, message: List[dict], **kwargs) -> AsyncGenerator:

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -266,6 +266,7 @@ class VariableType(str, Enum):
     STRING = "string"
     NUMBER = "number"
     BOOLEAN = "boolean"
+    ENUM = "enum"
 
 
 class EdgeConditionType(str, Enum):

--- a/bolna/helpers/agent_state.py
+++ b/bolna/helpers/agent_state.py
@@ -1,0 +1,89 @@
+"""Typed agent state (working memory).
+
+State lives as a typed namespace inside context_data (writes go under "state."),
+declared via the same variable_types map that drives expression routing. This module
+is the state layer: the read path (the pinned state block) and the two write paths
+(tool-result assignments and the built-in update_state tool). It reuses the dot-notation
+and coercion primitives from expression_evaluator so they stay defined once.
+"""
+
+from typing import Any, Optional
+
+from bolna.helpers.expression_evaluator import MISSING, coerce_to_type, resolve_variable, set_variable
+from bolna.helpers.logger_config import configure_logger
+
+logger = configure_logger(__name__)
+
+STATE_NAMESPACE = "state"
+
+
+def _render_state_value(value: Any) -> str:
+    """Render a value for the pinned state block (booleans as true/false)."""
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def format_state_block(context_data: Optional[dict], variable_types: Optional[dict]) -> str:
+    """Render declared variables and their current values as a compact, pinned state
+    block for the LLM. Returns '' when there is nothing to show. The model reads these
+    authoritative values instead of re-deriving them from the transcript."""
+    if not context_data or not variable_types:
+        return ""
+    lines = []
+    for path in variable_types:
+        value = resolve_variable(context_data, path)
+        if value is MISSING:
+            continue
+        lines.append(f"- {path}: {_render_state_value(value)}")
+    if not lines:
+        return ""
+    return (
+        "## Current state\n"
+        "Authoritative values for this call. Use these directly; do not re-derive them "
+        "from the conversation.\n" + "\n".join(lines)
+    )
+
+
+def apply_state_assignments(
+    context_data: dict, assignments: dict, source: dict, variable_types: Optional[dict]
+) -> list:
+    """Apply a tool's response_assignments map. For each {state_path: source_path},
+    read source_path from the tool response (dot-notation), coerce to the declared
+    type, and write it into context_data at state_path. Missing source paths are
+    skipped. Returns the list of state paths written (for logging)."""
+    written = []
+    if not assignments or not isinstance(source, dict) or context_data is None:
+        return written
+    for state_path, source_path in assignments.items():
+        value = resolve_variable(source, source_path)
+        if value is MISSING:
+            continue
+        set_variable(context_data, state_path, _coerce_for_state(value, state_path, variable_types))
+        written.append(state_path)
+    return written
+
+
+def apply_state_updates(
+    context_data: dict, updates: dict, variable_types: Optional[dict], namespace: str = STATE_NAMESPACE
+) -> list:
+    """Write update_state arguments into the state namespace, coercing each to its
+    declared type. updates keys are bare variable names (no namespace prefix).
+    Returns the list of state paths written (for logging)."""
+    written = []
+    if not updates or context_data is None:
+        return written
+    for name, value in updates.items():
+        state_path = f"{namespace}.{name}"
+        set_variable(context_data, state_path, _coerce_for_state(value, state_path, variable_types))
+        written.append(state_path)
+    return written
+
+
+def _coerce_for_state(value: Any, path: str, variable_types: Optional[dict]) -> Any:
+    """Coerce value to the type declared for path; store raw (and warn) on failure."""
+    try:
+        return coerce_to_type(value, path, variable_types)
+    except (TypeError, ValueError):
+        logger.warning(f"State coercion failed: {path}={value!r}; storing raw")
+        return value

--- a/bolna/helpers/agent_state.py
+++ b/bolna/helpers/agent_state.py
@@ -9,7 +9,7 @@ and coercion primitives from expression_evaluator so they stay defined once.
 
 from typing import Any, Optional
 
-from bolna.helpers.expression_evaluator import MISSING, coerce_to_type, resolve_variable, set_variable
+from bolna.helpers.expression_evaluator import MISSING, coerce_to_type, enum_values, resolve_variable, set_variable
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -81,9 +81,14 @@ def apply_state_updates(
 
 
 def _coerce_for_state(value: Any, path: str, variable_types: Optional[dict]) -> Any:
-    """Coerce value to the type declared for path; store raw (and warn) on failure."""
+    """Coerce value to the type declared for path; store raw (and warn) on failure.
+    For enum-typed variables, warn if the value is outside the allowed set."""
     try:
-        return coerce_to_type(value, path, variable_types)
+        coerced = coerce_to_type(value, path, variable_types)
     except (TypeError, ValueError):
         logger.warning(f"State coercion failed: {path}={value!r}; storing raw")
         return value
+    allowed = enum_values(path, variable_types)
+    if allowed is not None and coerced not in allowed:
+        logger.warning(f"State {path}={coerced!r} not in allowed values {allowed}; storing anyway")
+    return coerced

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -84,27 +84,52 @@ def _coerce_value(value: Any, declared_type: VariableType) -> Any:
         return float(value)
     if declared_type == VariableType.BOOLEAN:
         return _to_bool(value)
+    if declared_type == VariableType.ENUM:
+        # Enum values are strings; compare/store in string form. Membership against the
+        # allowed set is enforced at write time and via the update_state tool schema.
+        return str(value)
     raise ValueError(f"unsupported variable type: {declared_type!r}")
 
 
-def _resolve_declared_type(
-    variable: str, variable_types: Optional[dict], log_unknown: bool = True
-) -> Optional[VariableType]:
-    """Resolve a variable's declared type. Keys match the condition's variable path
-    exactly. An unrecognized type name falls back to inference, warning once when
-    log_unknown (the trace/describe pass passes False to avoid duplicate warnings).
-    """
+def _resolve_spec(variable: str, variable_types: Optional[dict], log_unknown: bool = True):
+    """Resolve a variable's declared (type, enum_values). A value is either a bare type
+    ("boolean") or a spec carrying allowed values ({"type": "enum", "values": [...]}, or
+    a VariableSpec). Returns None when no known type is declared."""
     if not variable_types:
         return None
     raw = variable_types.get(variable)
     if raw is None:
         return None
+    if isinstance(raw, dict):
+        type_raw, values = raw.get("type"), raw.get("values")
+    elif hasattr(raw, "type"):  # a VariableSpec instance
+        type_raw, values = raw.type, getattr(raw, "values", None)
+    else:
+        type_raw, values = raw, None
     try:
-        return VariableType(raw)
-    except ValueError:
+        return VariableType(type_raw), values
+    except (ValueError, TypeError):
         if log_unknown:
-            logger.warning(f"Unknown variable type {raw!r} for {variable!r}; falling back to inference")
+            logger.warning(f"Unknown variable type {type_raw!r} for {variable!r}; falling back to inference")
         return None
+
+
+def _resolve_declared_type(
+    variable: str, variable_types: Optional[dict], log_unknown: bool = True
+) -> Optional[VariableType]:
+    """Resolve a variable's declared type (the type half of its spec), or None to fall
+    back to inference. log_unknown is False on the trace/describe pass to avoid duplicate
+    warnings."""
+    spec = _resolve_spec(variable, variable_types, log_unknown)
+    return spec[0] if spec else None
+
+
+def enum_values(variable: str, variable_types: Optional[dict]) -> Optional[list]:
+    """Return the allowed values for an enum-typed variable, else None."""
+    spec = _resolve_spec(variable, variable_types, log_unknown=False)
+    if spec and spec[0] == VariableType.ENUM:
+        return spec[1] or []
+    return None
 
 
 def coerce_to_type(value: Any, variable: str, variable_types: Optional[dict]) -> Any:

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -102,8 +102,6 @@ def _resolve_spec(variable: str, variable_types: Optional[dict], log_unknown: bo
         return None
     if isinstance(raw, dict):
         type_raw, values = raw.get("type"), raw.get("values")
-    elif hasattr(raw, "type"):  # a VariableSpec instance
-        type_raw, values = raw.type, getattr(raw, "values", None)
     else:
         type_raw, values = raw, None
     try:

--- a/bolna/helpers/expression_evaluator.py
+++ b/bolna/helpers/expression_evaluator.py
@@ -13,6 +13,7 @@ from bolna.helpers.logger_config import configure_logger
 logger = configure_logger(__name__)
 
 _MISSING = object()
+MISSING = _MISSING  # public alias so sibling modules can test for "path not found"
 
 _COMPARISON_OPS = {
     ExpressionOperator.EQ: op.eq,
@@ -33,6 +34,20 @@ def resolve_variable(context_data: dict, path: str) -> Any:
         else:
             return _MISSING
     return current
+
+
+def set_variable(context_data: dict, path: str, value: Any) -> None:
+    """Dot-notation setter (the write twin of resolve_variable), creating intermediate
+    dicts as needed."""
+    segments = path.split(".")
+    current = context_data
+    for segment in segments[:-1]:
+        nxt = current.get(segment)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            current[segment] = nxt
+        current = nxt
+    current[segments[-1]] = value
 
 
 _TRUE_TOKENS = {"true", "1", "yes"}
@@ -90,6 +105,13 @@ def _resolve_declared_type(
         if log_unknown:
             logger.warning(f"Unknown variable type {raw!r} for {variable!r}; falling back to inference")
         return None
+
+
+def coerce_to_type(value: Any, variable: str, variable_types: Optional[dict]) -> Any:
+    """Coerce value to the type declared for `variable`, or return it unchanged if no
+    known type is declared. Raises TypeError/ValueError if coercion fails."""
+    declared = _resolve_declared_type(variable, variable_types, log_unknown=False)
+    return _coerce_value(value, declared) if declared is not None else value
 
 
 def _coerce_operands(actual: Any, expected: Any, operator: str, declared_type: Optional[VariableType]):

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, ConfigDict
 
@@ -17,6 +17,10 @@ class APIParams(BaseModel):
     # Graph-agent tool scope; None == GLOBAL. NODE limits visibility to ``nodes``.
     scope: Optional[ToolScope] = None
     nodes: Optional[List[str]] = None
+    # Typed-state write path: maps a state path (e.g. "state.credit_limit") to a
+    # dot-notation field in this tool's JSON response. Applied and type-coerced after
+    # the tool returns, writing into context_data["state"].
+    response_assignments: Optional[Dict[str, str]] = None
 
 
 class LatencyData(BaseModel):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -293,6 +293,13 @@ class RagConfig(BaseModel):
     used_sources: Optional[List[UsedSource]] = None
 
 
+class VariableSpec(BaseModel):
+    """Declared type for a variable. `values` is the allowed set when type is enum."""
+
+    type: VariableType
+    values: Optional[List[str]] = None
+
+
 class Llm(BaseModel):
     model: Optional[str] = "gpt-3.5-turbo"
     max_tokens: Optional[int] = 100
@@ -311,11 +318,12 @@ class Llm(BaseModel):
     verbosity: Optional[Verbosity] = None
     use_responses_api: Optional[bool] = False
     compact_threshold: Optional[int] = None
-    # Variable path -> declared type. Coerces values into the right domain for typed state
-    # seeding, the pinned state block, and expression-routing comparisons. Keys are exact
-    # dot-notation paths (e.g. "recipient_data.age", "state.otp_verified"). Available on
-    # every agent type (graph and simple) since it lives on the base Llm config.
-    variable_types: Optional[Dict[str, VariableType]] = None
+    # Variable path -> declared type. Coerces values into the right domain for the typed
+    # state block, write coercion, and expression-routing comparisons. Keys are exact
+    # dot-notation paths (e.g. "recipient_data.age", "state.otp_verified"). A value is
+    # either a bare type ("boolean") or a VariableSpec ({"type": "enum", "values": [...]})
+    # for enum-constrained variables. Available on every agent type since it lives on Llm.
+    variable_types: Optional[Dict[str, Union[VariableType, VariableSpec]]] = None
 
     @model_validator(mode="after")
     def validate_reasoning_effort_for_model(self):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -322,7 +322,8 @@ class Llm(BaseModel):
     # state block, write coercion, and expression-routing comparisons. Keys are exact
     # dot-notation paths (e.g. "recipient_data.age", "state.otp_verified"). A value is
     # either a bare type ("boolean") or a VariableSpec ({"type": "enum", "values": [...]})
-    # for enum-constrained variables. Available on every agent type since it lives on Llm.
+    # for enum-constrained variables. VariableSpec validates the spec shape at the config
+    # boundary; the runtime reads the raw values. Available on every agent type via Llm.
     variable_types: Optional[Dict[str, Union[VariableType, VariableSpec]]] = None
 
     @model_validator(mode="after")

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -311,6 +311,11 @@ class Llm(BaseModel):
     verbosity: Optional[Verbosity] = None
     use_responses_api: Optional[bool] = False
     compact_threshold: Optional[int] = None
+    # Variable path -> declared type. Coerces values into the right domain for typed state
+    # seeding, the pinned state block, and expression-routing comparisons. Keys are exact
+    # dot-notation paths (e.g. "recipient_data.age", "state.otp_verified"). Available on
+    # every agent type (graph and simple) since it lives on the base Llm config.
+    variable_types: Optional[Dict[str, VariableType]] = None
 
     @model_validator(mode="after")
     def validate_reasoning_effort_for_model(self):
@@ -405,9 +410,7 @@ class GraphAgentConfig(Llm):
     nodes: List[GraphNode]
     current_node_id: str
     context_data: Optional[dict] = None
-    # Variable path -> declared type, used to coerce expression-routing comparisons into
-    # the right domain. Keys match the condition's variable exactly (e.g. "recipient_data.age").
-    variable_types: Optional[Dict[str, VariableType]] = None
+    # variable_types is inherited from the base Llm config.
     # Global knowledge base. Nodes without their own rag_config fall back to this at retrieval time.
     rag_config: Optional[RagConfig] = None
     # Routing configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.122"
+version = "0.10.123"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_typed_agent_state.py
+++ b/tests/tests/test_typed_agent_state.py
@@ -174,7 +174,9 @@ class TestUpdateStateToolInjection:
         return stub.kwargs.get("api_tools")
 
     def test_injects_typed_tool_for_writable_vars(self):
-        api_tools = self._inject({"state.otp_verified": "boolean", "state.total": "number", "recipient_data.age": "number"})
+        api_tools = self._inject(
+            {"state.otp_verified": "boolean", "state.total": "number", "recipient_data.age": "number"}
+        )
         assert "update_state" in api_tools["tools_params"]
         tool = next(t for t in api_tools["tools"] if t["function"]["name"] == "update_state")
         props = tool["function"]["parameters"]["properties"]

--- a/tests/tests/test_typed_agent_state.py
+++ b/tests/tests/test_typed_agent_state.py
@@ -1,0 +1,229 @@
+"""Tests for typed agent state (working memory).
+
+Covers the read path (pinned state block), the two write paths (tool-result
+assignments and the built-in update_state tool), seeding-time coercion, and that
+typed routing reads state after a flag is set.
+"""
+
+import asyncio
+import json
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.helpers.expression_evaluator import evaluate_condition, resolve_variable, set_variable
+from bolna.helpers.agent_state import (
+    apply_state_assignments,
+    apply_state_updates,
+    format_state_block,
+)
+
+
+# ---------------------------------------------------------------------------
+# update_state write path (write path B)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStateWrites:
+    def test_bare_names_written_under_state_namespace_and_coerced(self):
+        ctx = {"state": {}}
+        vt = {"state.otp_verified": "boolean", "state.total": "number"}
+        written = apply_state_updates(ctx, {"otp_verified": "true", "total": "420"}, vt)
+        assert ctx["state"]["otp_verified"] is True
+        assert ctx["state"]["total"] == 420.0
+        assert set(written) == {"state.otp_verified", "state.total"}
+
+    def test_empty_updates_noop(self):
+        ctx = {"state": {}}
+        assert apply_state_updates(ctx, {}, {}) == []
+
+
+# ---------------------------------------------------------------------------
+# Tool-result assignment write path (write path A)
+# ---------------------------------------------------------------------------
+
+
+class TestToolResultAssignment:
+    def test_dotpath_response_field_coerced_into_state(self):
+        ctx = {"state": {}}
+        source = {"data": {"limit": "4800"}}
+        written = apply_state_assignments(
+            ctx, {"state.credit_limit": "data.limit"}, source, {"state.credit_limit": "number"}
+        )
+        assert ctx["state"]["credit_limit"] == 4800.0
+        assert written == ["state.credit_limit"]
+
+    def test_missing_source_field_skipped(self):
+        ctx = {"state": {}}
+        written = apply_state_assignments(ctx, {"state.x": "a.b"}, {"a": {}}, {"state.x": "number"})
+        assert written == []
+        assert ctx["state"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Pinned state block (read path)
+# ---------------------------------------------------------------------------
+
+
+class TestStateBlockRender:
+    def test_renders_declared_present_values(self):
+        ctx = {"recipient_data": {"age": 42.0}, "state": {"otp_verified": True}}
+        vt = {"recipient_data.age": "number", "state.otp_verified": "boolean"}
+        block = format_state_block(ctx, vt)
+        assert "## Current state" in block
+        assert "state.otp_verified: true" in block
+        assert "recipient_data.age: 42.0" in block
+
+    def test_empty_without_variable_types(self):
+        assert format_state_block({"state": {"x": 1}}, {}) == ""
+        assert format_state_block({}, {"state.x": "number"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# Typed routing reads state after a flag is set
+# ---------------------------------------------------------------------------
+
+
+class TestTypedRoutingOnState:
+    def test_edge_condition_matches_after_flag_set(self):
+        ctx = {"state": {}}
+        vt = {"state.otp_verified": "boolean"}
+        cond = {"variable": "state.otp_verified", "operator": "eq", "value": True}
+        assert evaluate_condition(cond, ctx, vt) is False  # missing -> no match
+        apply_state_updates(ctx, {"otp_verified": "true"}, vt)
+        assert evaluate_condition(cond, ctx, vt) is True
+
+    def test_string_value_still_routes_via_declared_bool(self):
+        # The flag arrives as the string "false"; declared boolean makes it route correctly.
+        ctx = {"state": {"otp_verified": "false"}}
+        vt = {"state.otp_verified": "boolean"}
+        cond = {"variable": "state.otp_verified", "operator": "eq", "value": False}
+        assert evaluate_condition(cond, ctx, vt) is True
+
+
+# ---------------------------------------------------------------------------
+# set_variable dot-notation
+# ---------------------------------------------------------------------------
+
+
+class TestSetVariable:
+    def test_creates_intermediate_dicts(self):
+        ctx = {}
+        set_variable(ctx, "state.nested.flag", True)
+        assert ctx == {"state": {"nested": {"flag": True}}}
+        assert resolve_variable(ctx, "state.nested.flag") is True
+
+
+# ---------------------------------------------------------------------------
+# GraphAgent injects the state block into its messages
+# ---------------------------------------------------------------------------
+
+
+def _make_graph_agent(variable_types, context_data):
+    cfg = {
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "temperature": 0.7,
+        "max_tokens": 150,
+        "current_node_id": "greeting",
+        "nodes": [{"id": "greeting", "prompt": "Greet the user.", "edges": []}],
+        "variable_types": variable_types,
+        "context_data": context_data,
+    }
+    mock_llm = MagicMock()
+    mock_llm.trigger_function_call = False
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=MagicMock()),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": MagicMock(return_value=mock_llm)}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        return GraphAgent(cfg)
+
+
+class TestGraphAgentStateBlock:
+    def test_build_messages_appends_state_block(self):
+        agent = _make_graph_agent(
+            {"state.otp_verified": "boolean"},
+            {"recipient_data": {}, "state": {"otp_verified": True}},
+        )
+        messages = asyncio.run(agent._build_messages([{"role": "user", "content": "hi"}]))
+        system_contents = [m["content"] for m in messages if m["role"] == "system"]
+        assert any("## Current state" in c and "state.otp_verified: true" in c for c in system_contents)
+
+    def test_no_state_block_without_variable_types(self):
+        agent = _make_graph_agent({}, {"recipient_data": {}})
+        messages = asyncio.run(agent._build_messages([{"role": "user", "content": "hi"}]))
+        assert not any("## Current state" in m["content"] for m in messages if m["role"] == "system")
+
+
+# ---------------------------------------------------------------------------
+# update_state tool injection (write path B wiring)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateStateToolInjection:
+    def _inject(self, variable_types, api_tools=None):
+        from bolna.agent_manager.task_manager import TaskManager
+
+        stub = MagicMock()
+        stub.variable_types = variable_types
+        stub.kwargs = {"api_tools": api_tools} if api_tools is not None else {}
+        TaskManager._TaskManager__inject_update_state_tool.__get__(stub, TaskManager)()
+        return stub.kwargs.get("api_tools")
+
+    def test_injects_typed_tool_for_writable_vars(self):
+        api_tools = self._inject({"state.otp_verified": "boolean", "state.total": "number", "recipient_data.age": "number"})
+        assert "update_state" in api_tools["tools_params"]
+        tool = next(t for t in api_tools["tools"] if t["function"]["name"] == "update_state")
+        props = tool["function"]["parameters"]["properties"]
+        # only state.* vars become params, with their JSON-schema types
+        assert props == {"otp_verified": {"type": "boolean"}, "total": {"type": "number"}}
+        assert tool["function"]["parameters"]["required"] == []
+
+    def test_noop_without_writable_state_vars(self):
+        api_tools = self._inject({"recipient_data.age": "number"})
+        assert api_tools is None
+
+    def test_enum_var_emits_enum_schema(self):
+        api_tools = self._inject({"state.status": {"type": "enum", "values": ["pending", "approved", "rejected"]}})
+        tool = next(t for t in api_tools["tools"] if t["function"]["name"] == "update_state")
+        prop = tool["function"]["parameters"]["properties"]["status"]
+        assert prop == {"type": "string", "enum": ["pending", "approved", "rejected"]}
+
+
+# ---------------------------------------------------------------------------
+# Enum type (backward-compatible with the bare-string form)
+# ---------------------------------------------------------------------------
+
+
+class TestEnumType:
+    _VT = {"state.status": {"type": "enum", "values": ["pending", "approved", "rejected"]}}
+
+    def test_update_coerces_enum_to_string_and_stores(self):
+        ctx = {"state": {}}
+        apply_state_updates(ctx, {"status": "approved"}, self._VT)
+        assert ctx["state"]["status"] == "approved"
+
+    def test_out_of_set_value_stored_anyway(self):
+        # write-time membership is a warning, not a hard reject (the tool schema is the
+        # real enforcement); the value is still stored.
+        ctx = {"state": {}}
+        apply_state_updates(ctx, {"status": "weird"}, self._VT)
+        assert ctx["state"]["status"] == "weird"
+
+    def test_routing_eq_on_enum(self):
+        ctx = {"state": {"status": "approved"}}
+        assert evaluate_condition({"variable": "state.status", "operator": "eq", "value": "approved"}, ctx, self._VT)
+        assert not evaluate_condition({"variable": "state.status", "operator": "eq", "value": "pending"}, ctx, self._VT)
+
+    def test_routing_in_on_enum(self):
+        ctx = {"state": {"status": "approved"}}
+        cond = {"variable": "state.status", "operator": "in", "value": ["approved", "rejected"]}
+        assert evaluate_condition(cond, ctx, self._VT) is True
+
+    def test_bare_string_form_still_works(self):
+        ctx = {"state": {}}
+        apply_state_updates(ctx, {"flag": "true"}, {"state.flag": "boolean"})
+        assert ctx["state"]["flag"] is True


### PR DESCRIPTION
Adds a typed, per-call agent state ("working memory") the agent reads and writes during a call, instead of re-inferring it from the transcript every turn.

What it does:

* Declare typed variables via `variable_types` (dot-path to string/number/boolean) on the agent/graph config. The field is lifted onto the base Llm config so simple and graph agents both get it.
* State lives in a `state` namespace inside `context_data`, rendered to the model each turn as a compact pinned block. It is never string-substituted into prompts.
* Two write paths: a tool's `response_assignments` map (response field to a typed state variable), and a built-in `update_state` tool auto-injected for the declared writable variables.
* Graph routing reads the typed state through the existing expression evaluator, so edges branch deterministically on values like `state.otp_verified == true`.
* The final state is surfaced in the call output for persistence.

Works for graph and simple agents (simple agents get everything except node routing). No behavior change for agents that declare no `variable_types`.
