### PR TITLE
fix: tag text input with the text pipeline's sequence index

### DIFF
--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -243,7 +243,7 @@ class DefaultInputHandler:
     def __process_text(self, text):
         logger.info(f"Sequences {self.input_types}")
         ws_data_packet = create_ws_data_packet(
-            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["audio"]}
+            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["text"]}
         )
 
         if self.turn_based_conversation:


### PR DESCRIPTION
__process_text() in bolna/input_handlers/defualt.py currently tags text mesages with self.input_types["audio"] instead of self.input_types["text"]. Since meta_info["sequence"] is later used by _get_next_step() to determine the pipeline, text messages end up following the audio pipeline instead of text pipeline.

This also raises a KeyError for text-only tasks where input_types doesn't contain an "audio" entry. 

This changes update __process_text() to use self.input_types["text"], matching the pipeline assigned by get_required_input_types() and existing behaviour in __process_audio.