### PR TITLE
fix: log the provider-qualified model name in azure tool-call request logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,7 @@ async def main():
     # Configure audio output (TTS)
     synthesizer = Synthesizer(
         provider="elevenlabs",
-        provider_config=ElevenLabsConfig(
-            voice="George", voice_id="JBFqnCBsd6RMkjVDRZzb", model="eleven_turbo_v2_5"
-        ),
+        provider_config=ElevenLabsConfig(voice="George", voice_id="JBFqnCBsd6RMkjVDRZzb", model="eleven_turbo_v2_5"),
         stream=True,
         audio_format="wav",
     )

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.155"
+__version__ = "0.10.156"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -44,6 +44,7 @@ class AzureLLM(OpenAICompatibleLLM):
             self.model = model.replace("azure/", "", 1)
         else:
             self.model = model
+        self._request_log_model = model
 
         self.custom_tools = kwargs.get("api_tools", None)
         self.language = language
@@ -144,7 +145,9 @@ class AzureLLM(OpenAICompatibleLLM):
         tools = model_args.get("tools", [])
         accumulator = None
         if self.trigger_function_call:
-            accumulator = ToolCallAccumulator(self.api_params, tools, self.language, self.model, self.run_id)
+            accumulator = ToolCallAccumulator(
+                self.api_params, tools, self.language, self.request_log_model, self.run_id
+            )
 
         text_tool_buffer = None
         captured_tool_text = None

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -54,6 +54,14 @@ class OpenAICompatibleLLM(BaseLLM):
     - Override _responses_client property if they need a different client
     """
 
+    # Set by subclasses that strip a provider prefix off self.model before calling the API.
+    _request_log_model = None
+
+    @property
+    def request_log_model(self):
+        """Provider-qualified model name, so request logs key the same way the task manager records."""
+        return self._request_log_model or self.model
+
     @staticmethod
     def _find_tool_call_end(text):
         """Return the index after the closing brace/paren of a text tool call
@@ -402,7 +410,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     convert_to_request_log(
                         arguments_str,
                         meta_info,
-                        self.model,
+                        self.request_log_model,
                         LogComponent.LLM,
                         direction=LogDirection.RESPONSE,
                         is_cached=False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.155"
+version = "0.10.156"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Azure agents strip the `azure/` prefix off `self.model` before calling the API, but the two tool-call paths logged that stripped name while the task manager logs the provider-qualified one. A single call therefore wrote request-log rows under two different model names, and the usage breakdown came back with a spurious extra key carrying 0 tokens and 0 cost.

Observed on an `azure/gpt-5.4-mini` call, whose usage breakdown listed both `azure/gpt-5.4-mini` (all real tokens) and `ptu-gpt-5.4-mini` (empty). Cost attribution was already correct; the problem is that an internal deployment name is exposed in customer-facing usage data.

`request_log_model` now carries the name as configured, and both tool-call log paths use it. The name sent to Azure is unchanged, so only logging is affected. `OpenAiLLM` has no prefix to strip and falls through to `self.model` untouched.

`gemini_llm` strips a prefix the same way and logs `self.model`, so it likely has the same split. Left alone here since it is a separate class and untested.
