### PR TITLE
fix: bind static-node audio cache key to synth voice

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.142"
+__version__ = "0.10.143"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -81,6 +81,7 @@ from bolna.helpers.utils import (
     save_audio_file_to_s3,
     update_prompt_with_context,
     get_md5_hash,
+    static_node_audio_key,
     clean_json_string,
     wav_bytes_to_pcm,
     mp3_bytes_to_pcm,
@@ -275,6 +276,8 @@ class TaskManager(BaseManager):
 
         self.timezone = pytz.timezone(DEFAULT_TIMEZONE)
         self.language = DEFAULT_LANGUAGE_CODE
+        self.synthesizer_voice_id = None
+        self.synthesizer_model = None
         self.transfer_call_params = self.kwargs.get("transfer_call_params", None)
 
         if task["tools_config"].get("api_tools", None) is not None:
@@ -1638,6 +1641,8 @@ class TaskManager(BaseManager):
             synthesizer_class = SUPPORTED_SYNTHESIZER_MODELS.get(self.synthesizer_provider)
             provider_config = synth_config.pop("provider_config")
             self.synthesizer_voice = provider_config["voice"]
+            self.synthesizer_voice_id = provider_config.get("voice_id")
+            self.synthesizer_model = provider_config.get("model")
             if self.turn_based_conversation:
                 synth_config["audio_format"] = "mp3"  # Hard code mp3 if we're connected through dashboard
                 synth_config["stream"] = (
@@ -5924,6 +5929,16 @@ class TaskManager(BaseManager):
             # This will help with interruption in IVR
             audio_chunk = None
             static_node_audio = meta_info.get("message_category") in ("static_node", "event_proactive")
+            if meta_info.get("message_category") == "static_node" and meta_info.get("text"):
+                # Fetch the clip keyed to the active voice/language, not text alone, so a voice
+                # change regenerates it instead of replaying the stale pre-generated clip.
+                text = static_node_audio_key(
+                    meta_info["text"],
+                    provider=self.synthesizer_provider,
+                    voice=self.synthesizer_voice,
+                    voice_id=self.synthesizer_voice_id,
+                    model=self.synthesizer_model,
+                )
             if self.turn_based_conversation or self.task_config["tools_config"]["output"]["provider"] == "default":
                 # Static-node clips are pre-generated as mp3 keyed by md5(text); fetch that
                 # format explicitly rather than the output format, which may differ (e.g. wav).

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -236,6 +236,12 @@ def get_md5_hash(text):
     return hashlib.md5(text.encode(), usedforsecurity=False).hexdigest()
 
 
+def static_node_audio_key(text, provider=None, voice=None, voice_id=None, model=None):
+    """S3 filename stem for a static-node clip, bound to the voice it was rendered with."""
+    identity = "|".join(str(part or "") for part in (provider, voice, voice_id, model))
+    return get_md5_hash(f"{identity}|{text}")
+
+
 def is_valid_md5(hash_string):
     return bool(re.fullmatch(r"[0-9a-f]{32}", hash_string))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.142"
+version = "0.10.143"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Pre-generated static-node clips are stored in S3 keyed by md5(static_text) only, and the runtime fetches by that same key, so nothing ties a clip to the voice it was rendered with. When an agent's synthesizer voice changes while the static text stays the same, the pregen writer's check_file_exists short-circuit keeps the old clip and the runtime keeps serving it, so the static node plays the previous voice while every live turn uses the new one. The same key also lets a multilingual static message resolve to a clip that was rendered under a different language's voice.

This binds provider, voice, voice_id and model into the key through a shared helper (static_node_audio_key) so a voice change yields a new key. The clip then regenerates, and a miss falls back to live synthesis in the current voice rather than replaying a stale clip. Clips keyed by text alone become unreferenced and regenerate on the next agent save. The dashboard-backend pregen writer is updated to call the same helper in a companion change.