### PR TITLE
fix(openai-transcriber): force-finalize late finals from interims (#711)

### DIFF
--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -11,7 +11,13 @@ WEB_BASED_CALL_PROVIDER = "web_based_call"
 WEBCALL_TTS_SAMPLE_RATE = 24000
 
 OPENAI_TRANSCRIBER_HEARTBEAT_INTERVAL_S = 5
-OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 0.5
+# Wait this long after commit for transcription.completed before force-finalizing
+# from accumulated interim deltas (avoids 20–35s silent waits on Twilio).
+OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 2.0
+# Default client-side speech gate (RMS of 24 kHz PCM16). Telephony often needs a
+# higher floor so line noise does not keep a turn open indefinitely.
+OPENAI_TRANSCRIBER_SPEECH_RMS_THRESHOLD = 400
+OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD = 500
 
 # ElevenLabs realtime (scribe_v2_realtime) accepts up to 50 keyterms for biasing.
 ELEVENLABS_REALTIME_MAX_KEYTERMS = 50

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -148,6 +148,9 @@ class Transcriber(BaseModel):
     noise_reduction: Optional[bool] = False
     vad_threshold: Optional[float] = 0.5
     vad_prefix_padding_ms: Optional[int] = 300
+    # OpenAI realtime client-side VAD: RMS gate on resampled 24 kHz PCM16.
+    # Lower = more sensitive (soft speech); raise for noisy Twilio/mulaw lines.
+    speech_rms_threshold: Optional[int] = None
 
     @field_validator("provider")
     def validate_model(cls, value):

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -16,6 +16,8 @@ from websockets.exceptions import InvalidHandshake, ConnectionClosed, Connection
 from .base_transcriber import BaseTranscriber
 from bolna.constants import (
     OPENAI_TRANSCRIBER_HEARTBEAT_INTERVAL_S,
+    OPENAI_TRANSCRIBER_SPEECH_RMS_THRESHOLD,
+    OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD,
     OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S,
 )
 from bolna.helpers.logger_config import configure_logger
@@ -40,7 +42,7 @@ class OpenAITranscriber(BaseTranscriber):
         endpointing=400,
         delay="medium",
         noise_reduction=False,
-        speech_rms_threshold=400,
+        speech_rms_threshold=None,
         vad_threshold=0.5,
         vad_prefix_padding_ms=300,
         **kwargs,
@@ -56,7 +58,7 @@ class OpenAITranscriber(BaseTranscriber):
         # 'effort' was the old parameter name; accept it for backward compat
         self.delay = kwargs.pop("effort", None) or delay
         self.noise_reduction = noise_reduction
-        self.speech_rms_threshold = speech_rms_threshold
+        self.speech_rms_threshold = self._resolve_speech_rms_threshold(telephony_provider, speech_rms_threshold)
         self.vad_threshold = float(vad_threshold)
         self.vad_prefix_padding_ms = int(vad_prefix_padding_ms)
 
@@ -103,8 +105,19 @@ class OpenAITranscriber(BaseTranscriber):
         self._turn_committed = False
         # Timestamp of last committed turn (for utterance timeout)
         self._commit_time: Optional[float] = None
+        # Set when we emit a transcript from interim deltas after utterance timeout;
+        # used to ignore a late transcription.completed for the same turn.
+        self._force_finalized_turn_id: Optional[str] = None
 
         self._configure_audio_params()
+
+    @staticmethod
+    def _resolve_speech_rms_threshold(telephony_provider, speech_rms_threshold) -> float:
+        if speech_rms_threshold is not None:
+            return float(speech_rms_threshold)
+        if telephony_provider in ("twilio", "plivo", "exotel", "vobiz"):
+            return float(OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD)
+        return float(OPENAI_TRANSCRIBER_SPEECH_RMS_THRESHOLD)
 
     def _configure_audio_params(self):
         if self.telephony_provider == "twilio":
@@ -115,6 +128,9 @@ class OpenAITranscriber(BaseTranscriber):
             self.input_sampling_rate = 8000
         else:
             self.input_sampling_rate = self.sampling_rate
+
+    def _interim_transcript_text(self) -> str:
+        return "".join(detail.get("transcript", "") for detail in self.current_turn_interim_details).strip()
 
     def _resample_to_24k(self, audio_bytes: bytes) -> bytes:
         """Convert incoming audio (any rate/encoding) to 24 kHz linear16."""
@@ -244,8 +260,61 @@ class OpenAITranscriber(BaseTranscriber):
         except Exception as e:
             logger.error(f"Error in OpenAI heartbeat: {e}")
 
+    async def _force_finalize_from_interims(self):
+        """Emit a transcript from interim deltas when transcription.completed is late/missing.
+
+        Without this, Twilio calls can sit silent for tens of seconds while the LLM
+        waits for the final event, and the agent appears non-responsive (#711).
+        """
+        turn_id = self._last_committed_turn_id or self.current_turn_id
+        transcript = self._interim_transcript_text()
+        self._final_transcript_event.set()
+
+        if not transcript:
+            logger.warning(
+                f"Utterance timeout on turn {turn_id}: no interim text available to force-finalize"
+            )
+            self._reset_turn_state()
+            return
+
+        logger.warning(
+            f"Utterance timeout on turn {turn_id}: force-finalizing from interim text "
+            f"({len(transcript)} chars): {transcript[:80]}"
+        )
+        self._force_finalized_turn_id = turn_id
+
+        if self.current_turn_start_time:
+            total_ms = round((time.perf_counter() - self.current_turn_start_time) * 1000)
+            self.meta_info["transcriber_total_stream_duration"] = total_ms / 1000
+
+        first_interim_to_final_ms, last_interim_to_final_ms = self.calculate_interim_to_final_latencies(
+            self.current_turn_interim_details
+        )
+        self.turn_latencies.append(
+            {
+                "turn_id": turn_id,
+                "sequence_id": turn_id,
+                "interim_details": self.current_turn_interim_details,
+                "first_interim_to_final_ms": first_interim_to_final_ms,
+                "last_interim_to_final_ms": last_interim_to_final_ms,
+                "total_stream_duration_ms": round(
+                    (self.meta_info.get("transcriber_total_stream_duration") or 0) * 1000
+                ),
+                "asr_start_epoch_ms": self._turn_start_epoch_ms,
+                "asr_finalized_epoch_ms": timestamp_ms(),
+                "final_transcript": transcript,
+                "force_finalized": True,
+            }
+        )
+        self._reset_turn_state()
+        self.meta_info["turn_latencies"] = self.turn_latencies
+        await self.push_to_transcriber_queue(
+            create_ws_data_packet({"type": "transcript", "content": transcript}, self.meta_info)
+        )
+        del self.meta_info["turn_latencies"]
+
     async def monitor_utterance_timeout(self):
-        """Force-finalize a committed turn if completed event never arrives."""
+        """Force-finalize a committed turn if completed event never arrives in time."""
         try:
             while True:
                 await asyncio.sleep(0.1)
@@ -256,12 +325,7 @@ class OpenAITranscriber(BaseTranscriber):
                 ):
                     elapsed = time.time() - self._commit_time
                     if elapsed > OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S:
