### PR TITLE
fix: gate inactivity hangup on un-played final chunk (prevent false inactivity hangup) — approach B

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.157"
+__version__ = "0.10.158"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -306,6 +306,20 @@ class InterruptionManager:
                 logger.info(f"Recorded agent audio fully played: sequence_id={sequence_id}")
                 return
 
+    def is_agent_audio_pending_playback(self) -> bool:
+        """True when the most recent agent turn has started sending audio but the telephony
+        provider has not yet ACKed its final chunk (agent_end_s unset) — i.e. the caller is
+        still hearing the agent.
+
+        The completion watchdog uses this because is_audio_being_played can be cleared early
+        (at synth stream-end) while ~10-20s of audio is still buffered on the provider. For a
+        long single turn that gap lets the watchdog fire a false INACTIVITY_TIMEOUT hangup
+        mid-monologue. agent_end_s is set from the is_final_chunk mark ACK (real playback end)."""
+        if not self.user_bot_latencies:
+            return False
+        last = self.user_bot_latencies[-1]
+        return bool(last.get("agent_start_s")) and not last.get("agent_end_s")
+
     def _finalize_agent_speaking_session(self) -> None:
         """Close current agent speaking window; called on clean end or barge-in."""
         if self._agent_speaking_start_time <= 0:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6447,7 +6447,18 @@ class TaskManager(BaseManager):
                 await self.process_call_hangup()
                 break
 
-            if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
+            # is_audio_being_played can be cleared early (at synth stream-end) while the
+            # provider is still playing out a long buffered turn, which lets the inactivity
+            # hangup below fire mid-monologue. Also treat "the latest turn's final chunk has
+            # not been ACKed yet" as busy. NOTE: this intentionally does NOT gate the stall
+            # backstop above (which keeps the raw flag), so a genuinely stuck stream is still
+            # cleaned up after STALL_HANGUP_FLOOR_S.
+            audio_pending_playback = self.interruption_manager.is_agent_audio_pending_playback()
+            if (
+                self.tools["input"].is_audio_being_played_to_user()
+                or audio_pending_playback
+                or self.response_in_pipeline
+            ):
                 continue
 
             if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.157"
+version = "0.10.158"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

Some calls hang up with `hangup_reason = "Inactivity timeout"` **while the agent is mid-speech**. Root cause is in the completion watchdog `__check_for_completion`:

- It skips the inactivity hangup while `is_audio_being_played_to_user()` is True.
- That flag is cleared **early** — at synthesizer stream-end — while ~10-20s of the agent's audio is still buffered and playing on the telephony provider.
- For one very long single response (~90s of TTS, e.g. a long sales pitch), that gap lets the `hang_conversation_after` branch fire an `INACTIVITY_TIMEOUT` hangup mid-monologue. The call drops the instant playback finishes, before the user can answer the agent's closing question.

Real incident (Plivo hosted outbound): agent delivered a 1445-char / ~90s closing pitch; watchdog logged `91.5s since AI last spoke and 15.1s since user last spoke, both exceed 10s timeout - hanging up` **while the audio was still playing**. Plivo then cleared the leg as `4010 End Of XML Instructions / NORMAL_CLEARING` because we closed the media stream.

## Approach (B of 2): gate on "final chunk not yet played"

Add `InterruptionManager.is_agent_audio_pending_playback()` — True when the latest agent turn has started sending audio but the provider has **not yet ACKed its final chunk** (`agent_end_s` unset; `agent_end_s` is set from the `is_final_chunk` mark ACK, i.e. real playback end at the caller's phone). Treat that as a busy state in the watchdog's audio gate, so the inactivity path can't fire until the caller has actually finished hearing the agent.

This is a **state-based** guard (vs approach A's timestamp-freshness). It's robust even if the provider front-loads a buffer and stops ACKing mid-playout, because it keys off the final-chunk-played state, not mark recency. After the final chunk ACKs, `last_transmitted_timestamp` is refreshed too, so the user still gets the full `hangup_after_silence` window to respond.

## No latch-open risk

The stall backstop (`_should_stall_hangup`, floor `STALL_HANGUP_FLOOR_S = 20s`) is intentionally left on the **raw** `is_audio_being_played_to_user()` flag — not the new pending signal. So if the final-chunk ACK genuinely never arrives (stuck stream), the backstop still cleans up after 20s and the call can't stay open forever.

## Changes
- `agent_manager/interruption_manager.py`: add `is_agent_audio_pending_playback()` (pure; reads the latest `user_bot_latencies` entry).
- `agent_manager/task_manager.py`: fold `audio_pending_playback` into the watchdog's audio gate.

## Trade-off vs approach A
More robust to odd provider buffering/ACK patterns, slightly more code (a new lifecycle predicate). Approach A (refresh the AI-activity clock from playback marks) is the smaller, recency-based alternative — see the companion PR.

## Test
- `ruff check` clean; `py_compile` clean.
- `is_agent_audio_pending_playback()` is pure and easily unit-tested.