### PR TITLE
feat: add router nodes for silent dispatch in graph agents

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.123"
+__version__ = "0.10.124"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -495,6 +495,110 @@ class GraphAgent(BaseAgent):
         node_turns = sum(1 for msg in node_history if msg.get("role") == "user")
         return node_turns, total_turns
 
+    def _enrich_routing_context(self, history: list) -> None:
+        """Inject live time variables and turn counts into context_data so
+        expression edges evaluate against the current state."""
+        recipient_data = self.context_data.get("recipient_data")
+        timezone_str = recipient_data.get("timezone") if isinstance(recipient_data, dict) else None
+        if timezone_str:
+            enrich_context_with_time_variables(self.context_data, timezone_str)
+
+        node_turns, total_turns = self._compute_turn_counts(history)
+        self.context_data["_node_turns"] = node_turns
+        self.context_data["_total_turns"] = total_turns
+        self.context_data["_silence_repeats"] = self._silence_repeats
+
+    def _resolve_router_chain(self, history: list) -> List[dict]:
+        """Resolve a chain of router nodes without speaking.
+
+        A router node emits nothing: on entry it evaluates its deterministic
+        edges and transitions again, within the same turn, until it lands on a
+        node that speaks. Expression edges are checked in priority order; the
+        unconditional catch-all is taken only if no expression matched. The
+        visited-set bounds the chain to the number of router nodes, so it always
+        terminates. Returns one routing_info dict per hop for the caller to emit.
+        """
+        hops = []
+        visited = set()
+
+        while True:
+            node = self.get_node_by_id(self.current_node_id)
+            node_type = node.get("node_type", NodeType.LLM) if node else NodeType.LLM
+            if node_type != NodeType.ROUTER:
+                break
+
+            if self.current_node_id in visited:
+                logger.error(
+                    f"Router cycle detected at '{self.current_node_id}', stopping chain. "
+                    f"Flow: {' -> '.join(self.node_history)}"
+                )
+                break
+            visited.add(self.current_node_id)
+
+            hop_start = time.perf_counter()
+            self._enrich_routing_context(history)
+
+            deterministic_edges, _ = self._classify_edges(node.get("edges", []))
+            expression_edges = [
+                e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.EXPRESSION
+            ]
+            matched_edge, det_evaluations = self._evaluate_deterministic_edges(expression_edges)
+            if matched_edge is None:
+                matched_edge = next(
+                    (e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
+                    None,
+                )
+            eval_trace = "; ".join(det_evaluations) or "no expression edge matched"
+
+            if matched_edge is None:
+                logger.error(
+                    f"Router node '{self.current_node_id}' has no matching edge and no catch-all, "
+                    f"stopping chain. Evaluations: {eval_trace}"
+                )
+                break
+
+            previous_node = self.current_node_id
+            latency_ms = (time.perf_counter() - hop_start) * 1000
+            self.current_node_id = matched_edge["to_node_id"]
+            self.current_node_entry_index = len(history)
+            self._silence_repeats = 0
+
+            if not self.node_history or self.node_history[-1] != self.current_node_id:
+                self.node_history.append(self.current_node_id)
+
+            target_node = self.get_node_by_id(self.current_node_id)
+            target_type = target_node.get("node_type", NodeType.LLM) if target_node else NodeType.LLM
+            condition = matched_edge.get("condition") or matched_edge.get("condition_type", "router")
+
+            logger.info(
+                f"Router dispatch on node '{previous_node}': -> {self.current_node_id} "
+                f"| {eval_trace} (latency: {latency_ms:.1f}ms)"
+            )
+
+            hops.append(
+                {
+                    "previous_node": previous_node,
+                    "current_node": self.current_node_id,
+                    "transitioned": True,
+                    "routing_type": "deterministic",
+                    "routing_model": None,
+                    "routing_provider": None,
+                    "routing_latency_ms": round(latency_ms, 1),
+                    "extracted_params": {},
+                    "node_history": list(self.node_history),
+                    "routing_messages": None,
+                    "routing_tools": None,
+                    "reasoning": f"{_DETERMINISTIC_REASONING_PREFIX}router:{condition}",
+                    "routing_expression": eval_trace,
+                    "confidence": 1.0,
+                    "routing_usage": None,
+                    "node_type": target_type,
+                    "is_silence_trigger": False,
+                }
+            )
+
+        return hops
+
     async def _decide_next_node_llm(
         self, node: dict, llm_edges: list, history: List[dict], start_time: float
     ) -> Tuple[
@@ -678,18 +782,7 @@ class GraphAgent(BaseAgent):
             return None, None, 0, None, None, None, None, None
 
         # Inject time variables and turn counts for expression evaluation
-        timezone_str = (
-            self.context_data.get("recipient_data", {}).get("timezone")
-            if isinstance(self.context_data.get("recipient_data"), dict)
-            else None
-        )
-        if timezone_str:
-            enrich_context_with_time_variables(self.context_data, timezone_str)
-
-        node_turns, total_turns = self._compute_turn_counts(history)
-        self.context_data["_node_turns"] = node_turns
-        self.context_data["_total_turns"] = total_turns
-        self.context_data["_silence_repeats"] = self._silence_repeats
+        self._enrich_routing_context(history)
 
         deterministic_edges, llm_edges = self._classify_edges(edges)
 
@@ -956,6 +1049,12 @@ class GraphAgent(BaseAgent):
                     }
                 }
 
+                if node_type == NodeType.ROUTER:
+                    for hop in self._resolve_router_chain(message):
+                        yield {"routing_info": hop}
+                    current_node = self.get_node_by_id(self.current_node_id)
+                    node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
+
                 if node_type == NodeType.STATIC:
                     static_text = current_node.get("static_message", "") if current_node else ""
                     if static_text:
@@ -989,6 +1088,13 @@ class GraphAgent(BaseAgent):
             is_silence_trigger = bool(message and message[-1].get("content", "").startswith("[silence]"))
             if is_silence_trigger:
                 self._silence_repeats += 1
+
+            # Entry-node dispatch: if the turn begins on a router node (a router
+            # start node, first turn), resolve it to a speaking node before routing.
+            entry_node = self.get_node_by_id(self.current_node_id)
+            if entry_node and entry_node.get("node_type") == NodeType.ROUTER:
+                for hop in self._resolve_router_chain(message):
+                    yield {"routing_info": hop}
 
             previous_node = self.current_node_id
             (
@@ -1042,6 +1148,14 @@ class GraphAgent(BaseAgent):
                     "is_silence_trigger": is_silence_trigger,
                 }
             }
+
+            # Silent deterministic dispatch: if the transition landed on a router
+            # node, resolve the chain in this turn until a speaking node is reached.
+            if node_type == NodeType.ROUTER:
+                for hop in self._resolve_router_chain(message):
+                    yield {"routing_info": hop}
+                current_node = self.get_node_by_id(self.current_node_id)
+                node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
 
             if node_type == NodeType.STATIC:
                 static_text = current_node.get("static_message", "") if current_node else ""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -41,6 +41,7 @@ load_dotenv()
 logger = configure_logger(__name__)
 
 _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
+_ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
 _PROMPT_VAR_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
@@ -496,8 +497,7 @@ class GraphAgent(BaseAgent):
         return node_turns, total_turns
 
     def _enrich_routing_context(self, history: list) -> None:
-        """Inject live time variables and turn counts into context_data so
-        expression edges evaluate against the current state."""
+        """Refresh time variables and turn counts in context_data for expression evaluation."""
         recipient_data = self.context_data.get("recipient_data")
         timezone_str = recipient_data.get("timezone") if isinstance(recipient_data, dict) else None
         if timezone_str:
@@ -508,25 +508,53 @@ class GraphAgent(BaseAgent):
         self.context_data["_total_turns"] = total_turns
         self.context_data["_silence_repeats"] = self._silence_repeats
 
