### PR TITLE
fix: make the reasoning summary request opt-in so it stops delaying the first token

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.163"
+__version__ = "0.10.164"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -530,6 +530,9 @@ class TaskManager(BaseManager):
                 if "reasoning_effort" in self.llm_agent_config:
                     self.llm_config["reasoning_effort"] = self.llm_agent_config["reasoning_effort"]
 
+                if "reasoning_summary" in self.llm_agent_config:
+                    self.llm_config["reasoning_summary"] = self.llm_agent_config["reasoning_summary"]
+
                 if "thinking_budget" in self.llm_agent_config:
                     self.llm_config["thinking_budget"] = self.llm_agent_config["thinking_budget"]
 
@@ -1751,6 +1754,8 @@ class TaskManager(BaseManager):
                 injected_cfg["api_tools"] = self.kwargs["api_tools"]
             if "reasoning_effort" in self.kwargs:
                 injected_cfg["reasoning_effort"] = self.kwargs["reasoning_effort"]
+            if "reasoning_summary" in self.kwargs:
+                injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
             if "routing_reasoning_effort" in self.kwargs:
@@ -1790,6 +1795,8 @@ class TaskManager(BaseManager):
                 injected_cfg["api_tools"] = self.kwargs["api_tools"]
             if "reasoning_effort" in self.kwargs:
                 injected_cfg["reasoning_effort"] = self.kwargs["reasoning_effort"]
+            if "reasoning_summary" in self.kwargs:
+                injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
             if self.llm_config.get("use_responses_api"):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -144,6 +144,7 @@ class GraphAgent(BaseAgent):
                 "api_tools",
                 "buffer_size",
                 "reasoning_effort",
+                "reasoning_summary",
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -70,6 +70,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 "api_tools",
                 "buffer_size",
                 "reasoning_effort",
+                "reasoning_summary",
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -71,6 +71,7 @@ class AzureLLM(OpenAICompatibleLLM):
                 self.model_family
             )
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
+            self.reasoning_summary = kwargs.get("reasoning_summary")
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -58,6 +58,10 @@ class OpenAICompatibleLLM(BaseLLM):
     _request_log_model = None
     _model_family = None
 
+    # A reasoning summary streams ahead of the answer text, so it is opt-in: requesting one costs
+    # time to first spoken token on a live call. Set from config by subclasses; None omits it.
+    reasoning_summary = None
+
     @property
     def request_log_model(self):
         """Provider-qualified model name, so request logs key the same way the task manager records."""
@@ -466,7 +470,8 @@ class OpenAICompatibleLLM(BaseLLM):
             reasoning_config = {}
             if reasoning_effort:
                 reasoning_config["effort"] = reasoning_effort
-            reasoning_config["summary"] = "auto"
+            if self.reasoning_summary:
+                reasoning_config["summary"] = self.reasoning_summary
             create_kwargs["reasoning"] = reasoning_config
             verbosity = self.model_args.get("verbosity")
             if verbosity:
@@ -701,7 +706,8 @@ class OpenAICompatibleLLM(BaseLLM):
             reasoning_effort = self.model_args.get("reasoning_effort")
             if reasoning_effort:
                 reasoning_config["effort"] = reasoning_effort
-            reasoning_config["summary"] = "auto"
+            if self.reasoning_summary:
+                reasoning_config["summary"] = self.reasoning_summary
             create_kwargs["reasoning"] = reasoning_config
             verbosity = self.model_args.get("verbosity")
             if verbosity:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -165,6 +165,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             max_tokens_key = "max_completion_tokens"
             self.model_args["reasoning_effort"] = kwargs.get("reasoning_effort") or default_reasoning_effort(model)
             self.model_args["verbosity"] = kwargs.get("verbosity", None) or Verbosity.LOW.value
+            self.reasoning_summary = kwargs.get("reasoning_summary")
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.163"
+version = "0.10.164"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Every gpt-5 request sets `reasoning.summary = "auto"` unconditionally. The summary is emitted before the answer text, so on a live call the caller waits through it before hearing anything.

Measured at `effort=low` with a ~14K token prompt, holding everything but this field constant:

```
Azure  ptu-gpt-5.4-mini, HTTP SSE     summary=auto 2856 ms   omitted  766 ms
OpenAI gpt-5.4-mini, HTTP SSE         summary=auto 2034 ms   omitted 1128 ms
OpenAI gpt-5.4-mini, WebSocket        summary=auto 1539 ms   omitted 1043 ms
```

Reasoning token counts are unchanged either way (26 to 48 in both arms), so the model is not thinking more. The cost is emitting the summary first, and it scales with how much reasoning there is to summarise: gpt-5.4-mini and gpt-5.4 reason at `low` and show the penalty, while gpt-5.4-nano, gpt-5.5 and gpt-5.6-sol produce no reasoning tokens at `low` and show no measurable difference.

`reasoning_summary` now defaults to unset, which omits the field. Passing `reasoning_summary: "auto"` in the agent's llm config restores the previous behaviour, wired the same way as `reasoning_effort`. Both request paths go through `_build_responses_create_kwargs`, so this covers Azure and OpenAI, streaming and non-streaming.

Nothing functional reads the summary. It surfaces only as `reasoning_content` on execution log rows, and no `reasoning_content` appears in prod logs over the last six hours while `reasoning_tokens` appears 239 times. Reasoning token counts are unaffected, since `output_tokens_details.reasoning_tokens` is reported regardless of this setting.

The OpenAI figures include roughly 900 ms of network round trip from the machine running the measurement, so the relative penalty holds but the absolute floor is not representative.
