### PR TITLE
fix: add utterance timeout monitor to Soniox transcriber

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.136"
+__version__ = "0.10.137"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.139"
+__version__ = "0.10.148"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.137"
+__version__ = "0.10.138"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.138"
+__version__ = "0.10.139"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.148"
+__version__ = "0.10.151"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.134"
+__version__ = "0.10.135"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/soniox_transcriber.py
+++ b/bolna/transcriber/soniox_transcriber.py
@@ -420,6 +420,7 @@ class SonioxTranscriber(BaseTranscriber):
             raise
         except Exception as e:
             logger.error(f"Soniox utterance timeout monitor error: {e}")
+            raise
 
     async def push_to_transcriber_queue(self, data_packet):
         await self.transcriber_output_queue.put(data_packet)

--- a/bolna/transcriber/soniox_transcriber.py
+++ b/bolna/transcriber/soniox_transcriber.py
@@ -71,6 +71,11 @@ class SonioxTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5
         self._resolve_audio_params()
 
+        # Utterance timeout — force-finalize if Soniox never sends endpoint after last interim
+        _interim_timeout = kwargs.get("interim_timeout")
+        self.interim_timeout = float(_interim_timeout) if _interim_timeout is not None else 8.0
+        self.utterance_timeout_task = None
+
         # Connection + task state
         self.websocket_connection = None
         self.connection_authenticated = False
@@ -356,18 +361,74 @@ class SonioxTranscriber(BaseTranscriber):
                         self._reset_turn_state()
 
                 if res.get("finished"):
-                    logger.info("Soniox session finished")
+                    logger.info(
+                        f"Soniox session finished — num_frames={self.num_frames} "
+                        f"audio_submitted={self.audio_submitted} turn_counter={self.turn_counter}"
+                    )
                     break
 
             except Exception as e:
                 logger.error(f"Error processing Soniox message: {e}")
                 traceback.print_exc()
 
+    async def _force_finalize_utterance(self):
+        """Force-finalize a stuck utterance when Soniox never sends the endpoint token."""
+        transcript_to_send = self.final_transcript.strip()
+
+        if not transcript_to_send and self.current_turn_interim_details:
+            transcript_to_send = self.current_turn_interim_details[-1]["transcript"]
+            logger.info(f"Soniox force-finalize: using last interim as fallback: {transcript_to_send}")
+
+        if not transcript_to_send:
+            logger.warning("Soniox force-finalize: no transcript available, resetting turn state")
+            self._reset_turn_state()
+            return
+
+        try:
+            self._build_finalized_turn_latency(transcript_to_send)
+        except Exception as e:
+            logger.error(f"Soniox force-finalize: error building turn latencies: {e}")
+
+        self.meta_info["user_stop_offset_ms"] = self.user_stop_offset_ms
+        if self._last_detected_language:
+            self.meta_info["transcriber_detected_language"] = self._last_detected_language
+
+        data = {"type": "transcript", "content": transcript_to_send, "force_finalized": True}
+        logger.info(f"Soniox force-finalized transcript after timeout: {transcript_to_send}")
+        await self.push_to_transcriber_queue(create_ws_data_packet(data, self.meta_info))
+        self._reset_turn_state()
+
+    async def monitor_utterance_timeout(self):
+        """Monitor for utterances stuck mid-turn — force-finalize if Soniox never sends endpoint."""
+        try:
+            while True:
+                await asyncio.sleep(1.0)
+                if (
+                    self.last_interim_time
+                    and not self.is_transcript_sent_for_processing
+                    and (self.final_transcript.strip() or self.current_turn_interim_details)
+                ):
+                    elapsed = time.time() - self.last_interim_time
+                    if elapsed > self.interim_timeout:
+                        logger.warning(
+                            f"Soniox utterance timeout: no endpoint for {elapsed:.1f}s, "
+                            f"force-finalizing turn {self.current_turn_id}"
+                        )
+                        await self._force_finalize_utterance()
+        except asyncio.CancelledError:
+            logger.info("Soniox utterance timeout monitor cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Soniox utterance timeout monitor error: {e}")
+
     async def push_to_transcriber_queue(self, data_packet):
         await self.transcriber_output_queue.put(data_packet)
 
     async def toggle_connection(self):
         self.connection_on = False
+        if self.utterance_timeout_task is not None:
+            self.utterance_timeout_task.cancel()
+            self.utterance_timeout_task = None
         if self.sender_task is not None:
             self.sender_task.cancel()
         if self.websocket_connection is not None:
@@ -387,6 +448,7 @@ class SonioxTranscriber(BaseTranscriber):
         for task_name, task in [
             ("sender_task", getattr(self, "sender_task", None)),
             ("transcription_task", getattr(self, "transcription_task", None)),
+            ("utterance_timeout_task", getattr(self, "utterance_timeout_task", None)),
         ]:
             if task is not None and not task.done():
                 task.cancel()
@@ -435,6 +497,7 @@ class SonioxTranscriber(BaseTranscriber):
                 self.connection_time = round(timestamp_ms() - start_time)
 
             self.sender_task = asyncio.create_task(self.sender_stream(soniox_ws))
+            self.utterance_timeout_task = asyncio.create_task(self.monitor_utterance_timeout())
 
             try:
                 async for message in self.receiver(soniox_ws):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.148"
+version = "0.10.151"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.137"
+version = "0.10.138"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.134"
+version = "0.10.135"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.136"
+version = "0.10.137"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.139"
+version = "0.10.148"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.138"
+version = "0.10.139"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Soniox uses semantic endpoint detection which can stall indefinitely if audio stops mid-utterance (e.g. due to a degraded/dropped Plivo media stream). Unlike Deepgram and Gladia, Soniox had no monitor_utterance_timeout mechanism to recover from this.

Add _force_finalize_utterance() and monitor_utterance_timeout() to SonioxTranscriber, mirroring the existing Deepgram implementation. If no endpoint token arrives within 8 seconds of the last interim, the accumulated transcript is force-finalized and pushed to the pipeline so the call can continue instead of freezing silently.

The 8s default is intentionally larger than Deepgram's 1.2s because Soniox's semantic endpointing legitimately takes longer on natural pauses. Configurable via interim_timeout kwarg.