### PR TITLE
fix: allow chained intent routers in graph agents

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.148"
+__version__ = "0.10.149"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -459,8 +459,9 @@ class GraphAgentConfig(Llm):
 
     @model_validator(mode="after")
     def validate_router_graph(self):
-        """Router edges must target existing nodes, routers must not cycle, and a chain
-        may contain at most one intent router (so a turn makes at most one routing call)."""
+        """Router edges must target existing nodes and routers must not cycle; either would
+        leave the chain unable to reach a speaking node. Chained intent routers are allowed
+        (each makes its own routing call, a latency tradeoff, not a correctness one)."""
         router_nodes = [n for n in self.nodes if n.node_type == NodeType.ROUTER]
         if not router_nodes:
             return self
@@ -490,26 +491,6 @@ class GraphAgentConfig(Llm):
                 raise ValueError(
                     f"Router nodes form a cycle involving '{rid}'; a router chain must terminate at a non-router node."
                 )
-
-        # At most one intent router per chain: an intent router must not reach another via
-        # router-to-router edges (that would force a second routing LLM call in one turn).
-        intent_router_ids = {
-            n.id for n in router_nodes if any(e.condition_type in (None, EdgeConditionType.LLM) for e in n.edges)
-        }
-        for start in intent_router_ids:
-            seen, stack = set(), list(adjacency.get(start, []))
-            while stack:
-                rid = stack.pop()
-                if rid in seen:
-                    continue
-                seen.add(rid)
-                if rid in intent_router_ids:
-                    raise ValueError(
-                        f"Router chain from '{start}' reaches another intent router '{rid}'; "
-                        f"a router chain may contain at most one intent router. Split the intent "
-                        f"decisions across speaking nodes, or use expression edges."
-                    )
-                stack.extend(adjacency.get(rid, []))
         return self
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.148"
+version = "0.10.149"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_router_nodes.py
+++ b/tests/tests/test_router_nodes.py
@@ -191,9 +191,10 @@ class TestRouterNodeValidation:
         cfg = GraphAgentConfig(**_base_config(nodes, "r1"))
         assert len(cfg.nodes) == 3
 
-    def test_two_intent_routers_in_chain_rejected(self):
-        # A router chain that passes through two intent routers would force two routing
-        # LLM calls in one silent turn, so it is rejected at load time.
+    def test_two_intent_routers_in_chain_allowed(self):
+        # Chained intent routers are allowed: each makes its own routing call, a latency
+        # tradeoff, not a correctness one. The runtime routes them independently
+        # (see test_chained_intent_routers_route_independently).
         nodes = [
             {
                 "id": "r1",
@@ -215,8 +216,8 @@ class TestRouterNodeValidation:
             {"id": "support", "prompt": "s", "edges": []},
             {"id": "general", "prompt": "g", "edges": []},
         ]
-        with pytest.raises(ValidationError, match="at most one intent router"):
-            GraphAgentConfig(**_base_config(nodes, "r1"))
+        cfg = GraphAgentConfig(**_base_config(nodes, "r1"))
+        assert len(cfg.nodes) == 5
 
     def test_expression_router_then_intent_router_allowed(self):
         # An expression router chaining into a single intent router is fine: only one


### PR DESCRIPTION
The at-most-one-intent-router-per-chain validation added in #864 was too strict: it blocked a legitimate agent config that chains two intent routers (hierarchical intent classification on one utterance). Chained intent routers are semantically valid and the runtime already routes them correctly (each makes its own routing call); the only cost is latency, not correctness, so it should not be a hard load-time error. Drops the validation and keeps the cycle and edge-target checks.