### PR TITLE
fix: don't assume tool-call index 0 in ToolCallAccumulator.build_api_payload

### DIFF
--- a/bolna/llms/tool_call_accumulator.py
+++ b/bolna/llms/tool_call_accumulator.py
@@ -68,12 +68,18 @@ class ToolCallAccumulator:
         if not self.final_tool_calls:
             return None
 
-        first_func_name = self.final_tool_calls[0]["function"]["name"]
+        # final_tool_calls is keyed by the provider's tool-call index, which is not
+        # guaranteed to start at 0 (some providers, notably via LiteLLM normalization,
+        # report a non-zero or absent first index). Take the first accumulated call by
+        # insertion order — consistent with model_response=list(...values()) below —
+        # instead of assuming key 0 exists, which would otherwise raise KeyError.
+        first_tool_call = next(iter(self.final_tool_calls.values()))
+        first_func_name = first_tool_call["function"]["name"]
         if first_func_name not in self.api_params:
             return None
 
         func_conf = self.api_params[first_func_name]
-        arguments_received = self.final_tool_calls[0]["function"]["arguments"]
+        arguments_received = first_tool_call["function"]["arguments"]
 
         logger.info(f"Payload to send {arguments_received} func_dict {func_conf}")
         self._gave_pre_call_msg = False
@@ -89,7 +95,7 @@ class ToolCallAccumulator:
             meta_info=meta_info,
             called_fun=first_func_name,
             model_response=list(self.final_tool_calls.values()),
-            tool_call_id=self.final_tool_calls[0].get("id", ""),
+            tool_call_id=first_tool_call.get("id", ""),
             textual_response=answer.strip() if self.received_textual else None,
         )
 

--- a/tests/tests/test_tool_call_accumulator_index.py
+++ b/tests/tests/test_tool_call_accumulator_index.py
@@ -1,0 +1,104 @@
+"""Tests for ToolCallAccumulator.build_api_payload index handling.
+
+final_tool_calls is keyed by the provider's streamed tool-call index, not by
+list position. build_api_payload used to read final_tool_calls[0], which assumes
+the first tool call always has index 0. That holds for OpenAI/Azure but is not
+guaranteed across providers (LiteLLM normalizes several backends), so a non-zero
+first index raised KeyError and dropped the whole function call. These verify the
+first accumulated call is used regardless of its index, and index 0 still works.
+"""
+
+import json
+from types import SimpleNamespace
+
+from bolna.llms.tool_call_accumulator import ToolCallAccumulator
+
+
+def _delta(index, call_id, name, arguments):
+    """Mimic one streamed tool-call delta chunk (OpenAI/LiteLLM shape)."""
+    return SimpleNamespace(
+        index=index,
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _accumulator_for(func_name):
+    api_params = {
+        func_name: {
+            "url": "https://example.com/api",
+            "method": "POST",
+            "param": None,
+            "api_token": None,
+            "headers": None,
+        }
+    }
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": func_name,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            },
+        }
+    ]
+    return ToolCallAccumulator(
+        api_params=api_params, tools=tools, language="en", model="gpt-4o-mini", run_id="run-1"
+    )
+
+
+def _no_op_request_log(monkeypatch):
+    # convert_to_request_log schedules an asyncio task and writes trace logs;
+    # stub it so the unit test needs no event loop and touches no files.
+    monkeypatch.setattr(
+        "bolna.llms.tool_call_accumulator.convert_to_request_log",
+        lambda *args, **kwargs: None,
+    )
+
+
+def test_build_api_payload_with_nonzero_first_index(monkeypatch):
+    _no_op_request_log(monkeypatch)
+    acc = _accumulator_for("get_weather")
+    # Provider streams the only tool call with index 1 (not 0).
+    acc.process_delta([_delta(1, "call_abc", "get_weather", json.dumps({"city": "Paris"}))])
+
+    payload = acc.build_api_payload(model_args={"model": "gpt-4o-mini"}, meta_info={}, answer="")
+
+    assert payload is not None
+    assert payload.called_fun == "get_weather"
+    assert payload.tool_call_id == "call_abc"
+    assert getattr(payload, "city") == "Paris"
+
+
+def test_build_api_payload_zero_index_still_works(monkeypatch):
+    _no_op_request_log(monkeypatch)
+    acc = _accumulator_for("get_weather")
+    acc.process_delta([_delta(0, "call_xyz", "get_weather", json.dumps({"city": "Berlin"}))])
+
+    payload = acc.build_api_payload(model_args={"model": "gpt-4o-mini"}, meta_info={}, answer="")
+
+    assert payload is not None
+    assert payload.tool_call_id == "call_xyz"
+    assert getattr(payload, "city") == "Berlin"
+
+
+def test_build_api_payload_uses_insertion_order_not_numeric_min(monkeypatch):
+    """Deltas can arrive with any index the provider assigns; build_api_payload must use
+    the FIRST one accumulated (insertion order), not search for the numerically smallest
+    index. Regression guard against a fix that swaps [0] for min(final_tool_calls) instead
+    of next(iter(...values()))."""
+    _no_op_request_log(monkeypatch)
+    acc = _accumulator_for("get_weather")
+    # First delta received has index=3; a second (different-index) delta arrives after.
+    acc.process_delta([_delta(3, "call_first", "get_weather", json.dumps({"city": "Rome"}))])
+    acc.process_delta([_delta(1, "call_second", "get_weather", json.dumps({"city": "Oslo"}))])
+
+    payload = acc.build_api_payload(model_args={"model": "gpt-4o-mini"}, meta_info={}, answer="")
+
+    assert payload is not None
+    assert payload.tool_call_id == "call_first"
+    assert getattr(payload, "city") == "Rome"