-    def _resolve_router_chain(self, history: list) -> List[dict]:
-        """Resolve a chain of router nodes without speaking.
+    @staticmethod
+    def _node_type_of(node: Optional[dict]) -> str:
+        return node.get("node_type", NodeType.LLM) if node else NodeType.LLM
 
-        A router node emits nothing: on entry it evaluates its deterministic
-        edges and transitions again, within the same turn, until it lands on a
-        node that speaks. Expression edges are checked in priority order; the
-        unconditional catch-all is taken only if no expression matched. The
-        visited-set bounds the chain to the number of router nodes, so it always
-        terminates. Returns one routing_info dict per hop for the caller to emit.
-        """
+    def _select_router_edge(self, node: dict) -> Tuple[Optional[dict], str]:
+        """Matching expression edge (priority order) if any, else the unconditional catch-all."""
+        deterministic_edges, _ = self._classify_edges(node.get("edges", []))
+        expression_edges = [e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.EXPRESSION]
+
+        matched_edge, evaluations = self._evaluate_deterministic_edges(expression_edges)
+        if matched_edge is None:
+            matched_edge = next(
+                (e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
+                None,
+            )
+        trace = "; ".join(evaluations) or "no expression edge matched"
+        return matched_edge, trace
+
+    def _router_hop_info(self, previous_node: str, edge: dict, eval_trace: str, latency_ms: float) -> dict:
+        condition = edge.get("condition") or edge.get("condition_type", "router")
+        return {
+            "previous_node": previous_node,
+            "current_node": self.current_node_id,
+            "transitioned": True,
+            "routing_type": "deterministic",
+            "routing_model": None,
+            "routing_provider": None,
+            "routing_latency_ms": round(latency_ms, 1),
+            "extracted_params": {},
+            "node_history": list(self.node_history),
+            "routing_messages": None,
+            "routing_tools": None,
+            "reasoning": f"{_ROUTER_REASONING_PREFIX}{condition}",
+            "routing_expression": eval_trace,
+            "confidence": 1.0,
+            "routing_usage": None,
+            "node_type": self._node_type_of(self.get_node_by_id(self.current_node_id)),
+            "is_silence_trigger": False,
+        }
+
+    def _resolve_router_chain(self, history: list) -> List[dict]:
+        """Hop silently through router nodes until a speaking node is reached, one
+        routing_info per hop. The visited-set bounds the chain, so it always terminates."""
         hops = []
         visited = set()
 
-        while True:
-            node = self.get_node_by_id(self.current_node_id)
-            node_type = node.get("node_type", NodeType.LLM) if node else NodeType.LLM
-            if node_type != NodeType.ROUTER:
-                break
-
+        while self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
             if self.current_node_id in visited:
                 logger.error(
                     f"Router cycle detected at '{self.current_node_id}', stopping chain. "
@@ -537,20 +565,10 @@ class GraphAgent(BaseAgent):
 
             hop_start = time.perf_counter()
             self._enrich_routing_context(history)
+            router_node = self.get_node_by_id(self.current_node_id)
+            edge, eval_trace = self._select_router_edge(router_node)
 
-            deterministic_edges, _ = self._classify_edges(node.get("edges", []))
-            expression_edges = [
-                e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.EXPRESSION
-            ]
-            matched_edge, det_evaluations = self._evaluate_deterministic_edges(expression_edges)
-            if matched_edge is None:
-                matched_edge = next(
-                    (e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
-                    None,
-                )
-            eval_trace = "; ".join(det_evaluations) or "no expression edge matched"
-
-            if matched_edge is None:
+            if edge is None:
                 logger.error(
                     f"Router node '{self.current_node_id}' has no matching edge and no catch-all, "
                     f"stopping chain. Evaluations: {eval_trace}"
@@ -558,46 +576,23 @@ class GraphAgent(BaseAgent):
                 break
 
             previous_node = self.current_node_id
+            self._advance_to_node(edge["to_node_id"], entry_index=len(history))
             latency_ms = (time.perf_counter() - hop_start) * 1000
-            self.current_node_id = matched_edge["to_node_id"]
-            self.current_node_entry_index = len(history)
-            self._silence_repeats = 0
-
-            if not self.node_history or self.node_history[-1] != self.current_node_id:
-                self.node_history.append(self.current_node_id)
-
-            target_node = self.get_node_by_id(self.current_node_id)
-            target_type = target_node.get("node_type", NodeType.LLM) if target_node else NodeType.LLM
-            condition = matched_edge.get("condition") or matched_edge.get("condition_type", "router")
 
             logger.info(
                 f"Router dispatch on node '{previous_node}': -> {self.current_node_id} "
                 f"| {eval_trace} (latency: {latency_ms:.1f}ms)"
             )
-
-            hops.append(
-                {
-                    "previous_node": previous_node,
-                    "current_node": self.current_node_id,
-                    "transitioned": True,
-                    "routing_type": "deterministic",
-                    "routing_model": None,
-                    "routing_provider": None,
-                    "routing_latency_ms": round(latency_ms, 1),
-                    "extracted_params": {},
-                    "node_history": list(self.node_history),
-                    "routing_messages": None,
-                    "routing_tools": None,
-                    "reasoning": f"{_DETERMINISTIC_REASONING_PREFIX}router:{condition}",
-                    "routing_expression": eval_trace,
-                    "confidence": 1.0,
-                    "routing_usage": None,
-                    "node_type": target_type,
-                    "is_silence_trigger": False,
-                }
-            )
+            hops.append(self._router_hop_info(previous_node, edge, eval_trace, latency_ms))
 
         return hops
+
+    def _advance_to_node(self, node_id: str, entry_index: int) -> None:
+        self.current_node_id = node_id
+        self.current_node_entry_index = entry_index
+        self._silence_repeats = 0
+        if not self.node_history or self.node_history[-1] != self.current_node_id:
+            self.node_history.append(self.current_node_id)
 
     async def _decide_next_node_llm(
         self, node: dict, llm_edges: list, history: List[dict], start_time: float
@@ -1053,7 +1048,10 @@ class GraphAgent(BaseAgent):
                     for hop in self._resolve_router_chain(message):
                         yield {"routing_info": hop}
                     current_node = self.get_node_by_id(self.current_node_id)
-                    node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
+                    node_type = self._node_type_of(current_node)
+                    if node_type == NodeType.ROUTER:
+                        logger.error(f"Router '{self.current_node_id}' did not resolve to a speaking node")
+                        return
 
                 if node_type == NodeType.STATIC:
                     static_text = current_node.get("static_message", "") if current_node else ""
@@ -1091,8 +1089,7 @@ class GraphAgent(BaseAgent):
 
             # Entry-node dispatch: if the turn begins on a router node (a router
             # start node, first turn), resolve it to a speaking node before routing.
-            entry_node = self.get_node_by_id(self.current_node_id)
-            if entry_node and entry_node.get("node_type") == NodeType.ROUTER:
+            if self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
                 for hop in self._resolve_router_chain(message):
                     yield {"routing_info": hop}
 
@@ -1155,7 +1152,10 @@ class GraphAgent(BaseAgent):
                 for hop in self._resolve_router_chain(message):
                     yield {"routing_info": hop}
                 current_node = self.get_node_by_id(self.current_node_id)
-                node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
+                node_type = self._node_type_of(current_node)
+                if node_type == NodeType.ROUTER:
+                    logger.error(f"Router '{self.current_node_id}' did not resolve to a speaking node")
+                    return
 
             if node_type == NodeType.STATIC:
                 static_text = current_node.get("static_message", "") if current_node else ""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -470,7 +470,7 @@ class GraphAgent(BaseAgent):
                     self.node_history.append(self.current_node_id)
 
                 target_node = self.get_node_by_id(edge["to_node_id"])
-                node_type = target_node.get("node_type", NodeType.LLM) if target_node else NodeType.LLM
+                node_type = self._node_type_of(target_node)
 
                 logger.info(f"Event '{event_name}' matched edge: {previous_node} -> {self.current_node_id}")
                 return {
@@ -488,11 +488,10 @@ class GraphAgent(BaseAgent):
         return {"matched": False, "event": event_name}
 
     def _compute_turn_counts(self, history: list) -> tuple:
-        """Count (node_turns, total_turns) from history."""
+        """Count (node_turns, total_turns) from history. A node just entered this
+        turn (entry_index == len(history), as during a router hop) has 0 node turns."""
         total_turns = sum(1 for msg in history if msg.get("role") == "user")
-        node_history = (
-            history[self.current_node_entry_index :] if self.current_node_entry_index < len(history) else history
-        )
+        node_history = history[self.current_node_entry_index :]
         node_turns = sum(1 for msg in node_history if msg.get("role") == "user")
         return node_turns, total_turns
 
@@ -521,10 +520,11 @@ class GraphAgent(BaseAgent):
 
     @staticmethod
     def _catch_all_edge(node: dict) -> Optional[dict]:
-        return next(
-            (e for e in node.get("edges", []) if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
-            None,
-        )
+        """Lowest-priority unconditional edge, matching the priority precedence used everywhere else."""
+        unconditional = [e for e in node.get("edges", []) if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL]
+        if not unconditional:
+            return None
+        return min(unconditional, key=lambda e: e["priority"] if e.get("priority") is not None else 0)
 
     def _router_hop_info(
         self,
@@ -534,20 +534,23 @@ class GraphAgent(BaseAgent):
         latency_ms: float,
         reasoning: Optional[str],
         confidence: Optional[float],
+        is_silence_trigger: bool = False,
         extracted_params: Optional[dict] = None,
         routing_messages: Optional[List[dict]] = None,
         routing_tools: Optional[List[dict]] = None,
         routing_expression: Optional[str] = None,
         routing_usage: Optional[dict] = None,
     ) -> dict:
-        is_llm = routing_type == "llm"
+        # A routing-LLM call happened whenever it produced messages, even on a hop that
+        # then fell back to the catch-all — so its model/usage stay attributed and counted.
+        made_llm_call = routing_messages is not None
         return {
             "previous_node": previous_node,
             "current_node": self.current_node_id,
             "transitioned": True,
             "routing_type": routing_type,
-            "routing_model": self.routing_model if is_llm else None,
-            "routing_provider": self.routing_provider if is_llm else None,
+            "routing_model": self.routing_model if made_llm_call else None,
+            "routing_provider": self.routing_provider if made_llm_call else None,
             "routing_latency_ms": round(latency_ms, 1),
             "extracted_params": extracted_params or {},
             "node_history": list(self.node_history),
@@ -558,7 +561,7 @@ class GraphAgent(BaseAgent):
             "confidence": confidence,
             "routing_usage": routing_usage,
             "node_type": self._node_type_of(self.get_node_by_id(self.current_node_id)),
-            "is_silence_trigger": False,
+            "is_silence_trigger": is_silence_trigger,
         }
 
     async def _resolve_router_chain(self, history: list) -> List[dict]:
@@ -570,6 +573,7 @@ class GraphAgent(BaseAgent):
         hops = []
         visited = set()
         intent_call_spent = False
+        is_silence_trigger = bool(history and history[-1].get("content", "").startswith("[silence]"))
 
         while self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
             if self.current_node_id in visited:
@@ -586,6 +590,10 @@ class GraphAgent(BaseAgent):
             previous_node = self.current_node_id
 
             edge, eval_trace = self._match_expression_edge(router_node)
+
+            # Telemetry from an intent call that returned no match, carried onto the
+            # catch-all hop so its tokens are still counted and the call is still logged.
+            spent_messages = spent_tools = spent_usage = None
 
             if edge is None and not intent_call_spent:
                 _, intent_edges = self._classify_edges(router_node.get("edges", []))
@@ -616,6 +624,7 @@ class GraphAgent(BaseAgent):
                                 latency_ms=latency_ms,
                                 reasoning=reasoning,
                                 confidence=confidence,
+                                is_silence_trigger=is_silence_trigger,
                                 extracted_params=extracted_params,
                                 routing_messages=routing_messages,
                                 routing_tools=routing_tools,
@@ -623,6 +632,7 @@ class GraphAgent(BaseAgent):
                             )
                         )
                         continue
+                    spent_messages, spent_tools, spent_usage = routing_messages, routing_tools, routing_usage
                     eval_trace = f"{eval_trace}; intent: no match"
 
             if edge is None:
@@ -649,7 +659,11 @@ class GraphAgent(BaseAgent):
                     latency_ms=latency_ms,
                     reasoning=f"{_ROUTER_REASONING_PREFIX}{condition}",
                     confidence=1.0,
+                    is_silence_trigger=is_silence_trigger,
                     routing_expression=eval_trace,
+                    routing_messages=spent_messages,
+                    routing_tools=spent_tools,
+                    routing_usage=spent_usage,
                 )
             )
 
@@ -661,6 +675,19 @@ class GraphAgent(BaseAgent):
         self._silence_repeats = 0
         if not self.node_history or self.node_history[-1] != self.current_node_id:
             self.node_history.append(self.current_node_id)
+
+    def _end_turn_chunk(self, meta_info: Optional[dict], start_time: float) -> LLMStreamChunk:
+        """Terminal empty chunk so a turn that produces no speech (e.g. a router that
+        could not resolve) still ends the stream cleanly instead of wedging the pipeline."""
+        return LLMStreamChunk(
+            data="",
+            end_of_stream=True,
+            latency=LatencyData(
+                sequence_id=meta_info.get("sequence_id") if meta_info else None,
+                first_token_latency_ms=0,
+                total_stream_duration_ms=now_ms() - start_time,
+            ),
+        )
 
     async def _decide_next_node_llm(
         self, node: dict, llm_edges: list, history: List[dict], start_time: float
@@ -1089,7 +1116,7 @@ class GraphAgent(BaseAgent):
             if is_event:
                 self._event_triggered_generation = False
                 current_node = self.get_node_by_id(self.current_node_id)
-                node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
+                node_type = self._node_type_of(current_node)
 
                 yield {
                     "routing_info": {
@@ -1119,6 +1146,7 @@ class GraphAgent(BaseAgent):
                     node_type = self._node_type_of(current_node)
                     if node_type == NodeType.ROUTER:
                         logger.error(f"Router '{self.current_node_id}' did not resolve to a speaking node")
+                        yield self._end_turn_chunk(meta_info, start_time)
                         return
 
                 if node_type == NodeType.STATIC:
@@ -1155,75 +1183,74 @@ class GraphAgent(BaseAgent):
             if is_silence_trigger:
                 self._silence_repeats += 1
 
-            # Entry-node dispatch: if the turn begins on a router node (a router
-            # start node, first turn), resolve it to a speaking node before routing.
+            # Entry-node dispatch: the turn begins on a router start node. Resolve it
+            # and let the resolved node speak this turn — do NOT re-route it through
+            # decide_next (that would stack another routing call and could transition it
+            # away before it speaks, unlike a router reached mid-turn by a transition).
             if self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
                 for hop in await self._resolve_router_chain(message):
                     yield {"routing_info": hop}
+            else:
+                previous_node = self.current_node_id
+                (
+                    next_node_id,
+                    extracted_params,
+                    routing_latency_ms,
+                    routing_messages,
+                    routing_tools,
+                    reasoning,
+                    confidence,
+                    routing_usage,
+                ) = await self.decide_next_node_with_functions(message)
 
-            previous_node = self.current_node_id
-            (
-                next_node_id,
-                extracted_params,
-                routing_latency_ms,
-                routing_messages,
-                routing_tools,
-                reasoning,
-                confidence,
-                routing_usage,
-            ) = await self.decide_next_node_with_functions(message)
+                if next_node_id:
+                    logger.info(f"Transitioning: {self.current_node_id} -> {next_node_id} (params: {extracted_params})")
+                    self._advance_to_node(next_node_id, entry_index=len(message))
+                    if extracted_params:
+                        self.context_data.update(extracted_params)
 
-            if next_node_id:
-                logger.info(f"Transitioning: {self.current_node_id} -> {next_node_id} (params: {extracted_params})")
-                self.current_node_id = next_node_id
-                self.current_node_entry_index = len(message)
-                self._silence_repeats = 0
-                if extracted_params:
-                    self.context_data.update(extracted_params)
+                routing_type = (
+                    "deterministic" if (reasoning and reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)) else "llm"
+                )
+                node_type = self._node_type_of(self.get_node_by_id(self.current_node_id))
 
-            if next_node_id and (not self.node_history or self.node_history[-1] != self.current_node_id):
-                self.node_history.append(self.current_node_id)
-
-            routing_type = (
-                "deterministic" if (reasoning and reasoning.startswith(_DETERMINISTIC_REASONING_PREFIX)) else "llm"
-            )
-
-            current_node = self.get_node_by_id(self.current_node_id)
-            node_type = current_node.get("node_type", NodeType.LLM) if current_node else NodeType.LLM
-
-            yield {
-                "routing_info": {
-                    "previous_node": previous_node,
-                    "current_node": self.current_node_id,
-                    "transitioned": next_node_id is not None,
-                    "routing_type": routing_type,
-                    "routing_model": self.routing_model,
-                    "routing_provider": getattr(self, "routing_provider", None),
-                    "routing_latency_ms": round(routing_latency_ms, 1),
-                    "routing_reasoning_effort": getattr(self, "_routing_reasoning_effort_used", None),
-                    "extracted_params": extracted_params or {},
-                    "node_history": list(self.node_history),
-                    "routing_messages": routing_messages,
-                    "routing_tools": routing_tools,
-                    "reasoning": reasoning,
-                    "routing_expression": self._last_deterministic_eval,
-                    "confidence": confidence,
-                    "routing_usage": routing_usage,
-                    "node_type": node_type,
-                    "is_silence_trigger": is_silence_trigger,
+                yield {
+                    "routing_info": {
+                        "previous_node": previous_node,
+                        "current_node": self.current_node_id,
+                        "transitioned": next_node_id is not None,
+                        "routing_type": routing_type,
+                        "routing_model": self.routing_model,
+                        "routing_provider": getattr(self, "routing_provider", None),
+                        "routing_latency_ms": round(routing_latency_ms, 1),
+                        "routing_reasoning_effort": getattr(self, "_routing_reasoning_effort_used", None),
+                        "extracted_params": extracted_params or {},
+                        "node_history": list(self.node_history),
+                        "routing_messages": routing_messages,
+                        "routing_tools": routing_tools,
+                        "reasoning": reasoning,
+                        "routing_expression": self._last_deterministic_eval,
+                        "confidence": confidence,
+                        "routing_usage": routing_usage,
+                        "node_type": node_type,
+                        "is_silence_trigger": is_silence_trigger,
+                    }
                 }
-            }
 
-            # Silent deterministic dispatch: if the transition landed on a router
-            # node, resolve the chain in this turn until a speaking node is reached.
-            if node_type == NodeType.ROUTER:
-                for hop in await self._resolve_router_chain(message):
-                    yield {"routing_info": hop}
-                current_node = self.get_node_by_id(self.current_node_id)
-                node_type = self._node_type_of(current_node)
+                # Silent deterministic dispatch: if the transition landed on a router,
+                # resolve the chain in this turn until a speaking node is reached.
                 if node_type == NodeType.ROUTER:
-                    logger.error(f"Router '{self.current_node_id}' did not resolve to a speaking node")
-                    return
+                    for hop in await self._resolve_router_chain(message):
+                        yield {"routing_info": hop}
+
+            # A router that could not resolve (invalid config that bypassed validation)
+            # ends the turn cleanly rather than speaking from an empty node prompt.
+            current_node = self.get_node_by_id(self.current_node_id)
+            node_type = self._node_type_of(current_node)
+            if node_type == NodeType.ROUTER:
+                logger.error(f"Router '{self.current_node_id}' did not resolve to a speaking node")
+                yield self._end_turn_chunk(meta_info, start_time)
+                return
 
             if node_type == NodeType.STATIC:
                 static_text = current_node.get("static_message", "") if current_node else ""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -677,8 +677,10 @@ class GraphAgent(BaseAgent):
             self.node_history.append(self.current_node_id)
 
     def _end_turn_chunk(self, meta_info: Optional[dict], start_time: float) -> LLMStreamChunk:
-        """Terminal empty chunk so a turn that produces no speech (e.g. a router that
-        could not resolve) still ends the stream cleanly instead of wedging the pipeline."""
+        """Terminal empty end-of-stream chunk for a turn that produces no speech (a router
+        that could not resolve — only reachable via an invalid config that skipped
+        validation). Closes the stream on the end_of_llm_stream contract; the turn stays
+        silent and the next user turn resumes normally."""
         return LLMStreamChunk(
             data="",
             end_of_stream=True,

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -512,47 +512,64 @@ class GraphAgent(BaseAgent):
     def _node_type_of(node: Optional[dict]) -> str:
         return node.get("node_type", NodeType.LLM) if node else NodeType.LLM
 
-    def _select_router_edge(self, node: dict) -> Tuple[Optional[dict], str]:
-        """Matching expression edge (priority order) if any, else the unconditional catch-all."""
+    def _match_expression_edge(self, node: dict) -> Tuple[Optional[dict], str]:
+        """First matching expression edge in priority order, with the evaluation trace."""
         deterministic_edges, _ = self._classify_edges(node.get("edges", []))
         expression_edges = [e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.EXPRESSION]
-
         matched_edge, evaluations = self._evaluate_deterministic_edges(expression_edges)
-        if matched_edge is None:
-            matched_edge = next(
-                (e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
-                None,
-            )
-        trace = "; ".join(evaluations) or "no expression edge matched"
-        return matched_edge, trace
+        return matched_edge, "; ".join(evaluations) or "no expression edge matched"
 
-    def _router_hop_info(self, previous_node: str, edge: dict, eval_trace: str, latency_ms: float) -> dict:
-        condition = edge.get("condition") or edge.get("condition_type", "router")
+    @staticmethod
+    def _catch_all_edge(node: dict) -> Optional[dict]:
+        return next(
+            (e for e in node.get("edges", []) if e.get("condition_type") == EdgeConditionType.UNCONDITIONAL),
+            None,
+        )
+
+    def _router_hop_info(
+        self,
+        previous_node: str,
+        *,
+        routing_type: str,
+        latency_ms: float,
+        reasoning: Optional[str],
+        confidence: Optional[float],
+        extracted_params: Optional[dict] = None,
+        routing_messages: Optional[List[dict]] = None,
+        routing_tools: Optional[List[dict]] = None,
+        routing_expression: Optional[str] = None,
+        routing_usage: Optional[dict] = None,
+    ) -> dict:
+        is_llm = routing_type == "llm"
         return {
             "previous_node": previous_node,
             "current_node": self.current_node_id,
             "transitioned": True,
-            "routing_type": "deterministic",
-            "routing_model": None,
-            "routing_provider": None,
+            "routing_type": routing_type,
+            "routing_model": self.routing_model if is_llm else None,
+            "routing_provider": self.routing_provider if is_llm else None,
             "routing_latency_ms": round(latency_ms, 1),
-            "extracted_params": {},
+            "extracted_params": extracted_params or {},
             "node_history": list(self.node_history),
-            "routing_messages": None,
-            "routing_tools": None,
-            "reasoning": f"{_ROUTER_REASONING_PREFIX}{condition}",
-            "routing_expression": eval_trace,
-            "confidence": 1.0,
-            "routing_usage": None,
+            "routing_messages": routing_messages,
+            "routing_tools": routing_tools,
+            "reasoning": reasoning,
+            "routing_expression": routing_expression,
+            "confidence": confidence,
+            "routing_usage": routing_usage,
             "node_type": self._node_type_of(self.get_node_by_id(self.current_node_id)),
             "is_silence_trigger": False,
         }
 
-    def _resolve_router_chain(self, history: list) -> List[dict]:
+    async def _resolve_router_chain(self, history: list) -> List[dict]:
         """Hop silently through router nodes until a speaking node is reached, one
-        routing_info per hop. The visited-set bounds the chain, so it always terminates."""
+        routing_info per hop. Each hop: expression edges first (priority order), then
+        intent edges via one routing-LLM call, then the unconditional catch-all. The
+        LLM is called at most once per chain so a chain never stacks routing latency;
+        the visited-set bounds the hops, so the chain always terminates."""
         hops = []
         visited = set()
+        intent_call_spent = False
 
         while self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
             if self.current_node_id in visited:
@@ -566,8 +583,50 @@ class GraphAgent(BaseAgent):
             hop_start = time.perf_counter()
             self._enrich_routing_context(history)
             router_node = self.get_node_by_id(self.current_node_id)
-            edge, eval_trace = self._select_router_edge(router_node)
+            previous_node = self.current_node_id
 
+            edge, eval_trace = self._match_expression_edge(router_node)
+
+            if edge is None and not intent_call_spent:
+                _, intent_edges = self._classify_edges(router_node.get("edges", []))
+                if intent_edges:
+                    intent_call_spent = True
+                    (
+                        next_node_id,
+                        extracted_params,
+                        latency_ms,
+                        routing_messages,
+                        routing_tools,
+                        reasoning,
+                        confidence,
+                        routing_usage,
+                    ) = await self._decide_next_node_llm(router_node, intent_edges, history, hop_start)
+                    if next_node_id:
+                        self._advance_to_node(next_node_id, entry_index=len(history))
+                        if extracted_params:
+                            self.context_data.update(extracted_params)
+                        logger.info(
+                            f"Router dispatch (intent) on node '{previous_node}': -> {self.current_node_id} "
+                            f"| {reasoning} (latency: {latency_ms:.1f}ms)"
+                        )
+                        hops.append(
+                            self._router_hop_info(
+                                previous_node,
+                                routing_type="llm",
+                                latency_ms=latency_ms,
+                                reasoning=reasoning,
+                                confidence=confidence,
+                                extracted_params=extracted_params,
+                                routing_messages=routing_messages,
+                                routing_tools=routing_tools,
+                                routing_usage=routing_usage,
+                            )
+                        )
+                        continue
+                    eval_trace = f"{eval_trace}; intent: no match"
+
+            if edge is None:
+                edge = self._catch_all_edge(router_node)
             if edge is None:
                 logger.error(
                     f"Router node '{self.current_node_id}' has no matching edge and no catch-all, "
@@ -575,15 +634,24 @@ class GraphAgent(BaseAgent):
                 )
                 break
 
-            previous_node = self.current_node_id
             self._advance_to_node(edge["to_node_id"], entry_index=len(history))
             latency_ms = (time.perf_counter() - hop_start) * 1000
+            condition = edge.get("condition") or edge.get("condition_type", "router")
 
             logger.info(
                 f"Router dispatch on node '{previous_node}': -> {self.current_node_id} "
                 f"| {eval_trace} (latency: {latency_ms:.1f}ms)"
             )
-            hops.append(self._router_hop_info(previous_node, edge, eval_trace, latency_ms))
+            hops.append(
+                self._router_hop_info(
+                    previous_node,
+                    routing_type="deterministic",
+                    latency_ms=latency_ms,
+                    reasoning=f"{_ROUTER_REASONING_PREFIX}{condition}",
+                    confidence=1.0,
+                    routing_expression=eval_trace,
+                )
+            )
 
         return hops
 
@@ -631,7 +699,7 @@ class GraphAgent(BaseAgent):
             except Exception as e:
                 logger.debug(f"Variable substitution in routing_instructions failed: {e}")
 
-        node_objective = node.get("prompt", "")
+        node_objective = node.get("prompt") or node.get("description") or ""
         system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {node["id"]}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""
 
         logger.debug(f"Routing system prompt:\n{system_prompt}")
@@ -1045,7 +1113,7 @@ class GraphAgent(BaseAgent):
                 }
 
                 if node_type == NodeType.ROUTER:
-                    for hop in self._resolve_router_chain(message):
+                    for hop in await self._resolve_router_chain(message):
                         yield {"routing_info": hop}
                     current_node = self.get_node_by_id(self.current_node_id)
                     node_type = self._node_type_of(current_node)
@@ -1090,7 +1158,7 @@ class GraphAgent(BaseAgent):
             # Entry-node dispatch: if the turn begins on a router node (a router
             # start node, first turn), resolve it to a speaking node before routing.
             if self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
-                for hop in self._resolve_router_chain(message):
+                for hop in await self._resolve_router_chain(message):
                     yield {"routing_info": hop}
 
             previous_node = self.current_node_id
@@ -1149,7 +1217,7 @@ class GraphAgent(BaseAgent):
             # Silent deterministic dispatch: if the transition landed on a router
             # node, resolve the chain in this turn until a speaking node is reached.
             if node_type == NodeType.ROUTER:
-                for hop in self._resolve_router_chain(message):
+                for hop in await self._resolve_router_chain(message):
                     yield {"routing_info": hop}
                 current_node = self.get_node_by_id(self.current_node_id)
                 node_type = self._node_type_of(current_node)

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -278,6 +278,7 @@ class EdgeConditionType(str, Enum):
 class NodeType(str, Enum):
     LLM = "llm"
     STATIC = "static"
+    ROUTER = "router"
 
 
 class ToolScope(str, Enum):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -401,20 +401,19 @@ class GraphNode(BaseModel):
 
     @model_validator(mode="after")
     def validate_router_node(self):
-        """A router node dispatches silently: it never speaks, routes only on
-        deterministic edges, and must have a catch-all so it always advances."""
+        """A router node dispatches silently: it never speaks and must have a
+        catch-all so it always advances."""
         if self.node_type != NodeType.ROUTER:
             return self
 
         if self.prompt or self.static_message:
             raise ValueError(f"Router node '{self.id}' must not set a prompt or static_message; it never speaks.")
 
-        allowed = {EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL}
         for edge in self.edges:
-            if edge.condition_type not in allowed:
+            if edge.condition_type == EdgeConditionType.EVENT:
                 raise ValueError(
-                    f"Router node '{self.id}' edge to '{edge.to_node_id}' must be an expression or unconditional edge; "
-                    f"intent/LLM and event edges are not allowed on router nodes."
+                    f"Router node '{self.id}' edge to '{edge.to_node_id}' cannot be an event edge; "
+                    f"a call never rests on a router, so event edges there would never fire."
                 )
 
         if not any(edge.condition_type == EdgeConditionType.UNCONDITIONAL for edge in self.edges):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -454,18 +454,21 @@ class GraphAgentConfig(Llm):
         return self
 
     @model_validator(mode="after")
-    def validate_no_router_cycle(self):
-        """Router nodes that only route into other router nodes must terminate.
-        A cycle among router nodes would never reach a speaking node."""
-        router_ids = {n.id for n in self.nodes if n.node_type == NodeType.ROUTER}
-        if not router_ids:
+    def validate_router_graph(self):
+        """Router edges must target existing nodes, and routers must not cycle among
+        themselves (either would leave the chain unable to reach a speaking node)."""
+        router_nodes = [n for n in self.nodes if n.node_type == NodeType.ROUTER]
+        if not router_nodes:
             return self
 
-        adjacency = {
-            n.id: [e.to_node_id for e in n.edges if e.to_node_id in router_ids]
-            for n in self.nodes
-            if n.node_type == NodeType.ROUTER
-        }
+        node_ids = {n.id for n in self.nodes}
+        for node in router_nodes:
+            for edge in node.edges:
+                if edge.to_node_id not in node_ids:
+                    raise ValueError(f"Router node '{node.id}' routes to unknown node '{edge.to_node_id}'.")
+
+        router_ids = {n.id for n in router_nodes}
+        adjacency = {n.id: [e.to_node_id for e in n.edges if e.to_node_id in router_ids] for n in router_nodes}
 
         WHITE, GRAY, BLACK = 0, 1, 2
         color = {rid: WHITE for rid in router_ids}

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -399,6 +399,30 @@ class GraphNode(BaseModel):
     completion_check: Optional[Callable[[List[dict]], bool]] = None
     rag_config: Optional[RagConfig] = None
 
+    @model_validator(mode="after")
+    def validate_router_node(self):
+        """A router node dispatches silently: it never speaks, routes only on
+        deterministic edges, and must have a catch-all so it always advances."""
+        if self.node_type != NodeType.ROUTER:
+            return self
+
+        if self.prompt or self.static_message:
+            raise ValueError(f"Router node '{self.id}' must not set a prompt or static_message; it never speaks.")
+
+        allowed = {EdgeConditionType.EXPRESSION, EdgeConditionType.UNCONDITIONAL}
+        for edge in self.edges:
+            if edge.condition_type not in allowed:
+                raise ValueError(
+                    f"Router node '{self.id}' edge to '{edge.to_node_id}' must be an expression or unconditional edge; "
+                    f"intent/LLM and event edges are not allowed on router nodes."
+                )
+
+        if not any(edge.condition_type == EdgeConditionType.UNCONDITIONAL for edge in self.edges):
+            raise ValueError(
+                f"Router node '{self.id}' must have one unconditional catch-all edge so it always advances."
+            )
+        return self
+
 
 class GraphAgentConfig(Llm):
     agent_information: str
@@ -427,6 +451,38 @@ class GraphAgentConfig(Llm):
             target_model = self.routing_model or self.model
             if target_model is not None:
                 validate_reasoning_effort_for_model(target_model, effort_value)
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_router_cycle(self):
+        """Router nodes that only route into other router nodes must terminate.
+        A cycle among router nodes would never reach a speaking node."""
+        router_ids = {n.id for n in self.nodes if n.node_type == NodeType.ROUTER}
+        if not router_ids:
+            return self
+
+        adjacency = {
+            n.id: [e.to_node_id for e in n.edges if e.to_node_id in router_ids]
+            for n in self.nodes
+            if n.node_type == NodeType.ROUTER
+        }
+
+        WHITE, GRAY, BLACK = 0, 1, 2
+        color = {rid: WHITE for rid in router_ids}
+
+        def has_cycle(rid):
+            color[rid] = GRAY
+            for nxt in adjacency.get(rid, []):
+                if color[nxt] == GRAY or (color[nxt] == WHITE and has_cycle(nxt)):
+                    return True
+            color[rid] = BLACK
+            return False
+
+        for rid in router_ids:
+            if color[rid] == WHITE and has_cycle(rid):
+                raise ValueError(
+                    f"Router nodes form a cycle involving '{rid}'; a router chain must terminate at a non-router node."
+                )
         return self
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.123"
+version = "0.10.124"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -105,19 +105,19 @@ class TestRouterNodeValidation:
                 edges=[{"to_node_id": "a", "condition_type": "unconditional"}],
             )
 
-    def test_router_with_llm_edge_rejected(self):
-        with pytest.raises(ValidationError, match="expression or unconditional"):
-            GraphNode(
-                id="dispatch",
-                node_type=NodeType.ROUTER,
-                edges=[
-                    {"to_node_id": "a", "condition": "user wants a"},  # no condition_type -> llm
-                    {"to_node_id": "b", "condition_type": "unconditional"},
-                ],
-            )
+    def test_router_with_intent_edge_allowed(self):
+        node = GraphNode(
+            id="dispatch",
+            node_type=NodeType.ROUTER,
+            edges=[
+                {"to_node_id": "a", "condition": "user wants a"},  # no condition_type -> llm/intent
+                {"to_node_id": "b", "condition_type": "unconditional"},
+            ],
+        )
+        assert node.node_type == NodeType.ROUTER
 
     def test_router_with_event_edge_rejected(self):
-        with pytest.raises(ValidationError, match="expression or unconditional"):
+        with pytest.raises(ValidationError, match="event edge"):
             GraphNode(
                 id="dispatch",
                 node_type=NodeType.ROUTER,
@@ -219,9 +219,10 @@ def _router_agent(current="dispatch", **ctx):
 
 
 class TestResolveRouterChain:
-    def test_single_hop_expression_match(self):
+    @pytest.mark.asyncio
+    async def test_single_hop_expression_match(self):
         agent = _router_agent(detected_language="hi")
-        hops = agent._resolve_router_chain([])
+        hops = await agent._resolve_router_chain([])
         assert agent.current_node_id == "hindi"
         assert len(hops) == 1
         assert hops[0]["previous_node"] == "dispatch"
@@ -231,14 +232,16 @@ class TestResolveRouterChain:
         assert hops[0]["confidence"] == 1.0
         assert hops[0]["node_type"] == NodeType.LLM
 
-    def test_catch_all_fallback_when_no_expression_matches(self):
+    @pytest.mark.asyncio
+    async def test_catch_all_fallback_when_no_expression_matches(self):
         agent = _router_agent(detected_language="fr")
-        hops = agent._resolve_router_chain([])
+        hops = await agent._resolve_router_chain([])
         assert agent.current_node_id == "english"
         assert len(hops) == 1
         assert hops[0]["current_node"] == "english"
 
-    def test_catch_all_wins_even_if_listed_first(self):
+    @pytest.mark.asyncio
+    async def test_catch_all_wins_even_if_listed_first(self):
         # The unconditional is listed BEFORE the expression; it must still be a
         # fallback, not pre-empt a matching expression edge.
         nodes = [
@@ -259,10 +262,11 @@ class TestResolveRouterChain:
             {"id": "vip", "prompt": "v", "edges": []},
         ]
         agent = _make_agent(_base_config(nodes, "dispatch", context_data={"tier": "vip"}))
-        agent._resolve_router_chain([])
+        await agent._resolve_router_chain([])
         assert agent.current_node_id == "vip"
 
-    def test_expression_priority_order(self):
+    @pytest.mark.asyncio
+    async def test_expression_priority_order(self):
         nodes = [
             {
                 "id": "dispatch",
@@ -288,10 +292,11 @@ class TestResolveRouterChain:
             {"id": "default", "prompt": "d", "edges": []},
         ]
         agent = _make_agent(_base_config(nodes, "dispatch", context_data={"flag": "on"}))
-        agent._resolve_router_chain([])
+        await agent._resolve_router_chain([])
         assert agent.current_node_id == "high"  # lower priority number wins
 
-    def test_multi_hop_chain(self):
+    @pytest.mark.asyncio
+    async def test_multi_hop_chain(self):
         nodes = [
             {
                 "id": "r1",
@@ -306,12 +311,13 @@ class TestResolveRouterChain:
             {"id": "leaf", "prompt": "done", "edges": []},
         ]
         agent = _make_agent(_base_config(nodes, "r1"))
-        hops = agent._resolve_router_chain([])
+        hops = await agent._resolve_router_chain([])
         assert agent.current_node_id == "leaf"
         assert [h["current_node"] for h in hops] == ["r2", "leaf"]
         assert agent.node_history[-1] == "leaf"
 
-    def test_runtime_cycle_is_bounded(self):
+    @pytest.mark.asyncio
+    async def test_runtime_cycle_is_bounded(self):
         # Build a cyclic router graph directly as a dict (bypasses Pydantic
         # validation) to prove the visited-set prevents an infinite loop.
         nodes = [
@@ -327,13 +333,14 @@ class TestResolveRouterChain:
             },
         ]
         agent = _make_agent(_base_config(nodes, "r1"))
-        hops = agent._resolve_router_chain([])  # must return, not hang
+        hops = await agent._resolve_router_chain([])  # must return, not hang
         assert len(hops) == 2  # r1->r2, r2->r1, then r1 already visited -> stop
 
-    def test_no_hops_when_current_not_router(self):
+    @pytest.mark.asyncio
+    async def test_no_hops_when_current_not_router(self):
         nodes = [{"id": "leaf", "prompt": "hi", "edges": []}]
         agent = _make_agent(_base_config(nodes, "leaf"))
-        hops = agent._resolve_router_chain([])
+        hops = await agent._resolve_router_chain([])
         assert hops == []
         assert agent.current_node_id == "leaf"
 
@@ -435,3 +442,116 @@ class TestGenerateWithRouter:
 
         assert agent.current_node_id == "vip"
         assert any(r["previous_node"] == "entry" and r["current_node"] == "vip" for r in routing)
+
+
+# ---------------------------------------------------------------------------
+# Intent edges on routers
+# ---------------------------------------------------------------------------
+
+
+def _intent_router_agent(**ctx):
+    nodes = [
+        {
+            "id": "dispatch",
+            "node_type": "router",
+            "description": "Route the caller to the right department.",
+            "edges": [
+                {
+                    "to_node_id": "hindi",
+                    "condition_type": "expression",
+                    "expression": _expr("detected_language", "eq", "hi"),
+                },
+                {"to_node_id": "billing", "condition": "user asks about billing", "function_name": "go_to_billing"},
+                {"to_node_id": "support", "condition": "user needs technical support"},
+                {"to_node_id": "general", "condition_type": "unconditional"},
+            ],
+        },
+        {"id": "hindi", "prompt": "Hindi.", "edges": []},
+        {"id": "billing", "prompt": "Billing.", "edges": []},
+        {"id": "support", "prompt": "Support.", "edges": []},
+        {"id": "general", "prompt": "General.", "edges": []},
+    ]
+    return _make_agent(_base_config(nodes, "dispatch", context_data=ctx or {}))
+
+
+class TestRouterIntentRouting:
+    @pytest.mark.asyncio
+    async def test_expression_match_skips_intent_llm(self):
+        agent = _intent_router_agent(detected_language="hi")
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock) as mock_llm:
+            await agent._resolve_router_chain([{"role": "user", "content": "namaste"}])
+        mock_llm.assert_not_called()
+        assert agent.current_node_id == "hindi"
+
+    @pytest.mark.asyncio
+    async def test_intent_routes_when_no_expression_matches(self):
+        agent = _intent_router_agent(detected_language="en")
+        picked = (
+            "billing",
+            {"topic": "invoice"},
+            320.0,
+            [{"role": "system", "content": "routing"}],
+            [{"type": "function"}],
+            "asks about an invoice",
+            0.9,
+            {"input_tokens": 12},
+        )
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=picked) as mock_llm:
+            hops = await agent._resolve_router_chain([{"role": "user", "content": "my invoice is wrong"}])
+
+        mock_llm.assert_called_once()
+        offered = mock_llm.call_args.args[1]  # only intent edges go to the routing LLM
+        assert {e["to_node_id"] for e in offered} == {"billing", "support"}
+        assert agent.current_node_id == "billing"
+        assert agent.context_data["topic"] == "invoice"
+        assert len(hops) == 1
+        assert hops[0]["routing_type"] == "llm"
+        assert hops[0]["routing_messages"] is not None
+        assert hops[0]["extracted_params"] == {"topic": "invoice"}
+        assert hops[0]["confidence"] == 0.9
+
+    @pytest.mark.asyncio
+    async def test_intent_no_match_falls_to_catch_all(self):
+        agent = _intent_router_agent(detected_language="en")
+        stay = (None, None, 250.0, [{"role": "system", "content": "routing"}], [], "unclear", 0.3, None)
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=stay) as mock_llm:
+            hops = await agent._resolve_router_chain([{"role": "user", "content": "ummm"}])
+
+        mock_llm.assert_called_once()
+        assert agent.current_node_id == "general"
+        assert hops[0]["routing_type"] == "deterministic"
+        assert "intent: no match" in hops[0]["routing_expression"]
+
+    @pytest.mark.asyncio
+    async def test_one_intent_call_per_chain(self):
+        # r1 routes via intent to r2 (another intent router); r2 must take its
+        # catch-all instead of making a second LLM call.
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "r2", "condition": "user wants a specialist"},
+                    {"to_node_id": "general", "condition_type": "unconditional"},
+                ],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "billing", "condition": "billing question"},
+                    {"to_node_id": "support", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "billing", "prompt": "b", "edges": []},
+            {"id": "support", "prompt": "s", "edges": []},
+            {"id": "general", "prompt": "g", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "r1"))
+        pick_r2 = ("r2", None, 300.0, [{"role": "system", "content": "r"}], [], "specialist", 0.8, None)
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=pick_r2) as mock_llm:
+            hops = await agent._resolve_router_chain([{"role": "user", "content": "hi"}])
+
+        assert mock_llm.call_count == 1
+        assert agent.current_node_id == "support"  # r2's catch-all, no second call
+        assert [h["current_node"] for h in hops] == ["r2", "support"]

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 from bolna.agent_types.graph_agent import GraphAgent, _DETERMINISTIC_REASONING_PREFIX
 from bolna.models import GraphNode, GraphAgentConfig
 from bolna.enums import NodeType
+from bolna.llms.types import LLMStreamChunk
 
 
 # ---------------------------------------------------------------------------
@@ -415,6 +416,8 @@ class TestGenerateWithRouter:
         out = await _collect(agent.generate([{"role": "user", "content": "hi"}]))
         assert agent.current_node_id == "dispatch"  # never left the router
         assert not any(isinstance(o, dict) and "messages" in o for o in out)  # did not speak
+        # ends the turn with a terminal end-of-stream chunk so the pipeline unwinds cleanly
+        assert any(isinstance(o, LLMStreamChunk) and o.end_of_stream for o in out)
 
     @pytest.mark.asyncio
     async def test_entry_router_resolves_on_first_generate(self):
@@ -521,6 +524,9 @@ class TestRouterIntentRouting:
         assert agent.current_node_id == "general"
         assert hops[0]["routing_type"] == "deterministic"
         assert "intent: no match" in hops[0]["routing_expression"]
+        # the intent call's telemetry is carried onto the catch-all hop, not dropped
+        assert hops[0]["routing_messages"] is not None
+        assert hops[0]["routing_model"] is not None
 
     @pytest.mark.asyncio
     async def test_one_intent_call_per_chain(self):
@@ -555,3 +561,86 @@ class TestRouterIntentRouting:
         assert mock_llm.call_count == 1
         assert agent.current_node_id == "support"  # r2's catch-all, no second call
         assert [h["current_node"] for h in hops] == ["r2", "support"]
+
+
+# ---------------------------------------------------------------------------
+# Regression fixes (post-review)
+# ---------------------------------------------------------------------------
+
+
+class TestRouterFixes:
+    @pytest.mark.asyncio
+    async def test_node_turns_is_zero_on_router_entry(self):
+        # A stuck-detection edge (_node_turns gte 1) on a router must NOT fire the
+        # instant the router is entered mid-turn: node turns are 0 on arrival.
+        nodes = [
+            {
+                "id": "chat",
+                "prompt": "Chat.",
+                "edges": [{"to_node_id": "dispatch", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {
+                        "to_node_id": "escalation",
+                        "condition_type": "expression",
+                        "expression": _expr("_node_turns", "gte", 1),
+                    },
+                    {"to_node_id": "normal", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "escalation", "prompt": "Esc.", "edges": []},
+            {"id": "normal", "prompt": "Normal.", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "chat"))
+        history = [{"role": "user", "content": f"m{i}"} for i in range(3)] + [{"role": "assistant", "content": "hi"}]
+        await _collect(agent.generate(history))
+        assert agent.current_node_id == "normal"  # not "escalation"
+
+    @pytest.mark.asyncio
+    async def test_entry_router_landed_node_speaks_without_yank(self):
+        # The node an entry router resolves to must speak this turn, not be re-routed
+        # away by its own unconditional out-edge.
+        nodes = [
+            {
+                "id": "entry",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "vip", "condition_type": "expression", "expression": _expr("tier", "eq", "vip")},
+                    {"to_node_id": "standard", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "vip", "prompt": "VIP.", "edges": [{"to_node_id": "wrapup", "condition_type": "unconditional"}]},
+            {"id": "standard", "prompt": "Std.", "edges": []},
+            {"id": "wrapup", "prompt": "Wrap.", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "entry", context_data={"tier": "vip"}))
+        out = await _collect(agent.generate([{"role": "user", "content": "hi"}]))
+        assert agent.current_node_id == "vip"  # not "wrapup"
+        assert any(isinstance(o, dict) and "messages" in o for o in out)  # vip spoke
+
+    @pytest.mark.asyncio
+    async def test_catch_all_lowest_priority_wins(self):
+        nodes = [
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "generic", "condition_type": "unconditional", "priority": 5},
+                    {"to_node_id": "premium", "condition_type": "unconditional", "priority": 1},
+                ],
+            },
+            {"id": "generic", "prompt": "g", "edges": []},
+            {"id": "premium", "prompt": "p", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "dispatch"))
+        await agent._resolve_router_chain([{"role": "user", "content": "x"}])
+        assert agent.current_node_id == "premium"  # priority 1 < 5, not declaration order
+
+    @pytest.mark.asyncio
+    async def test_silence_flag_threaded_into_hops(self):
+        agent = _router_agent(detected_language="hi")
+        hops = await agent._resolve_router_chain([{"role": "user", "content": "[silence] "}])
+        assert hops[0]["is_silence_trigger"] is True

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -1,0 +1,402 @@
+"""Tests for router nodes (silent deterministic dispatch) in GraphAgent.
+
+Covers:
+  * config validation (GraphNode + GraphAgentConfig): router constraints and cycle rejection
+  * _resolve_router_chain: single hop, catch-all fallback, priority order, multi-hop,
+    runtime cycle bounding, hop routing_info shape
+  * generate(): transition into a router resolves to a speaking node, entry-node dispatch
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from pydantic import ValidationError
+
+from bolna.agent_types.graph_agent import GraphAgent, _DETERMINISTIC_REASONING_PREFIX
+from bolna.models import GraphNode, GraphAgentConfig
+from bolna.enums import NodeType
+
+
+# ---------------------------------------------------------------------------
+# Agent construction helper (mirrors test_expression_routing.py)
+# ---------------------------------------------------------------------------
+
+
+async def _async_iter(items):
+    for item in items:
+        yield item
+
+
+def _make_agent(config):
+    mock_llm = MagicMock()
+    mock_llm.generate_stream = MagicMock(side_effect=lambda *a, **k: _async_iter([]))
+    mock_llm.trigger_function_call = False
+    mock_openai_client = MagicMock()
+    mock_openai_llm_cls = MagicMock(return_value=mock_llm)
+
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=mock_openai_client),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": mock_openai_llm_cls}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        agent = GraphAgent(config)
+
+    agent._mock_llm = mock_llm
+    return agent
+
+
+def _base_config(nodes, current_node_id, **overrides):
+    cfg = {
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "temperature": 0.7,
+        "max_tokens": 150,
+        "current_node_id": current_node_id,
+        "nodes": nodes,
+    }
+    cfg.update(overrides)
+    return cfg
+
+
+def _expr(variable, operator, value=None):
+    cond = {"variable": variable, "operator": operator}
+    if value is not None:
+        cond["value"] = value
+    return {"logic": "and", "conditions": [cond]}
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestRouterNodeValidation:
+    def test_valid_router_node(self):
+        node = GraphNode(
+            id="dispatch",
+            node_type=NodeType.ROUTER,
+            edges=[
+                {
+                    "to_node_id": "hindi",
+                    "condition_type": "expression",
+                    "expression": _expr("detected_language", "eq", "hi"),
+                },
+                {"to_node_id": "default", "condition_type": "unconditional"},
+            ],
+        )
+        assert node.node_type == NodeType.ROUTER
+
+    def test_router_with_prompt_rejected(self):
+        with pytest.raises(ValidationError, match="never speaks"):
+            GraphNode(
+                id="dispatch",
+                node_type=NodeType.ROUTER,
+                prompt="say hi",
+                edges=[{"to_node_id": "a", "condition_type": "unconditional"}],
+            )
+
+    def test_router_with_static_message_rejected(self):
+        with pytest.raises(ValidationError, match="never speaks"):
+            GraphNode(
+                id="dispatch",
+                node_type=NodeType.ROUTER,
+                static_message="hi",
+                edges=[{"to_node_id": "a", "condition_type": "unconditional"}],
+            )
+
+    def test_router_with_llm_edge_rejected(self):
+        with pytest.raises(ValidationError, match="expression or unconditional"):
+            GraphNode(
+                id="dispatch",
+                node_type=NodeType.ROUTER,
+                edges=[
+                    {"to_node_id": "a", "condition": "user wants a"},  # no condition_type -> llm
+                    {"to_node_id": "b", "condition_type": "unconditional"},
+                ],
+            )
+
+    def test_router_with_event_edge_rejected(self):
+        with pytest.raises(ValidationError, match="expression or unconditional"):
+            GraphNode(
+                id="dispatch",
+                node_type=NodeType.ROUTER,
+                edges=[
+                    {"to_node_id": "a", "condition_type": "event", "event_name": "ping"},
+                    {"to_node_id": "b", "condition_type": "unconditional"},
+                ],
+            )
+
+    def test_router_without_catch_all_rejected(self):
+        with pytest.raises(ValidationError, match="catch-all"):
+            GraphNode(
+                id="dispatch",
+                node_type=NodeType.ROUTER,
+                edges=[
+                    {
+                        "to_node_id": "a",
+                        "condition_type": "expression",
+                        "expression": _expr("x", "eq", "1"),
+                    },
+                ],
+            )
+
+    def test_non_router_node_unconstrained(self):
+        # A normal LLM node keeps its prompt and llm edges.
+        node = GraphNode(id="greeting", prompt="Greet.", edges=[{"to_node_id": "a", "condition": "wants a"}])
+        assert node.node_type == NodeType.LLM
+
+    def test_router_cycle_rejected(self):
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r2", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r1", "condition_type": "unconditional"}],
+            },
+        ]
+        with pytest.raises(ValidationError, match="cycle"):
+            GraphAgentConfig(**_base_config(nodes, "r1"))
+
+    def test_router_chain_terminating_ok(self):
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r2", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [{"to_node_id": "leaf", "condition_type": "unconditional"}],
+            },
+            {"id": "leaf", "prompt": "done", "edges": []},
+        ]
+        cfg = GraphAgentConfig(**_base_config(nodes, "r1"))
+        assert len(cfg.nodes) == 3
+
+
+# ---------------------------------------------------------------------------
+# _resolve_router_chain
+# ---------------------------------------------------------------------------
+
+
+def _router_agent(current="dispatch", **ctx):
+    nodes = [
+        {
+            "id": "dispatch",
+            "node_type": "router",
+            "edges": [
+                {
+                    "to_node_id": "hindi",
+                    "condition": "hindi speaker",
+                    "condition_type": "expression",
+                    "expression": _expr("detected_language", "eq", "hi"),
+                },
+                {"to_node_id": "english", "condition": "default", "condition_type": "unconditional"},
+            ],
+        },
+        {"id": "hindi", "prompt": "Respond in Hindi.", "edges": []},
+        {"id": "english", "prompt": "Respond in English.", "edges": []},
+    ]
+    cfg = _base_config(nodes, current, context_data=ctx or {})
+    return _make_agent(cfg)
+
+
+class TestResolveRouterChain:
+    def test_single_hop_expression_match(self):
+        agent = _router_agent(detected_language="hi")
+        hops = agent._resolve_router_chain([])
+        assert agent.current_node_id == "hindi"
+        assert len(hops) == 1
+        assert hops[0]["previous_node"] == "dispatch"
+        assert hops[0]["current_node"] == "hindi"
+        assert hops[0]["routing_type"] == "deterministic"
+        assert hops[0]["reasoning"].startswith(_DETERMINISTIC_REASONING_PREFIX)
+        assert hops[0]["confidence"] == 1.0
+        assert hops[0]["node_type"] == NodeType.LLM
+
+    def test_catch_all_fallback_when_no_expression_matches(self):
+        agent = _router_agent(detected_language="fr")
+        hops = agent._resolve_router_chain([])
+        assert agent.current_node_id == "english"
+        assert len(hops) == 1
+        assert hops[0]["current_node"] == "english"
+
+    def test_catch_all_wins_even_if_listed_first(self):
+        # The unconditional is listed BEFORE the expression; it must still be a
+        # fallback, not pre-empt a matching expression edge.
+        nodes = [
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "fallback", "condition_type": "unconditional", "priority": 0},
+                    {
+                        "to_node_id": "vip",
+                        "condition_type": "expression",
+                        "priority": 1,
+                        "expression": _expr("tier", "eq", "vip"),
+                    },
+                ],
+            },
+            {"id": "fallback", "prompt": "f", "edges": []},
+            {"id": "vip", "prompt": "v", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "dispatch", context_data={"tier": "vip"}))
+        agent._resolve_router_chain([])
+        assert agent.current_node_id == "vip"
+
+    def test_expression_priority_order(self):
+        nodes = [
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {
+                        "to_node_id": "low",
+                        "condition_type": "expression",
+                        "priority": 10,
+                        "expression": _expr("flag", "eq", "on"),
+                    },
+                    {
+                        "to_node_id": "high",
+                        "condition_type": "expression",
+                        "priority": 1,
+                        "expression": _expr("flag", "eq", "on"),
+                    },
+                    {"to_node_id": "default", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "low", "prompt": "l", "edges": []},
+            {"id": "high", "prompt": "h", "edges": []},
+            {"id": "default", "prompt": "d", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "dispatch", context_data={"flag": "on"}))
+        agent._resolve_router_chain([])
+        assert agent.current_node_id == "high"  # lower priority number wins
+
+    def test_multi_hop_chain(self):
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r2", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [{"to_node_id": "leaf", "condition_type": "unconditional"}],
+            },
+            {"id": "leaf", "prompt": "done", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "r1"))
+        hops = agent._resolve_router_chain([])
+        assert agent.current_node_id == "leaf"
+        assert [h["current_node"] for h in hops] == ["r2", "leaf"]
+        assert agent.node_history[-1] == "leaf"
+
+    def test_runtime_cycle_is_bounded(self):
+        # Build a cyclic router graph directly as a dict (bypasses Pydantic
+        # validation) to prove the visited-set prevents an infinite loop.
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r2", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [{"to_node_id": "r1", "condition_type": "unconditional"}],
+            },
+        ]
+        agent = _make_agent(_base_config(nodes, "r1"))
+        hops = agent._resolve_router_chain([])  # must return, not hang
+        assert len(hops) == 2  # r1->r2, r2->r1, then r1 already visited -> stop
+
+    def test_no_hops_when_current_not_router(self):
+        nodes = [{"id": "leaf", "prompt": "hi", "edges": []}]
+        agent = _make_agent(_base_config(nodes, "leaf"))
+        hops = agent._resolve_router_chain([])
+        assert hops == []
+        assert agent.current_node_id == "leaf"
+
+
+# ---------------------------------------------------------------------------
+# generate() integration
+# ---------------------------------------------------------------------------
+
+
+async def _collect(agen):
+    return [item async for item in agen]
+
+
+class TestGenerateWithRouter:
+    @pytest.mark.asyncio
+    async def test_transition_into_router_resolves_and_speaks(self):
+        nodes = [
+            {
+                "id": "greeting",
+                "prompt": "Greet.",
+                "edges": [{"to_node_id": "dispatch", "condition_type": "unconditional"}],
+            },
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {
+                        "to_node_id": "hindi",
+                        "condition_type": "expression",
+                        "expression": _expr("detected_language", "eq", "hi"),
+                    },
+                    {"to_node_id": "english", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "hindi", "prompt": "Hindi.", "edges": []},
+            {"id": "english", "prompt": "English.", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "greeting", context_data={"detected_language": "hi"}))
+
+        out = await _collect(agent.generate([{"role": "user", "content": "hello"}]))
+        routing = [o["routing_info"] for o in out if isinstance(o, dict) and "routing_info" in o]
+
+        # greeting -> dispatch (unconditional), then dispatch -> hindi (router hop)
+        assert agent.current_node_id == "hindi"
+        assert routing[-1]["current_node"] == "hindi"
+        assert routing[-1]["node_type"] == NodeType.LLM
+        # a router hop was emitted with deterministic routing
+        assert any(r["current_node"] == "hindi" and r["routing_type"] == "deterministic" for r in routing)
+        # the terminal (speaking) node produced a messages payload, i.e. it did not stay silent
+        assert any(isinstance(o, dict) and "messages" in o for o in out)
+
+    @pytest.mark.asyncio
+    async def test_entry_router_resolves_on_first_generate(self):
+        nodes = [
+            {
+                "id": "entry",
+                "node_type": "router",
+                "edges": [
+                    {
+                        "to_node_id": "vip",
+                        "condition_type": "expression",
+                        "expression": _expr("tier", "eq", "vip"),
+                    },
+                    {"to_node_id": "standard", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "vip", "prompt": "VIP.", "edges": []},
+            {"id": "standard", "prompt": "Standard.", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "entry", context_data={"tier": "vip"}))
+        assert agent.current_node_id == "entry"  # not resolved at construction
+
+        out = await _collect(agent.generate([{"role": "user", "content": "hi"}]))
+        routing = [o["routing_info"] for o in out if isinstance(o, dict) and "routing_info" in o]
+
+        assert agent.current_node_id == "vip"
+        assert any(r["previous_node"] == "entry" and r["current_node"] == "vip" for r in routing)

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -162,6 +162,17 @@ class TestRouterNodeValidation:
         with pytest.raises(ValidationError, match="cycle"):
             GraphAgentConfig(**_base_config(nodes, "r1"))
 
+    def test_router_edge_to_unknown_node_rejected(self):
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [{"to_node_id": "does_not_exist", "condition_type": "unconditional"}],
+            },
+        ]
+        with pytest.raises(ValidationError, match="unknown node"):
+            GraphAgentConfig(**_base_config(nodes, "r1"))
+
     def test_router_chain_terminating_ok(self):
         nodes = [
             {
@@ -373,6 +384,30 @@ class TestGenerateWithRouter:
         assert any(r["current_node"] == "hindi" and r["routing_type"] == "deterministic" for r in routing)
         # the terminal (speaking) node produced a messages payload, i.e. it did not stay silent
         assert any(isinstance(o, dict) and "messages" in o for o in out)
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_router_stays_silent(self):
+        # A router that matches no expression and has no catch-all (built as a raw
+        # dict, bypassing validation) must not fall through to speaking.
+        nodes = [
+            {
+                "id": "dispatch",
+                "node_type": "router",
+                "edges": [
+                    {
+                        "to_node_id": "hindi",
+                        "condition_type": "expression",
+                        "expression": _expr("detected_language", "eq", "hi"),
+                    },
+                ],
+            },
+            {"id": "hindi", "prompt": "Hindi.", "edges": []},
+        ]
+        agent = _make_agent(_base_config(nodes, "dispatch", context_data={"detected_language": "fr"}))
+
+        out = await _collect(agent.generate([{"role": "user", "content": "hi"}]))
+        assert agent.current_node_id == "dispatch"  # never left the router
+        assert not any(isinstance(o, dict) and "messages" in o for o in out)  # did not speak
 
     @pytest.mark.asyncio
     async def test_entry_router_resolves_on_first_generate(self):


### PR DESCRIPTION
Adds a `router` node type to graph agents: a node that emits nothing and, on entry, routes and transitions again within the same turn until it lands on a node that speaks.

## Why

A graph node today couples a conversational state with a routing decision and always routes as part of a spoken turn. Router nodes give a place for complex deterministic branching, silent NLU dispatch, and pre-conversation routing without a spoken turn. This also resolves a recurring confusion: intent and expression edges cannot be ranked against each other by `priority` (expression edges short-circuit before the intent LLM runs), so a router node is the right primitive when routing logic needs its own place in the graph.

## Behavior

Each hop picks an edge in three phases:

1. Expression edges first, in priority order, instant and free.
2. Intent edges via one routing-LLM call, only if no expression matched. The LLM runs at most once per chain, so chained routers can never stack routing latency; a second intent router reached in the same chain takes its catch-all.
3. The unconditional catch-all as fallback, including when the routing LLM finds no match or errors.

* The chain is bounded by a visited-set, so it always terminates.
* A router never speaks: if a chain cannot reach a speaking node, the turn stays silent instead of generating from an empty prompt.
* Routers work as transition targets, as event-edge targets, and as the start node (resolved on the first turn).
* Each hop emits its own routing_info, so multi-hop dispatch shows up per hop in request logs.
* Intent transitions extract edge parameters into context_data, same as normal intent routing.
* For intent classification the routing LLM sees the router's `description` as the node objective (routers have no prompt), the edge conditions as tool descriptions, and the agent-level routing_instructions.

## Validation (at config load)

* Router nodes have no prompt or static_message, and one unconditional catch-all.
* Expression, intent, and unconditional edges are allowed; event edges are rejected (a call never rests on a router, so they would never fire).
* Router edges must target existing nodes, and routers cannot form an all-router cycle.

## Compatibility

Fully backward compatible. Existing configs are untouched; the new validators and `generate()` branches are gated on `node_type == router`.

BOLNA-1598