### PR TITLE
fixed the llm not sent issue

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.128"
+__version__ = "0.10.129"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4550,11 +4550,12 @@ class TaskManager(BaseManager):
                             transcript_content[:120],
                         )
 
+                        # response_in_pipeline deliberately not counted: with no audio playing yet, a short
+                        # speech_final is a split-utterance tail — _handle_transcriber_output merges it.
                         if self.interruption_manager.is_false_interruption(
                             word_count=word_count,
                             transcript=transcript_content,
-                            is_audio_playing=self.tools["input"].is_audio_being_played_to_user()
-                            or self.response_in_pipeline,
+                            is_audio_playing=self.tools["input"].is_audio_being_played_to_user(),
                             welcome_played=self.tools["input"].welcome_message_played(),
                         ):
                             logger.info(

--- a/bolna/prompts.py
+++ b/bolna/prompts.py
@@ -159,7 +159,6 @@ Return a single JSON object. Each key is a field name in snake_case. Each value 
 """
 
 
-
 CONVERSATION_SUMMARY_PROMPT = """
 Your job is to create the persona of users on based of previous messages in a conversation between an AI persona and a human to maintain a persona of user from assistant's perspective.
 Messages sent by the AI are marked with the 'assistant' role.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.128"
+version = "0.10.129"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_split_utterance_tail_not_dropped.py
+++ b/tests/tests/test_split_utterance_tail_not_dropped.py
@@ -1,0 +1,100 @@
+"""Short speech_final transcripts must not be dropped while the agent is only
+thinking (response_in_pipeline=True, no audio playing).
+
+Reproduces call 032a233d: Deepgram force-finalized "hello" mid-utterance and
+dispatched it to the LLM; the real speech_final tail "हिंदी में" (2 words) arrived
+1s later and was discarded as a "false interruption" because the guard counted
+response_in_pipeline as audio playing. The user's request for Hindi never
+reached the LLM. The fix: only actual audio playback gates the drop —
+_handle_transcriber_output already merges the tail and supersedes the in-flight
+LLM turn (pop_and_merge_user + cancel/regenerate).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.agent_manager.interruption_manager import InterruptionManager
+
+
+_TAIL_FINAL = {
+    "data": {"type": "transcript", "content": " हिंदी में"},
+    "meta_info": {"io": "plivo", "sequence_id": 2, "request_id": "req-1"},
+}
+
+
+def _make_tm(*, audio_playing, response_in_pipeline, function_call_in_flight=False):
+    tm = MagicMock()
+    tm.hangup_triggered = False
+    tm._end_call_in_progress = False
+    tm.has_transfer = False
+    tm.stream = True
+    tm.history = []
+    tm.response_in_pipeline = response_in_pipeline
+    tm.function_call_in_flight = function_call_in_flight
+    tm.output_task = MagicMock()
+    tm.eager_llm_task = None
+    tm.transcriber_output_queue = asyncio.Queue()
+    tm.process_transcriber_request = AsyncMock(return_value=0)
+    tm._set_call_details = MagicMock()
+    tm._get_next_step = MagicMock(return_value="llm")
+    tm.tools = {"input": MagicMock(), "transcriber": MagicMock()}
+    tm.tools["input"].welcome_message_played = MagicMock(return_value=True)
+    tm.tools["input"].is_audio_being_played_to_user = MagicMock(return_value=audio_playing)
+    tm.interruption_manager = InterruptionManager(number_of_words_for_interruption=2)
+    tm._maybe_update_tts_language = AsyncMock()
+    tm._handle_transcriber_output = AsyncMock()
+    tm._TaskManager__get_updated_meta_info = MagicMock(side_effect=lambda m: m)
+    tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
+    tm._end_call_on_component_error = AsyncMock()
+    tm.task_config = {"tools_config": {"transcriber": {"provider": "deepgram"}}}
+    tm._should_ignore_transcriber_input = TaskManager._should_ignore_transcriber_input.__get__(tm, TaskManager)
+    tm._listen_transcriber = TaskManager._listen_transcriber.__get__(tm, TaskManager)
+    return tm
+
+
+async def _drive(tm, message=_TAIL_FINAL):
+    await tm.transcriber_output_queue.put(message)
+    try:
+        await asyncio.wait_for(tm._listen_transcriber(), timeout=0.3)
+    except asyncio.TimeoutError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_tail_processed_while_llm_generating_no_audio():
+    # The 032a233d repro: agent thinking, nothing playing — tail must reach the LLM path.
+    tm = _make_tm(audio_playing=False, response_in_pipeline=True)
+    await _drive(tm)
+    tm._handle_transcriber_output.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_short_final_still_dropped_while_audio_playing():
+    # Real barge-in protection unchanged: short finals during agent SPEECH stay dropped.
+    tm = _make_tm(audio_playing=True, response_in_pipeline=False)
+    await _drive(tm)
+    tm._handle_transcriber_output.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tail_deferred_not_processed_during_tool_call():
+    # function_call_in_flight ordering intact: no cancel/regenerate mid tool call.
+    tm = _make_tm(audio_playing=False, response_in_pipeline=True, function_call_in_flight=True)
+    await _drive(tm)
+    tm._handle_transcriber_output.assert_not_awaited()
+    tm._TaskManager__cleanup_downstream_tasks.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_long_final_processed_while_audio_playing():
+    # 3+ words exceeds number_of_words_for_interruption=2 — never treated as false interruption.
+    tm = _make_tm(audio_playing=True, response_in_pipeline=False)
+    long_final = {
+        "data": {"type": "transcript", "content": "मुझे हिंदी में बात करनी है"},
+        "meta_info": {"io": "plivo", "sequence_id": 2, "request_id": "req-1"},
+    }
+    await _drive(tm, long_final)
+    tm._handle_transcriber_output.assert_awaited_once()


### PR DESCRIPTION
## Issue

On call 032a233d-b31e-41ba-9952-34305654f60b, the user said "hello… हिंदी में"
(asking to continue in Hindi). The ASR transcribed everything — but the LLM only
ever received "hello" and replied "Okay, I will continue in English then…". The
user's actual request never reached the LLM and appears nowhere in conversation
history, despite being visible in raw ASR data.

Root cause — two mechanisms interacting:

1. Deepgram sent interims but no finalization for 1.4s (user mid-sentence), so
   monitor_utterance_timeout force-finalized the partial "hello" and dispatched
   it to the LLM → response_in_pipeline=True.

2. The real speech_final tail " हिंदी में" (2 words) arrived 1s later. The
   false-interruption guard in _listen_transcriber computes
   is_audio_playing = is_audio_being_played_to_user() OR response_in_pipeline —
   so with the LLM still generating and no audio playing, the 2-word transcript
   (<= number_of_words_for_interruption=2) was classified as an accidental
   barge-in and silently discarded.

The guard exists to ignore short backchannel noise while the agent is SPEAKING.
Here the agent was silent and the user was finishing a sentence that the
force-finalize had artificially split. The loss is general: any utterance
Deepgram splits into two finals with a short tail during LLM generation loses
the tail — force-finalize is just one trigger.

## Fix

One-line semantic change: the guard now receives
is_audio_playing=is_audio_being_played_to_user() only — response_in_pipeline no
longer counts as "audio playing".

- Agent speaking → short finals still dropped (real barge-in protection
  unchanged).
- Agent thinking (LLM generating, silent) → the final flows to
  _handle_transcriber_output, whose existing machinery merges it with the
  pending user turn (pop_and_merge_user → "hello हिंदी में") and
  cancels/regenerates the in-flight LLM task — one response, full context.

## Why safe

- No back-to-back responses (the reason `or response_in_pipeline` was added in
  2a4a2a0): that same commit also added the cancel-existing-llm_task logic in
  _handle_transcriber_output, which alone guarantees a single response.
  Duplicate finals are separately rejected by is_duplicate_user.
- No double tool execution: the function_call_in_flight defer branch sits AFTER
  this guard — short finals during a live tool call are deferred, never cancel
  it.
- Eager/speculative path untouched: response_in_pipeline stays False during the
  speculative window, so the drop could never fire there anyway.
- Trade-off: genuine 1-2-word noise during the 1-3s thinking window now costs
  one LLM regeneration instead of being free — correctness over latency; user
  content can no longer be silently deleted.
