### PR TITLE
fixed the filler word missing from transcript

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.147"
+__version__ = "0.10.148"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.149"
+__version__ = "0.10.150"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3824,30 +3824,32 @@ class TaskManager(BaseManager):
 
                     # A hack as during the 'await' part control passes to llm streaming function parameters
                     # So we have to make sure we've commited the filler message
-                    # Match the language snapshotted at pre-call time (what the accumulator built the filler with), not live self.language which can flip mid-turn.
-                    pre_call_language = meta_info.get("detected_language") or self.language
-                    if pre_call_language != self.language:
-                        logger.info(
-                            f"Filler language mismatch: pre_call_language={pre_call_language} vs current self.language={self.language}; matching against pre_call_language"
+                    # Only the function-call chunk carries function_tool; gate here so the compute + mismatch log run once for the filler, not per text chunk.
+                    if function_tool:
+                        # Match the language snapshotted at pre-call time (what the accumulator built the filler with), not live self.language which can flip mid-turn.
+                        pre_call_language = meta_info.get("detected_language") or self.language
+                        if pre_call_language != self.language:
+                            logger.info(
+                                f"Filler language mismatch: pre_call_language={pre_call_language} vs current self.language={self.language}; matching against pre_call_language"
+                            )
+                        filler_message = compute_function_pre_call_message(
+                            pre_call_language, function_tool, function_tool_message
                         )
-                    filler_message = compute_function_pre_call_message(
-                        pre_call_language, function_tool, function_tool_message
-                    )
-                    # filler_message = PRE_FUNCTION_CALL_MESSAGE.get(self.language, PRE_FUNCTION_CALL_MESSAGE[DEFAULT_LANGUAGE_CODE])
-                    if text_chunk == filler_message:
-                        logger.info("Got a pre function call message")
-                        turn_id = meta_info.get("turn_id")
-                        response_uid = meta_info.get("response_uid")
-                        messages.append(
-                            {
-                                "role": "assistant",
-                                "content": filler_message,
-                                "turn_id": turn_id,
-                                "response_uid": response_uid,
-                            }
-                        )
-                        self._stage_assistant_history(meta_info, filler_message)
-                        self.conversation_history.sync_interim(messages)
+                        # filler_message = PRE_FUNCTION_CALL_MESSAGE.get(self.language, PRE_FUNCTION_CALL_MESSAGE[DEFAULT_LANGUAGE_CODE])
+                        if text_chunk == filler_message:
+                            logger.info("Got a pre function call message")
+                            turn_id = meta_info.get("turn_id")
+                            response_uid = meta_info.get("response_uid")
+                            messages.append(
+                                {
+                                    "role": "assistant",
+                                    "content": filler_message,
+                                    "turn_id": turn_id,
+                                    "response_uid": response_uid,
+                                }
+                            )
+                            self._stage_assistant_history(meta_info, filler_message)
+                            self.conversation_history.sync_interim(messages)
 
                     await self._handle_llm_output(next_step, text_chunk, should_bypass_synth, meta_info)
         except BolnaComponentError:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3824,8 +3824,14 @@ class TaskManager(BaseManager):
 
                     # A hack as during the 'await' part control passes to llm streaming function parameters
                     # So we have to make sure we've commited the filler message
+                    # Match the language snapshotted at pre-call time (what the accumulator built the filler with), not live self.language which can flip mid-turn.
+                    pre_call_language = meta_info.get("detected_language") or self.language
+                    if pre_call_language != self.language:
+                        logger.info(
+                            f"Filler language mismatch: pre_call_language={pre_call_language} vs current self.language={self.language}; matching against pre_call_language"
+                        )
                     filler_message = compute_function_pre_call_message(
-                        self.language, function_tool, function_tool_message
+                        pre_call_language, function_tool, function_tool_message
                     )
                     # filler_message = PRE_FUNCTION_CALL_MESSAGE.get(self.language, PRE_FUNCTION_CALL_MESSAGE[DEFAULT_LANGUAGE_CODE])
                     if text_chunk == filler_message:
@@ -3849,7 +3855,9 @@ class TaskManager(BaseManager):
         except Exception as e:
             raise LLMError(str(e), provider=self.llm_config.get("provider"), model=self.llm_config.get("model")) from e
 
-        filler_message = compute_function_pre_call_message(self.language, function_tool, function_tool_message)
+        filler_message = compute_function_pre_call_message(
+            meta_info.get("detected_language") or self.language, function_tool, function_tool_message
+        )
         if self.stream and llm_response != filler_message:
             self.__store_into_history(
                 meta_info,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.149"
+version = "0.10.150"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.147"
+version = "0.10.148"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
A pre-tool-call filler message that the agent actually speaks can be missing from the stored transcript (a content=None placeholder appears instead). This fixes the transcript-staging so it records the filler that was actually spoken, even when the agent's effective language flips mid-turn.

Reported by client Bitespeed — exec 42f81006-ae85-4706-a9f2-308fdd1e947b (16 Jul, ~00:32 into the call). The spoken line "कोई बात नहीं, मैं ये कारण नोट कर लेती हूँ।" (pre-call filler for custom_task_non_purchase_reason) was present in logs/audio but absent from the transcript.

Root cause

self.language is a computed property (task_manager.py:1067-1080): it returns language_detector.dominant_language once detection resolves, otherwise the base language (self._language). So a single read can change value mid-call.

The pre-call filler is built and staged using two different reads of that property:
- Built (spoken): tool_call_accumulator.get_pre_call_message uses meta_info["detected_language"], snapshotted at pre-call time (task_manager.py:3563).
- Staged (transcript): the equality gate if text_chunk == filler_message recomputed compute_function_pre_call_message(self.language, …) with the live property, read after the streaming await.

On a Hindi-base agent whose caller spoke English, the one-time language detector resolved en between filler-build and the staging check (Bitespeed timeline: build @ 13:29:48.0 → detection en @ 13:29:49.247 → check @ 13:29:49.446). The filler was built in hi but the check expected en, so text_chunk != filler_message, the filler was never staged, and attach_tool_calls_to_turn wrote a content=None placeholder — dropping the spoken line.

Changes

bolna/agent_manager/task_manager.py — both filler comparisons now use the pre-call language snapshot (meta_info["detected_language"], the same value the accumulator built the filler with) instead of the live self.language:
- Staging gate (~3827): compute pre_call_language = meta_info.get("detected_language") or self.language, match against it, and log when it differs from the live self.language (this divergence was previously invisible in logs).
- Double-store guard (~3852): same snapshot, for consistency.

This guarantees "what was spoken" and "what we compare against" always use the same language, so a mid-turn detection flip can no longer drop the line.