### PR TITLE
refactor: introduce TaskType enum for task string literals (#265)

### DIFF
--- a/bolna/agent_manager/assistant_manager.py
+++ b/bolna/agent_manager/assistant_manager.py
@@ -4,6 +4,7 @@ import uuid
 
 from .base_manager import BaseManager
 from .task_manager import TaskManager
+from bolna.enums import TaskType
 from bolna.helpers.logger_config import configure_logger
 from bolna.models import AGENT_WELCOME_MESSAGE
 from bolna.helpers.utils import update_prompt_with_context
@@ -85,6 +86,6 @@ class AssistantManager(BaseManager):
             self.task_states[task_id] = True
             if task_id == 0:
                 input_parameters = task_output
-            if task["task_type"] == "extraction":
+            if task["task_type"] == TaskType.EXTRACTION:
                 input_parameters["extraction_details"] = task_output["extracted_data"]
         logger.info("Done with execution of the agent")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -57,6 +57,7 @@ from bolna.enums import (
     NodeType,
     ChatRole,
     ToolScope,
+    TaskType,
 )
 from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
 from bolna.prompts import *
@@ -803,7 +804,7 @@ class TaskManager(BaseManager):
                 llm_agent = self.__setup_tasks(**agent_params)
                 self.llm_agent_map[agent] = llm_agent
 
-        elif self.task_config["task_type"] == "webhook":
+        elif self.task_config["task_type"] == TaskType.WEBHOOK:
             if "webhookURL" in self.task_config["tools_config"]["api_tools"]:
                 webhook_url = self.task_config["tools_config"]["api_tools"]["webhookURL"]
             else:
@@ -1089,25 +1090,25 @@ class TaskManager(BaseManager):
         return select_message_by_language(self.call_hangup_message_config, self.language)
 
     def __is_multiagent(self):
-        if self.task_config["task_type"] == "webhook":
+        if self.task_config["task_type"] == TaskType.WEBHOOK:
             return False
         agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
         return agent_type == "multiagent"
 
     def __is_knowledgebase_agent(self):
-        if self.task_config["task_type"] == "webhook":
+        if self.task_config["task_type"] == TaskType.WEBHOOK:
             return False
         agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
         return agent_type == "knowledgebase_agent"
 
     def __is_graph_agent(self):
-        if self.task_config["task_type"] == "webhook":
+        if self.task_config["task_type"] == TaskType.WEBHOOK:
             return False
         agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
         return agent_type == "graph_agent"
 
     # def __is_knowledge_agent(self):
-    #     if self.task_config["task_type"] == "webhook":
+    #     if self.task_config["task_type"] == TaskType.WEBHOOK:
     #         return False
     #     agent_type = self.task_config['tools_config']["llm_agent"].get("agent_type", None)
     #     return agent_type == "knowledge_agent"
@@ -1781,15 +1782,15 @@ class TaskManager(BaseManager):
         return llm_agent
 
     def __setup_tasks(self, llm=None, agent_type=None, assistant_config=None):
-        if self.task_config["task_type"] == "conversation" and not self.__is_multiagent():
+        if self.task_config["task_type"] == TaskType.CONVERSATION and not self.__is_multiagent():
             self.tools["llm_agent"] = self.__get_agent_object(llm, agent_type, assistant_config)
         elif self.__is_multiagent():
             return self.__get_agent_object(llm, agent_type, assistant_config)
-        elif self.task_config["task_type"] == "extraction":
+        elif self.task_config["task_type"] == TaskType.EXTRACTION:
             logger.info("Setting up extraction agent")
             self.tools["llm_agent"] = ExtractionContextualAgent(llm, prompt=self.system_prompt)
             self.extracted_data = None
-        elif self.task_config["task_type"] == "summarization":
+        elif self.task_config["task_type"] == TaskType.SUMMARIZATION:
             logger.info("Setting up summarization agent")
             self.tools["llm_agent"] = SummarizationContextualAgent(llm, prompt=self.system_prompt)
             self.summarized_data = None
@@ -1810,7 +1811,7 @@ class TaskManager(BaseManager):
         return f"{enriched_prompt}\n{notes}\n{DATE_PROMPT.format(today, current_time, current_timezone)}"
 
     async def load_prompt(self, assistant_name, task_id, local, **kwargs):
-        if self.task_config["task_type"] == "webhook":
+        if self.task_config["task_type"] == TaskType.WEBHOOK:
             return
 
         agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", "simple_llm_agent")
@@ -1919,14 +1920,14 @@ class TaskManager(BaseManager):
             self.timezone = pytz.timezone(self.context_data["recipient_data"]["timezone"])
         current_date, current_time = get_date_time_from_timezone(self.timezone)
 
-        if not prompt and task_type in ("extraction", "summarization"):
-            if task_type == "extraction":
+        if not prompt and task_type in (TaskType.EXTRACTION, TaskType.SUMMARIZATION):
+            if task_type == TaskType.EXTRACTION:
                 extraction_json = (
                     task.get("tools_config").get("llm_agent", {}).get("llm_config", {}).get("extraction_json")
                 )
                 prompt = EXTRACTION_PROMPT.format(current_date, current_time, self.timezone, extraction_json)
                 return {"system_prompt": prompt}
-            elif task_type == "summarization":
+            elif task_type == TaskType.SUMMARIZATION:
                 return {"system_prompt": SUMMARIZATION_PROMPT}
         return prompt
 
@@ -2445,13 +2446,13 @@ class TaskManager(BaseManager):
         return sequence, meta_info
 
     def _is_extraction_task(self):
-        return self.task_config["task_type"] == "extraction"
+        return self.task_config["task_type"] == TaskType.EXTRACTION
 
     def _is_summarization_task(self):
-        return self.task_config["task_type"] == "summarization"
+        return self.task_config["task_type"] == TaskType.SUMMARIZATION
 
     def _is_conversation_task(self):
-        return self.task_config["task_type"] == "conversation"
+        return self.task_config["task_type"] == TaskType.CONVERSATION
 
     def _get_next_step(self, sequence, origin):
         try:
@@ -2481,7 +2482,7 @@ class TaskManager(BaseManager):
             self.stream_sid = message["meta_info"]["stream_sid"]
 
     async def _process_followup_task(self, message=None):
-        if self.task_config["task_type"] == "webhook":
+        if self.task_config["task_type"] == TaskType.WEBHOOK:
             logger.info(f"Input patrameters {self.input_parameters}")
             extraction_details = self.input_parameters.get("extraction_details", {})
             logger.info(f"DOING THE POST REQUEST TO WEBHOOK {extraction_details}")
@@ -2504,7 +2505,7 @@ class TaskManager(BaseManager):
                 ) from e
             latency_ms = (time.time() - start_time) * 1000
 
