### PR TITLE
fix: detect text-narrated tool calls by tool name, not just the functions. prefix

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.119"
+__version__ = "0.10.120"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -233,9 +233,8 @@ class AzureLLM(OpenAICompatibleLLM):
                         text_tool_buffer = None
                         answer += remainder
                         buffer = remainder
-                elif re.search(r"functions\.\w", buffer + content):
+                elif (idx := self._find_text_tool_call_start(buffer + content, tools)) != -1:
                     combined = buffer + content
-                    idx = combined.find("functions.")
                     before = combined[:idx]
                     after = combined[idx:]
                     if before:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -80,20 +80,23 @@ class OpenAICompatibleLLM(BaseLLM):
 
     @staticmethod
     def _find_offered_tool_name(text, offered):
-        """Earliest offered tool name appearing as a substring in text, or None. Tool names are
-        underscored ids (e.g. transfer_call_911206480701) that don't occur in natural speech."""
+        """Earliest offered tool name in text (longest wins on a tie, to prefer the most specific),
+        or None. Used to recover which tool a captured narration fragment refers to."""
         best, best_i = None, len(text) + 1
         for t in offered or []:
             name = (t.get("function") or {}).get("name")
-            if name and (i := text.find(name)) != -1 and i < best_i:
+            if not name or (i := text.find(name)) == -1:
+                continue
+            if i < best_i or (i == best_i and len(name) > len(best or "")):
                 best, best_i = name, i
         return best
 
     @staticmethod
     def _find_text_tool_call_start(text, offered):
-        """Earliest index where a narrated tool call begins: a `functions.` prefix or a wrapped/bare
-        offered tool name (e.g. {type:transfer_call_..}). Backs up to a '{' within 25 chars so the
-        wrapper is held out of TTS. Returns -1 if none."""
+        """Earliest index where a narrated tool call begins: a `functions.` prefix, or an offered
+        tool name that sits inside an unclosed { } wrapper (e.g. {type:transfer_call_..}). A bare
+        tool name in plain text is left as speech, so a tool named like a common word ('book') never
+        triggers on an ordinary sentence. Returns -1 if none."""
         idx = -1
         m = re.search(r"functions\.\w", text)
         if m:
@@ -102,10 +105,11 @@ class OpenAICompatibleLLM(BaseLLM):
             name = (t.get("function") or {}).get("name")
             if not name or (i := text.find(name)) == -1:
                 continue
-            brace = text.rfind("{", max(0, i - 25), i)
-            start = brace if brace != -1 else i
-            if idx == -1 or start < idx:
-                idx = start
+            brace = text.rfind("{", 0, i)
+            if brace == -1 or "}" in text[brace:i]:
+                continue  # not inside a { } wrapper -> ordinary speech, not a tool call
+            if idx == -1 or brace < idx:
+                idx = brace
         return idx
 
     @staticmethod

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -56,11 +56,15 @@ class OpenAICompatibleLLM(BaseLLM):
 
     @staticmethod
     def _find_tool_call_end(text):
-        """Return the index after the closing brace/paren of a text-based tool call, or -1 if incomplete."""
+        """Return the index after the closing brace/paren of a text tool call
+        (functions.x(...) or a bare {...} object), or -1 if incomplete."""
         m = re.search(r"functions\.\w+\s*[({]", text)
-        if not m:
+        if m:
+            start = m.end() - 1
+        elif text.lstrip().startswith("{"):
+            start = text.index("{")
+        else:
             return -1
-        start = m.end() - 1
         depth = 0
         for i in range(start, len(text)):
             if text[i] in "({":
@@ -73,6 +77,36 @@ class OpenAICompatibleLLM(BaseLLM):
                         end += 1
                     return end
         return -1
