### PR TITLE
Fix SIP-trunk audio encoding and sample rate across ASR transcribers

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.144"
+__version__ = "0.10.145"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -37,6 +37,16 @@ class TelephonyProvider(str, Enum):
         """Return telephony provider values as a list of strings."""
         return [provider.value for provider in cls.telephony_providers()]
 
+    @classmethod
+    def mulaw_providers(cls):
+        """Telephony providers that stream mulaw; every other telephony provider streams linear16."""
+        return [cls.TWILIO, cls.SIP_TRUNK]
+
+    @classmethod
+    def mulaw_values(cls):
+        """Return mulaw telephony provider values as a list of strings."""
+        return [provider.value for provider in cls.mulaw_providers()]
+
 
 class SynthesizerProvider(str, Enum):
     """Enum for synthesizer (TTS) providers."""

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -45,7 +45,7 @@ class SarvamLID(LIDBackend):
         if self._telephony in ("plivo", "vobiz", "exotel"):
             self._encoding = "linear16"
             self._input_sr = 8000
-        elif self._telephony == "twilio":
+        elif self._telephony in ("twilio", "sip-trunk"):
             self._encoding = "mulaw"
             self._input_sr = 8000
         else:

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -8,6 +8,7 @@ import wave
 
 from dotenv import load_dotenv
 
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 
 from .base import LIDBackend
@@ -42,11 +43,8 @@ class SarvamLID(LIDBackend):
         # stream 8kHz, so we resample 8k→16k. Getting this wrong (e.g. treating vobiz's
         # 8kHz as 16kHz) feeds garbled audio to Saaras → no transcripts → no detection.
         self._sr = int(config.get("sampling_rate", 16000))
-        if self._telephony in ("plivo", "vobiz", "exotel"):
-            self._encoding = "linear16"
-            self._input_sr = 8000
-        elif self._telephony in ("twilio", "sip-trunk"):
-            self._encoding = "mulaw"
+        if self._telephony in TelephonyProvider.telephony_values():
+            self._encoding = "mulaw" if self._telephony in TelephonyProvider.mulaw_values() else "linear16"
             self._input_sr = 8000
         else:
             self._encoding = "linear16"

--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -9,6 +9,7 @@ from bolna.constants import (
     SONIOX_ENDPOINT_TOKEN,
     SONIOX_WEBSOCKET_HOST,
 )
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import build_soniox_config, soniox_ws_url
@@ -34,11 +35,8 @@ class SonioxLID(LIDBackend):
         self._host = config.get("soniox_host") or SONIOX_WEBSOCKET_HOST
         self._telephony = config.get("telephony_provider", "")
         # Telephony streams 8kHz; Soniox accepts mulaw/pcm natively, no resampling.
-        if self._telephony in ("plivo", "vobiz", "exotel"):
-            self._audio_format = "pcm_s16le"
-            self._input_sr = 8000
-        elif self._telephony in ("twilio", "sip-trunk"):
-            self._audio_format = "mulaw"
+        if self._telephony in TelephonyProvider.telephony_values():
+            self._audio_format = "mulaw" if self._telephony in TelephonyProvider.mulaw_values() else "pcm_s16le"
             self._input_sr = 8000
         else:
             self._audio_format = "pcm_s16le"

--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -37,7 +37,7 @@ class SonioxLID(LIDBackend):
         if self._telephony in ("plivo", "vobiz", "exotel"):
             self._audio_format = "pcm_s16le"
             self._input_sr = 8000
-        elif self._telephony == "twilio":
+        elif self._telephony in ("twilio", "sip-trunk"):
             self._audio_format = "mulaw"
             self._input_sr = 8000
         else:

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -84,8 +84,8 @@ class AssemblyAITranscriber(BaseTranscriber):
         """Get the AssemblyAI WebSocket URL with appropriate parameters"""
         connection_params = {"sample_rate": self.sampling_rate, "format_turns": self.format_turns}
 
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            self.encoding = "mulaw" if self.provider in ("twilio") else "linear16"
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2
             connection_params["sample_rate"] = self.sampling_rate
