### PR TITLE
fix: name TTS connect failures and bound the reconnect budget by wall clock

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.167"
+__version__ = "0.10.168"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -234,7 +234,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url)), timeout=10.0
+                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=None), timeout=10.0
             )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
@@ -246,7 +246,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
             else:
                 logger.info(f"Cartesia WebSocket connected connection_time={self.connection_time}ms")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Cartesia websocket")
             return None
         except InvalidHandshake as e:
@@ -260,7 +260,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
             self.connection_error = str(e)
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Cartesia: {e}")
+            logger.error(f"Failed to connect to Cartesia: {e!r}", exc_info=True)
             return None
 
     # ------------------------------------------------------------------

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -9,7 +9,7 @@ import base64
 import websockets
 from websockets.exceptions import InvalidHandshake
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 
@@ -233,8 +233,8 @@ class CartesiaSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=None), timeout=10.0
+            websocket = await websockets.connect(
+                self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=CONNECT_TIMEOUT_SECONDS
             )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -10,7 +10,7 @@ import aiohttp
 import websockets
 from dotenv import load_dotenv
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import convert_audio_to_wav, create_ws_data_packet
@@ -202,14 +202,11 @@ class DeepgramSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(
-                    self.ws_url,
-                    additional_headers={"Authorization": f"Token {self.api_key}"},
-                    ssl=get_ssl_context(self.ws_url),
-                    open_timeout=None,
-                ),
-                timeout=10.0,
+            websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers={"Authorization": f"Token {self.api_key}"},
+                ssl=get_ssl_context(self.ws_url),
+                open_timeout=CONNECT_TIMEOUT_SECONDS,
             )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)

--- a/bolna/synthesizer/deepgram_synthesizer.py
+++ b/bolna/synthesizer/deepgram_synthesizer.py
@@ -207,6 +207,7 @@ class DeepgramSynthesizer(StreamSynthesizer):
                     self.ws_url,
                     additional_headers={"Authorization": f"Token {self.api_key}"},
                     ssl=get_ssl_context(self.ws_url),
+                    open_timeout=None,
                 ),
                 timeout=10.0,
             )
@@ -214,7 +215,7 @@ class DeepgramSynthesizer(StreamSynthesizer):
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to Deepgram TTS WebSocket: {self.ws_url}")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Deepgram TTS WebSocket")
             return None
         except websockets.exceptions.InvalidStatusCode as e:
@@ -227,7 +228,7 @@ class DeepgramSynthesizer(StreamSynthesizer):
             self.connection_error = str(e)
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Deepgram TTS WebSocket: {e}")
+            logger.error(f"Failed to connect to Deepgram TTS WebSocket: {e!r}", exc_info=True)
             return None
 
     async def cleanup(self):

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -334,7 +334,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         try:
             start_time = time.perf_counter()
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url)), timeout=10.0
+                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=None), timeout=10.0
             )
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")
@@ -357,7 +357,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to ElevenLabs websocket")
             return None
         except InvalidHandshake as e:
@@ -369,7 +369,7 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             self.connection_error = str(e)
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to ElevenLabs: {e}")
+            logger.error(f"Failed to connect to ElevenLabs: {e!r}", exc_info=True)
             return None
 
     # ------------------------------------------------------------------

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -10,7 +10,7 @@ import base64
 import aiohttp
 import websockets
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, resample
@@ -333,8 +333,8 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=None), timeout=10.0
+            websocket = await websockets.connect(
+                self.ws_url, ssl=get_ssl_context(self.ws_url), open_timeout=CONNECT_TIMEOUT_SECONDS
             )
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -14,6 +14,7 @@ from collections import deque
 
 from bolna.helpers.ssl_context import get_ssl_context
 from .base_synthesizer import BaseSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import create_ws_data_packet
 
@@ -338,11 +339,11 @@ class PixaSynthesizer(BaseSynthesizer):
             if self.api_key:
                 headers["Authorization"] = f"Bearer {self.api_key}"
 
