### PR TITLE
fix: unify graph edge precedence so an unconditional edge never suppresses intent edges

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.146"
+__version__ = "0.10.147"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -324,8 +324,8 @@ class GraphAgent(BaseAgent):
     def _edge_function_name(edge: dict) -> str:
         return edge.get("function_name") or f"transition_to_{edge['to_node_id']}"
 
-    def _build_transition_tools_for_edges(self, edges: list) -> list:
-        """Build function/tool definitions for a list of edges."""
+    def _build_transition_tools_for_edges(self, edges: list, allow_stay: bool = True) -> list:
+        """allow_stay=False omits stay_on_current_node so the model must pick a real edge."""
         tools = []
         for edge in edges:
             func_name = self._edge_function_name(edge)
@@ -359,29 +359,30 @@ class GraphAgent(BaseAgent):
                 }
             )
 
-        tools.append(
-            {
-                "type": "function",
-                "function": {
-                    "name": "stay_on_current_node",
-                    "description": "No transition matches. Need more info or clarification.",
-                    "parameters": {
-                        "type": "object",
-                        "properties": {
-                            "reasoning": {
-                                "type": "string",
-                                "description": "Brief explanation of why this routing decision was made",
+        if allow_stay:
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "stay_on_current_node",
+                        "description": "No transition matches. Need more info or clarification.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "reasoning": {
+                                    "type": "string",
+                                    "description": "Brief explanation of why this routing decision was made",
+                                },
+                                "confidence": {
+                                    "type": "number",
+                                    "description": "Confidence score from 0.0 to 1.0 for this routing decision",
+                                },
                             },
-                            "confidence": {
-                                "type": "number",
-                                "description": "Confidence score from 0.0 to 1.0 for this routing decision",
-                            },
+                            "required": ["reasoning", "confidence"],
                         },
-                        "required": ["reasoning", "confidence"],
                     },
-                },
-            }
-        )
+                }
+            )
         return tools
 
     def _build_transition_tools(self, node: dict) -> List[dict]:
@@ -515,9 +516,13 @@ class GraphAgent(BaseAgent):
     def _node_type_of(node: Optional[dict]) -> str:
         return node.get("node_type", NodeType.LLM) if node else NodeType.LLM
 
-    def _match_expression_edge(self, node: dict) -> Tuple[Optional[dict], str]:
-        """First matching expression edge in priority order, with the evaluation trace."""
-        deterministic_edges, _ = self._classify_edges(node.get("edges", []))
+    def _match_expression_edge(
+        self, node: dict, deterministic_edges: Optional[list] = None
+    ) -> Tuple[Optional[dict], str]:
+        """First matching expression edge in priority order, with the evaluation trace.
+        Pass deterministic_edges from a prior _classify_edges to avoid re-classifying."""
+        if deterministic_edges is None:
+            deterministic_edges, _ = self._classify_edges(node.get("edges", []))
         expression_edges = [e for e in deterministic_edges if e.get("condition_type") == EdgeConditionType.EXPRESSION]
         matched_edge, evaluations = self._evaluate_deterministic_edges(expression_edges)
         return matched_edge, "; ".join(evaluations) or "no expression edge matched"
@@ -529,6 +534,11 @@ class GraphAgent(BaseAgent):
         if not unconditional:
             return None
         return min(unconditional, key=lambda e: e["priority"] if e.get("priority") is not None else 0)
+
+    @staticmethod
+    def _catch_all_reasoning(edge: dict) -> str:
+        ct = edge.get("condition_type", "unconditional")
+        return f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{edge.get('condition') or ct}"
 
     def _router_hop_info(
         self,
@@ -569,14 +579,11 @@ class GraphAgent(BaseAgent):
         }
 
     async def _resolve_router_chain(self, history: list) -> List[dict]:
-        """Hop silently through router nodes until a speaking node is reached, one
-        routing_info per hop. Each hop: expression edges first (priority order), then
-        intent edges via one routing-LLM call, then the unconditional catch-all. The
-        LLM is called at most once per chain so a chain never stacks routing latency;
-        the visited-set bounds the hops, so the chain always terminates."""
+        """Hop silently through routers to a speaking node, one routing_info per hop.
+        Per hop: expression, then one intent-LLM call, then the unconditional catch-all.
+        The visited-set bounds the hops so the chain always terminates."""
         hops = []
         visited = set()