@@ -338,7 +338,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                 audio_data = ws_data_packet.get("data")
                 if isinstance(audio_data, bytes):
                     try:
-                        if self.provider == "twilio" and self.encoding == "mulaw":
+                        if self.provider in ("twilio", "sip-trunk") and self.encoding == "mulaw":
                             audio_data = ulaw2lin(audio_data, 2)
 
                         await ws.send(audio_data)

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -339,7 +339,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                 audio_data = ws_data_packet.get("data")
                 if isinstance(audio_data, bytes):
                     try:
-                        if self.provider in TelephonyProvider.mulaw_values() and self.encoding == "mulaw":
+                        if self.encoding == "mulaw":
                             audio_data = ulaw2lin(audio_data, 2)
 
                         await ws.send(audio_data)

--- a/bolna/transcriber/assemblyai_transcriber.py
+++ b/bolna/transcriber/assemblyai_transcriber.py
@@ -12,6 +12,7 @@ from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosedError, InvalidHandshake
 
 from .base_transcriber import BaseTranscriber
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
@@ -84,8 +85,8 @@ class AssemblyAITranscriber(BaseTranscriber):
         """Get the AssemblyAI WebSocket URL with appropriate parameters"""
         connection_params = {"sample_rate": self.sampling_rate, "format_turns": self.format_turns}
 
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
-            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
+        if self.provider in TelephonyProvider.telephony_values():
+            self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2
             connection_params["sample_rate"] = self.sampling_rate
@@ -338,7 +339,7 @@ class AssemblyAITranscriber(BaseTranscriber):
                 audio_data = ws_data_packet.get("data")
                 if isinstance(audio_data, bytes):
                     try:
-                        if self.provider in ("twilio", "sip-trunk") and self.encoding == "mulaw":
+                        if self.provider in TelephonyProvider.mulaw_values() and self.encoding == "mulaw":
                             audio_data = ulaw2lin(audio_data, 2)
 
                         await ws.send(audio_data)

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -50,8 +50,8 @@ class AzureTranscriber(BaseTranscriber):
         self._turn_start_epoch_ms = None
         self.turn_counter = 0
 
-        if self.audio_provider in ("twilio", "exotel", "plivo"):
-            self.encoding = "mulaw" if self.audio_provider in ("twilio",) else "linear16"
+        if self.audio_provider in ("twilio", "exotel", "plivo", "sip-trunk"):
+            self.encoding = "mulaw" if self.audio_provider in ("twilio", "sip-trunk") else "linear16"
             if self.encoding == "mulaw":
                 self.bits_per_sample = 8
             self.audio_frame_duration = 0.2

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -8,6 +8,7 @@ from dotenv import load_dotenv
 from .base_transcriber import BaseTranscriber
 import azure.cognitiveservices.speech as speechsdk
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -50,8 +51,8 @@ class AzureTranscriber(BaseTranscriber):
         self._turn_start_epoch_ms = None
         self.turn_counter = 0
 
-        if self.audio_provider in ("twilio", "exotel", "plivo", "sip-trunk"):
-            self.encoding = "mulaw" if self.audio_provider in ("twilio", "sip-trunk") else "linear16"
+        if self.audio_provider in TelephonyProvider.telephony_values():
+            self.encoding = "mulaw" if self.audio_provider in TelephonyProvider.mulaw_values() else "linear16"
             if self.encoding == "mulaw":
                 self.bits_per_sample = 8
             self.audio_frame_duration = 0.2

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -152,13 +152,8 @@ class DeepgramTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5  # We're sending 8k samples with a sample rate of 16k
 
         if self.provider in TelephonyProvider.telephony_values():
