### PR TITLE
fixed the elevan labs eos issue

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.127"
+__version__ = "0.10.128"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.129"
+__version__ = "0.10.130"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/prompts.py
+++ b/bolna/prompts.py
@@ -159,7 +159,6 @@ Return a single JSON object. Each key is a field name in snake_case. Each value 
 """
 
 
-
 CONVERSATION_SUMMARY_PROMPT = """
 Your job is to create the persona of users on based of previous messages in a conversation between an AI persona and a human to maintain a persona of user from assistant's perspective.
 Messages sent by the AI are marked with the 'assistant' role.

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -97,7 +97,9 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         return audio, {"text_synthesized": text_synthesized}
 
     def _on_push(self, meta_info, text):
-        if not self.context_id:
+        # Mint only for pushes that will actually synthesize — a superseded push must not
+        # advance current_turn_context_id, or the prior turn's real isFinal gets suppressed.
+        if not self.context_id and self.should_synthesize_response(meta_info.get("sequence_id")):
             self.context_id = str(uuid.uuid4())
             self.current_turn_context_id = self.context_id
 

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -73,6 +73,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         self.context_id = None
         self.context_ids_to_ignore = set()
         self._eos_context_id = None  # context the last end-of-stream was emitted for
+        self.current_turn_context_id = None  # survives close_context, unlike context_id
         self.ws_send_time = None
         self.ws_trace_id = None
         self.current_turn_ttfb = None
@@ -98,6 +99,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
     def _on_push(self, meta_info, text):
         if not self.context_id:
             self.context_id = str(uuid.uuid4())
+            self.current_turn_context_id = self.context_id
 
     # ------------------------------------------------------------------
     # Format helper
@@ -112,14 +114,18 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
 
     async def handle_interruption(self):
         try:
+            # Also covers a context already closed at end_of_llm_stream but still draining frames.
+            if self.current_turn_context_id:
+                self.context_ids_to_ignore.add(self.current_turn_context_id)
+                self.current_turn_context_id = None
+                # The interrupted context's end-of-stream is now dropped, so the
+                # next turn must be re-detected as new to clear stale queue entries.
+                self.current_turn_start_time = None
             if self.context_id:
                 self.context_ids_to_ignore.add(self.context_id)
                 interrupt_message = {"context_id": self.context_id, "close_context": True}
                 await self.websocket.send(json.dumps(interrupt_message))
                 self.context_id = None
-                # The interrupted context's end-of-stream is now dropped, so the
-                # next turn must be re-detected as new to clear stale queue entries.
-                self.current_turn_start_time = None
         except Exception:
             pass
 
@@ -269,9 +275,15 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 else:
                     logger.info("No audio data in the response")
 
+                # A stale (previous-turn) context's frames must never end the current turn's stream.
+                is_stale_context = (
+                    ctx is not None and self.current_turn_context_id is not None and ctx != self.current_turn_context_id
+                )
+                if emit_eos and is_stale_context:
+                    logger.info(f"Suppressing end-of-stream from stale context {ctx}")
                 # isFinal and the text-match can both fire within one turn; emit end-of-stream
                 # only once per context.
-                if emit_eos and not (ctx is not None and ctx == self._eos_context_id):
+                elif emit_eos and not (ctx is not None and ctx == self._eos_context_id):
                     self._eos_context_id = ctx
                     yield b"\x00", ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.129"
+version = "0.10.130"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.127"
+version = "0.10.128"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_elevenlabs_close_context_eos.py
+++ b/tests/test_elevenlabs_close_context_eos.py
@@ -3,6 +3,7 @@ isFinal, with a text-match backstop and per-context dedup so each turn emits one
 
 import asyncio
 import base64
+from types import SimpleNamespace
 import json
 
 from websockets.exceptions import ConnectionClosed
@@ -220,3 +221,29 @@ def test_on_push_stamps_turn_context_surviving_close():
     minted = synth.context_id
     synth.context_id = None  # close_context
     assert synth.current_turn_context_id == minted
+
+
+def test_superseded_push_does_not_advance_turn_context():
+    """A push for an invalidated sequence must not mint/advance the turn context —
+    otherwise the prior turn's real isFinal is suppressed with no successor EOS."""
+    synth = _make_synth()
+    synth.task_manager_instance = SimpleNamespace(is_sequence_id_in_current_ids=lambda sid: False)
+    synth.current_turn_context_id = "ctx-a"
+
+    synth._on_push({"sequence_id": 99}, "stale text")
+
+    assert synth.context_id is None, "superseded push must not mint a context"
+    assert synth.current_turn_context_id == "ctx-a", "turn context pointer must not advance"
+
+    synth.ws_send_time = 1.0
+    synth.websocket = FakeWS([_final_msg("ctx-a")])
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1, "prior turn's isFinal must still emit end-of-stream"
+
+
+def test_valid_push_advances_turn_context():
+    """A push for a live sequence mints the context and advances the turn pointer."""
+    synth = _make_synth()
+    synth._on_push({"sequence_id": 5}, "hello")
+    assert synth.context_id is not None
+    assert synth.current_turn_context_id == synth.context_id

--- a/tests/test_elevenlabs_close_context_eos.py
+++ b/tests/test_elevenlabs_close_context_eos.py
@@ -133,3 +133,90 @@ def test_sender_does_not_close_when_not_end_of_stream():
 
     assert not any(m.get("close_context") for m in synth.websocket.sent)
     assert synth.context_id == "ctx-live"