+
+    @staticmethod
+    def _find_offered_tool_name(text, offered):
+        """Earliest offered tool name appearing as a substring in text, or None. Tool names are
+        underscored ids (e.g. transfer_call_911206480701) that don't occur in natural speech."""
+        best, best_i = None, len(text) + 1
+        for t in offered or []:
+            name = (t.get("function") or {}).get("name")
+            if name and (i := text.find(name)) != -1 and i < best_i:
+                best, best_i = name, i
+        return best
+
+    @staticmethod
+    def _find_text_tool_call_start(text, offered):
+        """Earliest index where a narrated tool call begins: a `functions.` prefix or a wrapped/bare
+        offered tool name (e.g. {type:transfer_call_..}). Backs up to a '{' within 25 chars so the
+        wrapper is held out of TTS. Returns -1 if none."""
+        idx = -1
+        m = re.search(r"functions\.\w", text)
+        if m:
+            idx = m.start()
+        for t in offered or []:
+            name = (t.get("function") or {}).get("name")
+            if not name or (i := text.find(name)) == -1:
+                continue
+            brace = text.rfind("{", max(0, i - 25), i)
+            start = brace if brace != -1 else i
+            if idx == -1 or start < idx:
+                idx = start
+        return idx
 
     @staticmethod
     def _parse_text_tool_call(text):
@@ -133,32 +167,35 @@ class OpenAICompatibleLLM(BaseLLM):
         if not self.trigger_function_call:
             return None
 
+        # Respect per-call tool visibility (node scoping): only rescue a tool offered this turn.
+        offered = model_args.get("tools") or []
+        if isinstance(offered, str):
+            offered = json.loads(offered)
+
         parsed = self._parse_text_tool_call(text)
         if parsed:
             func_name, args_str = parsed
             args_recovered = False
         else:
-            # Args unparseable (e.g. truncated call): recover the name, fire only if no required args.
-            m = re.search(r"functions\.(\w+)", text)
-            if not m:
+            # No functions.NAME(...) form — e.g. a {type:transfer_call_..} shape, a truncated call,
+            # or a mangled wrapper. Recover by matching any offered tool name; fire only if it needs
+            # no model args (the required-args gate below).
+            func_name = self._find_offered_tool_name(text, offered)
+            if not func_name:
                 return None
-            func_name, args_str, args_recovered = m.group(1), "{}", True
+            args_str, args_recovered = "{}", True
 
         if func_name not in self.api_params:
             logger.warning(f"Text tool call rescue: '{func_name}' not in api_params, falling back to TTS")
             return None
 
-        # Respect per-call tool visibility (node scoping): only rescue a tool offered this turn.
-        offered = model_args.get("tools") or []
-        if isinstance(offered, str):
-            offered = json.loads(offered)
         tool_spec = next((t for t in offered if t.get("function", {}).get("name") == func_name), None)
         if tool_spec is None:
             logger.warning(f"Text tool call rescue: '{func_name}' not offered this turn, falling back to TTS")
             return None
 
         if args_recovered and (tool_spec["function"].get("parameters") or {}).get("required"):
-            logger.warning(f"Text tool call rescue: '{func_name}' truncated with required args, dropping")
+            logger.warning(f"Text tool call rescue: '{func_name}' recovered by name but needs model args, dropping")
             return None
 
         func_conf = self.api_params[func_name]

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -357,9 +357,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         text_tool_buffer = None
                         answer += remainder
                         buffer = remainder
-                elif re.search(r"functions\.\w", buffer + content):
+                elif (idx := self._find_text_tool_call_start(buffer + content, tools)) != -1:
                     combined = buffer + content
-                    idx = combined.find("functions.")
                     before = combined[:idx]
                     after = combined[idx:]
                     if before:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.119"
+version = "0.10.120"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The model sometimes narrates a tool call as plain text instead of emitting a structured call, e.g. `{type:transfer_call_911206480701}` instead of `functions.transfer_call_911206480701(...)`. The old detection only matched the `functions.` prefix, so other shapes were spoken aloud to the caller and the tool never fired (the transfer was announced but never happened).

This keys detection on the registered tool name instead of the wrapper, so a narrated call is caught in any shape: `functions.x(...)`, `{type:x...}`, `{"name":"x"...}`, bare, or truncated. On a match it holds the text out of TTS and recovers the tool name.

Firing stays gated: a tool is only fired when it needs no model-supplied args (e.g. transfer_call), reusing the existing required-args gate. Data tools like product_search are suppressed but not fired, since we cannot fabricate their arguments from a mangled shape.

Tool names are underscored identifiers that do not occur in natural speech, so matching them as substrings is safe (verified: plain speech, the words "transfer"/"call", and `{amount}`-style braces do not trigger).