-            # For sip-trunk (Asterisk), encoding and sampling_rate are already set in task_manager
-            # Don't override them - use what was passed from task_config
-            if self.provider != TelephonyProvider.SIP_TRUNK.value:
-                self.encoding = "mulaw" if self.provider in ("twilio") else "linear16"
-                self.sampling_rate = 8000
-            # For sip-trunk, encoding and sampling_rate come from task_config (set in task_manager)
-            # They're already set from the __init__ parameters, so we don't override
+            self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
+            self.sampling_rate = 8000
             self.audio_frame_duration = 0.2  # 200ms chunks for telephony
 
             dg_params["encoding"] = self.encoding
@@ -222,9 +217,8 @@ class DeepgramTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5
 
         if self.provider in TelephonyProvider.telephony_values():
-            if self.provider != TelephonyProvider.SIP_TRUNK.value:
-                self.encoding = "mulaw" if self.provider == "twilio" else "linear16"
-                self.sampling_rate = 8000
+            self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
+            self.sampling_rate = 8000
             self.audio_frame_duration = 0.2
             dg_params["encoding"] = self.encoding
             dg_params["sample_rate"] = self.sampling_rate

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -117,12 +117,12 @@ class ElevenLabsTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5  # Default for 8k samples at 16kHz
         audio_format = "pcm_16000"  # Default
 
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            # Twilio uses mulaw at 8kHz, exotel/plivo use linear16 at 8kHz
-            self.encoding = "mulaw" if self.provider == "twilio" else "linear16"
+        if self.provider in ("twilio", "sip-trunk", "exotel", "plivo", "vobiz"):
+            # Twilio/sip-trunk use mulaw at 8kHz, exotel/plivo use linear16 at 8kHz
+            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2  # 200ms chunks for telephony
-            audio_format = "ulaw_8000" if self.provider == "twilio" else "pcm_8000"
+            audio_format = "ulaw_8000" if self.provider in ("twilio", "sip-trunk") else "pcm_8000"
 
         elif self.provider == "web_based_call":
             self.encoding = "linear16"

--- a/bolna/transcriber/elevenlabs_transcriber.py
+++ b/bolna/transcriber/elevenlabs_transcriber.py
@@ -12,6 +12,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 
 from .base_transcriber import BaseTranscriber
 from bolna.constants import ELEVENLABS_REALTIME_MAX_KEYTERMS
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
@@ -117,12 +118,13 @@ class ElevenLabsTranscriber(BaseTranscriber):
         self.audio_frame_duration = 0.5  # Default for 8k samples at 16kHz
         audio_format = "pcm_16000"  # Default
 
-        if self.provider in ("twilio", "sip-trunk", "exotel", "plivo", "vobiz"):
-            # Twilio/sip-trunk use mulaw at 8kHz, exotel/plivo use linear16 at 8kHz
-            self.encoding = "mulaw" if self.provider in ("twilio", "sip-trunk") else "linear16"
+        if self.provider in TelephonyProvider.telephony_values():
+            # Twilio/sip-trunk use mulaw at 8kHz, exotel/plivo/vobiz use linear16 at 8kHz
+            is_mulaw = self.provider in TelephonyProvider.mulaw_values()
+            self.encoding = "mulaw" if is_mulaw else "linear16"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2  # 200ms chunks for telephony
-            audio_format = "ulaw_8000" if self.provider in ("twilio", "sip-trunk") else "pcm_8000"
+            audio_format = "ulaw_8000" if is_mulaw else "pcm_8000"
 
         elif self.provider == "web_based_call":
             self.encoding = "linear16"

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -131,8 +131,8 @@ class GladiaTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider == "twilio":
-            # Twilio sends mulaw at 8kHz - Gladia supports this natively
+        if self.provider in ("twilio", "sip-trunk"):
+            # Twilio/sip-trunk send mulaw at 8kHz - Gladia supports this natively
             self.encoding = "wav/ulaw"
             self.sample_rate = 8000
             self.bit_depth = 8