-            websocket = await asyncio.wait_for(
-                websockets.connect(
-                    self.ws_url, additional_headers=headers, ssl=get_ssl_context(self.ws_url), open_timeout=None
-                ),
-                timeout=10.0,
+            websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers=headers,
+                ssl=get_ssl_context(self.ws_url),
+                open_timeout=CONNECT_TIMEOUT_SECONDS,
             )
 
             # Send initial configuration

--- a/bolna/synthesizer/pixa_synthesizer.py
+++ b/bolna/synthesizer/pixa_synthesizer.py
@@ -339,7 +339,9 @@ class PixaSynthesizer(BaseSynthesizer):
                 headers["Authorization"] = f"Bearer {self.api_key}"
 
             websocket = await asyncio.wait_for(
-                websockets.connect(self.ws_url, additional_headers=headers, ssl=get_ssl_context(self.ws_url)),
+                websockets.connect(
+                    self.ws_url, additional_headers=headers, ssl=get_ssl_context(self.ws_url), open_timeout=None
+                ),
                 timeout=10.0,
             )
 
@@ -358,7 +360,7 @@ class PixaSynthesizer(BaseSynthesizer):
             logger.info(f"Connected to Pixa TTS at {self.ws_url}")
             return websocket
 
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Pixa websocket")
             return None
         except InvalidHandshake as e:
@@ -372,7 +374,7 @@ class PixaSynthesizer(BaseSynthesizer):
             self.connection_error = str(e)
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Pixa: {e}")
+            logger.error(f"Failed to connect to Pixa: {e!r}", exc_info=True)
             return None
 
     async def monitor_connection(self):

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -9,7 +9,7 @@ import aiohttp
 import websockets
 from dotenv import load_dotenv
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import convert_audio_to_wav
@@ -195,14 +195,11 @@ class RimeSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(
-                    self.ws_url,
-                    additional_headers={"Authorization": f"Bearer {self.api_key}"},
-                    ssl=get_ssl_context(self.ws_url),
-                    open_timeout=None,
-                ),
-                timeout=10.0,
+            websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers={"Authorization": f"Bearer {self.api_key}"},
+                ssl=get_ssl_context(self.ws_url),
+                open_timeout=CONNECT_TIMEOUT_SECONDS,
             )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)

--- a/bolna/synthesizer/rime_synthesizer.py
+++ b/bolna/synthesizer/rime_synthesizer.py
@@ -200,6 +200,7 @@ class RimeSynthesizer(StreamSynthesizer):
                     self.ws_url,
                     additional_headers={"Authorization": f"Bearer {self.api_key}"},
                     ssl=get_ssl_context(self.ws_url),
+                    open_timeout=None,
                 ),
                 timeout=10.0,
             )
@@ -207,11 +208,11 @@ class RimeSynthesizer(StreamSynthesizer):
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Rime websocket")
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Rime: {e}")
+            logger.error(f"Failed to connect to Rime: {e!r}", exc_info=True)
             return None
 
     # ------------------------------------------------------------------

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -10,7 +10,7 @@ import aiohttp
 import websockets
 from websockets.exceptions import InvalidHandshake
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, get_synth_audio_format, resample, wav_bytes_to_pcm
@@ -220,14 +220,11 @@ class SarvamSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(
-                    self.ws_url,
-                    additional_headers={"api-subscription-key": self.api_key},
-                    ssl=get_ssl_context(self.ws_url),
-                    open_timeout=None,
-                ),
-                timeout=10.0,
+            websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers={"api-subscription-key": self.api_key},
+                ssl=get_ssl_context(self.ws_url),
+                open_timeout=CONNECT_TIMEOUT_SECONDS,
             )
             await websocket.send(json.dumps(self._config_message()))
             if not self.connection_time:

--- a/bolna/synthesizer/sarvam_synthesizer.py
+++ b/bolna/synthesizer/sarvam_synthesizer.py
@@ -225,6 +225,7 @@ class SarvamSynthesizer(StreamSynthesizer):
                     self.ws_url,
                     additional_headers={"api-subscription-key": self.api_key},
                     ssl=get_ssl_context(self.ws_url),
+                    open_timeout=None,
                 ),
                 timeout=10.0,
             )
@@ -233,7 +234,7 @@ class SarvamSynthesizer(StreamSynthesizer):
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Sarvam TTS websocket")
             return None
         except InvalidHandshake as e:
@@ -247,7 +248,7 @@ class SarvamSynthesizer(StreamSynthesizer):
             self.connection_error = str(e)
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Sarvam TTS: {e}")
+            logger.error(f"Failed to connect to Sarvam TTS: {e!r}", exc_info=True)
             return None
 
     # ------------------------------------------------------------------

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -145,6 +145,7 @@ class SmallestSynthesizer(StreamSynthesizer):
                         "X-Source": self.SOURCE,
                     },
                     ssl=get_ssl_context(self.ws_url),
+                    open_timeout=None,
                 ),
                 timeout=10.0,
             )
@@ -152,11 +153,11 @@ class SmallestSynthesizer(StreamSynthesizer):
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
             return websocket
-        except asyncio.TimeoutError:
+        except (asyncio.TimeoutError, TimeoutError):
             logger.error("Timeout while connecting to Smallest websocket")
             return None
         except Exception as e:
-            logger.error(f"Failed to connect to Smallest: {e}")
+            logger.error(f"Failed to connect to Smallest: {e!r}", exc_info=True)
             return None
 
     def _process_http_audio(self, audio):

--- a/bolna/synthesizer/smallest_synthesizer.py
+++ b/bolna/synthesizer/smallest_synthesizer.py
@@ -7,7 +7,7 @@ import time
 import aiohttp
 import websockets
 
-from .stream_synthesizer import StreamSynthesizer
+from .stream_synthesizer import CONNECT_TIMEOUT_SECONDS, StreamSynthesizer
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 
@@ -137,17 +137,14 @@ class SmallestSynthesizer(StreamSynthesizer):
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
-            websocket = await asyncio.wait_for(
-                websockets.connect(
-                    self.ws_url,
-                    additional_headers={
-                        "Authorization": f"Bearer {self.api_key}",
-                        "X-Source": self.SOURCE,
-                    },
-                    ssl=get_ssl_context(self.ws_url),
-                    open_timeout=None,
-                ),
-                timeout=10.0,
+            websocket = await websockets.connect(
+                self.ws_url,
+                additional_headers={
+                    "Authorization": f"Bearer {self.api_key}",
+                    "X-Source": self.SOURCE,
+                },
+                ssl=get_ssl_context(self.ws_url),
+                open_timeout=CONNECT_TIMEOUT_SECONDS,
             )
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -16,6 +16,7 @@ monitor_connection, cleanup — lives here.
 import asyncio
 import copy
 import json
+import random
 import time
 import traceback
 from collections import deque
@@ -28,8 +29,19 @@ from bolna.helpers.utils import create_ws_data_packet
 
 logger = configure_logger(__name__)
 
-# Maximum consecutive connection failures before giving up
-MAX_CONNECTION_FAILURES = 3
+# The caller hears silence while we retry, so the wall-clock budget bounds the
+# dead air regardless of whether the provider refuses instantly or hangs.
+MAX_CONNECTION_FAILURES = 6
+CONNECT_RETRY_BUDGET_SECONDS = 12.0
+CONNECT_BACKOFF_BASE_SECONDS = 0.25
+CONNECT_BACKOFF_MAX_SECONDS = 2.0
+
+
+def _connect_backoff(attempt):
+    """Jittered exponential backoff, so a provider-wide blip doesn't resynchronise every
+    live call onto the same retry instant."""
+    delay = min(CONNECT_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1), CONNECT_BACKOFF_MAX_SECONDS)
+    return delay * (0.5 + random.random() / 2)
 
 
 class StreamSynthesizer(BaseSynthesizer):
@@ -314,26 +326,51 @@ class StreamSynthesizer(BaseSynthesizer):
     # ------------------------------------------------------------------
 
     async def monitor_connection(self):
-        consecutive_failures = 0
+        failures = 0
+        budget_started = None
 