+
+
+def test_stale_context_text_match_suppressed():
+    """A draining previous-turn chunk whose tail matches the new turn's text must not
+    emit end-of-stream (call 8909c48c: two turns ending in the same phrase)."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.last_text_sent = True
+    synth.current_text = "क्या आपके पास एक और hold है जिसके बारे में आप बात करना चाहेंगे?"
+    synth.current_turn_context_id = "ctx-new"
+    synth.websocket = FakeWS(
+        [
+            _audio_msg("ctx-old", "बात करना चाहेंगे?"),  # stale context, same trailing phrase
+            _audio_msg("ctx-new", "बात करना चाहेंगे?"),
+        ]
+    )
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1, "only the current context's tail may emit end-of-stream"
+    assert items[-1][0] == b"\x00", "end-of-stream must come after the current context's audio"
+
+
+def test_stale_isfinal_suppressed():
+    """A stale context's late isFinal must not end the current turn's stream."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.current_turn_context_id = "ctx-new"
+    synth.websocket = FakeWS([_final_msg("ctx-old"), _final_msg("ctx-new")])
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1, "stale isFinal must be suppressed, current one must fire"
+
+
+def test_isfinal_ungated_without_current_turn_context():
+    """With no current turn context tracked, isFinal behaves as before (no hang risk)."""
+    synth = _make_synth()
+    synth.ws_send_time = 1.0
+    synth.websocket = FakeWS([_final_msg("ctx-any")])
+    items = asyncio.run(_collect(synth.receiver()))
+    assert len(_end_markers(items)) == 1
+
+
+def test_handle_interruption_blacklists_closed_draining_context():
+    """Interruption after close_context (context_id already None) must still blacklist
+    the turn's context so its draining frames are dropped entirely."""
+    synth = _make_synth()
+    synth.context_id = None
+    synth.current_turn_context_id = "ctx-old"
+    synth.websocket = FakeWS([])
+
+    asyncio.run(synth.handle_interruption())
+
+    assert "ctx-old" in synth.context_ids_to_ignore
+    assert synth.current_turn_context_id is None
+    assert synth.current_turn_start_time is None
+
+    synth.ws_send_time = 1.0
+    synth.last_text_sent = True
+    synth.current_text = "x"
+    synth.websocket = FakeWS([_audio_msg("ctx-old", "anything at all"), _final_msg("ctx-old")])
+    items = asyncio.run(_collect(synth.receiver()))
+    assert items == [], "blacklisted context frames must be dropped before any EOS logic"
+
+
+def test_handle_interruption_live_context_still_closes():
+    """Live-context interruption keeps its original behavior and also clears turn tracking."""
+    synth = _make_synth()
+    synth.context_id = "ctx-live"
+    synth.current_turn_context_id = "ctx-live"
+    synth.websocket = FakeWS([])
+
+    asyncio.run(synth.handle_interruption())
+
+    assert any(m.get("close_context") for m in synth.websocket.sent)
+    assert "ctx-live" in synth.context_ids_to_ignore
+    assert synth.context_id is None
+    assert synth.current_turn_context_id is None
+
+
+def test_on_push_stamps_turn_context_surviving_close():
+    """_on_push mints the context and stamps current_turn_context_id, which survives close."""
+    synth = _make_synth()
+    synth._on_push({}, "hello")
+    assert synth.context_id is not None
+    assert synth.current_turn_context_id == synth.context_id
+
+    minted = synth.context_id
+    synth.context_id = None  # close_context
+    assert synth.current_turn_context_id == minted


### PR DESCRIPTION
Issue

On call 8909c48c-1afa-43d1-93f7-53cd7b3c03c3, the transcript showed the full LLM response but the caller heard almost none of it — only the tail of the previous turn. Both turns ended with the identical phrase ("…बात करना चाहेंगे?").

Root cause chain:

1. The ElevenLabs sender nulls context_id when a turn ends normally (close_context at end_of_llm_stream) — but that context's audio frames are still draining from ElevenLabs.
2. When the user barged in, handle_interruption found context_id = None and did nothing — the closed-but-draining context became invisible to the interruption machinery, so its frames kept flowing through the receiver.
3. One of those stale frames ended with the same phrase as the new turn's text, tripping the receiver's text-match end-of-stream heuristic (which compares against the shared mutable current_text, unscoped to context) — a false end_of_synthesizer_stream fired ~200ms into the new turn.
4. The false EOS caused on_successful_response_delivered → retire_sequence_id, so when the new turn's real audio arrived moments later, every chunk was dropped (Skipping message with sequence_id).

The transcript still showed the full text because assistant history is committed on first-chunk send, and the heard-text reconciliation (sync_history) never ran — the sequence was falsely marked successfully delivered.

The same misattribution also exists via isFinal: a stale context's late isFinal pops the new turn's meta_info from the FIFO and can retire it prematurely, even without a shared phrase.

Fix

Confined to elevenlabs_synthesizer.py:

1. current_turn_context_id — stamped in _on_push when the context is minted; unlike context_id, it survives close_context, keeping the draining context attributable.
2. handle_interruption blacklists it into context_ids_to_ignore (in addition to the live context_id), so a closed-but-draining context's frames are dropped by the existing ignore mechanism; also resets current_turn_start_time in that path so the next turn is re-detected as new.
3. Receiver EOS gate — end-of-stream (from either the text-match or isFinal branch) is suppressed when the frame's contextId differs from current_turn_context_id.

Why safe

- No hang risk (the stuck-audio_playing failure mode): suppression is only possible when a successor turn exists — whose own EOS sets the flags. With no successor, the gate always passes and behavior is byte-identical to before.
- No audio truncation: only EOS attribution is gated; audio yielding is untouched, so legitimately-draining tails (filler flows) still play.
- Zero base-class / task_manager changes — other stream synthesizers unaffected.