### PR TITLE
feat: add optional on_turn_usage per-turn callback hook

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.130"
+__version__ = "0.10.131"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3411,9 +3411,10 @@ class TaskManager(BaseManager):
         reasoning_content=None,
     ):
         self.llm_response_generated = True
-        # task 0 only, so aux LLMs (hangup/voicemail) never tally.
+        # task 0 only, so aux LLMs (hangup/voicemail) never tally. Report input/output/cached so the
+        # consumer can compute normalized load (cached is exempt, output is weighted).
         if self.task_id == 0 and self.on_turn_usage and input_tokens:
-            _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens))
+            _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens, output_tokens, cached_tokens))
             self._usage_tasks.add(_usage_task)
             _usage_task.add_done_callback(self._usage_tasks.discard)
         convert_to_request_log(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -228,6 +228,9 @@ class TaskManager(BaseManager):
         super().__init__()
         self.kwargs = kwargs
         self.kwargs["task_manager_instance"] = self
+        # Optional load-signal callback (set by the caller only for PTU-served calls).
+        self.on_turn_usage = kwargs.get("on_turn_usage")
+        self._usage_tasks = set()  # strong refs so fire-and-forget tallies aren't GC'd before they run
 
         self.conversation_start_init_ts = time.time() * 1000
         self.llm_latencies = ComponentLatencies()
@@ -3408,6 +3411,11 @@ class TaskManager(BaseManager):
         reasoning_content=None,
     ):
         self.llm_response_generated = True
+        # task 0 only, so aux LLMs (hangup/voicemail) never tally.
+        if self.task_id == 0 and self.on_turn_usage and input_tokens:
+            _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens))
+            self._usage_tasks.add(_usage_task)
+            _usage_task.add_done_callback(self._usage_tasks.discard)
         convert_to_request_log(
             message=llm_response,
             meta_info=meta_info,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.130"
+version = "0.10.131"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Adds an optional `on_turn_usage` callback to `TaskManager`. When a caller passes it in kwargs, the conversation task (task 0) invokes it after each LLM request with that request's input token count, fire-and-forget. No-op when not provided, and no new dependency, it lets an embedding caller collect a per-request usage signal without coupling the engine to any store.