### PR TITLE
Surface Sarvam stream rejections instead of ending the call silently

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.144"
+__version__ = "0.10.145"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/sarvam_transcriber.py
+++ b/bolna/transcriber/sarvam_transcriber.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 import aiohttp
 import websockets
 from websockets.asyncio.client import ClientConnection
-from websockets.exceptions import InvalidHandshake
+from websockets.exceptions import ConnectionClosed, InvalidHandshake
 
 import numpy as np
 from scipy.signal import resample_poly
@@ -443,10 +443,21 @@ class SarvamTranscriber(BaseTranscriber):
                         self.meta_info["transcriber_duration"] = data.get("duration", 0)
                         yield create_ws_data_packet("transcriber_connection_closed", self.meta_info)
                         return
+
+                    elif isinstance(data, dict) and data.get("type") == "error":
+                        # Sarvam rejects a stream by sending this and then closing (e.g. a
+                        # sample_rate the model won't accept). Record the reason and let its
+                        # close end the loop, so the call still tears down immediately.
+                        self.connection_error = (data.get("data") or {}).get("message") or json.dumps(data)
+                        logger.error(f"Sarvam rejected the stream: {self.connection_error}")
                 except Exception:
-                    traceback.print_exc()
+                    logger.error(f"Sarvam receiver error handling message: {traceback.format_exc()}")
+        except ConnectionClosed as e:
+            if e.code != 1000:
+                self.connection_error = f"sarvam closed the connection: code={e.code} reason={e.reason!r}"
+            logger.info(f"Sarvam websocket closed: code={e.code} reason={e.reason!r}")
         except Exception:
-            traceback.print_exc()
+            logger.error(f"Sarvam receiver error: {traceback.format_exc()}")
 
     async def _close(self, ws: ClientConnection, data=None):
         try:
@@ -561,7 +572,7 @@ class SarvamTranscriber(BaseTranscriber):
         try:
             self.transcription_task = asyncio.create_task(self.transcribe())
         except Exception:
-            traceback.print_exc()
+            logger.error(f"Sarvam transcriber failed to start: {traceback.format_exc()}")
 
     async def send_heartbeat(self, ws: ClientConnection, interval_sec: float = 10.0):
         try:
@@ -587,7 +598,7 @@ class SarvamTranscriber(BaseTranscriber):
                     meta["connection_error"] = self.connection_error
                     await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
                 except Exception:
-                    traceback.print_exc()
+                    logger.error(f"Sarvam failed to emit connection_closed: {traceback.format_exc()}")
                 return
 
             if not self.connection_time:
@@ -606,7 +617,7 @@ class SarvamTranscriber(BaseTranscriber):
                                 break
                 except Exception as e:
                     self.connection_error = str(e)
-                    traceback.print_exc()
+                    logger.error(f"Sarvam stream ended with an error: {traceback.format_exc()}")
             else:
                 self.sender_task = asyncio.create_task(self.sender())
                 try:
@@ -624,7 +635,7 @@ class SarvamTranscriber(BaseTranscriber):
                     meta["connection_error"] = self.connection_error
                 await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
             except Exception:
-                traceback.print_exc()
+                logger.error(f"Sarvam failed to emit connection_closed: {traceback.format_exc()}")
         finally:
             if self.sender_task:
                 self.sender_task.cancel()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.144"
+version = "0.10.145"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Sarvam signals a rejected stream with a `{"type": "error"}` message and then closes the socket. `receiver` had no branch for that message type, and the close was swallowed by `except Exception: traceback.print_exc()`, so `connection_error` stayed `None`.

The result was a call that ended with no reason recorded anywhere: the event was logged as a benign drop rather than an error, the execution was not attributed to a transcriber failure, and the only trace was a stderr traceback with no run_id on it. Diagnosing an inbound SIP-trunk outage took a manual replay against the Sarvam endpoint to recover a message the server had already sent us.

Changes:

1. Handle `type == "error"` in `receiver`, recording the message in `connection_error`. Sarvam's own close still ends the loop, so teardown timing is unchanged.
2. Log the websocket close code and reason, and treat a non-1000 close as a connection error.
3. Route the remaining `traceback.print_exc()` calls in this module through the logger, so they carry the run_id.

Behavior change: a Sarvam-side rejection or abnormal close is now attributed as `transcriber_connection_error` rather than ending the call silently.

Follow-up to #860, which fixes the sample-rate mismatch that this would have made obvious.

Verified against the live Sarvam endpoint. Sending 8 kHz to saaras:v3 now logs `Sarvam rejected the stream: Error in Pipeline : Invalid request: 'audio.sample_rate' must be 16000` and the emitted packet carries that message, at the same 254 ms teardown as before. A correctly configured 16 kHz stream is unaffected and still returns transcripts.