-        while consecutive_failures < MAX_CONNECTION_FAILURES:
-            if not self._is_ws_connected():
-                logger.info(f"Re-establishing {self.provider_name} connection...")
-                result = await self.establish_connection()
-                if result is None:
-                    consecutive_failures += 1
-                    logger.warning(
-                        f"{self.provider_name} connection failed "
-                        f"(attempt {consecutive_failures}/{MAX_CONNECTION_FAILURES})"
-                    )
-                    if consecutive_failures >= MAX_CONNECTION_FAILURES:
-                        logger.error(f"Max connection failures reached for {self.provider_name}")
-                        self.connection_error = self.connection_error or "Max connection failures reached"
-                        break
-                else:
-                    self.websocket = result
-                    consecutive_failures = 0
-            await asyncio.sleep(1)
+        while not self.conversation_ended:
+            if self._is_ws_connected():
+                await asyncio.sleep(1)
+                continue
+
+            logger.info(f"Re-establishing {self.provider_name} connection...")
+            started = time.perf_counter()
+            websocket = await self.establish_connection()
+            took = time.perf_counter() - started
+
+            if websocket is not None:
+                self.websocket = websocket
+                retried = f" after {failures} failed attempt(s)" if failures else ""
+                logger.info(f"{self.provider_name} connected in {round(took * 1000)}ms{retried}")
+                failures = 0
+                budget_started = None
+                await asyncio.sleep(1)
+                continue
+
+            failures += 1
+            if budget_started is None:
+                budget_started = started
+            spent = time.perf_counter() - budget_started
+            # The per-attempt duration is what separates an instant refusal from a hung
+            # connect; they look identical once the call is dead.
+            logger.warning(
+                f"{self.provider_name} connection failed in {round(took * 1000)}ms "
+                f"(attempt {failures}/{MAX_CONNECTION_FAILURES}, "
+                f"{max(0.0, CONNECT_RETRY_BUDGET_SECONDS - spent):.1f}s of budget left)"
+            )
+
+            # Stop when another attempt as slow as this one would run past the budget,
+            # else a provider that hangs the connect overshoots by a whole timeout.
+            if failures >= MAX_CONNECTION_FAILURES or spent + took >= CONNECT_RETRY_BUDGET_SECONDS:
+                logger.error(
+                    f"Max connection failures reached for {self.provider_name} "
+                    f"after {failures} attempts over {spent:.1f}s"
+                )
+                self.connection_error = self.connection_error or "Max connection failures reached"
+                return
+
+            await asyncio.sleep(_connect_backoff(failures))
 
     # ------------------------------------------------------------------
     # cleanup() — cancel tasks and close WS

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -29,6 +29,10 @@ from bolna.helpers.utils import create_ws_data_packet
 
 logger = configure_logger(__name__)
 
+# Per-attempt deadline handed to websockets' own open_timeout, which covers DNS, the TCP
+# connect and the opening handshake.
+CONNECT_TIMEOUT_SECONDS = 10.0
+
 # The caller hears silence while we retry, so the wall-clock budget bounds the
 # dead air regardless of whether the provider refuses instantly or hangs.
 MAX_CONNECTION_FAILURES = 6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.167"
