### PR TITLE
Migrate Smallest STT/TTS to unified Waves endpoints + X-Source tracking

### DIFF
--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -15,10 +15,13 @@ logger = configure_logger(__name__)
 
 
 class SmallestSynthesizer(StreamSynthesizer):
+    # Attribution tag sent to Smallest AI so requests are tracked as bolna traffic.
+    SOURCE = "bolna"
+
     def __init__(
         self,
         voice_id,
-        model="lightning",
+        model="lightning_v3.1",
         language="en",
         audio_format="mp3",
         sampling_rate="8000",
@@ -39,8 +42,10 @@ class SmallestSynthesizer(StreamSynthesizer):
         self.sampling_rate = int(sampling_rate)
         self.language = language
 
-        self.api_url = f"https://waves-api.smallest.ai/api/v1/{self.model}/get_speech"
-        self.ws_url = "wss://waves-api.smallest.ai/api/v1/lightning-v2/get_speech/stream?timeout=60"
+        # Unified Waves endpoints (docs.smallest.ai -> /text-to-speech).
+        # HTTP: POST /waves/v1/tts, streaming: WSS /waves/v1/tts/live
+        self.api_url = "https://api.smallest.ai/waves/v1/tts"
+        self.ws_url = "wss://api.smallest.ai/waves/v1/tts/live"
 
     # ------------------------------------------------------------------
     # StreamSynthesizer hooks
@@ -53,6 +58,7 @@ class SmallestSynthesizer(StreamSynthesizer):
         return {
             "voice_id": self.voice_id,
             "text": text,
+            "model": self.model,
             "language": self.language,
             "sample_rate": self.sampling_rate,
         }
@@ -134,7 +140,10 @@ class SmallestSynthesizer(StreamSynthesizer):
             websocket = await asyncio.wait_for(
                 websockets.connect(
                     self.ws_url,
-                    additional_headers={"Authorization": f"Token {self.api_key}"},
+                    additional_headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "X-Source": self.SOURCE,
+                    },
                     ssl=get_ssl_context(self.ws_url),
                 ),
                 timeout=10.0,
@@ -163,10 +172,16 @@ class SmallestSynthesizer(StreamSynthesizer):
         payload = {
             "text": text,
             "voice_id": self.voice_id,
+            "model": self.model,
             "sample_rate": self.sampling_rate,
-            "add_wav_header": False,
+            "output_format": self._get_audio_format(),
         }
-        headers = {"Authorization": f"Bearer {self.api_key}", "Content-Type": "application/json"}
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            "Accept": "audio/wav",
+            "X-Source": self.SOURCE,
+        }
         async with aiohttp.ClientSession() as session:
             async with session.post(self.api_url, headers=headers, json=payload) as response:
                 if response.status == 200:

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -22,15 +22,18 @@ logger = configure_logger(__name__)
 
 class SmallestTranscriber(BaseTranscriber):
     """
-    Streaming transcriber using Smallest AI Lightning ASR WebSocket API.
+    Streaming transcriber using Smallest AI Pulse STT WebSocket API.
 
-    Smallest AI Lightning ASR is optimized for:
-    - Sub-300ms time-to-first-transcript latency
-    - High accuracy across 24+ languages
+    Smallest AI Pulse is optimized for:
+    - 64ms time-to-first-transcript latency
+    - High accuracy across 38 languages with auto-detect
     - Real-time streaming without waiting for complete audio
 
-    API Documentation: https://waves-docs.smallest.ai/v4.0.0/content/api-references/lightning-asr-ws
+    API Documentation: https://docs.smallest.ai/waves/documentation/speech-to-text-pulse/realtime-web-socket/quickstart
     """