@@ -190,7 +190,7 @@ class GladiaTranscriber(BaseTranscriber):
             "endpointing": self.endpointing,
             "maximum_duration_without_endpointing": self.maximum_duration_without_endpointing,
             "pre_processing": {
-                "audio_enhancer": self.provider in ("twilio", "exotel", "plivo"),
+                "audio_enhancer": self.provider in ("twilio", "sip-trunk", "exotel", "plivo"),
                 "speech_threshold": self.speech_threshold,
             },
             "messages_config": {

--- a/bolna/transcriber/gladia_transcriber.py
+++ b/bolna/transcriber/gladia_transcriber.py
@@ -13,6 +13,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 from dotenv import load_dotenv
 
 from .base_transcriber import BaseTranscriber
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
@@ -131,7 +132,7 @@ class GladiaTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider in ("twilio", "sip-trunk"):
+        if self.provider in TelephonyProvider.mulaw_values():
             # Twilio/sip-trunk send mulaw at 8kHz - Gladia supports this natively
             self.encoding = "wav/ulaw"
             self.sample_rate = 8000
@@ -190,7 +191,7 @@ class GladiaTranscriber(BaseTranscriber):
             "endpointing": self.endpointing,
             "maximum_duration_without_endpointing": self.maximum_duration_without_endpointing,
             "pre_processing": {
-                "audio_enhancer": self.provider in ("twilio", "sip-trunk", "exotel", "plivo"),
+                "audio_enhancer": self.provider in TelephonyProvider.telephony_values(),
                 "speech_threshold": self.speech_threshold,
             },
             "messages_config": {

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -9,6 +9,7 @@ from dotenv import load_dotenv
 from google.cloud import speech_v1p1beta1 as speech
 
 from .base_transcriber import BaseTranscriber
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
@@ -42,8 +43,8 @@ class GoogleTranscriber(BaseTranscriber):
         self.run_id = run_id or kwargs.get("run_id", "")
 
         # Provider-specific audio configuration
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
-            self.encoding = "MULAW" if self.provider in ("twilio", "sip-trunk") else "LINEAR16"
+        if self.provider in TelephonyProvider.telephony_values():
+            self.encoding = "MULAW" if self.provider in TelephonyProvider.mulaw_values() else "LINEAR16"
             self.sample_rate_hertz = 8000
         elif self.provider == "web_based_call":
             self.encoding = "LINEAR16"
@@ -73,7 +74,7 @@ class GoogleTranscriber(BaseTranscriber):
         # Audio frame tracking
         self.audio_frame_duration = 0.0
         self.num_frames = 0
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+        if self.provider in TelephonyProvider.telephony_values():
             self.audio_frame_duration = 0.2
         elif self.provider == "web_based_call":
             self.audio_frame_duration = 0.256

--- a/bolna/transcriber/google_transcriber.py
+++ b/bolna/transcriber/google_transcriber.py
@@ -42,8 +42,8 @@ class GoogleTranscriber(BaseTranscriber):
         self.run_id = run_id or kwargs.get("run_id", "")
 
         # Provider-specific audio configuration
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
-            self.encoding = "MULAW" if self.provider in ("twilio") else "LINEAR16"
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
+            self.encoding = "MULAW" if self.provider in ("twilio", "sip-trunk") else "LINEAR16"
             self.sample_rate_hertz = 8000
         elif self.provider == "web_based_call":
             self.encoding = "LINEAR16"
@@ -73,7 +73,7 @@ class GoogleTranscriber(BaseTranscriber):
         # Audio frame tracking
         self.audio_frame_duration = 0.0
         self.num_frames = 0
-        if self.provider in ("twilio", "exotel", "plivo", "vobiz"):
+        if self.provider in ("twilio", "exotel", "plivo", "vobiz", "sip-trunk"):
             self.audio_frame_duration = 0.2
         elif self.provider == "web_based_call":
             self.audio_frame_duration = 0.256

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -450,8 +450,9 @@ class SarvamTranscriber(BaseTranscriber):
                 except Exception:
                     logger.error(f"Sarvam receiver error handling message: {traceback.format_exc()}")
         except ConnectionClosed as e:
-            if e.code != 1000:
-                self.connection_error = f"sarvam closed the connection: code={e.code} reason={e.reason!r}"
+            # Logged, not treated as an error: a socket dying abnormally is also what a
+            # normal hangup looks like from here, and only the error message above tells
+            # the two apart.
             logger.info(f"Sarvam websocket closed: code={e.code} reason={e.reason!r}")
         except Exception:
             logger.error(f"Sarvam receiver error: {traceback.format_exc()}")

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -19,6 +19,7 @@ from typing import Optional
 
 from .base_transcriber import BaseTranscriber
 from bolna.helpers.logger_config import configure_logger
+from bolna.enums import TelephonyProvider
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 
@@ -102,13 +103,9 @@ class SarvamTranscriber(BaseTranscriber):
             self.session = aiohttp.ClientSession()
 
     def _configure_audio_params(self):
-        if self.telephony_provider in ("plivo", "vobiz", "exotel"):
-            self.encoding = "linear16"
-            self.input_sampling_rate = 8000
-            self.sampling_rate = 16000
-            self.audio_frame_duration = 0.2
-        elif self.telephony_provider in ("twilio", "sip-trunk"):
-            self.encoding = "mulaw"
+        if self.telephony_provider in TelephonyProvider.telephony_values():
+            # Telephony streams 8kHz, saaras only accepts 16kHz; _convert_audio_to_wav upsamples.
+            self.encoding = "mulaw" if self.telephony_provider in TelephonyProvider.mulaw_values() else "linear16"
             self.input_sampling_rate = 8000
             self.sampling_rate = 16000
             self.audio_frame_duration = 0.2

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -107,7 +107,7 @@ class SarvamTranscriber(BaseTranscriber):
             self.input_sampling_rate = 8000
             self.sampling_rate = 16000
             self.audio_frame_duration = 0.2
-        elif self.telephony_provider == "twilio":
+        elif self.telephony_provider in ("twilio", "sip-trunk"):
             self.encoding = "mulaw"
             self.input_sampling_rate = 8000
             self.sampling_rate = 16000

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 import aiohttp
 import websockets
 from websockets.asyncio.client import ClientConnection
-from websockets.exceptions import InvalidHandshake
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
 
 import numpy as np
 from scipy.signal import resample_poly
@@ -443,10 +443,21 @@ class SarvamTranscriber(BaseTranscriber):
                         self.meta_info["transcriber_duration"] = data.get("duration", 0)
                         yield create_ws_data_packet("transcriber_connection_closed", self.meta_info)
                         return
+
+                    elif isinstance(data, dict) and data.get("type") == "error":
+                        # Sarvam rejects a stream by sending this and then closing (e.g. a
+                        # sample_rate the model won't accept). Record the reason and let its
+                        # close end the loop, so the call still tears down immediately.
+                        self.connection_error = (data.get("data") or {}).get("message") or json.dumps(data)
+                        logger.error(f"Sarvam rejected the stream: {self.connection_error}")
                 except Exception:
-                    traceback.print_exc()
+                    logger.error(f"Sarvam receiver error handling message: {traceback.format_exc()}")
+        except ConnectionClosed as e:
+            if e.code != 1000:
+                self.connection_error = f"sarvam closed the connection: code={e.code} reason={e.reason!r}"
+            logger.info(f"Sarvam websocket closed: code={e.code} reason={e.reason!r}")
         except Exception:
-            traceback.print_exc()
+            logger.error(f"Sarvam receiver error: {traceback.format_exc()}")
 
     async def _close(self, ws: ClientConnection, data=None):
         try:
@@ -561,7 +572,7 @@ class SarvamTranscriber(BaseTranscriber):
         try:
             self.transcription_task = asyncio.create_task(self.transcribe())
         except Exception:
-            traceback.print_exc()
+            logger.error(f"Sarvam transcriber failed to start: {traceback.format_exc()}")
 
     async def send_heartbeat(self, ws: ClientConnection, interval_sec: float = 10.0):
         try:
@@ -587,7 +598,7 @@ class SarvamTranscriber(BaseTranscriber):
                     meta["connection_error"] = self.connection_error
                     await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
                 except Exception:
-                    traceback.print_exc()
+                    logger.error(f"Sarvam failed to emit connection_closed: {traceback.format_exc()}")
                 return
 
             if not self.connection_time:
@@ -606,7 +617,7 @@ class SarvamTranscriber(BaseTranscriber):
                                 break
                 except Exception as e:
                     self.connection_error = str(e)
-                    traceback.print_exc()
+                    logger.error(f"Sarvam stream ended with an error: {traceback.format_exc()}")
             else:
                 self.sender_task = asyncio.create_task(self.sender())
                 try:
@@ -624,7 +635,7 @@ class SarvamTranscriber(BaseTranscriber):
                     meta["connection_error"] = self.connection_error
                 await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
             except Exception:
-                traceback.print_exc()
+                logger.error(f"Sarvam failed to emit connection_closed: {traceback.format_exc()}")
         finally:
             if self.sender_task:
                 self.sender_task.cancel()

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -12,6 +12,7 @@ from websockets.exceptions import ConnectionClosedError, InvalidHandshake, Conne
 from dotenv import load_dotenv
 
 from .base_transcriber import BaseTranscriber
+from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
@@ -122,7 +123,7 @@ class SmallestTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider in ("twilio", "sip-trunk"):
+        if self.provider in TelephonyProvider.mulaw_values():
             # Twilio and SIP-trunk send mulaw at 8kHz
             self.encoding = "mulaw"
             self.sampling_rate = 8000

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -122,8 +122,8 @@ class SmallestTranscriber(BaseTranscriber):
 
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
-        if self.provider == "twilio":
-            # Twilio sends mulaw at 8kHz
+        if self.provider in ("twilio", "sip-trunk"):
+            # Twilio and SIP-trunk send mulaw at 8kHz
             self.encoding = "mulaw"
             self.sampling_rate = 8000
             self.audio_frame_duration = 0.2

--- a/bolna/transcriber/soniox_transcriber.py
+++ b/bolna/transcriber/soniox_transcriber.py
@@ -99,10 +99,8 @@ class SonioxTranscriber(BaseTranscriber):
     def _resolve_audio_params(self):
         """Set encoding, sample rate and frame duration from the telephony/web I/O provider."""
         if self.provider in TelephonyProvider.telephony_values():
-            # sip-trunk passes its own encoding/sample_rate from task_config; don't override.
-            if self.provider != TelephonyProvider.SIP_TRUNK.value:
-                self.encoding = "mulaw" if self.provider == "twilio" else "linear16"
-                self.sampling_rate = 8000
+            self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
+            self.sampling_rate = 8000
             self.audio_frame_duration = 0.2
         elif self.provider == "web_based_call":
             self.encoding = "linear16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.144"
+version = "0.10.145"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
SIP-trunk telephony audio is mulaw at 8 kHz, byte-identical to Twilio, but seven ASR transcribers omitted `sip-trunk` from their Twilio audio-format branch and fell through to a wrong default encoding/sample rate, corrupting or mis-rating recognition on inbound SIP-trunk calls.

Sarvam was the visible failure: it sent 8 kHz to the `saaras:v2.5` streaming endpoint (every other telephony provider upsamples to 16 kHz), so Sarvam closed the WebSocket ~40 ms after the first audio frame and the engine tore the whole call down right after the welcome message — killing every inbound SIP-trunk call for affected agents (observed as `transcriber_connection_closed` with `total_stream_duration_ms: 38`, `conversation_duration ~0.2s`, `status=failed`).

This routes `sip-trunk` through the same branch as `twilio` in the sarvam, azure, assemblyai, google, gladia, elevenlabs, and smallest transcribers, plus the parallel language-ID side-tap (`lid/sarvam.py`, `lid/soniox.py`), so each resolves to its provider's telephony format identically to Twilio (mulaw/ulaw at 8 kHz; upsampled to 16 kHz for Sarvam). deepgram, pixa, openai, and soniox transcribers already handled sip-trunk correctly and are unchanged.

Supersedes #847 (same fix, rebased clean against current master).

Verified by constructing each transcriber and LID backend with `sip-trunk` vs `twilio` and confirming identical resolved audio params; ruff and py_compile pass on all changed files.

### Also folded in: surface the rejection instead of ending the call silently

Sarvam signals a rejected stream with a `{"type": "error"}` message and then closes. `receiver` had no branch for that message type and the close was swallowed by `except Exception: traceback.print_exc()`, so `connection_error` stayed `None`. The call ended with no reason recorded anywhere, the event was logged as a benign drop rather than an error, and the only trace was a stderr traceback with no run_id attached, which is why this outage needed a manual replay against the Sarvam endpoint to recover a message the server had already sent us.

The added commit records that message, logs the websocket close code and reason, treats a non-1000 close as a connection error, and routes the module's remaining `print_exc` calls through the logger. Sarvam's own close still ends the receive loop, so teardown timing is unchanged. A rejection or abnormal close is now attributed as `transcriber_connection_error` rather than ending the call silently.

A websocket close is logged with its code and reason but deliberately not treated as an error on its own, because an abnormal close is also what a normal hangup looks like from inside the transcriber. Only the explicit error message distinguishes them, so call attribution is unchanged for every close path.

Verified against the live Sarvam endpoint rather than by parity alone: at 8 kHz, saaras:v3 returns `Error in Pipeline : Invalid request: 'audio.sample_rate' must be 16000` and closes about 40 ms after the first audio frame, which is now logged and carried on the emitted packet. With the 16 kHz path this PR establishes, the stream is accepted and Sarvam streams results instead of rejecting the first frame.

Close handling was checked against a local server that accepts and then drops the socket: a clean close and an abnormal close both still produce `connection_error=None` and a `drop` event, exactly as before this PR, while an error frame produces the message and an `error` event.


### Also folded in: one source of truth for the telephony audio format

The reason seven files needed the same one-line fix is that "which providers stream mulaw at 8 kHz" was written out by hand in each of them, so a new provider had to be remembered in eleven places. `TelephonyProvider` now answers that question directly:

```python
if self.provider in TelephonyProvider.telephony_values():
    self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
```

Every transcriber and both LID side-taps now resolve their format this way, which also removes the second convention: deepgram and soniox used to skip sip-trunk entirely and trust whatever encoding and sample rate task_manager passed, while the others override. Both now resolve the same way as everyone else, and the values they land on for sip-trunk are the mulaw at 8000 that task_manager was already passing them.

Two omissions fall out of this for free: azure and gladia's `audio_enhancer` were both missing `vobiz`, which every other transcriber lists.

Verified by dumping every transcriber's resolved encoding, sample rate, input sample rate, bit depth and frame duration for all eight providers before and after, and diffing. The only rows that move are deepgram and soniox on sip-trunk, and only when the caller passes nothing, which is what the removed special case made possible in the first place.

Separately, `SmallestTranscriber` raises `AttributeError: connected_via_dashboard` at construction for vobiz and for non-telephony providers, because `_configure_audio_params` runs before that attribute is assigned. Pre-existing and left alone here.

