### PR TITLE
fix(transcriber): stream on live calls to avoid self-hosted Deepgram TLS crash

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.150"
+__version__ = "0.10.151"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1461,8 +1461,11 @@ class TaskManager(BaseManager):
                         elif provider in (WEB_BASED_CALL_PROVIDER, TelephonyProvider.FREESWITCH.value):
                             cfg["encoding"] = "linear16"
                             cfg["sampling_rate"] = 16000
-                        if self.turn_based_conversation:
-                            cfg["stream"] = True if self.enforce_streaming else False
+                        # Live calls (telephony/web) must stream; only turn-based playground
+                        # honors enforce_streaming. A non-streaming transcriber on a live call
+                        # falls back to the batch REST path, which the self-hosted Deepgram
+                        # engine (plaintext) can't serve — the connection dies on a TLS mismatch.
+                        cfg["stream"] = bool(self.enforce_streaming or not self.turn_based_conversation)
 
                         if "provider" in cfg:
                             cls = SUPPORTED_TRANSCRIBER_PROVIDERS.get(cfg["provider"])
@@ -1537,11 +1540,15 @@ class TaskManager(BaseManager):
                     transcriber_config["model"] in SUPPORTED_TRANSCRIBER_MODELS.keys()
                     or transcriber_config["provider"] in SUPPORTED_TRANSCRIBER_PROVIDERS.keys()
                 ):
-                    if self.turn_based_conversation:
-                        transcriber_config["stream"] = True if self.enforce_streaming else False
-                        logger.info(
-                            f"transcriber stream={transcriber_config['stream']} enforce_streaming={self.enforce_streaming}"
-                        )
+                    # Live calls (telephony/web) must stream; only turn-based playground
+                    # honors enforce_streaming. A non-streaming transcriber on a live call
+                    # falls back to the batch REST path, which the self-hosted Deepgram
+                    # engine (plaintext) can't serve — the connection dies on a TLS mismatch.
+                    transcriber_config["stream"] = bool(self.enforce_streaming or not self.turn_based_conversation)
+                    logger.info(
+                        f"transcriber stream={transcriber_config['stream']} "
+                        f"enforce_streaming={self.enforce_streaming} turn_based={self.turn_based_conversation}"
+                    )
                     if "provider" in transcriber_config:
                         transcriber_class = SUPPORTED_TRANSCRIBER_PROVIDERS.get(transcriber_config["provider"])
                     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.150"
+version = "0.10.151"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

Live (telephony/web) calls whose agent config has a Deepgram transcriber with
`stream: false` never transcribe user speech. `transcribe()` always opens the
`ws://…:8080` streaming socket first (so logs misleadingly say "Successfully
connected to Deepgram"), then branches on `self.stream`:

- `stream: true` → streams over the working `ws://` socket ✅
- `stream: false` → routes audio to the batch REST path
  (`_get_http_transcription`), which builds a **hardcoded `https://` URL**
  (`deepgram_transcriber.py:72`) and `POST`s to it (`:549`).

Against the **self-hosted Deepgram engine** (plaintext HTTP on `:8080`), that
TLS handshake fails with `SSL: WRONG_VERSION_NUMBER`. The transcriber retries
~10×/sec, no user audio is ever transcribed, and the call drops after a few
seconds carrying only the assistant welcome turn.

The crash is at the transport layer, **before** Deepgram reads the
`?model=&language=` query — so it is independent of provider model and
language (reproduced with `mr` **and** `hi`; the fleet skews English).

## Root cause

For non-turn-based (live) calls, the transcriber's `stream` value came straight
from the agent's **saved config**. The `enforce_streaming` override was applied
`if self.turn_based_conversation:` only — i.e. playground-only — so a live call
with a `stream: false` config silently took the broken REST path.

## Fix

Force `stream=True` whenever the conversation is **not** turn-based; only the
turn-based playground still honors `enforce_streaming`. This mirrors the
existing `self.stream` logic and is applied to **both** transcriber setup paths
(the multilingual pool and the single-transcriber branch), so live calls can
never fall onto the batch REST path regardless of provider, model, or language.

```python
# before (playground-only override; live calls used the saved flag as-is)
if self.turn_based_conversation:
    transcriber_config["stream"] = True if self.enforce_streaming else False

# after
transcriber_config["stream"] = bool(self.enforce_streaming or not self.turn_based_conversation)
```

## Blast radius

From prod agent configs (`agents.tasks`): **359 agents** currently have a
Deepgram transcriber with `stream: false` in the conversation task. Of the
**65** that placed calls in the last 90 days: **84 answered calls, only 3
transcribed a user turn** (2 agents) — a ~96% silence rate on answered calls.
Confirmed via ws-server logs (`WRONG_VERSION_NUMBER` on the `http transcription`
path) for 3 distinct recent agents/calls.

This fix resolves the whole class on deploy — no per-agent config edits needed.

## Testing

- `python -m py_compile` clean; `bandit` (pre-commit) clean.
- Reproduced pre-fix: a `stream: false` Deepgram agent → `WRONG_VERSION_NUMBER`,
  0 user turns. A `stream: true` clone on the same engine/model/language → clean
  streaming connect + full transcript.

## Follow-up (not in this PR)

`deepgram_transcriber.py:72` still hardcodes `https://` on the REST path. With
this change live calls no longer reach it, but it remains a latent trap for any
future non-streaming path against the plaintext self-hosted engine — the REST
scheme should derive from `DEEPGRAM_HOST_PROTOCOL` like the `ws`/`wss` path does.
