### PR TITLE
feat: add FunASR/SenseVoice self-hosted STT provider (#759)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,14 @@
 DEEPGRAM_AUTH_TOKEN=
 SONIOX_API_KEY=
+# Self-hosted FunASR / SenseVoice (see https://github.com/modelscope/FunASR)
+# Streaming WS runtime (classic funasr_wss or funasr-realtime-server)
+FUNASR_WS_URL=ws://127.0.0.1:10095
+# Optional: OpenAI-compatible HTTP base for non-stream batch transcription
+FUNASR_HTTP_URL=http://127.0.0.1:8000
+# Protocol: wss (classic JSON+PCM) or realtime (START/COMMIT/STOP)
+FUNASR_PROTOCOL=wss
+FUNASR_MODE=2pass
+FUNASR_API_KEY=
 ELEVENLABS_API_KEY=
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo

--- a/.env.sample
+++ b/.env.sample
@@ -5,8 +5,8 @@ SONIOX_API_KEY=
 FUNASR_WS_URL=ws://127.0.0.1:10095
 # Optional: OpenAI-compatible HTTP base for non-stream batch transcription
 FUNASR_HTTP_URL=http://127.0.0.1:8000
-# Protocol: wss (classic JSON+PCM) or realtime (START/COMMIT/STOP)
-FUNASR_PROTOCOL=wss
+# Protocol: realtime (START/COMMIT/STOP, default for agent loops) or wss (classic 2pass)
+FUNASR_PROTOCOL=realtime
 FUNASR_MODE=2pass
 FUNASR_API_KEY=
 ELEVENLABS_API_KEY=

--- a/README.md
+++ b/README.md
@@ -262,6 +262,28 @@ These are the current supported ASRs Providers:
 | Provider     | Environment variable to be added in `.env` file |
 |--------------|-------------------------------------------------|
 | Deepgram     | `DEEPGRAM_AUTH_TOKEN`                           |
+| FunASR / SenseVoice (self-hosted) | `FUNASR_WS_URL`, `FUNASR_HTTP_URL` (optional `FUNASR_PROTOCOL`, `FUNASR_API_KEY`) |
+
+**Self-hosted FunASR / SenseVoice**
+
+Bolna talks to a remote FunASR runtime (model weights stay on your FunASR host):
+
+- Streaming (default): realtime WebSocket (`FUNASR_PROTOCOL=realtime`) — START / PCM / COMMIT / STOP for agent turn-taking
+- Streaming (optional): classic `2pass` WebSocket (`FUNASR_PROTOCOL=wss`)
+- Non-stream: OpenAI-compatible `POST /v1/audio/transcriptions` against `funasr-server` (default `http://127.0.0.1:8000`)
+
+```python
+transcriber = Transcriber(provider="funasr", model="sensevoice", stream=True, language="en")
+```
+
+```bash
+# .env (see .env.sample)
+FUNASR_WS_URL=ws://127.0.0.1:10095
+FUNASR_HTTP_URL=http://127.0.0.1:8000
+FUNASR_PROTOCOL=realtime
+```
+
+SenseVoice language coverage is zh / en / ja / ko / yue. Run your own `funasr-server` or FunASR WebSocket runtime separately; Bolna only speaks the network protocol.
 
 </details>
 &nbsp;<br>

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ graph LR;
 
 ## Supported providers and models
 1. Initiating a phone call using telephony providers like `Twilio`, `Plivo`, `Exotel` (coming soon), `Vonage` (coming soon) etc.
-2. Transcribing the conversations using `Deepgram`, `Azure` etc.
+2. Transcribing the conversations using `Deepgram`, `Azure`, `OpenAI`, `Soniox`, self-hosted `FunASR` / SenseVoice, etc.
 3. Using LLMs like `OpenAI`, `DeepSeek`, `Llama`, `Cohere`, `Mistral`,  etc to handle conversations
 4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest` etc.
 

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -33,6 +33,10 @@ SONIOX_ENDPOINT_TOKEN = "<end>"  # sentinel token emitted when the speaker stops
 SONIOX_DEFAULT_MULTILINGUAL_HINTS = ["en", "hi", "ta", "te", "kn", "ml", "mr", "bn", "gu", "pa", "ur"]
 SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 
+# FunASR / SenseVoice self-hosted STT (remote server; weights are not bundled in Bolna)
+FUNASR_DEFAULT_WS_URL = "ws://127.0.0.1:10095"
+FUNASR_DEFAULT_CHUNK_SIZE = [5, 10, 5]
+
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"
 GPT5_4_MODEL_PREFIX = "gpt-5.4"

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -34,6 +34,7 @@ SONIOX_DEFAULT_MULTILINGUAL_HINTS = ["en", "hi", "ta", "te", "kn", "ml", "mr", "
 SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 
 # FunASR / SenseVoice self-hosted STT (remote server; weights are not bundled in Bolna)
+FUNASR_DEFAULT_HTTP_URL = "http://127.0.0.1:8000"
 FUNASR_DEFAULT_WS_URL = "ws://127.0.0.1:10095"
 FUNASR_DEFAULT_CHUNK_SIZE = [5, 10, 5]
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -72,6 +72,7 @@ class TranscriberProvider(str, Enum):
     SMALLEST = "smallest"
     OPENAI = "openai"
     SONIOX = "soniox"
+    FUNASR = "funasr"
 
     @classmethod
     def all_values(cls):

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -22,6 +22,7 @@ from .transcriber import (
     SmallestTranscriber,
     OpenAITranscriber,
     SonioxTranscriber,
+    FunASRTranscriber,
 )
 from .input_handlers import (
     DefaultInputHandler,
@@ -69,6 +70,7 @@ SUPPORTED_TRANSCRIBER_PROVIDERS = {
     TranscriberProvider.SMALLEST.value: SmallestTranscriber,
     TranscriberProvider.OPENAI.value: OpenAITranscriber,
     TranscriberProvider.SONIOX.value: SonioxTranscriber,
+    TranscriberProvider.FUNASR.value: FunASRTranscriber,
 }
 
 # Backwards compatibility

--- a/bolna/transcriber/__init__.py
+++ b/bolna/transcriber/__init__.py
@@ -10,5 +10,6 @@ from .elevenlabs_transcriber import ElevenLabsTranscriber
 from .smallest_transcriber import SmallestTranscriber
 from .openai_transcriber import OpenAITranscriber
 from .soniox_transcriber import SonioxTranscriber
+from .funasr_transcriber import FunASRTranscriber
 from .transcriber_pool import TranscriberPool
 from bolna.lid import LIDProvider, SarvamLID, SonioxLID

--- a/bolna/transcriber/funasr_transcriber.py
+++ b/bolna/transcriber/funasr_transcriber.py
@@ -1,0 +1,600 @@
+import asyncio
+import audioop
+import io
+import json
+import os
+import time
+import traceback
+import wave
+from typing import Optional
+from urllib.parse import urlparse
+
+import aiohttp
+import numpy as np
+import websockets
+from dotenv import load_dotenv
+from scipy.signal import resample_poly
+from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosedError, InvalidHandshake
+
+from .base_transcriber import BaseTranscriber
+from bolna.constants import FUNASR_DEFAULT_CHUNK_SIZE, FUNASR_DEFAULT_WS_URL, WEB_BASED_CALL_PROVIDER
+from bolna.enums import TelephonyProvider
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
+from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
+
+load_dotenv()
+logger = configure_logger(__name__)
+
+
+class FunASRTranscriber(BaseTranscriber):
+    """Self-hosted FunASR / SenseVoice STT.
+
+    Streaming uses the FunASR WebSocket runtime (classic ``2pass`` protocol or the
+    newer ``funasr-realtime-server`` START/COMMIT/STOP protocol). Non-stream uses the
+    OpenAI-compatible ``POST /v1/audio/transcriptions`` endpoint from ``funasr-server``.
+
+    Model weights stay on the FunASR server — Bolna only speaks the network protocol.
+    """
+
+    TARGET_SAMPLE_RATE = 16000
+
+    def __init__(
+        self,
+        telephony_provider,
+        input_queue=None,
+        model="sensevoice",
+        stream=True,
+        language="en",
+        encoding="linear16",
+        sampling_rate="16000",
+        output_queue=None,
+        endpointing=500,
+        keywords=None,
+        **kwargs,
+    ):
+        super().__init__(input_queue)
+        self.telephony_provider = telephony_provider
+        self.model = model
+        self.stream = stream
+        self.language = language or "en"
+        self.encoding = encoding
+        self.sampling_rate = int(sampling_rate)
+        self.endpointing_ms = int(endpointing) if endpointing is not None else 500
+        self.keywords = keywords
+        self.transcriber_output_queue = output_queue
+        self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
+
+        # Protocol: "wss" (classic funasr_wss) or "realtime" (START/COMMIT/STOP).
+        self.protocol = (kwargs.get("funasr_protocol") or os.getenv("FUNASR_PROTOCOL") or "wss").lower()
+        self.asr_mode = kwargs.get("funasr_mode") or os.getenv("FUNASR_MODE") or "2pass"
+        self.chunk_size = kwargs.get("chunk_size") or FUNASR_DEFAULT_CHUNK_SIZE
+        self.chunk_interval = int(kwargs.get("chunk_interval") or os.getenv("FUNASR_CHUNK_INTERVAL") or 10)
+        self.use_itn = bool(kwargs.get("use_itn", True))
+
+        self.api_key = kwargs.get("transcriber_key", os.getenv("FUNASR_API_KEY", ""))
+        self.ws_url = (
+            kwargs.get("transcriber_host")
+            or os.getenv("FUNASR_WS_URL")
+            or FUNASR_DEFAULT_WS_URL
+        )
+        self.http_base_url = (
+            kwargs.get("http_base_url")
+            or os.getenv("FUNASR_HTTP_URL")
+            or self._derive_http_base(self.ws_url)
+        )
+
+        self.audio_frame_duration = 0.2
+        self._resolve_audio_params()
+
+        self.websocket_connection: Optional[ClientConnection] = None
+        self.connection_authenticated = False
+        self.connection_error = None
+        self.http_session: Optional[aiohttp.ClientSession] = None
+
+        self.transcription_task = None
+        self.sender_task = None
+        self.commit_task = None
+
+        self.audio_submitted = False
+        self.num_frames = 0
+        self.connection_start_time = None
+        self.connection_time = None
+        self.audio_frame_timestamps = []
+        self._batch_pcm = bytearray()
+
+        self.final_transcript = ""
+        self.current_turn_id = None
+        self.current_turn_start_time = None
+        self.current_turn_interim_details = []
+        self.turn_counter = 0
+        self.last_interim_time = None
+        self._turn_first_speech_epoch_ms = None
+        self._config_sent = False
+        self._speech_active = False
+
+        # Client-endpoint realtime protocol: commit after silence (endpointing_ms).
+        self._silence_task: Optional[asyncio.Task] = None
+
+    @staticmethod
+    def _derive_http_base(ws_url: str) -> str:
+        parsed = urlparse(ws_url)
+        scheme = "https" if parsed.scheme == "wss" else "http"
+        host = parsed.hostname or "127.0.0.1"
+        port = parsed.port or (443 if scheme == "https" else 8000)
+        return f"{scheme}://{host}:{port}"
+
+    def _resolve_audio_params(self):
+        if self.telephony_provider in TelephonyProvider.telephony_values():
+            if self.telephony_provider != TelephonyProvider.SIP_TRUNK.value:
+                self.encoding = "mulaw" if self.telephony_provider == "twilio" else "linear16"
+                self.sampling_rate = 8000
+            self.audio_frame_duration = 0.2
+        elif self.telephony_provider == WEB_BASED_CALL_PROVIDER:
+            self.encoding = "linear16"
+            self.sampling_rate = 16000
+            self.audio_frame_duration = 0.256
+        elif not self.connected_via_dashboard:
+            self.encoding = "linear16"
+            self.sampling_rate = 16000
+
+    def get_meta_info(self):
+        return self.meta_info
+
+    def _to_pcm16k(self, data: bytes) -> bytes:
+        """Normalize telephony/web audio to 16-bit PCM at 16 kHz for FunASR."""
+        if not data:
+            return b""
+        if self.encoding in ("mulaw", "ulaw", "audio/x-mulaw"):
+            pcm = audioop.ulaw2lin(data, 2)
+            src_rate = self.sampling_rate or 8000
+        else:
+            pcm = data
+            src_rate = self.sampling_rate or self.TARGET_SAMPLE_RATE
+
+        if src_rate == self.TARGET_SAMPLE_RATE:
+            return pcm
+
+        samples = np.frombuffer(pcm, dtype=np.int16)
+        if samples.size == 0:
+            return b""
+        resampled = resample_poly(samples, self.TARGET_SAMPLE_RATE, src_rate)
+        return np.clip(resampled, -32768, 32767).astype(np.int16).tobytes()
+
+    def _build_wss_config(self) -> dict:
+        hotword_msg = ""
+        if self.keywords:
+            hotword_msg = ",".join(kw.strip() for kw in str(self.keywords).split(",") if kw.strip())
+        return {
+            "mode": self.asr_mode,
+            "chunk_size": self.chunk_size,
+            "chunk_interval": self.chunk_interval,
+            "encoder_chunk_look_back": 4,
+            "decoder_chunk_look_back": 0,
+            "audio_fs": self.TARGET_SAMPLE_RATE,
+            "wav_name": "bolna",
+            "wav_format": "pcm",
+            "is_speaking": True,
+            "hotwords": hotword_msg,
+            "itn": self.use_itn,
+        }
+
+    async def funasr_connect(self) -> ClientConnection:
+        try:
+            logger.info(f"Connecting to FunASR websocket: {self.ws_url} (protocol={self.protocol})")
+            extra = {}
+            if self.protocol == "wss":
+                extra["subprotocols"] = ["binary"]
+            ws = await asyncio.wait_for(
+                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url), **extra),
+                timeout=10.0,
+            )
+            if self.protocol == "realtime":
+                await ws.send("START")
+            else:
+                await ws.send(json.dumps(self._build_wss_config(), ensure_ascii=False))
+            self._config_sent = True
+            self.websocket_connection = ws
+            self.connection_authenticated = True
+            logger.info(f"Connected to FunASR (model={self.model}, protocol={self.protocol})")
+            return ws
+        except asyncio.TimeoutError:
+            raise ConnectionError("Timeout while connecting to FunASR websocket")
+        except InvalidHandshake as e:
+            raise ConnectionError(f"Invalid handshake during FunASR websocket connection: {e}")
+        except ConnectionClosedError as e:
+            raise ConnectionError(f"FunASR websocket connection closed unexpectedly: {e}")
+        except Exception as e:
+            raise ConnectionError(f"Unexpected error connecting to FunASR websocket: {e}")
+
+    def _start_turn(self):
+        self.turn_counter += 1
+        self.current_turn_id = self.turn_counter
+        now = timestamp_ms()
+        self.current_turn_start_time = now
+        self._turn_first_speech_epoch_ms = now
+        self.current_turn_interim_details = []
+        self.final_transcript = ""
+        self.is_transcript_sent_for_processing = False
+        self._speech_active = True
+        self.turn_latencies.append(
+            {
+                "turn_id": self.current_turn_id,
+                "asr_start_epoch_ms": self.current_turn_start_time,
+                "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+            }
+        )
+        logger.info(f"FunASR: starting turn {self.current_turn_id}")
+
+    def _reset_turn_state(self):
+        self._turn_first_speech_epoch_ms = None
+        self.current_turn_interim_details = []
+        self.current_turn_start_time = None
+        self.current_turn_id = None
+        self.final_transcript = ""
+        self.last_interim_time = None
+        self.is_transcript_sent_for_processing = True
+        self._speech_active = False
+
+    def _mark_last_interim_final(self):
+        if not self.current_turn_interim_details:
+            return
+        for entry in self.current_turn_interim_details:
+            entry["is_final"] = False
+        self.current_turn_interim_details[-1]["is_final"] = True
+
+    def _build_finalized_turn_latency(self, final_transcript):
+        self._mark_last_interim_final()
+        first_interim_to_final_ms, last_interim_to_final_ms = self.calculate_interim_to_final_latencies(
+            self.current_turn_interim_details
+        )
+        self._upsert_turn_latency(
+            {
+                "turn_id": self.current_turn_id,
+                "asr_start_epoch_ms": self.current_turn_start_time,
+                "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+                "asr_finalized_epoch_ms": timestamp_ms(),
+                "final_transcript": final_transcript,
+                "interim_details": self.current_turn_interim_details,
+                "first_interim_to_final_ms": first_interim_to_final_ms,
+                "last_interim_to_final_ms": last_interim_to_final_ms,
+            }
+        )
+
+    async def _schedule_realtime_commit(self, ws: ClientConnection):
+        if self.protocol != "realtime":
+            return
+        if self._silence_task and not self._silence_task.done():
+            self._silence_task.cancel()
+            try:
+                await self._silence_task
+            except asyncio.CancelledError:
+                pass
+
+        async def _commit_after_silence():
+            try:
+                await asyncio.sleep(max(self.endpointing_ms, 100) / 1000.0)
+                if self._speech_active and self.connection_on:
+                    logger.info("FunASR realtime: COMMIT after client silence")
+                    await ws.send("COMMIT")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                logger.error(f"FunASR realtime commit error: {e}")
+
+        self._silence_task = asyncio.create_task(_commit_after_silence())
+
+    async def sender_stream(self, ws: ClientConnection):
+        try:
+            while True:
+                ws_data_packet = await self.input_queue.get()
+
+                if not self.audio_submitted:
+                    self.meta_info = ws_data_packet.get("meta_info") or {}
+                    self.audio_submitted = True
+                    self.current_request_id = self.generate_request_id()
+                    self.meta_info["request_id"] = self.current_request_id
+
+                if ws_data_packet.get("meta_info", {}).get("eos") is True:
+                    try:
+                        if self.protocol == "realtime":
+                            if self._speech_active:
+                                await ws.send("COMMIT")
+                            await ws.send("STOP")
+                        else:
+                            await ws.send(json.dumps({"is_speaking": False}, ensure_ascii=False))
+                    except Exception as e:
+                        logger.error(f"Error sending FunASR end-of-stream: {e}")
+                    break
+
+                frame_start = self.num_frames * self.audio_frame_duration
+                frame_end = (self.num_frames + 1) * self.audio_frame_duration
+                self.audio_frame_timestamps.append((frame_start, frame_end, timestamp_ms()))
+                self.num_frames += 1
+
+                data = ws_data_packet.get("data")
+                if not data:
+                    continue
+                pcm = self._to_pcm16k(data)
+                if not pcm:
+                    continue
+                try:
+                    await ws.send(pcm)
+                    await self._schedule_realtime_commit(ws)
+                except ConnectionClosedError as e:
+                    logger.error(f"FunASR connection closed while sending audio: {e}")
+                    break
+                except Exception as e:
+                    logger.error(f"Error sending audio to FunASR: {e}")
+                    break
+        except asyncio.CancelledError:
+            logger.info("FunASR sender stream task cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Error in FunASR sender_stream: {e}")
+            raise
+
+    def _is_final_message(self, res: dict) -> bool:
+        if res.get("is_final") is True:
+            return True
+        mode = (res.get("mode") or "").lower()
+        return mode in ("offline", "2pass-offline")
+
+    def _is_interim_message(self, res: dict) -> bool:
+        mode = (res.get("mode") or "").lower()
+        if mode in ("online", "2pass-online"):
+            return True
+        # Realtime protocol often omits mode and uses is_final=false.
+        return res.get("is_final") is False and bool(res.get("text"))
+
+    async def receiver(self, ws: ClientConnection):
+        async for message in ws:
+            try:
+                if isinstance(message, bytes):
+                    message = message.decode("utf-8")
+                res = json.loads(message)
+
+                if self.connection_start_time is None:
+                    self.connection_start_time = time.time() - (self.num_frames * self.audio_frame_duration)
+
+                if res.get("error") or res.get("error_code") is not None:
+                    self.connection_error = str(res.get("error") or res.get("error_message") or res)
+                    logger.error(f"FunASR error: {self.connection_error}")
+                    break
+
+                text = (res.get("text") or res.get("transcript") or "").strip()
+                if not text and not self._is_final_message(res):
+                    continue
+
+                if text and self.current_turn_id is None:
+                    self._start_turn()
+                    yield create_ws_data_packet("speech_started", self.meta_info)
+
+                if text and self._is_interim_message(res) and not self._is_final_message(res):
+                    self.last_interim_time = time.time()
+                    running = text
+                    # Classic 2pass online is incremental; accumulate for display.
+                    if (res.get("mode") or "").lower() in ("online", "2pass-online"):
+                        self.final_transcript = text if not self.final_transcript else text
+                        running = text
+                    self.current_turn_interim_details.append(
+                        {
+                            "transcript": running,
+                            "latency_ms": None,
+                            "is_final": False,
+                            "received_at": time.time(),
+                        }
+                    )
+                    yield create_ws_data_packet(
+                        {"type": "interim_transcript_received", "content": running}, self.meta_info
+                    )
+
+                if text and self._is_final_message(res):
+                    final = text
+                    if not self.is_transcript_sent_for_processing:
+                        logger.info(f"FunASR final transcript: {final}")
+                        if self.current_turn_id is None:
+                            self._start_turn()
+                            yield create_ws_data_packet("speech_started", self.meta_info)
+                        self.final_transcript = final
+                        self._build_finalized_turn_latency(final)
+                        lang = res.get("language") or res.get("lang")
+                        if lang:
+                            self.meta_info["transcriber_detected_language"] = lang
+                        yield create_ws_data_packet({"type": "transcript", "content": final}, self.meta_info)
+                        self._reset_turn_state()
+                    continue
+
+                if res.get("finished"):
+                    logger.info("FunASR session finished")
+                    break
+
+            except Exception as e:
+                logger.error(f"Error processing FunASR message: {e}")
+                traceback.print_exc()
+
+    async def push_to_transcriber_queue(self, data_packet):
+        await self.transcriber_output_queue.put(data_packet)
+
+    async def toggle_connection(self):
+        self.connection_on = False
+        if self.sender_task is not None:
+            self.sender_task.cancel()
+        if self._silence_task is not None:
+            self._silence_task.cancel()
+        if self.websocket_connection is not None:
+            try:
+                await self.websocket_connection.close()
+            except Exception as e:
+                logger.error(f"Error closing FunASR websocket: {e}")
+            finally:
+                self.websocket_connection = None
+                self.connection_authenticated = False
+
+    async def cleanup(self):
+        logger.info("Cleaning up FunASR transcriber resources")
+        self.connection_on = False
+        for task in (self.sender_task, self.transcription_task, self._silence_task):
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                except Exception as e:
+                    logger.warning(f"Error cancelling FunASR task: {e}")
+        if self.websocket_connection is not None:
+            try:
+                await self.websocket_connection.close()
+            except Exception:
+                pass
+            finally:
+                self.websocket_connection = None
+                self.connection_authenticated = False
+        if self.http_session is not None:
+            await self.http_session.close()
+            self.http_session = None
+        self.audio_frame_timestamps = []
+        self.current_turn_interim_details = []
+        self._batch_pcm = bytearray()
+
+    def _pcm_to_wav_bytes(self, pcm: bytes) -> bytes:
+        buf = io.BytesIO()
+        with wave.open(buf, "wb") as wf:
+            wf.setnchannels(1)
+            wf.setsampwidth(2)
+            wf.setframerate(self.TARGET_SAMPLE_RATE)
+            wf.writeframes(pcm)
+        return buf.getvalue()
+
+    async def _http_transcribe_batch(self, pcm: bytes) -> str:
+        if self.http_session is None:
+            self.http_session = aiohttp.ClientSession()
+        url = f"{self.http_base_url.rstrip('/')}/v1/audio/transcriptions"
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        form = aiohttp.FormData()
+        form.add_field("model", self.model)
+        form.add_field("language", self.language)
+        form.add_field(
+            "file",
+            self._pcm_to_wav_bytes(pcm),
+            filename="audio.wav",
+            content_type="audio/wav",
+        )
+        async with self.http_session.post(url, data=form, headers=headers, timeout=aiohttp.ClientTimeout(total=60)) as resp:
+            body = await resp.text()
+            if resp.status >= 400:
+                raise ConnectionError(f"FunASR HTTP transcription failed ({resp.status}): {body}")
+            try:
+                payload = json.loads(body)
+            except json.JSONDecodeError:
+                return body.strip()
+            return (payload.get("text") or "").strip()
+
+    async def sender_http(self):
+        """Accumulate PCM until EOS, then call OpenAI-compatible FunASR HTTP API."""
+        try:
+            while True:
+                ws_data_packet = await self.input_queue.get()
+                if not self.audio_submitted:
+                    self.meta_info = ws_data_packet.get("meta_info") or {}
+                    self.audio_submitted = True
+                    self.current_request_id = self.generate_request_id()
+                    self.meta_info["request_id"] = self.current_request_id
+
+                if ws_data_packet.get("meta_info", {}).get("eos") is True:
+                    if self._batch_pcm:
+                        text = await self._http_transcribe_batch(bytes(self._batch_pcm))
+                        if text:
+                            self._start_turn()
+                            await self.push_to_transcriber_queue(create_ws_data_packet("speech_started", self.meta_info))
+                            self._build_finalized_turn_latency(text)
+                            await self.push_to_transcriber_queue(
+                                create_ws_data_packet({"type": "transcript", "content": text}, self.meta_info)
+                            )
+                            self._reset_turn_state()
+                        self._batch_pcm = bytearray()
+                    break
+
+                data = ws_data_packet.get("data")
+                if not data:
+                    continue
+                pcm = self._to_pcm16k(data)
+                if pcm:
+                    self._batch_pcm.extend(pcm)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Error in FunASR HTTP sender: {e}")
+            self.connection_error = str(e)
+            raise
+
+    async def run(self):
+        try:
+            self.transcription_task = asyncio.create_task(self.transcribe())
+        except Exception as e:
+            logger.error(f"Error starting FunASR transcriber: {e}")
+
+    async def transcribe(self):
+        self.num_frames = 0
+        self.audio_frame_timestamps = []
+        self.connection_start_time = None
+        funasr_ws = None
+        try:
+            if not self.stream:
+                self.sender_task = asyncio.create_task(self.sender_http())
+                await self.sender_task
+                return
+
+            start_time = timestamp_ms()
+            try:
+                funasr_ws = await self.funasr_connect()
+            except (ValueError, ConnectionError) as e:
+                logger.error(f"Failed to establish FunASR connection: {e}")
+                self.connection_error = str(e)
+                await self.toggle_connection()
+                return
+
+            if not self.connection_time:
+                self.connection_time = round(timestamp_ms() - start_time)
+
+            self.sender_task = asyncio.create_task(self.sender_stream(funasr_ws))
+            try:
+                async for message in self.receiver(funasr_ws):
+                    if self.connection_on:
+                        await self.push_to_transcriber_queue(message)
+                    else:
+                        break
+            except ConnectionClosedError as e:
+                logger.error(f"FunASR websocket closed during streaming: {e}")
+                self.connection_error = str(e)
+            except Exception as e:
+                logger.error(f"Error during FunASR streaming: {e}")
+                self.connection_error = str(e)
+                raise
+        except (ValueError, ConnectionError) as e:
+            logger.error(f"Connection error in FunASR transcribe: {e}")
+            self.connection_error = str(e)
+            await self.toggle_connection()
+        except Exception as e:
+            logger.error(f"Unexpected error in FunASR transcribe: {e}")
+            self.connection_error = str(e)
+            await self.toggle_connection()
+        finally:
+            if funasr_ws is not None:
+                try:
+                    await funasr_ws.close()
+                except Exception as e:
+                    logger.error(f"Error closing FunASR websocket in finally: {e}")
+                finally:
+                    self.websocket_connection = None
+                    self.connection_authenticated = False
+            if self.sender_task is not None:
+                self.sender_task.cancel()
+            meta = dict(getattr(self, "meta_info", None) or {})
+            if self.connection_error:
+                meta["connection_error"] = self.connection_error
+            await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))

--- a/bolna/transcriber/funasr_transcriber.py
+++ b/bolna/transcriber/funasr_transcriber.py
@@ -7,7 +7,6 @@ import time
 import traceback
 import wave
 from typing import Optional
-from urllib.parse import urlparse
 
 import aiohttp
 import numpy as np
@@ -18,7 +17,12 @@ from websockets.asyncio.client import ClientConnection
 from websockets.exceptions import ConnectionClosedError, InvalidHandshake
 
 from .base_transcriber import BaseTranscriber
-from bolna.constants import FUNASR_DEFAULT_CHUNK_SIZE, FUNASR_DEFAULT_WS_URL, WEB_BASED_CALL_PROVIDER
+from bolna.constants import (
+    FUNASR_DEFAULT_CHUNK_SIZE,
+    FUNASR_DEFAULT_HTTP_URL,
+    FUNASR_DEFAULT_WS_URL,
+    WEB_BASED_CALL_PROVIDER,
+)
 from bolna.enums import TelephonyProvider
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
@@ -31,9 +35,11 @@ logger = configure_logger(__name__)
 class FunASRTranscriber(BaseTranscriber):
     """Self-hosted FunASR / SenseVoice STT.
 
-    Streaming uses the FunASR WebSocket runtime (classic ``2pass`` protocol or the
-    newer ``funasr-realtime-server`` START/COMMIT/STOP protocol). Non-stream uses the
-    OpenAI-compatible ``POST /v1/audio/transcriptions`` endpoint from ``funasr-server``.
+    Streaming defaults to the FunASR realtime WebSocket runtime (START/COMMIT/STOP)
+    so Bolna can commit utterance boundaries for interruption/turn-taking. Classic
+    ``2pass`` ``funasr_wss`` remains available via ``funasr_protocol=wss``.
+    Non-stream uses OpenAI-compatible ``POST /v1/audio/transcriptions`` on
+    ``funasr-server`` (default ``http://127.0.0.1:8000``).
 
     Model weights stay on the FunASR server — Bolna only speaks the network protocol.
     """
@@ -66,8 +72,8 @@ class FunASRTranscriber(BaseTranscriber):
         self.transcriber_output_queue = output_queue
         self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
 
-        # Protocol: "wss" (classic funasr_wss) or "realtime" (START/COMMIT/STOP).
-        self.protocol = (kwargs.get("funasr_protocol") or os.getenv("FUNASR_PROTOCOL") or "wss").lower()
+        # Default realtime (client COMMIT) for voice-agent loops; classic 2pass via "wss".
+        self.protocol = (kwargs.get("funasr_protocol") or os.getenv("FUNASR_PROTOCOL") or "realtime").lower()
         self.asr_mode = kwargs.get("funasr_mode") or os.getenv("FUNASR_MODE") or "2pass"
         self.chunk_size = kwargs.get("chunk_size") or FUNASR_DEFAULT_CHUNK_SIZE
         self.chunk_interval = int(kwargs.get("chunk_interval") or os.getenv("FUNASR_CHUNK_INTERVAL") or 10)
@@ -79,10 +85,11 @@ class FunASRTranscriber(BaseTranscriber):
             or os.getenv("FUNASR_WS_URL")
             or FUNASR_DEFAULT_WS_URL
         )
+        # Do not derive HTTP from the WS URL — classic WS is :10095 while funasr-server is :8000.
         self.http_base_url = (
             kwargs.get("http_base_url")
             or os.getenv("FUNASR_HTTP_URL")
-            or self._derive_http_base(self.ws_url)
+            or FUNASR_DEFAULT_HTTP_URL
         )
 
         self.audio_frame_duration = 0.2
@@ -116,14 +123,6 @@ class FunASRTranscriber(BaseTranscriber):
 
         # Client-endpoint realtime protocol: commit after silence (endpointing_ms).
         self._silence_task: Optional[asyncio.Task] = None
-
-    @staticmethod
-    def _derive_http_base(ws_url: str) -> str:
-        parsed = urlparse(ws_url)
-        scheme = "https" if parsed.scheme == "wss" else "http"
-        host = parsed.hostname or "127.0.0.1"
-        port = parsed.port or (443 if scheme == "https" else 8000)
-        return f"{scheme}://{host}:{port}"
 
     def _resolve_audio_params(self):
         if self.telephony_provider in TelephonyProvider.telephony_values():
@@ -298,6 +297,12 @@ class FunASRTranscriber(BaseTranscriber):
 
                 if ws_data_packet.get("meta_info", {}).get("eos") is True:
                     try:
+                        if self._silence_task and not self._silence_task.done():
+                            self._silence_task.cancel()
+                            try:
+                                await self._silence_task
+                            except asyncio.CancelledError:
+                                pass
                         if self.protocol == "realtime":
                             if self._speech_active:
                                 await ws.send("COMMIT")
@@ -320,6 +325,10 @@ class FunASRTranscriber(BaseTranscriber):
                 if not pcm:
                     continue
                 try:
+                    # Mark speech active on first audio so realtime silence COMMIT can fire
+                    # even before the first interim arrives.
+                    if not self._speech_active:
+                        self._speech_active = True
                     await ws.send(pcm)
                     await self._schedule_realtime_commit(ws)
                 except ConnectionClosedError as e:
@@ -364,14 +373,23 @@ class FunASRTranscriber(BaseTranscriber):
                     break
 
                 text = (res.get("text") or res.get("transcript") or "").strip()
-                if not text and not self._is_final_message(res):
+                is_final = self._is_final_message(res)
+
+                # Empty final (e.g. COMMIT with no speech) — close the turn for Bolna.
+                if is_final and not text:
+                    if self.current_turn_id is not None or self._speech_active:
+                        yield create_ws_data_packet({"type": "speech_ended"}, self.meta_info)
+                        self._reset_turn_state()
+                    continue
+
+                if not text and not is_final:
                     continue
 
                 if text and self.current_turn_id is None:
                     self._start_turn()
                     yield create_ws_data_packet("speech_started", self.meta_info)
 
-                if text and self._is_interim_message(res) and not self._is_final_message(res):
+                if text and self._is_interim_message(res) and not is_final:
                     self.last_interim_time = time.time()
                     running = text
                     # Classic 2pass online is incremental; accumulate for display.
@@ -390,7 +408,7 @@ class FunASRTranscriber(BaseTranscriber):
                         {"type": "interim_transcript_received", "content": running}, self.meta_info
                     )
 
-                if text and self._is_final_message(res):
+                if text and is_final:
                     final = text
                     if not self.is_transcript_sent_for_processing:
                         logger.info(f"FunASR final transcript: {final}")
@@ -547,34 +565,32 @@ class FunASRTranscriber(BaseTranscriber):
             if not self.stream:
                 self.sender_task = asyncio.create_task(self.sender_http())
                 await self.sender_task
-                return
+            else:
+                start_time = timestamp_ms()
+                try:
+                    funasr_ws = await self.funasr_connect()
+                except (ValueError, ConnectionError) as e:
+                    logger.error(f"Failed to establish FunASR connection: {e}")
+                    self.connection_error = str(e)
+                    await self.toggle_connection()
+                else:
+                    if not self.connection_time:
+                        self.connection_time = round(timestamp_ms() - start_time)
 
-            start_time = timestamp_ms()
-            try:
-                funasr_ws = await self.funasr_connect()
-            except (ValueError, ConnectionError) as e:
-                logger.error(f"Failed to establish FunASR connection: {e}")
-                self.connection_error = str(e)
-                await self.toggle_connection()
-                return
-
-            if not self.connection_time:
-                self.connection_time = round(timestamp_ms() - start_time)
-
-            self.sender_task = asyncio.create_task(self.sender_stream(funasr_ws))
-            try:
-                async for message in self.receiver(funasr_ws):
-                    if self.connection_on:
-                        await self.push_to_transcriber_queue(message)
-                    else:
-                        break
-            except ConnectionClosedError as e:
-                logger.error(f"FunASR websocket closed during streaming: {e}")
-                self.connection_error = str(e)
-            except Exception as e:
-                logger.error(f"Error during FunASR streaming: {e}")
-                self.connection_error = str(e)
-                raise
+                    self.sender_task = asyncio.create_task(self.sender_stream(funasr_ws))
+                    try:
+                        async for message in self.receiver(funasr_ws):
+                            if self.connection_on:
+                                await self.push_to_transcriber_queue(message)
+                            else:
+                                break
+                    except ConnectionClosedError as e:
+                        logger.error(f"FunASR websocket closed during streaming: {e}")
+                        self.connection_error = str(e)
+                    except Exception as e:
+                        logger.error(f"Error during FunASR streaming: {e}")
+                        self.connection_error = str(e)
+                        raise
         except (ValueError, ConnectionError) as e:
             logger.error(f"Connection error in FunASR transcribe: {e}")
             self.connection_error = str(e)
@@ -592,9 +608,14 @@ class FunASRTranscriber(BaseTranscriber):
                 finally:
                     self.websocket_connection = None
                     self.connection_authenticated = False
-            if self.sender_task is not None:
+            if self.sender_task is not None and not self.sender_task.done():
                 self.sender_task.cancel()
+                try:
+                    await self.sender_task
+                except (asyncio.CancelledError, Exception):
+                    pass
             meta = dict(getattr(self, "meta_info", None) or {})
             if self.connection_error:
                 meta["connection_error"] = self.connection_error
-            await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
+            if self.transcriber_output_queue is not None:
+                await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))

--- a/tests/tests/test_funasr_transcriber.py
+++ b/tests/tests/test_funasr_transcriber.py
@@ -3,7 +3,7 @@
 import asyncio
 import audioop
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import numpy as np
 import pytest
@@ -12,6 +12,36 @@ from bolna.enums import TranscriberProvider
 from bolna.models import Transcriber
 from bolna.providers import SUPPORTED_TRANSCRIBER_PROVIDERS
 from bolna.transcriber.funasr_transcriber import FunASRTranscriber
+
+
+class FakeWS:
+    def __init__(self, messages):
+        self._messages = messages
+        self.sent = []
+
+    def __aiter__(self):
+        async def _gen():
+            for m in self._messages:
+                yield m
+
+        return _gen()
+
+    async def send(self, data):
+        self.sent.append(data)
+
+    async def close(self):
+        return None
+
+
+def _packet_types(packets):
+    types = []
+    for p in packets:
+        data = p["data"]
+        if isinstance(data, str):
+            types.append(data)
+        else:
+            types.append(data.get("type"))
+    return types
 
 
 def test_funasr_provider_registered():
@@ -29,6 +59,25 @@ def test_transcriber_model_accepts_funasr():
 def test_transcriber_model_rejects_unknown_provider():
     with pytest.raises(Exception):
         Transcriber(provider="not-a-real-asr", model="x", stream=True)
+
+
+def test_default_protocol_is_realtime():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+    )
+    assert tr.protocol == "realtime"
+
+
+def test_classic_wss_protocol_can_be_selected():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="wss",
+    )
+    assert tr.protocol == "wss"
 
 
 def test_to_pcm16k_mulaw_8k():
@@ -68,21 +117,32 @@ def test_is_final_and_interim_modes():
     assert tr._is_interim_message({"is_final": False, "text": "h"})
 
 
+def test_non_stream_default_uses_funasr_server_http_port():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        stream=False,
+    )
+    assert tr.ws_url == "ws://127.0.0.1:10095"
+    assert tr.http_base_url == "http://127.0.0.1:8000"
+
+
+def test_non_stream_http_base_url_can_be_overridden():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        stream=False,
+        http_base_url="http://localhost:18000",
+    )
+    assert tr.http_base_url == "http://localhost:18000"
+
+
 @pytest.mark.asyncio
 async def test_receiver_emits_interim_then_final():
     tr = FunASRTranscriber(telephony_provider="web_based_call", input_queue=asyncio.Queue(), output_queue=asyncio.Queue())
     tr.meta_info = {"request_id": "r1"}
-
-    class FakeWS:
-        def __init__(self, messages):
-            self._messages = messages
-
-        def __aiter__(self):
-            async def _gen():
-                for m in self._messages:
-                    yield m
-
-            return _gen()
 
     ws = FakeWS(
         [
@@ -95,19 +155,60 @@ async def test_receiver_emits_interim_then_final():
     async for packet in tr.receiver(ws):
         packets.append(packet)
 
-    types = []
-    for p in packets:
-        data = p["data"]
-        if isinstance(data, str):
-            types.append(data)
-        else:
-            types.append(data.get("type"))
-
+    types = _packet_types(packets)
     assert "speech_started" in types
     assert "interim_transcript_received" in types
     assert "transcript" in types
     finals = [p["data"]["content"] for p in packets if isinstance(p["data"], dict) and p["data"].get("type") == "transcript"]
     assert finals == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_receiver_empty_final_emits_speech_ended():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="realtime",
+    )
+    tr.meta_info = {"request_id": "r1"}
+    tr._speech_active = True
+
+    ws = FakeWS([json.dumps({"is_final": True, "text": ""})])
+    packets = []
+    async for packet in tr.receiver(ws):
+        packets.append(packet)
+
+    assert _packet_types(packets) == ["speech_ended"]
+    assert tr._speech_active is False
+
+
+@pytest.mark.asyncio
+async def test_realtime_partial_final_then_empty_close_turn():
+    """Agent-loop contract: interim → final transcript; empty final closes turn."""
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="realtime",
+    )
+    tr.meta_info = {"request_id": "r1"}
+
+    ws = FakeWS(
+        [
+            json.dumps({"is_final": False, "text": "hel"}),
+            json.dumps({"is_final": True, "text": "hello"}),
+            json.dumps({"is_final": True, "text": ""}),
+        ]
+    )
+    packets = []
+    async for packet in tr.receiver(ws):
+        packets.append(packet)
+
+    types = _packet_types(packets)
+    assert types == ["speech_started", "interim_transcript_received", "transcript"]
+    # Empty final after turn already reset is a no-op (no duplicate speech_ended).
+    assert "speech_ended" not in types
 
 
 @pytest.mark.asyncio
@@ -125,6 +226,62 @@ async def test_realtime_connect_sends_start():
     assert ws is mock_ws
     mock_ws.send.assert_awaited()
     assert mock_ws.send.await_args_list[0].args[0] == "START"
+
+
+@pytest.mark.asyncio
+async def test_realtime_eos_sends_commit_then_stop():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="realtime",
+        endpointing=50,
+    )
+    tr.meta_info = {}
+    tr._speech_active = True
+    ws = FakeWS([])
+    await tr.input_queue.put({"data": b"", "meta_info": {"eos": True}})
+    await tr.sender_stream(ws)
+    assert ws.sent == ["COMMIT", "STOP"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_silence_commit_after_audio():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="realtime",
+        endpointing=50,
+    )
+    pcm = np.zeros(320, dtype=np.int16).tobytes()
+    ws = FakeWS([])
+    await tr.input_queue.put({"data": pcm, "meta_info": {"request_id": "r1"}})
+    await tr.input_queue.put({"data": b"", "meta_info": {"eos": True}})
+
+    send_task = asyncio.create_task(tr.sender_stream(ws))
+    await asyncio.wait_for(send_task, timeout=2.0)
+
+    assert any(isinstance(m, (bytes, bytearray)) for m in ws.sent)
+    assert "COMMIT" in ws.sent
+    assert ws.sent[-1] == "STOP"
+
+
+@pytest.mark.asyncio
+async def test_connect_failure_emits_transcriber_connection_closed():
+    out_q = asyncio.Queue()
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=out_q,
+        funasr_protocol="realtime",
+    )
+    with patch.object(tr, "funasr_connect", new=AsyncMock(side_effect=ConnectionError("refused"))):
+        await tr.transcribe()
+
+    packet = out_q.get_nowait()
+    assert packet["data"] == "transcriber_connection_closed"
+    assert "refused" in (packet["meta_info"].get("connection_error") or "")
 
 
 @pytest.mark.asyncio

--- a/tests/tests/test_funasr_transcriber.py
+++ b/tests/tests/test_funasr_transcriber.py
@@ -1,0 +1,168 @@
+"""Unit tests for FunASR / SenseVoice self-hosted STT provider."""
+
+import asyncio
+import audioop
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from bolna.enums import TranscriberProvider
+from bolna.models import Transcriber
+from bolna.providers import SUPPORTED_TRANSCRIBER_PROVIDERS
+from bolna.transcriber.funasr_transcriber import FunASRTranscriber
+
+
+def test_funasr_provider_registered():
+    assert TranscriberProvider.FUNASR.value == "funasr"
+    assert "funasr" in TranscriberProvider.all_values()
+    assert SUPPORTED_TRANSCRIBER_PROVIDERS["funasr"] is FunASRTranscriber
+
+
+def test_transcriber_model_accepts_funasr():
+    t = Transcriber(provider="funasr", model="sensevoice", stream=True, language="en")
+    assert t.provider == "funasr"
+    assert t.model == "sensevoice"
+
+
+def test_transcriber_model_rejects_unknown_provider():
+    with pytest.raises(Exception):
+        Transcriber(provider="not-a-real-asr", model="x", stream=True)
+
+
+def test_to_pcm16k_mulaw_8k():
+    # 20ms of silence at 8k mulaw
+    pcm8 = np.zeros(160, dtype=np.int16).tobytes()
+    mulaw = audioop.lin2ulaw(pcm8, 2)
+    tr = FunASRTranscriber(telephony_provider="twilio", input_queue=asyncio.Queue(), output_queue=asyncio.Queue())
+    assert tr.encoding == "mulaw"
+    assert tr.sampling_rate == 8000
+    out = tr._to_pcm16k(mulaw)
+    assert len(out) > 0
+    assert len(out) % 2 == 0
+    # 8k → 16k roughly doubles sample count
+    assert abs(len(out) - len(pcm8) * 2) <= 4
+
+
+def test_build_wss_config_includes_mode_and_sample_rate():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        keywords="bolna,voice",
+    )
+    cfg = tr._build_wss_config()
+    assert cfg["mode"] == "2pass"
+    assert cfg["audio_fs"] == 16000
+    assert cfg["wav_format"] == "pcm"
+    assert cfg["is_speaking"] is True
+    assert "bolna" in cfg["hotwords"]
+
+
+def test_is_final_and_interim_modes():
+    tr = FunASRTranscriber(telephony_provider="web_based_call", input_queue=asyncio.Queue(), output_queue=asyncio.Queue())
+    assert tr._is_final_message({"mode": "2pass-offline", "text": "hi"})
+    assert tr._is_final_message({"is_final": True, "text": "hi"})
+    assert tr._is_interim_message({"mode": "2pass-online", "text": "h"})
+    assert tr._is_interim_message({"is_final": False, "text": "h"})
+
+
+@pytest.mark.asyncio
+async def test_receiver_emits_interim_then_final():
+    tr = FunASRTranscriber(telephony_provider="web_based_call", input_queue=asyncio.Queue(), output_queue=asyncio.Queue())
+    tr.meta_info = {"request_id": "r1"}
+
+    class FakeWS:
+        def __init__(self, messages):
+            self._messages = messages
+
+        def __aiter__(self):
+            async def _gen():
+                for m in self._messages:
+                    yield m
+
+            return _gen()
+
+    ws = FakeWS(
+        [
+            json.dumps({"mode": "2pass-online", "text": "hel"}),
+            json.dumps({"mode": "2pass-offline", "text": "hello", "is_final": True}),
+        ]
+    )
+
+    packets = []
+    async for packet in tr.receiver(ws):
+        packets.append(packet)
+
+    types = []
+    for p in packets:
+        data = p["data"]
+        if isinstance(data, str):
+            types.append(data)
+        else:
+            types.append(data.get("type"))
+
+    assert "speech_started" in types
+    assert "interim_transcript_received" in types
+    assert "transcript" in types
+    finals = [p["data"]["content"] for p in packets if isinstance(p["data"], dict) and p["data"].get("type") == "transcript"]
+    assert finals == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_realtime_connect_sends_start():
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        funasr_protocol="realtime",
+    )
+    mock_ws = AsyncMock()
+    with patch("bolna.transcriber.funasr_transcriber.websockets.connect", new=AsyncMock(return_value=mock_ws)):
+        with patch("bolna.transcriber.funasr_transcriber.get_ssl_context", return_value=None):
+            ws = await tr.funasr_connect()
+    assert ws is mock_ws
+    mock_ws.send.assert_awaited()
+    assert mock_ws.send.await_args_list[0].args[0] == "START"
+
+
+@pytest.mark.asyncio
+async def test_http_batch_posts_multipart(monkeypatch):
+    tr = FunASRTranscriber(
+        telephony_provider="web_based_call",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        stream=False,
+        model="sensevoice",
+        http_base_url="http://127.0.0.1:8000",
+    )
+
+    class FakeResp:
+        status = 200
+
+        async def text(self):
+            return json.dumps({"text": "bonjour"})
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return False
+
+    class FakeSession:
+        def __init__(self):
+            self.posted = None
+
+        def post(self, url, data=None, headers=None, timeout=None):
+            self.posted = {"url": url, "data": data, "headers": headers}
+            return FakeResp()
+
+        async def close(self):
+            pass
+
+    session = FakeSession()
+    tr.http_session = session
+    text = await tr._http_transcribe_batch(np.zeros(1600, dtype=np.int16).tobytes())
+    assert text == "bonjour"
+    assert session.posted["url"].endswith("/v1/audio/transcriptions")


### PR DESCRIPTION
## Summary
- Adds a `funasr` transcriber provider so Bolna can use **self-hosted FunASR / SenseVoice** without bundling model weights in-process.
- **Streaming:** classic FunASR WebSocket `2pass` protocol (partials + finals) and optional `funasr-realtime-server` START/COMMIT/STOP mode for voice-agent turn-taking.
- **Non-stream:** OpenAI-compatible `POST /v1/audio/transcriptions` against `funasr-server`.
- Telephony audio (e.g. Twilio mulaw 8 kHz) is normalized to 16-bit PCM @ 16 kHz before send.
- Wires provider into `TranscriberProvider`, `providers.py`, README, `.env.sample`, and unit tests.

Fixes #759

## Why this matters
Self-hosted ASR reduces per-minute cloud STT cost, keeps audio on the operator’s infrastructure, and unlocks strong multilingual models (SenseVoice / Fun-ASR-Nano) for production voice agents.

## Config example
```json
"transcriber": {
  "provider": "funasr",
  "model": "sensevoice",
  "stream": true,
  "language": "en"
}
```

Env:
- `FUNASR_WS_URL` (default `ws://127.0.0.1:10095`)
- `FUNASR_HTTP_URL` (for non-stream)
- `FUNASR_PROTOCOL` = `wss` | `realtime`
- `FUNASR_MODE` = `2pass` (classic WS)

## Test plan
- [x] `pytest tests/tests/test_funasr_transcriber.py -v` (9 passed)
- [ ] Point `FUNASR_WS_URL` at a running FunASR WS runtime and verify interim + final transcripts on a web/telephony call
- [ ] Optional: `stream: false` against `funasr-server` HTTP `/v1/audio/transcriptions`


Made with [Cursor](https://cursor.com)