### PR TITLE
fix: clear audio-playing flag when retired sequence is skipped

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.139"
+__version__ = "0.10.148"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.138"
+__version__ = "0.10.139"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5811,6 +5811,14 @@ class TaskManager(BaseManager):
                                 )
                         else:
                             logger.info(f"Skipping message with sequence_id: {sequence_id}")
+                            # A retired sequence's final chunk is skipped here, so its
+                            # is_final_chunk mark never reaches Plivo and no mark echo ever
+                            # arrives to clear is_audio_being_played. Without this, the flag
+                            # latches True forever and every later user utterance is dropped
+                            # as a false interruption. Mirror the BLOCK-path guard.
+                            if meta_info.get("end_of_synthesizer_stream", False):
+                                self._turn_audio_flushed.set()
+                                self.tools["input"].update_is_audio_being_played(False)
 
                         # Give control to other tasks
                         sleep_time = self.tools["synthesizer"].get_sleep_time()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.139"
+version = "0.10.148"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.138"
+version = "0.10.139"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION

A fast barge-in can retire a sequence before its synthesizer stream fully drains. The skipped final chunk means no is_final_chunk mark reaches Plivo, so no mark echo arrives to clear is_audio_being_played. The flag then latches True and every later user utterance is dropped as a false interruption, leaving the agent mute. Mirror the BLOCK-path guard in the skip path to clear the flag when a retired sequence's end_of_synthesizer_stream is skipped.