+
+    # Attribution tag sent to Smallest AI so requests are tracked as bolna traffic.
+    SOURCE = "bolna"
 
     def __init__(
         self,
@@ -42,7 +45,7 @@ class SmallestTranscriber(BaseTranscriber):
         endpointing: str = "400",
         encoding: str = "linear16",
         sampling_rate: str = "16000",
-        model: str = None,
+        model: str = "pulse",
         keywords: str = None,
         word_timestamps: bool = True,
         process_interim_results: str = "true",
@@ -62,7 +65,7 @@ class SmallestTranscriber(BaseTranscriber):
 
         # API configuration
         self.api_key = kwargs.get("transcriber_key", os.getenv("SMALLEST_API_KEY"))
-        self.smallest_host = os.getenv("SMALLEST_HOST", "waves-api.smallest.ai")
+        self.smallest_host = os.getenv("SMALLEST_HOST", "api.smallest.ai")
 
         # Queues
         self.transcriber_output_queue = output_queue
@@ -150,7 +153,7 @@ class SmallestTranscriber(BaseTranscriber):
 
     def get_smallest_ws_url(self) -> str:
         """
-        Build the WebSocket URL for Smallest AI Lightning ASR.
+        Build the WebSocket URL for Smallest AI Pulse STT.
 
         Query params:
         - language: Language code (en, hi, multi, etc.)
@@ -159,6 +162,7 @@ class SmallestTranscriber(BaseTranscriber):
         - word_timestamps: Enable word-level timing
         """
         params = {
+            "model": self.model or "pulse",  # required by the Pulse live endpoint
             "language": self.language,
             "sample_rate": str(self.sampling_rate),
         }
@@ -171,7 +175,8 @@ class SmallestTranscriber(BaseTranscriber):
         if self.word_timestamps:
             params["word_timestamps"] = "true"
 
-        websocket_url = f"wss://{self.smallest_host}/api/v1/lightning/get_text?{urlencode(params)}"
+        # Unified Waves endpoint (docs.smallest.ai -> /speech-to-text): WSS /waves/v1/stt/live
+        websocket_url = f"wss://{self.smallest_host}/waves/v1/stt/live?{urlencode(params)}"
         logger.info(
             f"Smallest WebSocket URL params - language: {self.language}, sample_rate: {self.sampling_rate}, encoding: {self.encoding}, word_timestamps: {self.word_timestamps}"
         )
@@ -187,7 +192,10 @@ class SmallestTranscriber(BaseTranscriber):
         while attempt < retries:
             try:
                 websocket_url = self.get_smallest_ws_url()
-                additional_headers = {"Authorization": f"Bearer {self.api_key}"}
+                additional_headers = {
+                    "Authorization": f"Bearer {self.api_key}",
+                    "X-Source": self.SOURCE,
+                }
 
                 logger.info(f"Attempting to connect to Smallest AI WebSocket: {websocket_url}")
 
@@ -390,8 +398,8 @@ class SmallestTranscriber(BaseTranscriber):
     async def _close_smallest(self, ws: ClientConnection):
         """Send end signal and close WebSocket."""
         try:
-            # Send Smallest AI end signal
-            end_msg = {"type": "end"}
+            # Send Smallest AI end signal (Pulse live expects "close_stream")
+            end_msg = {"type": "close_stream"}
             await ws.send(json.dumps(end_msg))
             await ws.close()
         except Exception as e:


### PR DESCRIPTION
Migrates the Smallest AI transcriber and synthesizer from the legacy `waves-api.smallest.ai` endpoints to the current unified Waves API (`api.smallest.ai/waves/v1/...`), and adds source tracking so requests are attributed to bolna.

## TTS — `bolna/synthesizer/smallest_synthesizer.py`
- HTTP: `waves-api.smallest.ai/api/v1/{model}/get_speech` → `https://api.smallest.ai/waves/v1/tts`
- Streaming WS: `.../lightning-v2/get_speech/stream` → `wss://api.smallest.ai/waves/v1/tts/live`
- WS auth header `Token` → `Bearer` (new API requirement)
- HTTP body now sends `model` + `output_format` (replaces `add_wav_header`) with `Accept: audio/wav`
- Default model `lightning` → `lightning_v3.1`; `lightning_v3.1_pro` is selectable via config (`SmallestConfig.model` is passed straight into the request body — same route for both)

## STT — `bolna/transcriber/smallest_transcriber.py`
- WS: `waves-api.smallest.ai/api/v1/lightning/get_text` → `api.smallest.ai/waves/v1/stt/live` (Pulse); `SMALLEST_HOST` default updated
- Added the now-required `model` query param (default `pulse`)
- End-of-stream signal `{"type":"end"}` → `{"type":"close_stream"}` (Pulse live protocol)
- Corrected provider naming from "Lightning ASR / 24+ languages" to "Pulse / 38 languages"

## Source tracking
- Adds `X-Source: bolna` header on all TTS (HTTP + WS) and STT (WS) requests

Confirmed the Pulse live response schema (`transcript`/`is_final`/`is_last`/`session_id`/`language`) matches the existing receiver, so no parsing changes were needed.

Docs: [text-to-speech](https://docs.smallest.ai/waves/documentation/text-to-speech-lightning/overview) · [speech-to-text](https://docs.smallest.ai/waves/documentation/speech-to-text-pulse/overview)