+version = "0.10.168"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_stream_synthesizer_reconnect.py
+++ b/tests/test_stream_synthesizer_reconnect.py
@@ -1,0 +1,117 @@
+"""Reconnect budget for a failed provider WebSocket: the caller hears silence while we
+retry, so an instant refusal gets more attempts and a hung connect stops sooner."""
+
+import asyncio
+import time
+
+from websockets.protocol import State
+
+from bolna.synthesizer import stream_synthesizer as ss
+
+
+class FakeWS:
+    def __init__(self):
+        self.state = State.OPEN
+
+    def drop(self):
+        self.state = State.CLOSED
+
+
+class ScriptedSynthesizer(ss.StreamSynthesizer):
+    """StreamSynthesizer whose establish_connection replays a script of
+    (seconds_to_take, succeeds) so each prod failure mode can be reproduced."""
+
+    def __init__(self, script):
+        self.provider_name = "fake"
+        self.websocket = None
+        self.conversation_ended = False
+        self.connection_error = None
+        self.script = list(script)
+        self.attempts = []
+
+    async def establish_connection(self):
+        delay, succeeds = self.script.pop(0) if self.script else (0.0, False)
+        self.attempts.append(delay)
+        await asyncio.sleep(delay)
+        return FakeWS() if succeeds else None
+
+
+def _run_until_gives_up(synth, timeout=60):
+    async def main():
+        start = time.perf_counter()
+        await asyncio.wait_for(synth.monitor_connection(), timeout=timeout)
+        return time.perf_counter() - start
+
+    return asyncio.run(main())
+
+
+def test_instant_refusal_gets_the_full_attempt_budget():
+    synth = ScriptedSynthesizer([(0.3, False)] * 20)
+    elapsed = _run_until_gives_up(synth)
+
+    assert len(synth.attempts) == ss.MAX_CONNECTION_FAILURES
+    assert elapsed < ss.CONNECT_RETRY_BUDGET_SECONDS
+    assert synth.connection_error == "Max connection failures reached"
+
+
+def test_hung_connect_does_not_overshoot_the_budget():
+    """A provider that hangs each connect must not spend one whole timeout past the
+    budget before noticing."""
+    synth = ScriptedSynthesizer([(10.0, False)] * 20)
+    elapsed = _run_until_gives_up(synth)
+
+    assert len(synth.attempts) < ss.MAX_CONNECTION_FAILURES
+    assert elapsed < ss.CONNECT_RETRY_BUDGET_SECONDS + 1
+    assert synth.connection_error == "Max connection failures reached"
+
+
+def test_a_blip_that_clears_late_no_longer_kills_the_call():
+    synth = ScriptedSynthesizer([(0.2, False)] * 3 + [(0.2, True)])
+
+    async def main():
+        task = asyncio.create_task(synth.monitor_connection())
+        while synth.websocket is None and not synth.connection_error:
+            await asyncio.sleep(0.05)
+        synth.conversation_ended = True
+        await asyncio.wait_for(task, timeout=5)
+
+    asyncio.run(main())
+
+    assert synth.connection_error is None
+    assert isinstance(synth.websocket, FakeWS)
+    assert len(synth.attempts) == 4
+
+
+def test_mid_call_reconnect_starts_from_a_clean_budget():
+    synth = ScriptedSynthesizer([(0.1, False), (0.1, False), (0.1, True)])
+
+    async def main():
+        task = asyncio.create_task(synth.monitor_connection())
+        while synth.websocket is None:
+            await asyncio.sleep(0.05)
+        synth.websocket.drop()
+        synth.script = [(0.1, False)] * 20
+        await asyncio.wait_for(task, timeout=30)
+
+    asyncio.run(main())
+
+    assert len(synth.attempts) == 3 + ss.MAX_CONNECTION_FAILURES
+
+
+def test_loop_stops_once_the_conversation_ends():
+    synth = ScriptedSynthesizer([(0.1, False)] * 100)
+    synth.conversation_ended = True
+
+    assert _run_until_gives_up(synth, timeout=5) < 1
+    assert synth.attempts == []
+    assert synth.connection_error is None
+
+
+def test_backoff_is_jittered_and_capped():
+    first = [ss._connect_backoff(1) for _ in range(200)]
+    assert len(set(first)) > 100, "backoff must be jittered so calls don't retry in lockstep"
+
+    for attempt in range(1, 12):
+        assert 0 < ss._connect_backoff(attempt) <= ss.CONNECT_BACKOFF_MAX_SECONDS
+
+    assert min(ss._connect_backoff(6) for _ in range(50)) > max(first)