-        intent_call_spent = False
         is_silence_trigger = bool(history and history[-1].get("content", "").startswith("[silence]"))
 
         while self._node_type_of(self.get_node_by_id(self.current_node_id)) == NodeType.ROUTER:
@@ -593,54 +600,55 @@ class GraphAgent(BaseAgent):
             router_node = self.get_node_by_id(self.current_node_id)
             previous_node = self.current_node_id
 
-            edge, eval_trace = self._match_expression_edge(router_node)
+            deterministic_edges, intent_edges = self._classify_edges(router_node.get("edges", []))
+            catch_all = self._catch_all_edge(router_node)
+            edge, eval_trace = self._match_expression_edge(router_node, deterministic_edges)
 
             # Telemetry from an intent call that returned no match, carried onto the
             # catch-all hop so its tokens are still counted and the call is still logged.
             spent_messages = spent_tools = spent_usage = None
 
-            if edge is None and not intent_call_spent:
-                _, intent_edges = self._classify_edges(router_node.get("edges", []))
-                if intent_edges:
-                    intent_call_spent = True
-                    (
-                        next_node_id,
-                        extracted_params,
-                        latency_ms,
-                        routing_messages,
-                        routing_tools,
-                        reasoning,
-                        confidence,
-                        routing_usage,
-                    ) = await self._decide_next_node_llm(router_node, intent_edges, history, hop_start)
-                    if next_node_id:
-                        self._advance_to_node(next_node_id, entry_index=len(history))
-                        if extracted_params:
-                            self.context_data.update(extracted_params)
-                        logger.info(
-                            f"Router dispatch (intent) on node '{previous_node}': -> {self.current_node_id} "
-                            f"| {reasoning} (latency: {latency_ms:.1f}ms)"
+            if edge is None and intent_edges:
+                (
+                    next_node_id,
+                    extracted_params,
+                    latency_ms,
+                    routing_messages,
+                    routing_tools,
+                    reasoning,
+                    confidence,
+                    routing_usage,
+                ) = await self._decide_next_node_llm(
+                    router_node, intent_edges, history, hop_start, default_edge=catch_all
+                )
+                if next_node_id:
+                    self._advance_to_node(next_node_id, entry_index=len(history))
+                    if extracted_params:
+                        self.context_data.update(extracted_params)
+                    logger.info(
+                        f"Router dispatch (intent) on node '{previous_node}': -> {self.current_node_id} "
+                        f"| {reasoning} (latency: {latency_ms:.1f}ms)"
+                    )
+                    hops.append(
+                        self._router_hop_info(
+                            previous_node,
+                            routing_type="llm",
+                            latency_ms=latency_ms,
+                            reasoning=reasoning,
+                            confidence=confidence,
+                            is_silence_trigger=is_silence_trigger,
+                            extracted_params=extracted_params,
+                            routing_messages=routing_messages,
+                            routing_tools=routing_tools,
+                            routing_usage=routing_usage,
                         )
-                        hops.append(
-                            self._router_hop_info(
-                                previous_node,
-                                routing_type="llm",
-                                latency_ms=latency_ms,
-                                reasoning=reasoning,
-                                confidence=confidence,
-                                is_silence_trigger=is_silence_trigger,
-                                extracted_params=extracted_params,
-                                routing_messages=routing_messages,
-                                routing_tools=routing_tools,
-                                routing_usage=routing_usage,
-                            )
-                        )
-                        continue
-                    spent_messages, spent_tools, spent_usage = routing_messages, routing_tools, routing_usage
-                    eval_trace = f"{eval_trace}; intent: no match"
+                    )
+                    continue
+                spent_messages, spent_tools, spent_usage = routing_messages, routing_tools, routing_usage
+                eval_trace = f"{eval_trace}; intent: no match"
 
             if edge is None:
-                edge = self._catch_all_edge(router_node)
+                edge = catch_all
             if edge is None:
                 logger.error(
                     f"Router node '{self.current_node_id}' has no matching edge and no catch-all, "
@@ -728,7 +736,7 @@ class GraphAgent(BaseAgent):
         )
 
     async def _decide_next_node_llm(
-        self, node: dict, llm_edges: list, history: List[dict], start_time: float
+        self, node: dict, llm_edges: list, history: List[dict], start_time: float, default_edge: Optional[dict] = None
     ) -> Tuple[
         Optional[str],
         Optional[Dict[str, Any]],
@@ -737,9 +745,19 @@ class GraphAgent(BaseAgent):
         Optional[List[dict]],
         Optional[str],
         Optional[float],
+        Optional[dict],
     ]:
-        """LLM-based routing. Only called when no deterministic edge matched."""
-        tools = self._build_transition_tools_for_edges(llm_edges)
+        """LLM routing over the intent edges. A default_edge (the catch-all) is offered as
+        a described transition instead of stay_on_current_node, so the model commits."""
+        option_edges = list(llm_edges)
+        if default_edge is not None:
+            # Always mark the default so the model can tell it apart from the intent edges,
+            # appending the author's condition/description when there is one.
+            hint = default_edge.get("function_description") or default_edge.get("condition")
+            marker = "Default route: choose this only when none of the other transitions apply."
+            default_edge = {**default_edge, "function_description": f"{marker} {hint}" if hint else marker}
+            option_edges.append(default_edge)
+        tools = self._build_transition_tools_for_edges(option_edges, allow_stay=default_edge is None)
 
         # Build compact context for routing
         context_section = ""
@@ -752,7 +770,15 @@ class GraphAgent(BaseAgent):
             if context_items:
                 context_section = f"\nContext: {', '.join(context_items)}"
 
-        default_instructions = "Call the transition function matching user intent, or stay_on_current_node if unclear."
+        if default_edge is not None:
+            default_instructions = (
+                "Call the transition function that best matches the user's intent. "
+                "Choose the default route only when none of the others clearly apply."
+            )
+        else:
+            default_instructions = (
+                "Call the transition function matching user intent, or stay_on_current_node if unclear."
+            )
         instructions = self.routing_instructions or default_instructions
 
         if self.context_data and instructions:
@@ -858,8 +884,8 @@ class GraphAgent(BaseAgent):
                 if function_name == "stay_on_current_node":
                     return None, None, latency_ms, messages, tools, reasoning, confidence, usage_info
 
-                # Find the edge for this function
-                edge = self._get_edge_by_function_name_from_edges(llm_edges, function_name)
+                # Find the edge for this function (may be the default)
+                edge = self._get_edge_by_function_name_from_edges(option_edges, function_name)
                 if edge:
                     return (
                         edge["to_node_id"],
@@ -895,7 +921,8 @@ class GraphAgent(BaseAgent):
         Optional[float],
         Optional[dict],
     ]:
-        """Two-phase routing: deterministic expressions first, then LLM fallback."""
+        """Precedence: expression edges, then intent edges via one LLM call, then the
+        unconditional default. Without an unconditional edge the node may stay."""
         start_time = time.perf_counter()
         self._last_deterministic_eval = None
 
@@ -912,31 +939,58 @@ class GraphAgent(BaseAgent):
         # Inject time variables and turn counts for expression evaluation
         self._enrich_routing_context(history)
 
-        deterministic_edges, llm_edges = self._classify_edges(edges)
+        deterministic_edges, intent_edges = self._classify_edges(edges)
+        catch_all = self._catch_all_edge(current_node)
 
-        # Phase 1: deterministic (0ms)
-        if deterministic_edges:
-            matched_edge, det_evaluations = self._evaluate_deterministic_edges(deterministic_edges)
-            self._last_deterministic_eval = "; ".join(det_evaluations)
-            if matched_edge:
-                latency_ms = (time.perf_counter() - start_time) * 1000
-                ct = matched_edge.get("condition_type", EdgeConditionType.EXPRESSION)
-                reasoning = f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{matched_edge.get('condition', ct)}"
-                logger.info(
-                    f"Routing decision (deterministic) on node '{self.current_node_id}': "
-                    f"-> {matched_edge['to_node_id']} | {self._last_deterministic_eval} (latency: {latency_ms:.1f}ms)"
-                )
-                return matched_edge["to_node_id"], None, latency_ms, None, None, reasoning, 1.0, None
-
+        # Tier 1: expression edges
+        matched_edge, self._last_deterministic_eval = self._match_expression_edge(current_node, deterministic_edges)
+        if matched_edge:
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            ct = matched_edge.get("condition_type", EdgeConditionType.EXPRESSION)
+            reasoning = f"{_DETERMINISTIC_REASONING_PREFIX}{ct}:{matched_edge.get('condition', ct)}"
             logger.info(
-                f"No deterministic edge matched on node '{self.current_node_id}' "
-                f"({'falling back to LLM routing' if llm_edges else 'staying on node'}): "
-                f"{self._last_deterministic_eval}"
+                f"Routing decision (expression) on node '{self.current_node_id}': "
+                f"-> {matched_edge['to_node_id']} | {self._last_deterministic_eval} (latency: {latency_ms:.1f}ms)"
             )
+            return matched_edge["to_node_id"], None, latency_ms, None, None, reasoning, 1.0, None
 
-        # Phase 2: LLM
-        if llm_edges:
-            return await self._decide_next_node_llm(current_node, llm_edges, history, start_time)
+        # Tier 2: intent edges via one LLM call; the catch-all is offered as the default (no stay).
+        if intent_edges:
+            result = await self._decide_next_node_llm(
+                current_node, intent_edges, history, start_time, default_edge=catch_all
+            )
+            if result[0] is not None:
+                return result
+            if catch_all is not None:
+                # LLM declined: advance via the default, carrying the spent telemetry.
+                latency_ms, r_messages, r_tools, r_usage = result[2], result[3], result[4], result[7]
+                self._last_deterministic_eval = f"intent: no match; default -> {catch_all['to_node_id']}"
+                return (
+                    catch_all["to_node_id"],
+                    None,
+                    latency_ms,
+                    r_messages,
+                    r_tools,
+                    self._catch_all_reasoning(catch_all),
+                    1.0,
+                    r_usage,
+                )
+            return result  # no default: stay
+
+        # Tier 3: no intent edges, take the default if present, else stay.
+        if catch_all is not None:
+            latency_ms = (time.perf_counter() - start_time) * 1000
+            self._last_deterministic_eval = f"default -> {catch_all['to_node_id']}"
+            return (
+                catch_all["to_node_id"],
+                None,
+                latency_ms,
+                None,
+                None,
+                self._catch_all_reasoning(catch_all),
+                1.0,
+                None,
+            )
 
         return None, None, 0, None, None, None, None, None
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -386,7 +386,9 @@ class GraphEdge(BaseModel):
     function_description: Optional[str] = None  # Detailed description for LLM
     # Optional parameters to collect during transition
     parameters: Optional[Dict[str, str]] = None  # e.g., {"city": "string"}
-    priority: Optional[int] = None  # lower = evaluated first. Defaults: expression/unconditional=0, llm=100
+    # lower = evaluated first within a tier (expression/intent/unconditional); does not rank across tiers.
+    # Defaults: expression/unconditional=0, llm=100
+    priority: Optional[int] = None
 
 
 class GraphNode(BaseModel):
@@ -457,8 +459,8 @@ class GraphAgentConfig(Llm):
 
     @model_validator(mode="after")
     def validate_router_graph(self):
-        """Router edges must target existing nodes, and routers must not cycle among
-        themselves (either would leave the chain unable to reach a speaking node)."""
+        """Router edges must target existing nodes, routers must not cycle, and a chain
+        may contain at most one intent router (so a turn makes at most one routing call)."""
         router_nodes = [n for n in self.nodes if n.node_type == NodeType.ROUTER]
         if not router_nodes:
             return self
@@ -488,6 +490,26 @@ class GraphAgentConfig(Llm):
                 raise ValueError(
                     f"Router nodes form a cycle involving '{rid}'; a router chain must terminate at a non-router node."
                 )
+
+        # At most one intent router per chain: an intent router must not reach another via
+        # router-to-router edges (that would force a second routing LLM call in one turn).
+        intent_router_ids = {
+            n.id for n in router_nodes if any(e.condition_type in (None, EdgeConditionType.LLM) for e in n.edges)
+        }
+        for start in intent_router_ids:
+            seen, stack = set(), list(adjacency.get(start, []))
+            while stack:
+                rid = stack.pop()
+                if rid in seen:
+                    continue
+                seen.add(rid)
+                if rid in intent_router_ids:
+                    raise ValueError(
+                        f"Router chain from '{start}' reaches another intent router '{rid}'; "
+                        f"a router chain may contain at most one intent router. Split the intent "
+                        f"decisions across speaking nodes, or use expression edges."
+                    )
+                stack.extend(adjacency.get(rid, []))
         return self
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.146"
+version = "0.10.147"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_event_injection_e2e.py
+++ b/tests/tests/test_event_injection_e2e.py
@@ -160,6 +160,7 @@ def _make_task_manager(agent=None, **overrides):
     tm.llm_task = None
     tm.run_id = f"test-{uuid.uuid4().hex[:8]}"
     tm.task_id = 0
+    tm._response_turn_id = 0  # real __init__ sets this; __get_updated_meta_info increments it
     tm.repeat_after_silence_seconds = None
     tm.conversation_history = ConversationHistory()
     tm.context_data = graph_agent.context_data  # Share context_data with agent

--- a/tests/tests/test_expression_routing.py
+++ b/tests/tests/test_expression_routing.py
@@ -101,6 +101,28 @@ def _mock_routing_response(function_name, function_args_dict):
     return mock_response
 
 
+def _uncond_intent_config():
+    """A normal node with both an intent edge and an unconditional default: the shape where
+    the intent edge used to be silently dead."""
+    return {
+        "nodes": [
+            {
+                "id": "greeting",
+                "prompt": "Greet.",
+                "edges": [
+                    {
+                        "to_node_id": "escalate",
+                        "condition": "user asks for a human agent",
+                    },  # intent (no condition_type)
+                    {"to_node_id": "proceed", "condition_type": "unconditional", "priority": 0},  # default advance
+                ],
+            },
+            {"id": "escalate", "prompt": "Escalate.", "edges": []},
+            {"id": "proceed", "prompt": "Proceed.", "edges": []},
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # _edge_function_name
 # ---------------------------------------------------------------------------
@@ -499,6 +521,92 @@ class TestPriorityOrdering:
 
         result = await agent.decide_next_node_with_functions(history)
         assert result[0] == "fallback"
+
+    @pytest.mark.asyncio
+    async def test_expression_beats_lower_priority_unconditional(self):
+        """Expression is Tier 1, so it beats a lower-priority-number unconditional default."""
+        agent = _make_agent(
+            {
+                "nodes": [
+                    {
+                        "id": "greeting",
+                        "prompt": "Greet.",
+                        "edges": [
+                            {"to_node_id": "fallback", "condition_type": "unconditional", "priority": 1},
+                            {
+                                "to_node_id": "escalation",
+                                "condition_type": "expression",
+                                "priority": 5,
+                                "expression": {
+                                    "logic": "and",
+                                    "conditions": [{"variable": "_node_turns", "operator": "gte", "value": 1}],
+                                },
+                            },
+                        ],
+                    },
+                    {"id": "escalation", "prompt": "Escalate.", "edges": []},
+                    {"id": "fallback", "prompt": "Fallback.", "edges": []},
+                ],
+            }
+        )
+        agent.context_data = {}
+        agent.current_node_entry_index = 0
+
+        with patch("asyncio.to_thread", new_callable=AsyncMock) as mock_thread:
+            result = await agent.decide_next_node_with_functions([{"role": "user", "content": "hi"}])
+            mock_thread.assert_not_called()  # deterministic, no routing LLM
+        assert result[0] == "escalation"  # expression wins over the lower-priority unconditional default
+
+
+# ---------------------------------------------------------------------------
+# Unconditional default alongside intent edges (unify)
+# ---------------------------------------------------------------------------
+
+
+class TestUnconditionalWithIntentEdges:
+    """An unconditional edge on a normal node no longer suppresses its intent edges.
+    Intent is evaluated (one LLM call); the unconditional is the default advance target."""
+
+    @pytest.mark.asyncio
+    async def test_intent_edge_is_live_not_suppressed(self):
+        agent = _make_agent(_uncond_intent_config())
+        agent.context_data = {}
+        mock_resp = _mock_routing_response("transition_to_escalate", {"reasoning": "wants a human", "confidence": 0.9})
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp) as mock_thread:
+            result = await agent.decide_next_node_with_functions([{"role": "user", "content": "get me a human"}])
+        mock_thread.assert_called_once()  # intent LLM ran; the unconditional did NOT short-circuit it
+        assert result[0] == "escalate"
+        assert not result[5].startswith(_DETERMINISTIC_REASONING_PREFIX)
+
+    @pytest.mark.asyncio
+    async def test_llm_can_pick_described_default(self):
+        agent = _make_agent(_uncond_intent_config())
+        agent.context_data = {}
+        mock_resp = _mock_routing_response("transition_to_proceed", {"reasoning": "no escalation", "confidence": 0.8})
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp):
+            result = await agent.decide_next_node_with_functions([{"role": "user", "content": "ok great"}])
+        assert result[0] == "proceed"
+
+    @pytest.mark.asyncio
+    async def test_default_taken_deterministically_on_llm_error(self):
+        agent = _make_agent(_uncond_intent_config())
+        agent.context_data = {}
+        with patch("asyncio.to_thread", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            result = await agent.decide_next_node_with_functions([{"role": "user", "content": "hmm"}])
+        assert result[0] == "proceed"  # node still advances via its default
+        assert result[5].startswith(_DETERMINISTIC_REASONING_PREFIX)
+
+    @pytest.mark.asyncio
+    async def test_stay_not_offered_when_default_present(self):
+        agent = _make_agent(_uncond_intent_config())
+        agent.context_data = {}
+        mock_resp = _mock_routing_response("transition_to_proceed", {"reasoning": "x", "confidence": 0.5})
+        with patch("asyncio.to_thread", new_callable=AsyncMock, return_value=mock_resp):
+            result = await agent.decide_next_node_with_functions([{"role": "user", "content": "hi"}])
+        tool_names = [t["function"]["name"] for t in result[4]]
+        assert "stay_on_current_node" not in tool_names
+        assert "transition_to_escalate" in tool_names
+        assert "transition_to_proceed" in tool_names  # default offered as a described option
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -191,6 +191,60 @@ class TestRouterNodeValidation:
         cfg = GraphAgentConfig(**_base_config(nodes, "r1"))
         assert len(cfg.nodes) == 3
 
+    def test_two_intent_routers_in_chain_rejected(self):
+        # A router chain that passes through two intent routers would force two routing
+        # LLM calls in one silent turn, so it is rejected at load time.
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "r2", "condition": "wants a specialist"},  # intent
+                    {"to_node_id": "general", "condition_type": "unconditional"},
+                ],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "billing", "condition": "billing question"},  # intent
+                    {"to_node_id": "support", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "billing", "prompt": "b", "edges": []},
+            {"id": "support", "prompt": "s", "edges": []},
+            {"id": "general", "prompt": "g", "edges": []},
+        ]
+        with pytest.raises(ValidationError, match="at most one intent router"):
+            GraphAgentConfig(**_base_config(nodes, "r1"))
+
+    def test_expression_router_then_intent_router_allowed(self):
+        # An expression router chaining into a single intent router is fine: only one
+        # intent router on the path, so only one routing LLM call.
+        nodes = [
+            {
+                "id": "r1",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "r2", "condition_type": "expression", "expression": _expr("x", "eq", "1")},
+                    {"to_node_id": "general", "condition_type": "unconditional"},
+                ],
+            },
+            {
+                "id": "r2",
+                "node_type": "router",
+                "edges": [
+                    {"to_node_id": "billing", "condition": "billing question"},  # intent
+                    {"to_node_id": "support", "condition_type": "unconditional"},
+                ],
+            },
+            {"id": "billing", "prompt": "b", "edges": []},
+            {"id": "support", "prompt": "s", "edges": []},
+            {"id": "general", "prompt": "g", "edges": []},
+        ]
+        cfg = GraphAgentConfig(**_base_config(nodes, "r1"))
+        assert len(cfg.nodes) == 5
+
 
 # ---------------------------------------------------------------------------
 # _resolve_router_chain