### PR DESCRIPTION
## Summary

`final_tool_calls` is keyed by the provider's streamed `tool_call.index`, not list
position, but `build_api_payload` read `final_tool_calls[0]` - assuming the first
tool call always has index 0. That holds for OpenAI/Azure but isn't guaranteed
across every provider LiteLLM normalizes; a non-zero first index raises an
uncaught `KeyError`. Traced end-to-end, this doesn't just drop the tool call -
it propagates through `generate_stream()` → `TaskManager.__do_llm_generation`'s
blanket exception handler → `LLMError` → `_run_llm_task`'s
`except BolnaComponentError` → `_end_call_on_component_error(HangupReason.LLM_ERROR)`,
which **ends the call**.

Possibly related to #742.

## Fix

Use the first accumulated call by insertion order (`next(iter(final_tool_calls.values()))`)
instead of assuming key `0`, consistent with `model_response=list(final_tool_calls.values())`
already used two lines below.

## Summary

`final_tool_calls` is keyed by the provider's streamed `tool_call.index`, not list
position, but `build_api_payload` read `final_tool_calls[0]` - assuming the first
tool call always has index 0. That holds for OpenAI/Azure but isn't guaranteed
across every provider LiteLLM normalizes; a non-zero first index raises an
uncaught `KeyError`. Traced end-to-end, this doesn't just drop the tool call -
it propagates through `generate_stream()` → `TaskManager.__do_llm_generation`'s
blanket exception handler → `LLMError` → `_run_llm_task`'s
`except BolnaComponentError` → `_end_call_on_component_error(HangupReason.LLM_ERROR)`,
which **ends the call**.

Possibly related to #742.

## Fix

Use the first accumulated call by insertion order (`next(iter(final_tool_calls.values()))`)
instead of assuming key `0`, consistent with `model_response=list(final_tool_calls.values())`
already used two lines below.
<details>
<summary><strong>Testing</strong> (click to expand - regression tests, before/after verification, full suite results)</summary>

- Added 3 regression tests in `tests/tests/test_tool_call_accumulator_index.py`:
  non-zero first index (the bug), index 0 (existing behavior, unaffected), and
  insertion-order-not-numeric-min (guards against a partial fix using `min()`).
- Verified against unpatched `master`: 2/3 tests fail with the exact `KeyError: 0`
  this issue describes; the index-0 test correctly still passes (confirms the test
  isn't a false positive).
- Verified against this branch: all 3 pass.
- Confirmed via `grep` that `final_tool_calls` is only read inside this class -
  external callers (`litellm.py`, `azure_llm.py`, `openai_llm.py`) only check
  truthiness (`if accumulator.final_tool_calls`), never index it - so this fix is
  fully self-contained and changes no external contract.
- Full suite (`pytest tests/`) on this branch: **502 passed, 10 failed.** The same
  10 failures reproduce identically on unpatched `master` with none of this
  branch's changes present (same test names, same order, same error types) -
  confirmed pre-existing and unrelated to this change:
  - 7 in `test_event_injection_e2e.py` - timing-sensitive async tests
    (`settle_time`-based waits + `AsyncMock.await_count` assertions).
  - 2 in `test_trace_log_encoding.py` + 1 in `test_elevenlabs_close_context_eos.py`
    - a Windows-only `UnicodeEncodeError`: `write_request_logs`'s `aiofiles.open`
    doesn't pin `encoding="utf-8"`, so non-ASCII (Hindi) transcript text fails to
    encode under the `cp1252` locale Windows defaults to. Not present on Linux
    CI; unrelated to tool-call handling. Happy to file this separately.
- `ruff check` on both changed files: all checks passed.

</details>

Closes #879 
