### PR TITLE
feat: multilingual presets for graph-agent static messages

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.135"
+__version__ = "0.10.136"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2617,7 +2617,9 @@ class TaskManager(BaseManager):
 
         if node_type == NodeType.STATIC:
             # Static node: play cached audio directly, no LLM cost
-            static_text = target_node.get("static_message", "") if target_node else ""
+            static_text = (
+                select_message_by_language(target_node.get("static_message"), self.language) if target_node else ""
+            )
             if static_text:
                 if self.context_data:
                     static_text = update_prompt_with_context(static_text, self.context_data)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5854,8 +5854,11 @@ class TaskManager(BaseManager):
                             text, self.assistant_name, "mp3", assistant_id=self.assistant_id, local=self.is_local
                         )
                         if audio is not None:
-                            audio_chunk = mp3_bytes_to_pcm(audio, target_sample_rate=8000)
-                            meta_info["format"] = "pcm"
+                            # Telephony wire format is 8k mu-law. Providers key off meta_info["format"]:
+                            # plivo/vobiz send non-wav bytes as audio/x-mulaw without converting, so raw
+                            # linear16 would play as noise. mu-law is correct across plivo/twilio/exotel.
+                            audio_chunk = audioop.lin2ulaw(mp3_bytes_to_pcm(audio, target_sample_rate=8000), 2)
+                            meta_info["format"] = "mulaw"
                     except Exception as static_audio_err:
                         logger.error(f"Failed to prepare static node audio {text}: {static_audio_err}")
                     if audio_chunk is None:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5811,13 +5811,25 @@ class TaskManager(BaseManager):
                 # Static-node clips are pre-generated as mp3 keyed by md5(text); fetch that
                 # format explicitly rather than the output format, which may differ (e.g. wav).
                 audio_format = "mp3" if static_node_audio else self.task_config["tools_config"]["output"]["format"]
-                audio_chunk = await get_raw_audio_bytes(
-                    text,
-                    self.assistant_name,
-                    audio_format,
-                    local=self.is_local,
-                    assistant_id=self.assistant_id,
-                )
+                try:
+                    audio_chunk = await get_raw_audio_bytes(
+                        text,
+                        self.assistant_name,
+                        audio_format,
+                        local=self.is_local,
+                        assistant_id=self.assistant_id,
+                    )
+                except Exception as static_audio_err:
+                    if not static_node_audio:
+                        raise
+                    logger.error(f"Failed to fetch static node audio {text}: {static_audio_err}")
+                    audio_chunk = None
+                if static_node_audio and audio_chunk is None:
+                    # Cache miss or fetch failure: synthesize live so the node still speaks.
+                    logger.info("Static node audio unavailable; synthesizing live from text")
+                    meta_info["cached"] = False
+                    await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
+                    return
                 logger.info("Sending preprocessed audio")
                 meta_info["format"] = audio_format
                 meta_info["end_of_synthesizer_stream"] = True
@@ -5835,16 +5847,19 @@ class TaskManager(BaseManager):
                         meta_info["format"] = "pcm"
                 elif static_node_audio:
                     logger.info(f"Getting static node audio {text} from S3")
-                    audio = await get_raw_audio_bytes(
-                        text, self.assistant_name, "mp3", assistant_id=self.assistant_id, local=self.is_local
-                    )
                     yield_in_chunks = False
-                    if audio is not None:
-                        audio_chunk = wav_bytes_to_pcm(resample(audio, format="mp3", target_sample_rate=8000))
-                        meta_info["format"] = "pcm"
-                    else:
-                        # Cache miss: synthesize live from the resolved text so the node still speaks.
-                        logger.info("Static node audio missing in S3; synthesizing live")
+                    try:
+                        audio = await get_raw_audio_bytes(
+                            text, self.assistant_name, "mp3", assistant_id=self.assistant_id, local=self.is_local
+                        )
+                        if audio is not None:
+                            audio_chunk = wav_bytes_to_pcm(resample(audio, format="mp3", target_sample_rate=8000))
+                            meta_info["format"] = "pcm"
+                    except Exception as static_audio_err:
+                        logger.error(f"Failed to prepare static node audio {text}: {static_audio_err}")
+                    if audio_chunk is None:
+                        # Cache miss or fetch/convert failure: synthesize live so the node still speaks.
+                        logger.info("Static node audio unavailable; synthesizing live from text")
                         meta_info["cached"] = False
                         await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
                         return

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -80,6 +80,7 @@ from bolna.helpers.utils import (
     get_md5_hash,
     clean_json_string,
     wav_bytes_to_pcm,
+    mp3_bytes_to_pcm,
     convert_to_request_log,
     yield_chunks_from_memory,
     process_task_cancellation,
@@ -5853,7 +5854,7 @@ class TaskManager(BaseManager):
                             text, self.assistant_name, "mp3", assistant_id=self.assistant_id, local=self.is_local
                         )
                         if audio is not None:
