### PR TITLE
fix: hold graph routing until a node delivers its first TTS turn (BOLNA-1582)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.139"
+__version__ = "0.10.140"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6215,6 +6215,11 @@ class TaskManager(BaseManager):
                             )
                         self.interruption_manager.on_successful_response_delivered(sequence_id)
                         self.interruption_manager.on_agent_speech_ended()
+                        if (
+                            self.__is_graph_agent()
+                            and message["meta_info"].get("message_category", "") != "is_user_online_message"
+                        ):
+                            self.tools["llm_agent"].mark_first_response_delivered()
                     # Reset asked_if_user_is_still_there flag after any message except is_user_online_message
                     if message["meta_info"].get("message_category", "") != "is_user_online_message":
                         self.asked_if_user_is_still_there = False

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1724,6 +1724,7 @@ class TaskManager(BaseManager):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
+            injected_cfg["turn_based_conversation"] = self.turn_based_conversation
 
             llm_agent = GraphAgent(injected_cfg)
             logger.info("Graph agent created with rag-proxy-server support")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -199,7 +199,9 @@ def build_lid_decision_record(
 HANDOFF_CLIP_CACHE: dict = {}
 HANDOFF_CLIP_CACHE_MAX = 256
 
-_NON_NODE_RESPONSE_CATEGORIES = frozenset({"is_user_online_message", "filler", "backchanneling"})
+_NON_NODE_RESPONSE_CATEGORIES = frozenset(
+    {"is_user_online_message", "filler", "backchanneling", "agent_welcome_message", "handoff"}
+)
 
 
 def trailing_utterance_text(segments, gap_seconds=4.0):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -199,6 +199,8 @@ def build_lid_decision_record(
 HANDOFF_CLIP_CACHE: dict = {}
 HANDOFF_CLIP_CACHE_MAX = 256
 
+_NON_NODE_RESPONSE_CATEGORIES = frozenset({"is_user_online_message", "filler", "backchanneling"})
+
 
 def trailing_utterance_text(segments, gap_seconds=4.0):
     """Text of the caller's LAST utterance: trailing detector segments in the same
@@ -6217,7 +6219,7 @@ class TaskManager(BaseManager):
                         self.interruption_manager.on_agent_speech_ended()
                         if (
                             self.__is_graph_agent()
-                            and message["meta_info"].get("message_category", "") != "is_user_online_message"
+                            and message["meta_info"].get("message_category", "") not in _NON_NODE_RESPONSE_CATEGORIES
                         ):
                             self.tools["llm_agent"].mark_first_response_delivered()
                     # Reset asked_if_user_is_still_there flag after any message except is_user_online_message

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -83,6 +83,7 @@ class GraphAgent(BaseAgent):
         self.current_node_entry_index = 0
         self._silence_repeats = 0
         self._event_triggered_generation = False
+        self._active_node_first_response_delivered = True
         self._last_deterministic_eval = None
         self._frozen_time_vars: Optional[Dict[str, Any]] = None
         self.rag_configs = self.initialize_rag_configs()
@@ -466,6 +467,7 @@ class GraphAgent(BaseAgent):
                 self.current_node_id = edge["to_node_id"]
                 self.current_node_entry_index = 0  # caller should set to len(history)
                 self._silence_repeats = 0
+                self._active_node_first_response_delivered = False
 
                 if self.current_node_id not in self.node_history or self.node_history[-1] != self.current_node_id:
                     self.node_history.append(self.current_node_id)
@@ -674,8 +676,39 @@ class GraphAgent(BaseAgent):
         self.current_node_id = node_id
         self.current_node_entry_index = entry_index
         self._silence_repeats = 0
+        self._active_node_first_response_delivered = False
         if not self.node_history or self.node_history[-1] != self.current_node_id:
             self.node_history.append(self.current_node_id)
+
+    def mark_first_response_delivered(self) -> None:
+        """Unblock routing once the active node's first customer-facing TTS turn is delivered."""
+        self._active_node_first_response_delivered = True
+
+    def _should_hold_for_first_delivery(self, node: Optional[dict]) -> bool:
+        return (
+            node is not None
+            and self._node_type_of(node) == NodeType.LLM
+            and not self._active_node_first_response_delivered
+        )
+
+    def _hold_routing_info(self, is_silence_trigger: bool) -> dict:
+        return {
+            "previous_node": self.current_node_id,
+            "current_node": self.current_node_id,
+            "transitioned": False,
+            "routing_type": "hold",
+            "routing_model": None,
+            "routing_provider": None,
+            "routing_latency_ms": None,
+            "extracted_params": {},
+            "node_history": list(self.node_history),
+            "routing_messages": None,
+            "routing_tools": None,
+            "reasoning": f"{_DETERMINISTIC_REASONING_PREFIX}hold:first_response_undelivered",
+            "confidence": 1.0,
+            "node_type": self._node_type_of(self.get_node_by_id(self.current_node_id)),
+            "is_silence_trigger": is_silence_trigger,
+        }
 
     def _end_turn_chunk(self, meta_info: Optional[dict], start_time: float) -> LLMStreamChunk:
         """Terminal empty end-of-stream chunk for a turn that produces no speech (a router
@@ -1201,6 +1234,12 @@ class GraphAgent(BaseAgent):
             if self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
                 for hop in await self._resolve_router_chain(message):
                     yield {"routing_info": hop}
+            elif self._should_hold_for_first_delivery(self.get_node_by_id(self.current_node_id)):
+                logger.info(
+                    f"Holding on node '{self.current_node_id}' until its first response is delivered; "
+                    f"user input registered as context, not a routing trigger"
+                )
+                yield {"routing_info": self._hold_routing_info(is_silence_trigger)}
             else:
                 previous_node = self.current_node_id
                 (

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -84,6 +84,7 @@ class GraphAgent(BaseAgent):
         self._silence_repeats = 0
         self._event_triggered_generation = False
         self._active_node_first_response_delivered = True
+        self._hold_until_first_delivery = not self.config.get("turn_based_conversation", False)
         self._last_deterministic_eval = None
         self._frozen_time_vars: Optional[Dict[str, Any]] = None
         self.rag_configs = self.initialize_rag_configs()
@@ -686,7 +687,8 @@ class GraphAgent(BaseAgent):
 
     def _should_hold_for_first_delivery(self, node: Optional[dict]) -> bool:
         return (
-            node is not None
+            self._hold_until_first_delivery
+            and node is not None
             and self._node_type_of(node) == NodeType.LLM
             and not self._active_node_first_response_delivered
         )

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -1231,10 +1231,11 @@ class GraphAgent(BaseAgent):
             # and let the resolved node speak this turn — do NOT re-route it through
             # decide_next (that would stack another routing call and could transition it
             # away before it speaks, unlike a router reached mid-turn by a transition).
-            if self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
+            active_node = self.get_node_by_id(self.current_node_id)
+            if self._node_type_of(active_node) == NodeType.ROUTER:
                 for hop in await self._resolve_router_chain(message):
                     yield {"routing_info": hop}
-            elif self._should_hold_for_first_delivery(self.get_node_by_id(self.current_node_id)):
+            elif self._should_hold_for_first_delivery(active_node):
                 logger.info(
                     f"Holding on node '{self.current_node_id}' until its first response is delivered; "
                     f"user input registered as context, not a routing trigger"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.139"
+version = "0.10.140"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -715,3 +715,18 @@ class TestFirstDeliveryHold:
         assert agent._active_node_first_response_delivered is True
         agent._advance_to_node("C", 0)
         assert agent._active_node_first_response_delivered is False
+
+    @pytest.mark.asyncio
+    async def test_no_hold_in_turn_based_text_mode(self):
+        agent = _make_agent(_base_config(self._nodes(), "A", turn_based_conversation=True))
+        agent._advance_to_node("B", 0)
+        assert agent._active_node_first_response_delivered is False
+        assert agent._hold_until_first_delivery is False
+
+        with patch.object(
+            agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C
+        ) as mock_llm:
+            await _collect(agent.generate([{"role": "user", "content": "yes"}]))
+
+        mock_llm.assert_called_once()
+        assert agent.current_node_id == "C"

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -644,3 +644,68 @@ class TestRouterFixes:
         agent = _router_agent(detected_language="hi")
         hops = await agent._resolve_router_chain([{"role": "user", "content": "[silence] "}])
         assert hops[0]["is_silence_trigger"] is True
+
+
+class TestFirstDeliveryHold:
+    """A node entered by a transition must speak its first question before it can route out
+    (BOLNA-1582): an utterance arriving before that first TTS turn is delivered is context only."""
+
+    def _nodes(self):
+        return [
+            {"id": "A", "prompt": "A.", "edges": [{"to_node_id": "B", "condition_type": "unconditional"}]},
+            {
+                "id": "B",
+                "prompt": "Ask Q1.",
+                "edges": [{"to_node_id": "C", "condition": "user answered", "function_name": "transition_to_C"}],
+            },
+            {"id": "C", "prompt": "C.", "edges": []},
+        ]
+
+    _PICK_C = ("C", {}, 1.0, [{"role": "system", "content": "routing"}], [], "user answered", 0.9, None)
+
+    @pytest.mark.asyncio
+    async def test_holds_and_speaks_when_first_response_undelivered(self):
+        agent = _make_agent(_base_config(self._nodes(), "A"))
+        agent._advance_to_node("B", 0)
+        assert agent._active_node_first_response_delivered is False
+
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+            out = await _collect(agent.generate([{"role": "user", "content": "haanji boliye"}]))
+
+        mock_llm.assert_not_called()
+        assert agent.current_node_id == "B"
+        routing = [o["routing_info"] for o in out if isinstance(o, dict) and "routing_info" in o]
+        assert routing[-1]["routing_type"] == "hold"
+        assert routing[-1]["transitioned"] is False
+        assert any(isinstance(o, dict) and "messages" in o for o in out)
+
+    @pytest.mark.asyncio
+    async def test_routes_after_first_response_delivered(self):
+        agent = _make_agent(_base_config(self._nodes(), "A"))
+        agent._advance_to_node("B", 0)
+        agent.mark_first_response_delivered()
+        assert agent._active_node_first_response_delivered is True
+
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+            await _collect(agent.generate([{"role": "user", "content": "yes I answered"}]))
+
+        mock_llm.assert_called_once()
+        assert agent.current_node_id == "C"
+
+    @pytest.mark.asyncio
+    async def test_initial_node_routes_on_first_turn(self):
+        agent = _make_agent(_base_config(self._nodes(), "B"))
+        assert agent._active_node_first_response_delivered is True
+
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+            await _collect(agent.generate([{"role": "user", "content": "answer"}]))
+
+        mock_llm.assert_called_once()
+        assert agent.current_node_id == "C"
+
+    @pytest.mark.asyncio
+    async def test_advance_resets_delivered_flag(self):
+        agent = _make_agent(_base_config(self._nodes(), "B"))
+        assert agent._active_node_first_response_delivered is True
+        agent._advance_to_node("C", 0)
+        assert agent._active_node_first_response_delivered is False

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -669,7 +669,9 @@ class TestFirstDeliveryHold:
         agent._advance_to_node("B", 0)
         assert agent._active_node_first_response_delivered is False
 
-        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+        with patch.object(
+            agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C
+        ) as mock_llm:
             out = await _collect(agent.generate([{"role": "user", "content": "haanji boliye"}]))
 
         mock_llm.assert_not_called()
@@ -686,7 +688,9 @@ class TestFirstDeliveryHold:
         agent.mark_first_response_delivered()
         assert agent._active_node_first_response_delivered is True
 
-        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+        with patch.object(
+            agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C
+        ) as mock_llm:
             await _collect(agent.generate([{"role": "user", "content": "yes I answered"}]))
 
         mock_llm.assert_called_once()
@@ -697,7 +701,9 @@ class TestFirstDeliveryHold:
         agent = _make_agent(_base_config(self._nodes(), "B"))
         assert agent._active_node_first_response_delivered is True
 
-        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C) as mock_llm:
+        with patch.object(
+            agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=self._PICK_C
+        ) as mock_llm:
             await _collect(agent.generate([{"role": "user", "content": "answer"}]))
 
         mock_llm.assert_called_once()


### PR DESCRIPTION
## Problem

A graph node could be skipped without ever speaking its first question. When a user's affirmation is split into two ASR turns, the first fragment transitions into the next node and begins generating its question, then the second fragment arrives as a barge-in and cancels that question before any audio is heard. On the next turn the agent evaluates the (never-spoken) node's edges and routes onward, so its required question is never asked.

## Fix

Track whether the active node has delivered its first customer-facing TTS turn, and hold routing out of a speaking node until that turn completes.

* The flag resets on every transition into a node (`_advance_to_node` and the event advance).
* The task manager sets it once a full response is delivered (`on_successful_response_delivered`), which always lands before the next user turn, so it is node-correct.
* `generate()` holds routing on an LLM node whose first response has not been delivered and lets the node speak its question instead. User input arriving in that window stays in conversation history as context but does not trigger forward routing.

The initial node starts as already delivered, since its first turn is the welcome message, preserving current first-turn routing.

## Behavior note

A barge-in during a node's very first question now re-delivers the question rather than treating the barge-in as its answer, matching the requirement that routing only follows a completed first TTS turn.