### PR TITLE
Enable LLM voicemail detection for SIP-trunk calls

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.125"
+__version__ = "0.10.126"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -471,4 +471,5 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             logger.error(f"sip-trunk send_hangup: {e}")
 
     def requires_custom_voicemail_detection(self):
-        return False
+        # SIP/BYOT (Asterisk) has no carrier-side AMD, so voicemail must be caught via the LLM path.
+        return True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.125"
+version = "0.10.126"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary
SIP-trunk calls never ran LLM voicemail detection even with `voicemail: true` on the agent. `SipTrunkOutputHandler.requires_custom_voicemail_detection()` returned `False`, so `TaskManager` set `output_tool_available=False` and `VoicemailHandler` forced `enabled=False`, silently overriding the agent config.

Twilio/Exotel return `False` because they rely on carrier-side AMD; SIP/BYOT (Asterisk) has no carrier AMD, so it must use the LLM path — the same behaviour as the default handler that Plivo/Vobiz inherit. This flips it to `True`.

Downstream persistence is already provider-agnostic (`answered_by_voice_mail` is set from the engine's `hangup_detail == "voicemail_detected"`), so no dashboard-backend or frontend changes are needed.