-                            audio_chunk = wav_bytes_to_pcm(resample(audio, format="mp3", target_sample_rate=8000))
+                            audio_chunk = mp3_bytes_to_pcm(audio, target_sample_rate=8000)
                             meta_info["format"] = "pcm"
                     except Exception as static_audio_err:
                         logger.error(f"Failed to prepare static node audio {text}: {static_audio_err}")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3635,6 +3635,7 @@ class TaskManager(BaseManager):
                     meta_info["end_of_llm_stream"] = True
                     meta_info["text"] = static_text
                     meta_info["cached"] = True
+                    meta_info["message_category"] = "static_node"
                     ws_packet = create_ws_data_packet(static_hash, meta_info=meta_info, is_md5_hash=True)
                     await self._synthesize(ws_packet)
                     return
@@ -5805,16 +5806,20 @@ class TaskManager(BaseManager):
             # TODO: Either load IVR audio into memory before call or user s3 iter_cunks
             # This will help with interruption in IVR
             audio_chunk = None
+            static_node_audio = meta_info.get("message_category") in ("static_node", "event_proactive")
             if self.turn_based_conversation or self.task_config["tools_config"]["output"]["provider"] == "default":
+                # Static-node clips are pre-generated as mp3 keyed by md5(text); fetch that
+                # format explicitly rather than the output format, which may differ (e.g. wav).
+                audio_format = "mp3" if static_node_audio else self.task_config["tools_config"]["output"]["format"]
                 audio_chunk = await get_raw_audio_bytes(
                     text,
                     self.assistant_name,
-                    self.task_config["tools_config"]["output"]["format"],
+                    audio_format,
                     local=self.is_local,
                     assistant_id=self.assistant_id,
                 )
                 logger.info("Sending preprocessed audio")
-                meta_info["format"] = self.task_config["tools_config"]["output"]["format"]
+                meta_info["format"] = audio_format
                 meta_info["end_of_synthesizer_stream"] = True
                 await self.tools["output"].handle(create_ws_data_packet(audio_chunk, meta_info))
             else:
@@ -5828,6 +5833,21 @@ class TaskManager(BaseManager):
                         logger.info(f"Got to convert it to pcm")
                         audio_chunk = wav_bytes_to_pcm(resample(audio, format="wav", target_sample_rate=8000))
                         meta_info["format"] = "pcm"
+                elif static_node_audio:
+                    logger.info(f"Getting static node audio {text} from S3")
+                    audio = await get_raw_audio_bytes(
+                        text, self.assistant_name, "mp3", assistant_id=self.assistant_id, local=self.is_local
+                    )
+                    yield_in_chunks = False
+                    if audio is not None:
+                        audio_chunk = wav_bytes_to_pcm(resample(audio, format="mp3", target_sample_rate=8000))
+                        meta_info["format"] = "pcm"
+                    else:
+                        # Cache miss: synthesize live from the resolved text so the node still speaks.
+                        logger.info("Static node audio missing in S3; synthesizing live")
+                        meta_info["cached"] = False
+                        await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
+                        return
                 else:
                     start_time = time.perf_counter()
                     audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -18,6 +18,7 @@ from bolna.helpers.utils import (
     enrich_context_with_time_variables,
     DictWithMissing,
     get_md5_hash,
+    select_message_by_language,
 )
 from bolna.helpers.expression_evaluator import evaluate_edge_expression, describe_edge_expression
 from bolna.enums import EdgeConditionType, NodeType, ToolScope
@@ -1103,6 +1104,19 @@ class GraphAgent(BaseAgent):
             messages.append(rag_message)
         return messages
 
+    def _static_message_chunk(self, current_node: Optional[dict]) -> Optional[dict]:
+        """Resolve a static node's message for the active language and build its
+        playback chunk: context-substituted text plus the audio-cache hash. None if empty."""
+        text = select_message_by_language(
+            current_node.get("static_message") if current_node else None,
+            self.context_data.get("detected_language"),
+        )
+        if not text:
+            return None
+        if self.context_data:
+            text = update_prompt_with_context(text, self.context_data)
+        return {"static_message": text, "static_audio_hash": get_md5_hash(text)}
+
     async def generate(self, message: List[dict], **kwargs) -> AsyncGenerator:
         meta_info = kwargs.get("meta_info", {})
         synthesize = kwargs.get("synthesize", True)
