### PR TITLE
feat: support gpt-5.6 sol/terra/luna and fix reasoning-effort default

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.140"
+__version__ = "0.10.141"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -33,7 +33,7 @@ from bolna.constants import (
     SWITCH_LANGUAGE_TOOL_DEFINITION,
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
-    GPT5_4_MODEL_PREFIX,
+    RESPONSES_API_MODEL_PREFIXES,
     STALL_HANGUP_FLOOR_S,
     WEB_BASED_CALL_PROVIDER,
     WEBCALL_TTS_SAMPLE_RATE,
@@ -513,8 +513,8 @@ class TaskManager(BaseManager):
                 if "thinking_budget" in self.llm_agent_config:
                     self.llm_config["thinking_budget"] = self.llm_agent_config["thinking_budget"]
 
-                if self.llm_agent_config.get("use_responses_api") or GPT5_4_MODEL_PREFIX in self.llm_config.get(
-                    "model", ""
+                if self.llm_agent_config.get("use_responses_api") or any(
+                    p in self.llm_config.get("model", "") for p in RESPONSES_API_MODEL_PREFIXES
                 ):
                     self.llm_config["use_responses_api"] = True
 

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -36,6 +36,11 @@ SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"
 GPT5_4_MODEL_PREFIX = "gpt-5.4"
+GPT5_5_MODEL_PREFIX = "gpt-5.5"
+GPT5_6_MODEL_PREFIX = "gpt-5.6"
+# Function tools with reasoning_effort are rejected on chat completions for these models,
+# so tool-using agents are routed through the Responses API.
+RESPONSES_API_MODEL_PREFIXES = (GPT5_4_MODEL_PREFIX, GPT5_5_MODEL_PREFIX, GPT5_6_MODEL_PREFIX)
 
 HIGH_LEVEL_ASSISTANT_ANALYTICS_DATA = {
     "extraction_details": {},
@@ -251,6 +256,8 @@ MODEL_REASONING_EFFORT_MAP = {
     "gpt-5.4": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.4-mini": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
     "gpt-5.4-nano": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gpt-5.5": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-5.5-pro": [RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.6-sol": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.6-terra": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.6-luna": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -251,4 +251,15 @@ MODEL_REASONING_EFFORT_MAP = {
     "gpt-5.4": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.4-mini": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
     "gpt-5.4-nano": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gpt-5.6-sol": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-5.6-terra": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-5.6-luna": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
 }
+
+
+def default_reasoning_effort(model: str) -> str:
+    """Lowest-latency effort the model supports: minimal where available, else the lowest in its map."""
+    supported = MODEL_REASONING_EFFORT_MAP.get(model)
+    if not supported or RE.MINIMAL in supported:
+        return RE.MINIMAL.value
+    return supported[0].value

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -21,8 +21,8 @@ from openai import (
 import websockets
 from websockets.protocol import State as WSState
 
-from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX
-from bolna.enums import ReasoningEffort, ResponseStreamEvent, ResponseItemType, Verbosity
+from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX, default_reasoning_effort
+from bolna.enums import ResponseStreamEvent, ResponseItemType, Verbosity
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
@@ -163,7 +163,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.model_args = {}
         if model.startswith(GPT5_MODEL_PREFIX):
             max_tokens_key = "max_completion_tokens"
-            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or ReasoningEffort.MINIMAL.value
+            self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort") or default_reasoning_effort(model)
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.140"
+version = "0.10.141"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Adds gpt-5.6 sol/terra/luna to the reasoning-effort map with their supported efforts (none, low, medium, high, xhigh). These models reject the previously hardcoded minimal default, so the GPT-5 branch now derives the default from each model's supported set via default_reasoning_effort(). This also fixes the same latent behavior for gpt-5.1, gpt-5.2, gpt-5.4, codex and pro, which do not support minimal either.