-                        logger.warning(
-                            f"Utterance timeout: completed event missing for {elapsed:.1f}s "
-                            f"after commit on turn {self.current_turn_id}. Force-finalizing."
-                        )
-                        self._final_transcript_event.set()
-                        self._reset_turn_state()
+                        await self._force_finalize_from_interims()
         except asyncio.CancelledError:
             logger.info("OpenAI utterance timeout task cancelled")
             raise
@@ -329,13 +393,21 @@ class OpenAITranscriber(BaseTranscriber):
                         self.audio_submission_time = time.time()
                         self._final_transcript_event.clear()
                         self._audio_appended_since_commit = False
+                        # Clear stale commit state so the utterance-timeout monitor
+                        # does not fire against the previous turn while new speech runs.
+                        self._turn_committed = False
+                        self._commit_time = None
+                        self._force_finalized_turn_id = None
                         self.turn_counter += 1
                         self.current_turn_id = f"turn_{self.turn_counter}"
                         self.current_turn_start_time = time.perf_counter()
                         self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []
                         self.is_transcript_sent_for_processing = False
-                        logger.info(f"Speech detected, starting turn {self.current_turn_id}")
+                        logger.info(
+                            f"Speech detected (RMS={rms:.0f} threshold={self.speech_rms_threshold}), "
+                            f"starting turn {self.current_turn_id}"
+                        )
                         await self.push_to_transcriber_queue(create_ws_data_packet("speech_started", self.meta_info))
                 else:
                     if self._speech_active:
@@ -407,11 +479,20 @@ class OpenAITranscriber(BaseTranscriber):
                         # Always unblock EOS drain, even for empty transcripts
                         self._final_transcript_event.set()
 
+                        # _last_committed_turn_id is saved at commit time and is the
+                        # most reliable identifier — current_turn_id may already point
+                        # to the next turn if the sender started speaking immediately.
+                        turn_id = self._last_committed_turn_id or self.current_turn_id or item_id
+
+                        # Skip duplicate if we already force-finalized this turn from interims.
+                        if turn_id and turn_id == self._force_finalized_turn_id:
+                            logger.info(
+                                f"Ignoring late transcription.completed for force-finalized turn {turn_id}"
+                            )
+                            self._force_finalized_turn_id = None
+                            continue
+
                         if transcript:
-                            # _last_committed_turn_id is saved at commit time and is the
-                            # most reliable identifier — current_turn_id may already point
-                            # to the next turn if the sender started speaking immediately.
-                            turn_id = self._last_committed_turn_id or self.current_turn_id or item_id
                             # OpenAI emits several items per committed turn; reusing one id made
                             # turn_latencies upserts clobber each other, so extras get a fresh id.
                             if turn_id is not None and turn_id == self._last_latency_turn_id:

--- a/tests/tests/test_openai_transcriber_force_finalize.py
+++ b/tests/tests/test_openai_transcriber_force_finalize.py
@@ -1,0 +1,153 @@
+"""Unit tests for OpenAITranscriber speech_rms_threshold config and force-finalize (#711)."""
+
+import asyncio
+import json
+
+import pytest
+
+from bolna.constants import (
+    OPENAI_TRANSCRIBER_SPEECH_RMS_THRESHOLD,
+    OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD,
+)
+from bolna.models import Transcriber
+from bolna.transcriber.openai_transcriber import OpenAITranscriber
+
+
+def _make_transcriber(telephony_provider="default", **kwargs):
+    return OpenAITranscriber(
+        telephony_provider=telephony_provider,
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        model="gpt-realtime-whisper",
+        language="en",
+        **kwargs,
+    )
+
+
+def test_speech_rms_threshold_exposed_on_transcriber_model():
+    cfg = Transcriber(provider="openai", speech_rms_threshold=250)
+    assert cfg.speech_rms_threshold == 250
+
+
+def test_speech_rms_threshold_default_none_on_model():
+    cfg = Transcriber(provider="openai")
+    assert cfg.speech_rms_threshold is None
+
+
+def test_default_speech_rms_threshold_non_telephony():
+    t = _make_transcriber(telephony_provider="default")
+    assert t.speech_rms_threshold == OPENAI_TRANSCRIBER_SPEECH_RMS_THRESHOLD
+
+
+def test_default_speech_rms_threshold_twilio():
+    t = _make_transcriber(telephony_provider="twilio")
+    assert t.speech_rms_threshold == OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD
+
+
+@pytest.mark.parametrize("provider", ["plivo", "exotel", "vobiz"])
+def test_default_speech_rms_threshold_other_telephony(provider):
+    t = _make_transcriber(telephony_provider=provider)
+    assert t.speech_rms_threshold == OPENAI_TRANSCRIBER_TELEPHONY_SPEECH_RMS_THRESHOLD
+
+
+def test_explicit_speech_rms_threshold_overrides_telephony_default():
+    t = _make_transcriber(telephony_provider="twilio", speech_rms_threshold=200)
+    assert t.speech_rms_threshold == 200.0
+
+
+def test_interim_transcript_text_joins_deltas():
+    t = _make_transcriber()
+    t.current_turn_interim_details = [
+        {"transcript": "Hey ", "received_at": 1.0, "is_final": False},
+        {"transcript": "Brooke", "received_at": 1.1, "is_final": False},
+    ]
+    assert t._interim_transcript_text() == "Hey Brooke"
+
+
+@pytest.mark.asyncio
+async def test_force_finalize_emits_transcript_from_interims():
+    output_queue = asyncio.Queue()
+    t = OpenAITranscriber(
+        telephony_provider="twilio",
+        input_queue=asyncio.Queue(),
+        output_queue=output_queue,
+        model="gpt-realtime-whisper",
+    )
+    t.current_turn_id = "turn_1"
+    t._last_committed_turn_id = "turn_1"
+    t._turn_committed = True
+    t._commit_time = 0.0
+    t.is_transcript_sent_for_processing = False
+    t.current_turn_start_time = None
+    t.current_turn_interim_details = [
+        {"transcript": "Hey Brooke", "received_at": 1.0, "is_final": False},
+    ]
+
+    await t._force_finalize_from_interims()
+
+    packet = output_queue.get_nowait()
+    assert packet["data"]["type"] == "transcript"
+    assert packet["data"]["content"] == "Hey Brooke"
+    assert t._force_finalized_turn_id == "turn_1"
+    assert t._final_transcript_event.is_set()
+    assert any(entry.get("force_finalized") for entry in t.turn_latencies)
+
+
+@pytest.mark.asyncio
+async def test_force_finalize_without_interims_resets_without_transcript():
+    output_queue = asyncio.Queue()
+    t = OpenAITranscriber(
+        telephony_provider="twilio",
+        input_queue=asyncio.Queue(),
+        output_queue=output_queue,
+        model="gpt-realtime-whisper",
+    )
+    t.current_turn_id = "turn_2"
+    t._last_committed_turn_id = "turn_2"
+    t._turn_committed = True
+    t.current_turn_interim_details = []
+
+    await t._force_finalize_from_interims()
+
+    assert output_queue.empty()
+    assert t._force_finalized_turn_id is None
+    assert t._final_transcript_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_receiver_ignores_late_completed_after_force_finalize():
+    t = _make_transcriber(telephony_provider="twilio")
+    t._force_finalized_turn_id = "turn_1"
+    t._last_committed_turn_id = "turn_1"
+    t.meta_info = {}
+
+    class _FakeWS:
+        def __init__(self, messages):
+            self._messages = messages
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._messages:
+                raise StopAsyncIteration
+            return self._messages.pop(0)
+
+    ws = _FakeWS(
+        [
+            json.dumps(
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "Hey Brooke",
+                    "item_id": "item_1",
+                }
+            )
+        ]
+    )
+
+    packets = []
+    async for packet in t.receiver(ws):
+        packets.append(packet)
+
+    assert packets == []
+    assert t._force_finalized_turn_id is None


### PR DESCRIPTION
## Summary
- Fixes [#711](https://github.com/bolna-ai/bolna/issues/711): OpenAI realtime whisper often delivers interim deltas quickly, but `transcription.completed` can arrive 20–35s later on Twilio. The LLM only starts on the final transcript, so the agent never replies in time.
- On utterance timeout after commit, force-finalize from accumulated interim deltas and ignore a late `completed` for the same turn (avoids duplicate LLM turns).
- Expose `speech_rms_threshold` on the `Transcriber` model so agents can tune the client-side RMS gate for noisy mulaw lines; default telephony threshold is 500 (non-telephony stays 400).
- Raise `OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S` from `0.5` → `2.0` so we wait briefly for a real completed event before falling back.

## Test plan
- [x] `pytest tests/tests/test_openai_transcriber_force_finalize.py -v` (12 passed)
- [ ] Optional live check: Twilio + `provider: openai` / `gpt-realtime-whisper` — confirm LLM responds within ~2s of end-of-utterance when `completed` is delayed
- [ ] Optional: set `"speech_rms_threshold": 250` (or higher) in agent transcriber config and confirm speech detection logs show the override


Made with [Cursor](https://cursor.com)