-            if self.task_config["task_type"] == "summarization":
+            if self.task_config["task_type"] == TaskType.SUMMARIZATION:
                 self.summarized_data = json_data["summary"]
                 self.llm_latencies.other_latencies.append(
                     {
@@ -6735,7 +6736,7 @@ class TaskManager(BaseManager):
             else:
                 # Run agent followup tasks
                 try:
-                    if self.task_config["task_type"] == "webhook":
+                    if self.task_config["task_type"] == TaskType.WEBHOOK:
                         await self._process_followup_task()
                     else:
                         await self._run_llm_task(self.input_parameters)
@@ -7072,21 +7073,21 @@ class TaskManager(BaseManager):
                     )
             else:
                 output = self.input_parameters
-                if self.task_config["task_type"] == "extraction":
+                if self.task_config["task_type"] == TaskType.EXTRACTION:
                     output = {
                         "extracted_data": self.extracted_data,
-                        "task_type": "extraction",
+                        "task_type": TaskType.EXTRACTION.value,
                         "latency_dict": {"llm_latencies": self.llm_latencies.model_dump()},
                     }
-                elif self.task_config["task_type"] == "summarization":
+                elif self.task_config["task_type"] == TaskType.SUMMARIZATION:
                     logger.info(f"self.summarized_data {self.summarized_data}")
                     output = {
                         "summary": self.summarized_data,
-                        "task_type": "summarization",
+                        "task_type": TaskType.SUMMARIZATION.value,
                         "latency_dict": {"llm_latencies": self.llm_latencies.model_dump()},
                     }
-                elif self.task_config["task_type"] == "webhook":
-                    output = {"status": self.webhook_response, "task_type": "webhook"}
+                elif self.task_config["task_type"] == TaskType.WEBHOOK:
+                    output = {"status": self.webhook_response, "task_type": TaskType.WEBHOOK.value}
 
             try:
                 await asyncio.gather(*tasks_to_cancel)

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -107,6 +107,20 @@ class LLMProvider(str, Enum):
         return [provider.value for provider in cls]
 
 
+class TaskType(str, Enum):
+    """Enum for agent task types (conversation pipeline stages)."""
+
+    CONVERSATION = "conversation"
+    EXTRACTION = "extraction"
+    SUMMARIZATION = "summarization"
+    WEBHOOK = "webhook"
+
+    @classmethod
+    def all_values(cls):
+        """Return all task type values as a list of strings."""
+        return [task_type.value for task_type in cls]
+
+
 class ReasoningEffort(str, Enum):
     NONE = "none"
     MINIMAL = "minimal"

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -7,6 +7,7 @@ from .enums import (
     TelephonyProvider,
     SynthesizerProvider,
     TranscriberProvider,
+    TaskType,
     ReasoningEffort,
     Verbosity,
     ExpressionOperator,
@@ -627,8 +628,14 @@ class ConversationConfig(BaseModel):
 class Task(BaseModel):
     tools_config: ToolsConfig
     toolchain: ToolsChainModel
-    task_type: Optional[str] = "conversation"  # extraction, summarization, notification
+    task_type: Optional[str] = TaskType.CONVERSATION.value
     task_config: ConversationConfig = dict()
+
+    @field_validator("task_type")
+    def validate_task_type(cls, value):
+        if value is None:
+            return TaskType.CONVERSATION.value
+        return validate_attribute(value, TaskType.all_values(), value_type="task_type")
 
 
 class AgentModel(BaseModel):

--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -10,6 +10,7 @@ from bolna.helpers.utils import store_file
 from bolna.prompts import *
 from bolna.helpers.logger_config import configure_logger
 from bolna.models import *
+from bolna.enums import TaskType
 from bolna.llms import LiteLLM
 from bolna.agent_manager.assistant_manager import AssistantManager
 
@@ -58,7 +59,7 @@ async def create_agent(agent_data: CreateAgentPayload):
     if len(data_for_db["tasks"]) > 0:
         logger.info("Setting up follow up tasks")
         for index, task in enumerate(data_for_db["tasks"]):
-            if task["task_type"] == "extraction":
+            if task["task_type"] == TaskType.EXTRACTION:
                 extraction_prompt_llm = os.getenv("EXTRACTION_PROMPT_GENERATION_MODEL")
                 extraction_prompt_generation_llm = LiteLLM(model=extraction_prompt_llm, max_tokens=2000)
                 extraction_prompt = await extraction_prompt_generation_llm.generate(
@@ -98,7 +99,7 @@ async def edit_agent(agent_id: str, agent_data: CreateAgentPayload = Body(...)):
         logger.info(f"Updating Agent {agent_id}: {new_data}")
 
         for index, task in enumerate(new_data.get("tasks", [])):
-            if task.get("task_type") == "extraction":
+            if task.get("task_type") == TaskType.EXTRACTION:
                 extraction_prompt_llm = os.getenv("EXTRACTION_PROMPT_GENERATION_MODEL")
                 if not extraction_prompt_llm:
                     raise HTTPException(status_code=500, detail="Extraction model not configured")

--- a/tests/tests/test_task_type_enum.py
+++ b/tests/tests/test_task_type_enum.py
@@ -1,0 +1,49 @@
+"""Unit tests for TaskType enum (#265)."""
+
+import pytest
+from pydantic import ValidationError
+
+from bolna.enums import TaskType
+from bolna.models import Task, ToolsConfig, ToolsChainModel, Transcriber, LlmAgent
+
+
+def _minimal_task(task_type: str | None = None) -> Task:
+    kwargs = {
+        "tools_config": ToolsConfig(
+            llm_agent=LlmAgent(
+                agent_type="simple_llm_agent",
+                agent_flow_type="streaming",
+                llm_config={"provider": "openai", "model": "gpt-4o-mini"},
+            ),
+            transcriber=Transcriber(provider="deepgram", stream=True),
+        ),
+        "toolchain": ToolsChainModel(execution="parallel", pipelines=[["llm"]]),
+    }
+    if task_type is not None:
+        kwargs["task_type"] = task_type
+    return Task(**kwargs)
+
+
+def test_task_type_all_values():
+    assert TaskType.all_values() == ["conversation", "extraction", "summarization", "webhook"]
+
+
+def test_task_type_str_equality():
+    assert TaskType.CONVERSATION == "conversation"
+    assert "extraction" == TaskType.EXTRACTION
+
+
+@pytest.mark.parametrize("task_type", TaskType.all_values())
+def test_task_model_accepts_known_task_types(task_type):
+    task = _minimal_task(task_type)
+    assert task.task_type == task_type
+
+
+def test_task_model_defaults_to_conversation():
+    task = _minimal_task()
+    assert task.task_type == TaskType.CONVERSATION.value
+
+
+def test_task_model_rejects_unknown_task_type():
+    with pytest.raises(ValidationError):
+        _minimal_task("not_a_real_task")


### PR DESCRIPTION
## Summary
- Continues [#265](https://github.com/bolna-ai/bolna/issues/265) with a short, reviewable PR focused only on `TaskType`.
- Adds `TaskType` (`conversation`, `extraction`, `summarization`, `webhook`) to `bolna/enums.py` using the same `str, Enum` + `all_values()` pattern as the provider enums.
- Validates `Task.task_type` in `models.py` and replaces hardcoded `task_type == "..."` checks in `task_manager.py`, `assistant_manager.py`, and `local_setup/quickstart_server.py`.
- String configs remain compatible (`TaskType.CONVERSATION == "conversation"`).

## Test plan
- [x] `pytest tests/tests/test_task_type_enum.py -v` (8 passed)
- [ ] Smoke: create a conversation agent via local quickstart / existing tests that build `Task` configs


Made with [Cursor](https://cursor.com)