### PR TITLE
feat: enable graph agents on PTU + priority routing

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.172"
+__version__ = "0.10.173"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1755,6 +1755,10 @@ class TaskManager(BaseManager):
                 injected_cfg["routing_reasoning_effort"] = self.kwargs["routing_reasoning_effort"]
             if "routing_max_tokens" in self.kwargs:
                 injected_cfg["routing_max_tokens"] = self.kwargs["routing_max_tokens"]
+            # Set when the caller serves the conversation LLM from a different backend than the agent's own.
+            for key in ("aux_model", "aux_provider", "route_routing_to_conversation"):
+                if key in self.kwargs:
+                    injected_cfg[key] = self.kwargs[key]
             if self.llm_config.get("use_responses_api"):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
@@ -3691,6 +3695,23 @@ class TaskManager(BaseManager):
                                 "service_tier": routing_usage.get("service_tier"),
                             }
                         )
+
+                    # on_turn_usage meters the conversation LLM's backend; routing on azure means the routing
+                    # hop shares that backend, so its tokens draw on the same capacity.
+                    if (
+                        self.on_turn_usage
+                        and routing_info.get("routing_provider") == "azure"
+                        and routing_usage.get("input_tokens")
+                    ):
+                        _routing_task = asyncio.create_task(
+                            self.on_turn_usage(
+                                routing_usage.get("input_tokens"),
+                                routing_usage.get("output_tokens"),
+                                routing_usage.get("cached_tokens"),
+                            )
+                        )
+                        self._usage_tasks.add(_routing_task)
+                        _routing_task.add_done_callback(self._usage_tasks.discard)
 
                     if routing_info.get("node_history"):
                         self.routing_latencies["node_flow"] = list(routing_info["node_history"])

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -110,14 +110,21 @@ class GraphAgent(BaseAgent):
         # Initialize main LLM for response generation (supports api_tools/function calling + real streaming)
         self.llm = self._initialize_llm()
 
-        # Initialize LLMs for hangup and voicemail detection
+        # Hangup/voicemail run on OpenAiLLM, which has no Azure support, so an Azure conversation LLM
+        # cannot serve them and they fall back to the platform OpenAI key.
+        aux_provider = self.config.get("aux_provider") or self.config.get("provider") or "openai"
+        aux_model = (self.config.get("aux_model") or self.llm_model or "").split("/", 1)[-1]
         llm_kwargs = {}
-        if self.llm_key:
-            llm_kwargs["llm_key"] = self.llm_key
-        if self.base_url:
-            llm_kwargs["base_url"] = self.base_url
+        if aux_provider == "azure" and os.getenv("OPENAI_API_KEY"):
+            llm_kwargs["llm_key"] = os.getenv("OPENAI_API_KEY")
+        else:
+            # No platform key to fall back to, so keep the agent's own creds rather than fail construction.
+            if self.llm_key:
+                llm_kwargs["llm_key"] = self.llm_key
+            if self.base_url:
+                llm_kwargs["base_url"] = self.base_url
         self.conversation_completion_llm = OpenAiLLM(
-            model=os.getenv("CHECK_FOR_COMPLETION_LLM", self.llm_model or "gpt-4o-mini"), **llm_kwargs
+            model=os.getenv("CHECK_FOR_COMPLETION_LLM", aux_model or "gpt-4o-mini"), **llm_kwargs
         )
         self.voicemail_llm = OpenAiLLM(model=os.getenv("VOICEMAIL_DETECTION_LLM", "gpt-4.1-mini"), **llm_kwargs)
 
@@ -238,6 +245,16 @@ class GraphAgent(BaseAgent):
         # Auto-detect provider if not specified
         if not self.routing_provider:
             self.routing_provider = "groq" if groq_available else "openai"
+
+        # Point routing at whatever backend the conversation LLM ended up on. Groq routing stays put: it is
+        # the faster hop and does not share the conversation provider anyway.
+        if self.config.get("route_routing_to_conversation") and not (
+            self.routing_provider == "groq" and groq_available
+        ):
+            self.routing_provider = self.config.get("provider") or self.routing_provider
+            conv_model = self.config.get("model")
+            if conv_model:
+                self.routing_model = conv_model.split("/", 1)[-1]
 
         if self.routing_provider == "groq":
             if groq_available:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.172"
+version = "0.10.173"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
When a graph agent's conversation LLM is swapped to a different provider/endpoint (e.g. an Azure provisioned deployment or OpenAI priority), its node-routing and hangup/voicemail LLMs previously broke because all four share one credential set.

This decouples them: the conversation LLM and the node-routing LLM take the swapped credentials, while the hangup/voicemail LLMs keep the caller-provided original credentials and model via new `aux_llm_key` / `aux_base_url` / `aux_model` config keys. Routing usage that lands on the swapped provisioned deployment is also reported to the `on_turn_usage` callback so load accounting stays accurate.

Backward-compatible: without the new keys, graph agents behave exactly as before.