### PR TITLE
fix: detect gpt-5 model family from the deployment's underlying model

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.156"
+__version__ = "0.10.157"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -270,3 +270,14 @@ def default_reasoning_effort(model: str) -> str:
     if not supported or RE.MINIMAL in supported:
         return RE.MINIMAL.value
     return supported[0].value
+
+
+def canonical_model(name: str) -> str:
+    """The known model a deployment serves, e.g. 'ptu-gpt-5.4-mini' -> 'gpt-5.4-mini'.
+
+    Azure deployment names are chosen freely, so model-family checks cannot read them directly.
+    Longest match wins so 'gpt-5.4-mini' beats 'gpt-5.4'. Unrecognised names pass through.
+    """
+    bare = (name or "").rsplit("/", 1)[-1]
+    known = [m for m in MODEL_REASONING_EFFORT_MAP if m in bare]
+    return max(known, key=len) if known else bare

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -16,7 +16,7 @@ from openai import (
     BadRequestError,
 )
 
-from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX, default_reasoning_effort
+from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX, canonical_model, default_reasoning_effort
 from bolna.enums import Verbosity
 from bolna.helpers.utils import convert_to_request_log, compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
@@ -44,7 +44,9 @@ class AzureLLM(OpenAICompatibleLLM):
             self.model = model.replace("azure/", "", 1)
         else:
             self.model = model
+        # self.model is the Azure deployment name, which need not resemble the model it serves.
         self._request_log_model = model
+        self._model_family = canonical_model(self.model)
 
         self.custom_tools = kwargs.get("api_tools", None)
         self.language = language
@@ -63,10 +65,10 @@ class AzureLLM(OpenAICompatibleLLM):
         self.temperature = temperature
         max_tokens_key = "max_tokens"
         self.model_args = {}
-        if self.model.startswith(GPT5_MODEL_PREFIX):
+        if self.model_family.startswith(GPT5_MODEL_PREFIX):
             max_tokens_key = "max_completion_tokens"
             self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort", None) or default_reasoning_effort(
-                self.model
+                self.model_family
             )
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
 
@@ -131,7 +133,7 @@ class AzureLLM(OpenAICompatibleLLM):
             "stream_options": {"include_usage": True},
         }
 
-        if not self.model.startswith(GPT5_MODEL_PREFIX):
+        if not self.model_family.startswith(GPT5_MODEL_PREFIX):
             model_args["stop"] = ["User:"]
 
         if self.trigger_function_call:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -54,13 +54,19 @@ class OpenAICompatibleLLM(BaseLLM):
     - Override _responses_client property if they need a different client
     """
 
-    # Set by subclasses that strip a provider prefix off self.model before calling the API.
+    # Both are set by subclasses whose self.model is a deployment name rather than the model itself.
     _request_log_model = None
+    _model_family = None
 
     @property
     def request_log_model(self):
         """Provider-qualified model name, so request logs key the same way the task manager records."""
         return self._request_log_model or self.model
+
+    @property
+    def model_family(self):
+        """Model self.model actually serves; family checks must use this, not the deployment name."""
+        return self._model_family or self.model
 
     @staticmethod
     def _find_tool_call_end(text):
@@ -454,7 +460,7 @@ class OpenAICompatibleLLM(BaseLLM):
         if service_tier:
             create_kwargs["service_tier"] = service_tier
 
-        if self.model.startswith(GPT5_MODEL_PREFIX):
+        if self.model_family.startswith(GPT5_MODEL_PREFIX):
             create_kwargs["temperature"] = 1
             reasoning_effort = self.model_args.get("reasoning_effort")
             reasoning_config = {}
@@ -689,7 +695,7 @@ class OpenAICompatibleLLM(BaseLLM):
         if service_tier:
             create_kwargs["service_tier"] = service_tier
 
-        if self.model.startswith(GPT5_MODEL_PREFIX):
+        if self.model_family.startswith(GPT5_MODEL_PREFIX):
             create_kwargs["temperature"] = 1
             reasoning_config = {}
             reasoning_effort = self.model_args.get("reasoning_effort")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.156"
+version = "0.10.157"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Azure deployment names are chosen freely, so a provisioned gpt-5 deployment is typically named something like `ptu-gpt-5.4-mini`. Every gpt-5 family check reads that name directly with `startswith("gpt-5")`, and the reasoning-effort lookup is an exact dict hit, so all of them miss on such a deployment.

Holding everything else constant and varying only the name bolna is told, against the same live deployment:

```
name='gpt-5.4-mini'        detected=True   token key=max_completion_tokens
                           sent temperature=1    reasoning={'effort':'none','summary':'auto'}
                           LatencyData.reasoning_effort='none'

name='ptu-gpt-5.4-mini'    detected=False  token key=max_tokens
                           sent temperature=0.1  reasoning=None
                           LatencyData.reasoning_effort=None
```

So a provisioned gpt-5 deployment silently runs with no reasoning effort, no verbosity, and the caller's temperature instead of the required 1. It survives only because the API accepts a non-default temperature while no reasoning block is present. The configured `reasoning_effort` is dropped, and `executions.latency_dict.llm_latencies.turn_latencies[].reasoning_effort` records null, which matches what a live provisioned call persists today.

`canonical_model` resolves the model a deployment serves by longest known-model match, and `model_family` exposes it, defaulting to `self.model` so anything already passing a real model name is unaffected. The family checks and the effort lookup now read it. The name sent to Azure does not change.

Unrecognised names pass through unchanged, so non-reasoning pools such as `ptu-gpt-4-1-mini` keep `max_tokens` and gain no reasoning params, and `OpenAiLLM` is untouched. Longest match means `gpt-5.1-codex-max` wins over `gpt-5.1`.

Conflicts textually with bolna/bolna#881, which adds a sibling property to the same two classes.
