### PR TITLE
feat: report per-turn ASR/TTS + stream-connect latency via on_provider_health

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.160"
+__version__ = "0.10.161"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -260,6 +260,10 @@ class TaskManager(BaseManager):
         # Optional per-provider health callback (circuit-breaker shadow); never affects the call.
         self.on_provider_health = kwargs.get("on_provider_health")
         self._cb_tasks = set()
+        self._cb_transcriber_connect_reported = False
+        self._cb_synthesizer_connect_reported = False
+        self._cb_stream_reported = False
+        self._cb_tts_last = None
 
         self.conversation_start_init_ts = time.time() * 1000
         self.llm_latencies = ComponentLatencies()
@@ -1352,6 +1356,7 @@ class TaskManager(BaseManager):
                 stream_sid = self.tools["input"].get_stream_sid()
                 if stream_sid is not None and self.output_handler_set:
                     self.stream_sid_ts = time.time() * 1000
+                    await self._report_stream_connect()
                     logger.info(f"Got stream sid and hence sending the first message {stream_sid}")
                     self.stream_sid = stream_sid
                     await self.tools["output"].set_stream_sid(stream_sid)
@@ -4395,17 +4400,18 @@ class TaskManager(BaseManager):
         else:
             logger.info(f"Need to separate out output task")
 
-    async def _report_provider_health(self, service, provider, model, ok, latency_ms=None, blocking=False):
+    async def _report_provider_health(self, service, provider, model, ok, latency_ms=None, phase=None, blocking=False):
         """Per-provider health signal for the circuit breaker (shadow). Never affects the call.
 
-        Fire-and-forget by default. On the error path pass blocking=True so the write lands before the
-        call tears down (a bare create_task would be cancelled by shutdown); the timeout keeps a slow
-        Redis from ever delaying teardown.
+        phase distinguishes connection setup ("connect") from per-turn processing ("process", the
+        default). Fire-and-forget by default. On the error path pass blocking=True so the write lands
+        before the call tears down (a bare create_task would be cancelled by shutdown); the timeout
+        keeps a slow Redis from ever delaying teardown.
         """
         if not self.on_provider_health or not provider:
             return
         try:
-            coro = self.on_provider_health(service, provider, model, ok, latency_ms)
+            coro = self.on_provider_health(service, provider, model, ok, latency_ms, phase)
             if blocking:
                 await asyncio.wait_for(coro, timeout=2)
                 return
@@ -4414,6 +4420,40 @@ class TaskManager(BaseManager):
             _cb.add_done_callback(self._cb_tasks.discard)
         except Exception:
             pass
+
+    def _active_tool(self, kind):
+        """Live pool member for a transcriber/synthesizer (or the tool itself when not pooled)."""
+        tool = self.tools.get(kind)
+        pool = getattr(tool, f"{kind}s", None)
+        if pool is not None and hasattr(tool, "active_label"):
+            return pool.get(tool.active_label, tool)
+        return tool
+
+    async def _report_component_health(self, service, provider, process_latency_ms, connect_flag):
+        """Per-turn ASR/TTS success for the shadow breaker, plus the connection latency once."""
+        if not self.on_provider_health or not provider:
+            return
+        # model=None matches the fail side (component errors carry no model) so both share one member.
+        if not getattr(self, connect_flag):
+            conn_ms = getattr(self._active_tool(service), "connection_time", None)
+            if conn_ms is not None:
+                setattr(self, connect_flag, True)
+                await self._report_provider_health(service, provider, None, True, conn_ms, phase="connect")
+        await self._report_provider_health(service, provider, None, True, process_latency_ms, phase="process")
+
+    async def _report_stream_connect(self):
+        """Media-stream (stream_sid) connect latency for the shadow breaker: telephony only, once/call."""
+        if not self.on_provider_health or self._cb_stream_reported or not self.stream_sid_ts:
+            return
+        provider = self.tools["input"].io_provider
+        if provider in (None, "default"):
+            return
+        self._cb_stream_reported = True
+        # welcome_message_delay is slept through before the poll; it is agent config, not carrier latency.
+        latency_ms = round(self.stream_sid_ts - self.conversation_start_init_ts - (self.welcome_message_delay or 0))
+        await self._report_provider_health(
+            "telephony_stream", provider, None, True, max(0, latency_ms), phase="connect"
+        )
 
     async def _end_call_on_component_error(self, error, hangup_detail):
         """End the call gracefully when a critical pipeline component fails.
@@ -4757,6 +4797,14 @@ class TaskManager(BaseManager):
 
                         transcriber_message = message["data"].get("content")
                         was_eager = message["data"].get("was_eager", False)
+
+                        # No process latency: transcribers store first-result latency inconsistently.
+                        await self._report_component_health(
+                            "transcriber",
+                            self.transcriber_provider,
+                            None,
+                            "_cb_transcriber_connect_reported",
+                        )
 
                         if was_eager and self.eager_llm_task is not None:
                             logger.info(f"EndOfTurn follows EagerEndOfTurn - using speculative LLM")
@@ -5907,6 +5955,17 @@ class TaskManager(BaseManager):
                             if self.stream:
                                 if meta_info.get("is_first_chunk", False):
                                     first_chunk_generation_timestamp = time.time()
+                                    # is_first_chunk re-stamps on every frame once the turn's text is flushed.
+                                    _ttfb = meta_info.get("synthesizer_latency")
+                                    _tts_key = (sequence_id, _ttfb)
+                                    if _tts_key != self._cb_tts_last:
+                                        self._cb_tts_last = _tts_key
+                                        await self._report_component_health(
+                                            "synthesizer",
+                                            self.synthesizer_provider,
+                                            round(_ttfb * 1000) if _ttfb is not None else None,
+                                            "_cb_synthesizer_connect_reported",
+                                        )
 
                                 if self.tools["output"].process_in_chunks(self.yield_chunks):
                                     number_of_chunks = math.ceil(len(message["data"]) / self.output_chunk_size)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.160"
+version = "0.10.161"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Reports per-turn ASR and TTS health, plus connection and telephony media-stream latency, to the provider health callback used by the circuit-breaker shadow, matching how the conversation LLM already reports per-turn first-token latency. Observe-only; nothing here affects the call.

* Adds an optional phase ("connect" or "process", default preserves current behavior) to `_report_provider_health` and the `on_provider_health` contract.
* Transcriber and synthesizer report a per-turn success and their connection latency once per call, resolved through the active pool member.
* Synthesizer also reports per-turn process latency (first-audio-chunk TTFB), which every streaming synth exposes uniformly via the `stream_synthesizer` base.
* Telephony stream connect latency (stream_sid receipt relative to conversation start) is reported for telephony calls.

Per-turn ASR process latency is intentionally out of scope here: transcribers store first-result latency inconsistently (different fields and units, and Deepgram's streaming path stores none), so it needs a canonical `first_result_latency_ms` on `base_transcriber` first. That is a separate follow-up. Failures already flow through the component-error path.
