### PR TITLE
 fixed the lid end call issue

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.145"
+__version__ = "0.10.146"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5048,8 +5048,14 @@ class TaskManager(BaseManager):
             mismatch_streak_fire = 10**9
         try:
             while not self.conversation_ended:
-                # No switches once hangup is underway — truncates the goodbye, deadlocks teardown.
-                if self.hangup_triggered:
+                # No switches once hangup / end-call / transfer is underway — a switch here
+                # truncates the goodbye and deadlocks teardown. Just as important: on these states
+                # __run_language_switch abandons the decision PRE-drain (the _should_ignore check
+                # below its entry), leaving the aged detector buffer intact and >= threshold. Without
+                # this guard the fire branch below would re-invoke the decision every iteration with
+                # no awaiting yield — a synchronous spin that pegs and blocks the pod's event loop,
+                # starving co-tenant calls of media/TTS (Jul 2026 transcript-missing incident).
+                if self._should_ignore_transcriber_input():
                     await asyncio.sleep(0.5)
                     continue
                 pool = self.tools.get("transcriber")
@@ -5099,6 +5105,13 @@ class TaskManager(BaseManager):
                     # Streak fires are saaras double-confirmations — high enough precision
                     # to also start the follow-up generation speculatively.
                     await self.handle_language_switch(spawn_language=self.language, speculate=streak_fired)
+                    # Spin-guard: a healthy decision drains the buffer (age → None) and the loop
+                    # parks on the buffer event next iteration. If it returned WITHOUT draining
+                    # (e.g. an ignore-input flag flipped after the loop-top guard), the buffer stays
+                    # >= threshold and we would re-fire immediately with no yield. Force one so the
+                    # loop can never busy-spin the event loop, whatever the return path.
+                    if pool.lid_buffer_age() is not None:
+                        await asyncio.sleep(0.1)
                     continue
                 # Buffered but not idle long enough — sleep the remaining time, but wake
                 # IMMEDIATELY if a new segment lands (clear-then-wait on the buffer event):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.145"