--- a/tests/test_synthesizer_connect_errors.py
+++ b/tests/test_synthesizer_connect_errors.py
@@ -20,6 +20,7 @@ for _var in [
     os.environ.setdefault(_var, "test-key")
 
 import bolna.synthesizer as synthesizers  # noqa: E402
+from bolna.synthesizer.stream_synthesizer import CONNECT_TIMEOUT_SECONDS  # noqa: E402
 
 PROVIDERS = [
     ("Deepgram", {"voice_id": "v", "voice": "v"}),
@@ -64,14 +65,14 @@ def fake_connect(monkeypatch):
 
 
 @pytest.mark.parametrize("name,kwargs", PROVIDERS, ids=PROVIDER_IDS)
-def test_connect_disables_the_library_open_timeout(name, kwargs, fake_connect):
-    """websockets' own open_timeout would race the wait_for wrapped around it, and on
-    py3.10 it raises the builtin TimeoutError, which the timeout branch used to miss."""
+def test_connect_deadline_comes_from_open_timeout(name, kwargs, fake_connect):
+    """One deadline, owned by the library: open_timeout covers DNS, the TCP connect and the
+    opening handshake, and cleans up its own half-opened transport."""
     synth = _build(name, kwargs)
 
     assert asyncio.run(synth.establish_connection()) is not None
     assert fake_connect, f"{name} did not call websockets.connect"
-    assert fake_connect[0].get("open_timeout", "absent") is None
+    assert fake_connect[0].get("open_timeout") == CONNECT_TIMEOUT_SECONDS
 
 
 @pytest.mark.parametrize("name,kwargs", PROVIDERS, ids=PROVIDER_IDS)

--- a/tests/test_synthesizer_connect_errors.py
+++ b/tests/test_synthesizer_connect_errors.py
@@ -1,0 +1,116 @@
+"""Connect-failure handling shared by the streaming synthesizers: a failure must be
+identifiable in the logs, and the wait_for must own the connect deadline outright."""
+
+import asyncio
+import logging
+import os
+
+import pytest
+import websockets
+
+for _var in [
+    "ELEVENLABS_API_KEY",
+    "DEEPGRAM_AUTH_TOKEN",
+    "CARTESIA_API_KEY",
+    "SARVAM_API_KEY",
+    "RIME_API_KEY",
+    "SMALLEST_API_KEY",
+    "PIXA_API_KEY",
+]:
+    os.environ.setdefault(_var, "test-key")
+
+import bolna.synthesizer as synthesizers  # noqa: E402
+
+PROVIDERS = [
+    ("Deepgram", {"voice_id": "v", "voice": "v"}),
+    ("Cartesia", {"voice_id": "v", "voice": "v"}),
+    ("Sarvam", {"voice_id": "v", "model": "bulbul:v2", "language": "en"}),
+    ("Rime", {"voice_id": "v", "voice": "v"}),
+    ("Pixa", {"voice_id": "v", "voice": "v"}),
+    ("Smallest", {"voice_id": "v"}),
+    ("Elevenlabs", {"voice_id": "v", "voice": "v"}),
+]
+PROVIDER_IDS = [name for name, _ in PROVIDERS]
+
+
+class FakeWS:
+    def __init__(self):
+        self.state = websockets.protocol.State.OPEN
+        self.sent = []
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+
+def _build(name, kwargs):
+    return getattr(synthesizers, f"{name}Synthesizer")(task_manager_instance=None, **kwargs)
+
+
+@pytest.fixture
+def fake_connect(monkeypatch):
+    """Replace websockets.connect and record the kwargs each provider passes."""
+    calls = []
+
+    def connect(*args, **kwargs):
+        calls.append(kwargs)
+
+        async def _await():
+            return FakeWS()
+
+        return _await()
+
+    monkeypatch.setattr(websockets, "connect", connect)
+    return calls
+
+
+@pytest.mark.parametrize("name,kwargs", PROVIDERS, ids=PROVIDER_IDS)
+def test_connect_disables_the_library_open_timeout(name, kwargs, fake_connect):
+    """websockets' own open_timeout would race the wait_for wrapped around it, and on
+    py3.10 it raises the builtin TimeoutError, which the timeout branch used to miss."""
+    synth = _build(name, kwargs)
+
+    assert asyncio.run(synth.establish_connection()) is not None
+    assert fake_connect, f"{name} did not call websockets.connect"
+    assert fake_connect[0].get("open_timeout", "absent") is None
+
+
+@pytest.mark.parametrize("name,kwargs", PROVIDERS, ids=PROVIDER_IDS)
+@pytest.mark.parametrize("exc", [TimeoutError(), asyncio.TimeoutError()], ids=["builtin", "asyncio"])
+def test_either_timeout_type_reaches_the_timeout_branch(name, kwargs, exc, monkeypatch, caplog):
+    """On py3.10 asyncio.TimeoutError is not the builtin, so a socket-level timeout fell
+    through to the generic handler and logged an empty message."""
+
+    def connect(*args, **kwargs):
+        async def _raise():
+            raise exc
+
+        return _raise()
+
+    monkeypatch.setattr(websockets, "connect", connect)
+    synth = _build(name, kwargs)
+
+    with caplog.at_level(logging.ERROR):
+        assert asyncio.run(synth.establish_connection()) is None
+
+    assert "Timeout while connecting" in caplog.text
+    assert "Failed to connect" not in caplog.text
+
+
+@pytest.mark.parametrize("name,kwargs", PROVIDERS, ids=PROVIDER_IDS)
+def test_bare_socket_error_is_named_in_the_log(name, kwargs, monkeypatch, caplog):
+    """str(ConnectionResetError()) is "", so logging {e} produced a blank line. The type
+    has to reach the log or these failures cannot be told apart."""
+
+    def connect(*args, **kwargs):
+        async def _raise():
+            raise ConnectionResetError()
+
+        return _raise()
+
+    monkeypatch.setattr(websockets, "connect", connect)
+    synth = _build(name, kwargs)
+
+    with caplog.at_level(logging.ERROR):
+        assert asyncio.run(synth.establish_connection()) is None
+
+    assert "ConnectionResetError" in caplog.text


### PR DESCRIPTION
Provider WebSocket connect failures were unreadable in the logs, and the retry budget gave up at the wrong times.

## Connect failures logged nothing

`logger.error(f"Failed to connect to X: {e}")` printed an empty string for a large share of real failures, because bare socket and TLS errors carry no args: `str(ConnectionResetError())` and `str(TimeoutError())` are both `""`. Switched to `{e!r}` plus `exc_info=True` on the generic handler, so the type, errno and origin reach the log:

```
Failed to connect to ElevenLabs: ConnectionRefusedError(61, "Connect call failed ...")
```

This is the point of the PR. Failures that produced a blank line were most likely a bare `ConnectionResetError()` raised by the TLS layer on EOF during the handshake, which fits what was observed: fast failures, no HTTP status. That cannot be confirmed until the type is actually logged, which is what this change enables.

## One connect deadline, owned by the library

`establish_connection` wrapped `websockets.connect` in `asyncio.wait_for(timeout=10.0)` while the library ran its own `open_timeout`, also defaulting to 10s. Two timers racing for the same job. Per review feedback the wrapper is gone and `open_timeout` owns the deadline, with the value in one shared `CONNECT_TIMEOUT_SECONDS` rather than repeated per provider. It covers DNS, the TCP connect and the opening handshake, and the library closes its own half-opened transport rather than relying on cancellation landing mid-handshake.

Timeout handlers now catch `(asyncio.TimeoutError, TimeoutError)`, because the class differs by version: on py3.10 `asyncio.TimeoutError` is a separate class from the builtin, and from 3.11 they are aliases. `open_timeout` itself raises `asyncio.TimeoutError`, which the original handler already caught.

## Retry budget

`MAX_CONNECTION_FAILURES = 3` with a flat `sleep(1)` and no backoff was wrong in both directions: a provider refusing instantly burned all three attempts in about 4s, and one hanging the connect held roughly 33s of dead air. Replaced with an attempt cap plus a wall-clock budget and jittered exponential backoff, where the budget stops early if another attempt as slow as the last would run past it.

| Per-attempt failure | Attempts | Dead air | Bound that fires |
|---|---|---|---|
| 0.3s | 6 | 6.1s | attempt cap |
| 1.0s | 6 | 10.0s | attempt cap |
| 2.0s | 5 | 12.3s | time budget |
| 10.0s | 1 | 10.0s | time budget |

Both bounds are load-bearing: the cap keeps fast refusals from hammering a struggling provider, the budget caps dead air when attempts are slow. Worst case is about 12s against 33s before, and fast failures get twice the chances to recover.

Also logs connect duration on every attempt, which gives the data to lower the connect deadline later without guessing, and the loop exits on `conversation_ended` instead of reconnecting into a finished call. The `connection_error` string is unchanged so existing log alerts keep matching.

`pixa_synthesizer.py` keeps its own copy of the retry loop because it extends `BaseSynthesizer` rather than `StreamSynthesizer`, so it does not inherit the budget change. It does get the connect and diagnostics fixes. Moving it onto `StreamSynthesizer` is a separate change.
