### PR TITLE
Use mulaw@8000 for SIP-trunk across transcribers and language-ID

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.136"
+__version__ = "0.10.137"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -45,7 +45,7 @@ class SarvamLID(LIDBackend):
         if self._telephony in ("plivo", "vobiz", "exotel"):
             self._encoding = "linear16"
             self._input_sr = 8000
-        elif self._telephony == "twilio":
+        elif self._telephony in ("twilio", "sip-trunk"):
             self._encoding = "mulaw"
             self._input_sr = 8000
         else:

--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -37,7 +37,7 @@ class SonioxLID(LIDBackend):
         if self._telephony in ("plivo", "vobiz", "exotel"):
             self._audio_format = "pcm_s16le"
             self._input_sr = 8000
-        elif self._telephony == "twilio":
+        elif self._telephony in ("twilio", "sip-trunk"):
             self._audio_format = "mulaw"
             self._input_sr = 8000
         else:

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -84,8 +84,8 @@ class AssemblyAITranscriber(BaseTranscriber):
         """Get the AssemblyAI WebSocket URL with appropriate parameters"""
         connection_params = {"sample_rate": self.sampling_rate, "format_turns": self.format_turns}
 
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            self.encoding = "mulaw" if self.provider in ("twilio") else "linear16"
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2
             connection_params["sample_rate"] = self.sampling_rate
@@ -338,7 +338,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                 audio_data = ws_data_packet.get("data")
                 if isinstance(audio_data, bytes):
                     try:
-                        if self.provider == "twilio" and self.encoding == "mulaw":
+                        if self.provider in ("twilio", "sip-trunk") and self.encoding == "mulaw":
                             audio_data = ulaw2lin(audio_data, 2)
 
                         await ws.send(audio_data)

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -50,8 +50,8 @@ class AzureTranscriber(BaseTranscriber):
         self._turn_start_epoch_ms = None
         self.turn_counter = 0
 
-        if self.audio_provider in ("twilio", "exotel", "plivo"):
-            self.encoding = "mulaw" if self.audio_provider in ("twilio",) else "linear16"
+        if self.audio_provider in ("twilio", "exotel", "plivo", "sip-trunk"):
+            self.encoding = "mulaw" if self.audio_provider in ("twilio", "sip-trunk") else "linear16"
             if self.encoding == "mulaw":
                 self.bits_per_sample = 8
             self.audio_frame_duration = 0.2

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -117,12 +117,12 @@ class ElevenLabsTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5  # Default for 8k samples at 16kHz
         audio_format = "pcm_16000"  # Default
 
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            # Twilio uses mulaw at 8kHz, exotel/plivo use linear16 at 8kHz
-            self.encoding = "mulaw" if self.provider == "twilio" else "linear16"
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+            # Twilio and sip-trunk (Asterisk) send mulaw at 8kHz; exotel/plivo use linear16 at 8kHz
+            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2  # 200ms chunks for telephony
-            audio_format = "ulaw_8000" if self.provider == "twilio" else "pcm_8000"
+            audio_format = "ulaw_8000" if self.provider in ("twilio", "sip-trunk") else "pcm_8000"
 
         elif self.provider == "web_based_call":
             self.encoding = "linear16"

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -131,8 +131,8 @@ class GladiaTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider == "twilio":
-            # Twilio sends mulaw at 8kHz - Gladia supports this natively
+        if self.provider in ("twilio", "sip-trunk"):
+            # Twilio and sip-trunk (Asterisk) send mulaw at 8kHz - Gladia supports this natively
             self.encoding = "wav/ulaw"
             self.sample_rate = 8000
             self.bit_depth = 8
@@ -190,7 +190,7 @@ class GladiaTranscriber(BaseTranscriber):
             "endpointing": self.endpointing,
             "maximum_duration_without_endpointing": self.maximum_duration_without_endpointing,
             "pre_processing": {
-                "audio_enhancer": self.provider in ("twilio", "exotel", "plivo"),
+                "audio_enhancer": self.provider in ("twilio", "exotel", "plivo", "sip-trunk"),
                 "speech_threshold": self.speech_threshold,
             },
             "messages_config": {

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -42,8 +42,8 @@ class GoogleTranscriber(BaseTranscriber):
         self.run_id = run_id or kwargs.get("run_id", "")
 
         # Provider-specific audio configuration
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            self.encoding = "MULAW" if self.provider in ("twilio") else "LINEAR16"
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+            self.encoding = "MULAW" if self.provider in ("twilio", "sip-trunk") else "LINEAR16"
             self.sample_rate_hertz = 8000
         elif self.provider == "web_based_call":
             self.encoding = "LINEAR16"
@@ -73,7 +73,7 @@ class GoogleTranscriber(BaseTranscriber):
         # Audio frame tracking
         self.audio_frame_duration = 0.0
         self.num_frames = 0
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
             self.audio_frame_duration = 0.2
         elif self.provider == "web_based_call":
             self.audio_frame_duration = 0.256

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -105,7 +105,7 @@ class OpenAITranscriber(BaseTranscriber):
         self._configure_audio_params()
 
     def _configure_audio_params(self):
-        if self.telephony_provider == "twilio":
+        if self.telephony_provider in ("twilio", "sip-trunk"):
             self.encoding = "mulaw"
             self.input_sampling_rate = 8000
         elif self.telephony_provider in ("plivo", "exotel", "vobiz"):

--- a/bolna/transcriber/pixa_transcriber.py
+++ b/bolna/transcriber/pixa_transcriber.py
@@ -97,7 +97,7 @@ class PixaTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.telephony_provider == "twilio":
+        if self.telephony_provider in ("twilio", "sip-trunk"):
             self.encoding = "mulaw"
             self.input_sampling_rate = 8000
             self.sampling_rate = 8000

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -107,7 +107,7 @@ class SarvamTranscriber(BaseTranscriber):
             self.input_sampling_rate = 8000
             self.sampling_rate = 16000
             self.audio_frame_duration = 0.2
-        elif self.telephony_provider == "twilio":
+        elif self.telephony_provider in ("twilio", "sip-trunk"):
             self.encoding = "mulaw"
             self.input_sampling_rate = 8000
             self.sampling_rate = 16000

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -122,8 +122,8 @@ class SmallestTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider == "twilio":
-            # Twilio sends mulaw at 8kHz
+        if self.provider in ("twilio", "sip-trunk"):
+            # Twilio and sip-trunk (Asterisk) send mulaw at 8kHz
             self.encoding = "mulaw"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.136"
+version = "0.10.137"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Summary
SIP-trunk (Asterisk/BYOT) streams ulaw@8000, but several transcribers and both language-ID backends had provider gates that omitted `sip-trunk`, so it fell through to a linear16/pcm @ 16000 default and decoded the audio as garbage — breaking ASR (and, via empty transcripts, voicemail/hangup detection) for SIP-trunk agents on those providers.

Only Deepgram and Soniox handled sip-trunk correctly (via `telephony_values()`). This adds sip-trunk to the twilio/mulaw branch across ElevenLabs, Azure, Smallest, Gladia, AssemblyAI, Google, Sarvam, Pixa, and OpenAI transcribers, plus the Sarvam and Soniox language-ID backends — treating it identically to Twilio (mulaw@8000), including the AssemblyAI ulaw→PCM send-time conversion and the Gladia audio enhancer.