### PR TITLE
fix: defer interim barge-ins while a tool call is in flight

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.121"
+__version__ = "0.10.122"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4298,6 +4298,11 @@ class TaskManager(BaseManager):
                             )
                             continue
 
+                        # Defer interim barge-ins while a tool call is in flight (same as speech_final path).
+                        if self.function_call_in_flight:
+                            logger.info(f"Tool call in flight; deferring interim barge-in {transcript_content!r}")
+                            continue
+
                         if self.interruption_manager.should_trigger_interruption(
                             word_count=interim_transcript_len,
                             transcript=transcript_content,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.121"
+version = "0.10.122"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_end_call_bargein_guard.py
+++ b/tests/tests/test_end_call_bargein_guard.py
@@ -53,10 +53,11 @@ _INTERIM_BARGEIN = {
 }
 
 
-def _make_tm(*, end_call_in_progress, hangup_triggered):
+def _make_tm(*, end_call_in_progress, hangup_triggered, function_call_in_flight=False):
     tm = MagicMock()
     tm.hangup_triggered = hangup_triggered
     tm._end_call_in_progress = end_call_in_progress
+    tm.function_call_in_flight = function_call_in_flight
     tm.has_transfer = False
     tm.stream = True
     tm.response_in_pipeline = False
@@ -97,6 +98,15 @@ async def test_bargein_cancels_turn_during_normal_conversation():
     tm = _make_tm(end_call_in_progress=False, hangup_triggered=False)
     await _drive_with_bargein(tm)
     tm._TaskManager__cleanup_downstream_tasks.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_bargein_does_not_cancel_turn_during_tool_call():
+    # A tool call is in flight: interim barge-in must be deferred, else the call is
+    # cancelled before its result is recorded and the pre-call filler loops.
+    tm = _make_tm(end_call_in_progress=False, hangup_triggered=False, function_call_in_flight=True)
+    await _drive_with_bargein(tm)
+    tm._TaskManager__cleanup_downstream_tasks.assert_not_called()
 
 
 class TestSourceGuards:


### PR DESCRIPTION
#819 added a `function_call_in_flight` guard so a barge-in can't cancel an in-flight tool call before its result is recorded, but it only covered the speech_final path. The interim-transcript interruption path in `_listen_transcriber` still called `__cleanup_downstream_tasks()` unconditionally.

When the user talks over the pre-call filler, that path cancels the tool turn before the tool_call/result pair is written to history. `_sanitize_tool_messages` then strips the orphaned pair, the LLM loses any record it called the tool, re-emits the same call, and the pre-call filler ("Just give me a moment, I'll be back with you") replays on a loop.

This applies the same guard to the interim path, so all streaming barge-in routes defer while a tool call is in flight. With the call no longer cancelled mid-flight, the tool_call/result pair stays adjacent and the LLM stops re-emitting.

The guard only activates while `function_call_in_flight` is true (reset in a `finally`), and the `continue` mirrors the existing short-transcript skip in the same block, so normal-conversation barge-ins are unchanged.