@@ -514,10 +568,14 @@ class TestRouterIntentRouting:
         assert hops[0]["confidence"] == 0.9
 
     @pytest.mark.asyncio
-    async def test_intent_no_match_falls_to_catch_all(self):
+    async def test_intent_llm_no_decision_falls_to_catch_all(self):
+        # When the routing LLM returns no decision (error or abstain), the router falls to
+        # the catch-all deterministically and carries the spent telemetry. A genuine
+        # no-intent-match now goes through the LLM picking the described default instead
+        # (see test_intent_router_offers_default_not_stay), which records as an llm hop.
         agent = _intent_router_agent(detected_language="en")
-        stay = (None, None, 250.0, [{"role": "system", "content": "routing"}], [], "unclear", 0.3, None)
-        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=stay) as mock_llm:
+        no_decision = (None, None, 250.0, [{"role": "system", "content": "routing"}], [], "unclear", 0.3, None)
+        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=no_decision) as mock_llm:
             hops = await agent._resolve_router_chain([{"role": "user", "content": "ummm"}])
 
         mock_llm.assert_called_once()
@@ -529,9 +587,23 @@ class TestRouterIntentRouting:
         assert hops[0]["routing_model"] is not None
 
     @pytest.mark.asyncio
-    async def test_one_intent_call_per_chain(self):
-        # r1 routes via intent to r2 (another intent router); r2 must take its
-        # catch-all instead of making a second LLM call.
+    async def test_intent_router_offers_default_not_stay(self):
+        # The routing LLM for an intent router is handed the catch-all as a described
+        # 'default' transition, and the stay_on_current_node escape is dropped.
+        agent = _intent_router_agent(detected_language="en")
+        intent_edges = [{"to_node_id": "billing", "condition": "billing", "function_name": "go_to_billing"}]
+        default = {"to_node_id": "general", "condition_type": "unconditional"}
+        tools = agent._build_transition_tools_for_edges(intent_edges + [default], allow_stay=False)
+        names = [t["function"]["name"] for t in tools]
+        assert "go_to_billing" in names
+        assert "transition_to_general" in names  # catch-all offered as a real option
+        assert "stay_on_current_node" not in names
+
+    @pytest.mark.asyncio
+    async def test_chained_intent_routers_route_independently(self):
+        # Two intent routers chained (built as raw dicts, bypassing the validation that
+        # now forbids this): with intent_call_spent removed, each routes on its own call
+        # rather than the second silently taking its catch-all.
         nodes = [
             {
                 "id": "r1",
@@ -555,12 +627,15 @@ class TestRouterIntentRouting:
         ]
         agent = _make_agent(_base_config(nodes, "r1"))
         pick_r2 = ("r2", None, 300.0, [{"role": "system", "content": "r"}], [], "specialist", 0.8, None)
-        with patch.object(agent, "_decide_next_node_llm", new_callable=AsyncMock, return_value=pick_r2) as mock_llm:
+        pick_billing = ("billing", None, 300.0, [{"role": "system", "content": "r"}], [], "billing", 0.8, None)
+        with patch.object(
+            agent, "_decide_next_node_llm", new_callable=AsyncMock, side_effect=[pick_r2, pick_billing]
+        ) as mock_llm:
             hops = await agent._resolve_router_chain([{"role": "user", "content": "hi"}])
 
-        assert mock_llm.call_count == 1
-        assert agent.current_node_id == "support"  # r2's catch-all, no second call
-        assert [h["current_node"] for h in hops] == ["r2", "support"]
+        assert mock_llm.call_count == 2
+        assert agent.current_node_id == "billing"
+        assert [h["current_node"] for h in hops] == ["r2", "billing"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Router nodes and normal graph nodes used two different edge-selection paths. On a normal node an unconditional edge was grouped with expression edges as deterministic and short-circuited the intent (LLM) phase, so intent edges on any node that also carried an unconditional edge were never evaluated. In practice this left intent edges silently dead, including flows that could never transfer to a human on a failed lookup or never escalate when the caller asked for one.

This unifies both node types onto one precedence: expression edges first (deterministic, in priority order), then intent edges via a single routing LLM call, then the unconditional default. The unconditional is pulled out of the deterministic short-circuit and is always the last-resort default. When a node has an unconditional edge it is offered to the routing LLM as a described default transition and the stay_on_current_node escape is dropped, so the model commits to a real edge and the default becomes a deliberate, logged decision rather than a hidden reinterpretation of stay. The deterministic catch-all still fires if the routing call errors, so a router always advances.

The per-chain single-call guard (intent_call_spent) is replaced by load-time validation that a router chain contains at most one intent router, so a turn never stacks routing latency. priority is documented as ordering edges within a tier only; it does not rank intent against expression.

Also fixes pre-existing fixture drift in test_event_injection_e2e.py where the TaskManager stub did not set _response_turn_id.
