### PR TITLE
Fix TaskManager exception suppression during teardown

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7281,7 +7281,7 @@ class TaskManager(BaseManager):
                 self.request_logs.clear()
                 self.function_tool_api_call_details.clear()
 
-            return output
+        return output
 
     async def handle_cancellation(self, message):
         try:

--- a/tests/tests/test_task_manager_run_error_propagation.py
+++ b/tests/tests/test_task_manager_run_error_propagation.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+def _make_followup_task_manager():
+    """Build the minimum TaskManager state needed to exercise run() teardown."""
+    task_manager = TaskManager.__new__(TaskManager)
+    task_manager._is_conversation_task = lambda: False
+    task_manager._process_followup_task = AsyncMock()
+
+    task_manager.task_config = {"task_type": "webhook"}
+    task_manager.webhook_response = {"status": "ok"}
+    task_manager.input_parameters = {}
+    task_manager.run_id = None
+    task_manager.task_id = "test-task"
+
+    for attribute in (
+        "llm_task",
+        "first_message_task_new",
+        "llm_queue_task",
+        "execute_function_call_task",
+        "_lid_idle_watcher_task",
+        "handoff_prewarm_task",
+        "_post_switch_fallback_task",
+    ):
+        setattr(task_manager, attribute, None)
+
+    task_manager.handoff_audio_cache = {"cached": b"audio"}
+    task_manager.observable_variables = {}
+    task_manager.tools = {}
+    task_manager.kwargs = {"task_manager_instance": task_manager}
+    task_manager.conversation_recording = {"input": {"data": b"input"}}
+    task_manager.conversation_history = object()
+    task_manager.request_logs = ["request"]
+    task_manager.function_tool_api_call_details = [{"name": "tool"}]
+    return task_manager
+
+
+@pytest.mark.asyncio
+async def test_run_propagates_followup_task_error_after_cleanup():
+    task_manager = _make_followup_task_manager()
+    task_manager._process_followup_task.side_effect = RuntimeError("provider failed")
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await TaskManager.run(task_manager)
+
+    assert task_manager.handoff_audio_cache == {}
+    assert task_manager.conversation_history is None
+    assert task_manager.request_logs == []
+    assert task_manager.function_tool_api_call_details == []
+
+
+@pytest.mark.asyncio
+async def test_run_returns_followup_output_after_cleanup():
+    task_manager = _make_followup_task_manager()
+    tool = SimpleNamespace(task_manager_instance=task_manager)
+    task_manager.tools["output"] = tool
+
+    output = await TaskManager.run(task_manager)
+
+    assert output == {"status": {"status": "ok"}, "task_type": "webhook"}
+    task_manager._process_followup_task.assert_awaited_once_with()
+    assert tool.task_manager_instance is None
+    assert task_manager.tools == {}


### PR DESCRIPTION
## Summary

Fix `TaskManager.run()` so call-breaking exceptions propagate to `AssistantManager` after teardown instead of being converted into a normal-looking output.

Closes #896.

## Root cause

`TaskManager.run()` deliberately re-raises component and orchestration failures from its main `try` block. However, its teardown lived in the corresponding `finally` block and ended with:

```python
return output
```

Python gives a `return` in `finally` precedence over an active exception. As a result, failures from follow-up tasks, stored component errors, or completed provider tasks could be suppressed once teardown reached that return statement. Python also emitted a `SyntaxWarning` for this control flow.

## Changes

- Move `return output` outside the outer `finally` block.
- Keep all existing cancellation, resource cleanup, output construction, and normal-success behavior in the teardown path.
- Add focused regression coverage that invokes the real `TaskManager.run()` method:
  - a failing webhook follow-up task still executes teardown and propagates its original `RuntimeError`;
  - a successful webhook follow-up still returns the expected output after teardown;
  - teardown state is verified in both paths, including cache clearing, history release, request-log cleanup, tool-reference cleanup, and function-call detail cleanup.

## Behavior after this change

| Path | Before | After |
| --- | --- | --- |
| Successful task | Teardown runs and output is returned | Unchanged |
| Failed task | Teardown runs and `return output` suppresses the failure | Teardown runs and the original failure propagates |
| Compilation | Emits `SyntaxWarning: 'return' in a 'finally' block` | No `SyntaxWarning` |

This is intentionally a narrow control-flow change: it does not alter how output is assembled or how teardown resources are cancelled.

## Validation

- `pytest -q tests/tests/test_task_manager_run_error_propagation.py`
  - `2 passed`
- Focused TaskManager teardown/interruption suite:
  - `30 passed`
- `ruff check bolna/agent_manager/task_manager.py tests/tests/test_task_manager_run_error_propagation.py`
  - passed
- `ruff format --check --diff bolna/agent_manager/task_manager.py tests/tests/test_task_manager_run_error_propagation.py`
  - passed
- `python -W error::SyntaxWarning -m py_compile bolna/agent_manager/task_manager.py`
  - passed
- `git diff --check`
  - passed

The full suite reached `521 passed` with 10 failures in existing event/audio tests. All 10 failures were reproduced unchanged against an untouched `master` worktree (`42 passed, 10 failed` for the affected test files), confirming they are unrelated to this patch.

## Risk

Low. The production change is a one-line indentation adjustment that restores the exception behavior already expressed by the existing `raise` statements. The regression tests cover both the newly restored error path and the existing successful return path.