@@ -1152,14 +1166,9 @@ class GraphAgent(BaseAgent):
                         return
 
                 if node_type == NodeType.STATIC:
-                    static_text = current_node.get("static_message", "") if current_node else ""
-                    if static_text:
-                        if self.context_data:
-                            static_text = update_prompt_with_context(static_text, self.context_data)
-                        yield {
-                            "static_message": static_text,
-                            "static_audio_hash": get_md5_hash(static_text),
-                        }
+                    chunk = self._static_message_chunk(current_node)
+                    if chunk:
+                        yield chunk
                     return
 
                 messages = await self._build_messages(message, meta_info=meta_info)
@@ -1255,14 +1264,9 @@ class GraphAgent(BaseAgent):
                 return
 
             if node_type == NodeType.STATIC:
-                static_text = current_node.get("static_message", "") if current_node else ""
-                if static_text:
-                    if self.context_data:
-                        static_text = update_prompt_with_context(static_text, self.context_data)
-                    yield {
-                        "static_message": static_text,
-                        "static_audio_hash": get_md5_hash(static_text),
-                    }
+                chunk = self._static_message_chunk(current_node)
+                if chunk:
+                    yield chunk
                 return
 
             messages = await self._build_messages(message, meta_info=meta_info)

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -433,6 +433,12 @@ def wav_bytes_to_mp3(wav_bytes):
     return buffer.getvalue()
 
 
+def mp3_bytes_to_pcm(mp3_bytes, target_sample_rate=8000):
+    audio = AudioSegment.from_file(io.BytesIO(mp3_bytes), format="mp3")
+    audio = audio.set_frame_rate(target_sample_rate).set_channels(1).set_sample_width(2)
+    return audio.raw_data
+
+
 def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, original_sample_rate=None):
     """
     Resample audio bytes

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -426,6 +426,13 @@ def convert_audio_to_wav(audio_bytes, source_format="flac"):
     return buffer.getvalue()
 
 
+def wav_bytes_to_mp3(wav_bytes):
+    audio = AudioSegment.from_file(io.BytesIO(wav_bytes), format="wav")
+    buffer = io.BytesIO()
+    audio.export(buffer, format="mp3")
+    return buffer.getvalue()
+
+
 def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, original_sample_rate=None):
     """
     Resample audio bytes

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -19,6 +19,9 @@ from .constants import MODEL_REASONING_EFFORT_MAP
 
 AGENT_WELCOME_MESSAGE = "This call is being recorded for quality assurance and training. Please speak now."
 
+# A message that is either a single string or a per-language {lang_code: text} map.
+LocalizedText = Union[str, Dict[str, str]]
+
 
 def validate_attribute(value, allowed_values, value_type="provider"):
     if value not in allowed_values:
@@ -391,7 +394,7 @@ class GraphNode(BaseModel):
     description: Optional[str] = None
     node_type: NodeType = NodeType.LLM
     prompt: str = ""
-    static_message: Optional[str] = None
+    static_message: Optional[LocalizedText] = None
     repeat_after_silence_seconds: Optional[float] = None
     examples: Optional[Dict[str, str]] = None
     edges: List[GraphEdge] = Field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.135"
+version = "0.10.136"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_event_injection_e2e.py
+++ b/tests/tests/test_event_injection_e2e.py
@@ -163,6 +163,7 @@ def _make_task_manager(agent=None, **overrides):
     tm.repeat_after_silence_seconds = None
     tm.conversation_history = ConversationHistory()
     tm.context_data = graph_agent.context_data  # Share context_data with agent
+    tm._language = "en"  # backs the `language` property (real __init__ sets this)
 
     # Task config (minimal)
     tm.task_config = {


### PR DESCRIPTION
## What
Graph-agent `static` nodes can now carry a per-language message. `GraphNode.static_message` accepts either a plain string (unchanged) or a `{lang_code: text}` map, and at runtime the active language's text is selected before it is spoken and hashed for audio caching.

## Why
Multilingual agents that switch language mid-call previously played the single hardcoded (usually English) static message regardless of the caller's language.

## Changes
1. `LocalizedText = Union[str, Dict[str, str]]` alias; `static_message` typed with it.
2. The two identical STATIC emission paths in `graph_agent.py` collapse into one `_static_message_chunk()` helper that resolves the language via the existing `select_message_by_language` before context substitution and hashing, so each language variant caches under its own `md5(text)`.
3. The proactive event path in `task_manager.py` selects by the active `self.language`.

Backward compatible: a plain-string `static_message` behaves exactly as before.

Pairs with the dashboard-backend PR that pre-generates the per-language audio.
