### PR TITLE
fix: reset audio flag after handle_interruption in is-user-online branch

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.132"
+__version__ = "0.10.133"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6289,6 +6289,13 @@ class TaskManager(BaseManager):
                         await self._synthesize(create_ws_data_packet(user_online_message, meta_info=meta_info))
                     self.conversation_history.append_assistant(user_online_message, exclude_from_llm=True)
 
+                    # Explicitly reset the audio flag after synthesizing the prompt.
+                    # handle_interruption() below sends clearAudio to Plivo and wipes the
+                    # mark dictionary, so the final-chunk mark echo will never arrive and
+                    # is_audio_being_played would stay stuck True forever — blocking the
+                    # silence-hangup gate in this loop indefinitely.
+                    self.tools["input"].update_is_audio_being_played(False)
+
                 # Just in case we need to clear messages sent before
                 await self.tools["output"].handle_interruption()
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.132"
+version = "0.10.133"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
When the "are you still there?" prompt is synthesized and then handle_interruption() is called immediately after, Plivo discards the queued audio (clearAudio) and the mark dictionary is wiped (clear_data). This means the final-chunk mark echo from Plivo never arrives, leaving is_audio_being_played_to_user() stuck True forever.

The audio gate in __check_for_completion (line 6213) then hits `continue` on every 2s tick, permanently blocking the silence-hangup path. The call runs until Plivo's 300s carrier max-duration kills it instead of hanging up cleanly at hangup_after_silence.

Fix: explicitly reset the audio flag to False right after handle_interruption() since cleared audio can never produce a completion mark and the flag must reflect that reality.

Fixes deterministic 300s call duration for silent callers on Plivo when check_if_user_online=true and trigger_user_online_message_after < hangup_after_silence.