+version = "0.10.146"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_lid_idle_watcher_spin.py
+++ b/tests/tests/test_lid_idle_watcher_spin.py
@@ -1,0 +1,83 @@
+"""Regression: the LID idle-flush watcher must never busy-spin the event loop.
+
+Jul 2026 transcript-missing incident: on a multilingual (llm_language_switch) call,
+when has_transfer / _end_call_in_progress was set, __run_language_switch abandoned the
+decision PRE-drain, so the aged detector buffer stayed >= threshold and __lid_idle_watcher
+re-fired it every iteration with no awaiting yield — a synchronous spin that pegged and
+blocked the pod's event loop, starving co-tenant calls of media/TTS (silence, empty
+transcript). Two guards fix it: (1) the loop-top skip now covers the full ignore-input
+condition, not just hangup; (2) a spin-guard forces a yield whenever a fire leaves the
+buffer undrained.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.transcriber.transcriber_pool import TranscriberPool
+
+
+def _tm(*, has_transfer=False, end_call=False, hangup=False, buffer_age=5.0):
+    """Minimal TaskManager whose idle watcher can run in isolation.
+
+    buffer_age is a constant so the buffer looks perpetually aged-but-undrained — the exact
+    state that produced the spin. handle_language_switch is a no-op mock (never drains).
+    """
+    tm = MagicMock()
+    tm.conversation_ended = False
+    tm.hangup_triggered = hangup
+    tm._end_call_in_progress = end_call
+    tm.has_transfer = has_transfer
+    tm._pending_switch_turn = None
+    tm.language = "hi"
+    tm.handle_language_switch = AsyncMock()  # no-op: never drains the buffer
+
+    pool = MagicMock(spec=TranscriberPool)
+    pool.lid_buffer_age.return_value = buffer_age
+    pool.lid_buffer_language.return_value = "hi"  # == active → mismatch False, threshold=idle_flush
+    pool.lid_buffer_language_streak.return_value = 0
+    pool.lid_buffer_event.return_value = None
+    tm.tools = {"transcriber": pool}
+
+    # Real methods under test / relied upon.
+    tm._should_ignore_transcriber_input = TaskManager._should_ignore_transcriber_input.__get__(tm, TaskManager)
+    tm._TaskManager__lid_idle_watcher = TaskManager._TaskManager__lid_idle_watcher.__get__(tm, TaskManager)
+    return tm
+
+
+async def _run_watcher_for(tm, seconds):
+    task = asyncio.create_task(tm._TaskManager__lid_idle_watcher())
+    await asyncio.sleep(seconds)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_no_fire_while_transfer_in_progress():
+    # has_transfer True → loop-top guard skips; the decision is never fired (it would
+    # abandon pre-drain anyway) and the watcher parks on a 0.5s sleep instead of spinning.
+    tm = _tm(has_transfer=True)
+    await _run_watcher_for(tm, 0.25)
+    assert tm.handle_language_switch.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_no_fire_while_end_call_in_progress():
+    tm = _tm(end_call=True)
+    await _run_watcher_for(tm, 0.25)
+    assert tm.handle_language_switch.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_undrained_fire_does_not_spin():
+    # Normal state (guard passes) but the decision returns WITHOUT draining (buffer stays
+    # aged). The spin-guard must force a yield so the loop is rate-limited (~10/s via the
+    # 0.1s floor), NOT a millions-per-second busy-spin. Pre-fix this count was unbounded.
+    tm = _tm()
+    await _run_watcher_for(tm, 0.35)
+    assert 0 < tm.handle_language_switch.await_count < 50


### PR DESCRIPTION
## Summary

Fixes a synchronous busy-spin in `TaskManager.__lid_idle_watcher()` that blocked the
entire pod's asyncio event loop, causing co-tenant calls to hear silence and complete
with empty transcripts. Root cause of the Jul 20 transcript-missing spike (2,772
executions across many orgs; predominantly vobiz).

## Symptom

Spike of `status = completed` calls with an empty transcript. The callee answers, hears
nothing, and hangs up (`hangup_by: callee`) after ~10–40s. Affected calls span many
orgs/agents and providers (2,659 vobiz + 109 plivo + 4 twilio). No OOM, pod restarts, or
CPU throttling on Datadog (~0.35 cores avg) — the signature of event-loop starvation, not
capacity exhaustion. `LanguageSwitcher` log volume exploded from ~1–2k/hour to 1.2M–3.3M/hour.

## Root cause

Only multilingual agents with `llm_language_switch: true` run `__lid_idle_watcher`, which
fires the language-switch decision when the unbiased detector buffer holds aged, undrained
speech. Its callee `__run_language_switch()` **abandons the decision _before_ its
`take_lid_transcript()` drain** (`task_manager.py:~5140`) whenever
`_should_ignore_transcriber_input()` is true — i.e. `has_transfer` **or**
`_end_call_in_progress`, **neither of which sets `hangup_triggered`**:

- `_end_call_in_progress = True` (`task_manager.py:2926`) — set when the `end_call` tool
  fires, before the goodbye is synthesized/played (multi-second window).
- `has_transfer = True` (`task_manager.py:3001`) — set on `transfer_call`, stays true for
  the rest of the call while the transfer completes.

The watcher's loop-top guard only skipped on `hangup_triggered`. So during those windows it:
fired → `__run_language_switch` returned pre-drain with **no awaiting yield** (an uncontended
`async with lock` does not suspend) → `lid_buffer_age()` stayed `>= threshold` → re-fired
immediately → **synchronous busy-spin**. That pegs and blocks the pod's event loop, so every
co-tenant call on the pod never attaches media / never plays its welcome → silence, empty
transcript.

This explains the broad org/agent spread (collateral co-tenants on a blocked pod), the vobiz
concentration (bulk of multilingual Indian-language traffic → switcher enabled), and the log
explosion.

## Fix

Two guards in `__lid_idle_watcher`:

1. **Root cause** — the loop-top skip now uses `self._should_ignore_transcriber_input()`
   (hangup **or** `_end_call_in_progress` **or** `has_transfer`) instead of `hangup_triggered`
   alone, mirroring `__run_language_switch`'s own abandon condition. The watcher no longer
   fires into a guaranteed pre-drain no-op.
2. **Defense-in-depth** — after the idle-flush fire, if the decision returned without draining
   (`pool.lid_buffer_age() is not None`), `await asyncio.sleep(0.1)`. A healthy fire drains
   the buffer (age → None) and skips this; an undrained fire is forced to yield, so the loop
   can never busy-spin regardless of return path.

No behavior change on the healthy path: a successful fire drains → age None → the loop parks
on the buffer event, and the spin-guard is skipped.
