### PR TITLE
fix: refresh AI-activity clock during long TTS turns (prevent false inactivity hangup) — approach A

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.157"
+__version__ = "0.10.158"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6424,7 +6424,14 @@ class TaskManager(BaseManager):
                 self.execute_function_call_task is not None and not self.execute_function_call_task.done()
             )
 
-            time_since_last_spoken_ai_word = time.time() - self.last_transmitted_timestamp
+            # last_transmitted_timestamp only advances when a turn's FINAL chunk is played,
+            # so during one long (~90s) single response it stays frozen at the previous turn
+            # and the watchdog wrongly reads the agent as silent. Fold in the last content
+            # mark ACK (advances on every chunk) so the AI-activity clock reflects audio that
+            # is actually still playing to the caller.
+            last_audio_played_ts = self.tools["input"].get_last_audio_played_ts() or 0
+            effective_last_ai_ts = max(self.last_transmitted_timestamp, last_audio_played_ts)
+            time_since_last_spoken_ai_word = time.time() - effective_last_ai_ts
             time_since_user_last_spoke = (
                 (time.time() - self.time_since_last_spoken_human_word)
                 if self.time_since_last_spoken_human_word > 0

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -58,6 +58,11 @@ class DefaultInputHandler:
         # agent_end_ms in user_bot_latencies.
         self.last_final_chunk_sequence_id: Optional[int] = None
         self.last_final_chunk_played_ts: Optional[float] = None
+        # Wall-clock time of the most recent content-audio mark ACK, i.e. the last moment
+        # the provider confirmed a chunk of agent audio was played to the caller. Unlike
+        # last_final_chunk_played_ts this advances on EVERY chunk, so the completion
+        # watchdog can tell that a long single turn is still actively playing.
+        self.last_audio_played_ts: Optional[float] = None
 
     def get_calculated_plivo_latency(self):
         return self.calculated_plivo_latency
@@ -136,6 +141,9 @@ class DefaultInputHandler:
     def get_current_mark_started_time(self):
         return self.update_start_ts
 
+    def get_last_audio_played_ts(self):
+        return self.last_audio_played_ts
+
     def welcome_message_played(self):
         return self.is_welcome_message_played
 
@@ -171,6 +179,10 @@ class DefaultInputHandler:
                 self.mark_event_meta_data.record_ack(delay, mark_event_meta_data_obj.get("sequence_id"))
 
         if is_content_audio:
+            # A content chunk was just played to the caller — record it so the completion
+            # watchdog treats an in-progress long turn as "AI still speaking" rather than
+            # relying only on the final-chunk ACK (which lands ~10-20s later).
+            self.last_audio_played_ts = time.time()
             heard_text = mark_event_meta_data_obj.get("text_synthesized") or ""
             self.response_heard_by_user += heard_text
             self.mark_event_meta_data.record_heard_text(mark_event_meta_data_obj, heard_text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.157"
+version = "0.10.158"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

Some calls hang up with `hangup_reason = "Inactivity timeout"` **while the agent is mid-speech**. Root cause is in the completion watchdog `__check_for_completion`:

- "time since AI last spoke" is derived from `last_transmitted_timestamp`.
- `last_transmitted_timestamp` only advances when a turn's **final** audio chunk is played (`final_chunk_played_observer`).
- For one very long single response (~90s of TTS, e.g. a long sales pitch), that timestamp stays frozen at the **previous** turn for the whole monologue.
- With the user passively listening (silence > `hangup_after_silence`), the watchdog concludes both sides are silent past the threshold and fires an `INACTIVITY_TIMEOUT` hangup — the call drops the instant the audio finishes, before the user can answer the agent's closing question.

Real incident (Plivo hosted outbound): agent delivered a 1445-char / ~90s closing pitch; watchdog logged `91.5s since AI last spoke and 15.1s since user last spoke, both exceed 10s timeout - hanging up` **while the audio was still playing**. Plivo then cleared the leg as `4010 End Of XML Instructions / NORMAL_CLEARING` because we closed the media stream.

## Approach (A of 2): make the AI-activity clock accurate

Track the wall-clock time of the most recent **content-audio mark ACK** (`last_audio_played_ts`) — this advances on *every* chunk actually played to the caller, not just the final chunk. In `__check_for_completion`, compute AI silence from the freshest of `last_transmitted_timestamp` and `last_audio_played_ts`. A turn whose audio is still playing out no longer reads as silence.

## Changes
- `input_handlers/default.py`: record `last_audio_played_ts` on each content mark ACK in `process_mark_message`; add `get_last_audio_played_ts()`. Inherited by all telephony handlers.
- `agent_manager/task_manager.py`: use `max(last_transmitted_timestamp, last_audio_played_ts)` when computing `time_since_last_spoken_ai_word`.

## Trade-off vs approach B
Recency-based and tiny. Fully prevents the false hangup as long as the provider is ACKing marks during playout (the normal case). It does not add an explicit "audio still in flight" state, so if a provider front-loads a long buffer and stops ACKing mid-playout, a residual few-second early cut is still theoretically possible. Approach B (state-based gate on un-played final chunk) is the alternative — see the companion PR.

## Test
- `ruff check` clean; `py_compile` clean.
- Behavior on genuine post-call silence is unchanged: once real playback stops, both `last_transmitted_timestamp` and `last_audio_played_ts` go stale and the inactivity hangup fires as before.