### PR TITLE
Fix Assistant pipelines for optional audio components

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -280,6 +280,8 @@ class TaskManager(BaseManager):
         self._committed_assistant_sequences: set = set()
 
         self.task_config = task
+        transcriber_config = self.task_config["tools_config"].get("transcriber") or {}
+        synthesizer_config = self.task_config["tools_config"].get("synthesizer") or {}
 
         self.timezone = pytz.timezone(DEFAULT_TIMEZONE)
         self.language = DEFAULT_LANGUAGE_CODE
@@ -476,10 +478,9 @@ class TaskManager(BaseManager):
         # Tasks
         self.extracted_data = None
         self.summarized_data = None
-        self.stream = (
-            self.task_config["tools_config"]["synthesizer"] is not None
-            and self.task_config["tools_config"]["synthesizer"]["stream"]
-        ) and (self.enforce_streaming or not self.turn_based_conversation)
+        self.stream = bool(synthesizer_config.get("stream")) and (
+            self.enforce_streaming or not self.turn_based_conversation
+        )
 
         self.is_local = False
         self.llm_config = None
@@ -490,9 +491,7 @@ class TaskManager(BaseManager):
         if self.__is_multiagent():
             for agent, config in self.task_config["tools_config"]["llm_agent"]["llm_config"]["agent_map"].items():
                 self.llm_config_map[agent] = config.copy()
-                self.llm_config_map[agent]["buffer_size"] = self.task_config["tools_config"]["synthesizer"][
-                    "buffer_size"
-                ]
+                self.llm_config_map[agent]["buffer_size"] = synthesizer_config.get("buffer_size")
         else:
             if self.task_config["tools_config"]["llm_agent"] is not None:
                 if self.__is_knowledgebase_agent():
@@ -501,7 +500,7 @@ class TaskManager(BaseManager):
                         "model": self.llm_agent_config["llm_config"]["model"],
                         "max_tokens": self.llm_agent_config["llm_config"]["max_tokens"],
                         "provider": self.llm_agent_config["llm_config"]["provider"],
-                        "buffer_size": self.task_config["tools_config"]["synthesizer"].get("buffer_size"),
+                        "buffer_size": synthesizer_config.get("buffer_size"),
                         "temperature": self.llm_agent_config["llm_config"]["temperature"],
                     }
                 elif self.__is_graph_agent():
@@ -510,7 +509,7 @@ class TaskManager(BaseManager):
                         "model": self.llm_agent_config["llm_config"]["model"],
                         "max_tokens": self.llm_agent_config["llm_config"]["max_tokens"],
                         "provider": self.llm_agent_config["llm_config"]["provider"],
-                        "buffer_size": self.task_config["tools_config"]["synthesizer"].get("buffer_size"),
+                        "buffer_size": synthesizer_config.get("buffer_size"),
                         "temperature": self.llm_agent_config["llm_config"]["temperature"],
                     }
                 else:
@@ -597,8 +596,8 @@ class TaskManager(BaseManager):
         self.conversation_config = None
 
         if task_id == 0:
-            provider_config = self.task_config["tools_config"]["synthesizer"].get("provider_config")
-            self.synthesizer_voice = provider_config["voice"]
+            provider_config = synthesizer_config.get("provider_config") or {}
+            self.synthesizer_voice = provider_config.get("voice")
             self.hangup_detail = None
             self.end_call_primary = False  # set below if task_config opts in
 
@@ -643,7 +642,7 @@ class TaskManager(BaseManager):
             # for long pauses and rushing
             if self.conversation_config is not None:
                 # TODO need to get this for azure - for azure the subtraction would not happen
-                self.minimum_wait_duration = self.task_config["tools_config"]["transcriber"]["endpointing"]
+                self.minimum_wait_duration = transcriber_config.get("endpointing", 0)
                 self.last_spoken_timestamp = time.time() * 1000
                 self.incremental_delay = self.conversation_config.get("incremental_delay", 100)
 
@@ -782,7 +781,7 @@ class TaskManager(BaseManager):
         # setting transcriber and synthesizer in parallel
         self.__setup_transcriber()
         self.__setup_synthesizer(self.llm_config)
-        if not self.turn_based_conversation and task_id == 0:
+        if not self.turn_based_conversation and task_id == 0 and "synthesizer" in self.tools:
             self.synthesizer_monitor_task = asyncio.create_task(self.tools["synthesizer"].monitor_connection())
 
         # Language switching, gated per call by the LANGUAGE_SWITCH feature flag
@@ -1186,6 +1185,7 @@ class TaskManager(BaseManager):
 
     def __setup_output_handlers(self, turn_based_conversation, output_queue):
         output_kwargs = {"websocket": self.websocket}
+        synthesizer_config = self.task_config["tools_config"].get("synthesizer") or {}
 
         if self.task_config["tools_config"]["output"] is None:
             logger.info("Not setting up any output handler as it is none")
@@ -1202,10 +1202,12 @@ class TaskManager(BaseManager):
                 if self.task_config["tools_config"]["output"]["provider"] in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS.keys():
                     output_kwargs["mark_event_meta_data"] = self.mark_event_meta_data
                     logger.info(f"Making sure that the sampling rate for output handler is 8000")
-                    self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"] = 8000
+                    if synthesizer_config:
+                        synthesizer_config["provider_config"]["sampling_rate"] = 8000
                     # sip-trunk (Asterisk) uses ulaw; other telephony use pcm (handler converts to mulaw)
                     if self.task_config["tools_config"]["output"]["provider"] == TelephonyProvider.SIP_TRUNK.value:
-                        self.task_config["tools_config"]["synthesizer"]["audio_format"] = "ulaw"
+                        if synthesizer_config:
+                            synthesizer_config["audio_format"] = "ulaw"
                         logger.info(f"Setting synthesizer audio format to ulaw for Asterisk sip-trunk")
                         # Pass input handler to output handler so it can simulate mark events
                         input_handler = self.tools.get("input")
@@ -1216,11 +1218,14 @@ class TaskManager(BaseManager):
                             f"Passing input_handler to sip-trunk output handler for mark event simulation: {input_handler is not None}"
                         )
                     else:
-                        self.task_config["tools_config"]["synthesizer"]["audio_format"] = "pcm"
+                        if synthesizer_config:
+                            synthesizer_config["audio_format"] = "pcm"
                 else:
-                    self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"] = 24000
+                    if synthesizer_config:
+                        synthesizer_config["provider_config"]["sampling_rate"] = 24000
                     output_kwargs["queue"] = output_queue
-                self.sampling_rate = self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"]
+                if synthesizer_config:
+                    self.sampling_rate = synthesizer_config["provider_config"]["sampling_rate"]
 
             if self.task_config["tools_config"]["output"]["provider"] == "default":
                 output_kwargs["is_web_based_call"] = self.is_web_based_call
@@ -1579,13 +1584,13 @@ class TaskManager(BaseManager):
             logger.error(f"Something went wrong with starting transcriber {e}")
 
     def __setup_synthesizer(self, llm_config=None):
-        if self._is_conversation_task():
+        synth_config = self.task_config["tools_config"]["synthesizer"]
+        if self._is_conversation_task() and synth_config is not None:
+            transcriber_config = self.task_config["tools_config"].get("transcriber") or {}
             self.kwargs["use_turbo"] = (
-                self.task_config["tools_config"]["transcriber"]["language"] == DEFAULT_LANGUAGE_CODE
+                transcriber_config.get("language", DEFAULT_LANGUAGE_CODE) == DEFAULT_LANGUAGE_CODE
             )
-        if self.task_config["tools_config"]["synthesizer"] is not None:
-            synth_config = self.task_config["tools_config"]["synthesizer"]
-
+        if synth_config is not None:
             # --- Multilingual pool path ---
             if "multilingual" in synth_config:
                 multilingual = synth_config["multilingual"]
@@ -1766,7 +1771,7 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
-            injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
+            injected_cfg["buffer_size"] = (self.task_config["tools_config"].get("synthesizer") or {}).get("buffer_size")
             injected_cfg["language"] = self.language
             injected_cfg["turn_based_conversation"] = self.turn_based_conversation
 
@@ -1803,7 +1808,7 @@ class TaskManager(BaseManager):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
                 injected_cfg["compact_threshold"] = self.llm_config["compact_threshold"]
-            injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
+            injected_cfg["buffer_size"] = (self.task_config["tools_config"].get("synthesizer") or {}).get("buffer_size")
             injected_cfg["language"] = self.language
 
             llm_agent = KnowledgeBaseAgent(injected_cfg)

--- a/bolna/assistant.py
+++ b/bolna/assistant.py
@@ -26,21 +26,25 @@ class Assistant:
         tools_config_args["input"] = {"format": "wav", "provider": "default"}
 
         tools_config_args["output"] = {"format": "wav", "provider": "default"}
-        if transcriber is None:
-            pipelines.append(["llm"])
-            tools_config_args["transcriber"] = transcriber
+        tools_config_args["transcriber"] = transcriber
+        tools_config_args["synthesizer"] = synthesizer
 
-        pipeline = ["transcriber", "llm"]
-        if synthesizer is not None:
-            pipeline.append("synthesizer")
-            tools_config_args["synthesizer"] = synthesizer
-        pipelines.append(pipeline)
+        if transcriber is not None:
+            audio_pipeline = ["transcriber", "llm"]
+            if synthesizer is not None:
+                audio_pipeline.append("synthesizer")
+            pipelines.append(audio_pipeline)
 
-        if enable_textual_input:
+        if enable_textual_input or transcriber is None:
             pipelines.append(["llm"])
 
         toolchain = ToolsChainModel(execution="parallel", pipelines=pipelines)
-        task = Task(tools_config=ToolsConfig(**tools_config_args), toolchain=toolchain, task_type=task_type).dict()
+        task = Task(
+            tools_config=ToolsConfig(**tools_config_args),
+            toolchain=toolchain,
+            task_type=task_type,
+            task_config=ConversationConfig(),
+        ).model_dump()
         self.tasks.append(task)
 
     async def execute(self):

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -244,7 +244,7 @@ class DefaultInputHandler:
     def __process_text(self, text):
         logger.info(f"Sequences {self.input_types}")
         ws_data_packet = create_ws_data_packet(
-            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["audio"]}
+            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["text"]}
         )
 
         if self.turn_based_conversation:

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -166,9 +166,10 @@ class Synthesizer(BaseModel):
     def preprocess(cls, values):
         provider = values.get("provider")
         config = values.get("provider_config", {})
+        config_values = config if isinstance(config, dict) else config.model_dump()
 
         if provider == "elevenlabs":
-            if not config.get("voice") or not config.get("voice_id"):
+            if not config_values.get("voice") or not config_values.get("voice_id"):
                 raise ValueError("ElevenLabs config requires 'voice' or 'voice_id'.")
             if isinstance(config, dict):
                 values["provider_config"] = ElevenLabsConfig(**config)
@@ -543,6 +544,9 @@ class LlmAgent(BaseModel):
             raise ValueError(f"Unsupported agent_type: {agent_type}")
 
         expected_type = valid_config_types[agent_type]
+
+        if isinstance(value, expected_type):
+            return value
 
         if not isinstance(value, dict):
             raise ValueError(f"llm_config must be a dict, got {type(value)}")

--- a/tests/tests/test_assistant_task_pipelines.py
+++ b/tests/tests/test_assistant_task_pipelines.py
@@ -1,0 +1,132 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.assistant import Assistant
+from bolna.helpers.utils import get_required_input_types
+from bolna.input_handlers.default import DefaultInputHandler
+from bolna.models import ElevenLabsConfig, LlmAgent, SimpleLlmAgent, Synthesizer, Transcriber
+
+
+def _llm_agent():
+    # Keep the README's public construction style covered: llm_config is a
+    # SimpleLlmAgent instance rather than its serialized dict.
+    return LlmAgent(
+        agent_type="simple_llm_agent",
+        agent_flow_type="streaming",
+        llm_config=SimpleLlmAgent(provider="openai", model="gpt-4o-mini"),
+    )
+
+
+def _transcriber():
+    return Transcriber(provider="deepgram", model="nova-2", stream=True, language="en")
+
+
+def _synthesizer():
+    return Synthesizer(
+        provider="elevenlabs",
+        provider_config=ElevenLabsConfig(
+            voice="George",
+            voice_id="JBFqnCBsd6RMkjVDRZzb",
+            model="eleven_turbo_v2_5",
+        ),
+        stream=True,
+    )
+
+
+@pytest.mark.parametrize(
+    ("transcriber", "synthesizer", "enable_textual_input", "expected_pipelines"),
+    [
+        (_transcriber(), _synthesizer(), False, [["transcriber", "llm", "synthesizer"]]),
+        (_transcriber(), None, False, [["transcriber", "llm"]]),
+        (None, None, True, [["llm"]]),
+        (
+            _transcriber(),
+            _synthesizer(),
+            True,
+            [["transcriber", "llm", "synthesizer"], ["llm"]],
+        ),
+        (None, None, False, [["llm"]]),
+    ],
+)
+def test_add_task_builds_pipelines_from_available_components(
+    transcriber,
+    synthesizer,
+    enable_textual_input,
+    expected_pipelines,
+):
+    assistant = Assistant()
+
+    assistant.add_task(
+        task_type="conversation",
+        llm_agent=_llm_agent(),
+        transcriber=transcriber,
+        synthesizer=synthesizer,
+        enable_textual_input=enable_textual_input,
+    )
+
+    task = assistant.tasks[0]
+    assert task["toolchain"]["pipelines"] == expected_pipelines
+    assert (task["tools_config"]["transcriber"] is not None) is (transcriber is not None)
+    assert (task["tools_config"]["synthesizer"] is not None) is (synthesizer is not None)
+
+
+@pytest.mark.asyncio
+async def test_text_input_uses_text_pipeline_sequence():
+    queues = {"llm": asyncio.Queue()}
+    handler = DefaultInputHandler(
+        queues=queues,
+        input_types={"audio": 0, "text": 1},
+        turn_based_conversation=True,
+    )
+
+    await handler.process_message({"type": "text", "data": "hello"})
+
+    packet = queues["llm"].get_nowait()
+    assert packet["data"] == "hello"
+    assert packet["meta_info"]["sequence"] == 1
+    assert packet["meta_info"]["bypass_synth"] is True
+
+
+@pytest.mark.asyncio
+async def test_text_only_readme_task_initializes_without_audio_tools():
+    assistant = Assistant(name="text_only_agent")
+    assistant.add_task(
+        task_type="conversation",
+        llm_agent=_llm_agent(),
+        enable_textual_input=True,
+    )
+    task = assistant.tasks[0]
+
+    def setup_input(task_manager, *_args):
+        task_manager.tools["input"] = SimpleNamespace(is_dtmf_active=False)
+
+    async def no_initial_message(_task_manager):
+        return None
+
+    with (
+        patch.object(TaskManager, "_TaskManager__setup_input_handlers", setup_input),
+        patch.object(TaskManager, "_TaskManager__setup_llm", return_value=object()),
+        patch.object(TaskManager, "_TaskManager__setup_tasks"),
+        patch.object(TaskManager, "message_task_new", no_initial_message),
+    ):
+        task_manager = TaskManager(
+            assistant_name=assistant.name,
+            task_id=0,
+            task=task,
+            ws=None,
+            turn_based_conversation=True,
+        )
+        await task_manager.first_message_task_new
+
+    assert get_required_input_types(task) == {"text": 0}
+    assert task_manager.pipelines == [["llm"]]
+    assert task_manager.synthesizer_voice is None
+    assert task_manager.minimum_wait_duration == 0
+    assert task_manager.stream is False
+    assert "transcriber" not in task_manager.tools
+    assert "synthesizer" not in task_manager.tools
+    assert task_manager.output_handler_set is True


### PR DESCRIPTION
## Summary

Build `Assistant.add_task()` pipelines from the components that are actually configured, and make `TaskManager` initialization tolerate conversation pipelines without a transcriber or synthesizer.

Closes #897.
Closes #898.

## Root causes

The public helper had three conflicting branches:

- `transcriber` was assigned to `tools_config` only when its value was `None`, so a real ASR configuration was discarded.
- `["transcriber", "llm"]` was always added, even when no transcriber existed.
- `["llm"]` could be added once because the transcriber was absent and again because textual input was enabled.

Correcting that builder exposes two related runtime assumptions:

- `TaskManager.__init__()` indexed transcriber and synthesizer fields unconditionally for task zero, output setup, LLM buffering, and synthesizer setup.
- `DefaultInputHandler` labeled text with `input_types["audio"]`, so a genuine text-only pipeline had no valid sequence index.

The README's object-based examples also passed instantiated `SimpleLlmAgent` and `ElevenLabsConfig` models, while the corresponding pre-validation hooks assumed dictionaries.

## Changes

### Component-aware pipeline construction

`Assistant.add_task()` now always preserves the supplied component configurations and emits only valid routes:

| Configuration | Pipelines |
| --- | --- |
| ASR + LLM + TTS | `["transcriber", "llm", "synthesizer"]` |
| ASR + LLM | `["transcriber", "llm"]` |
| Text-only LLM | `["llm"]` |
| Audio plus textual input | audio pipeline plus `["llm"]` |

When no transcriber is supplied, the existing implicit text-only behavior is retained for backward compatibility, but it now produces one `["llm"]` route rather than an impossible audio route or duplicate LLM routes.

### Optional audio components in TaskManager

- Treat missing transcriber/synthesizer configs as empty optional configuration during initialization.
- Keep the default 24 kHz output rate when no synthesizer exists.
- Avoid reading synthesizer voice, stream, buffer, or provider fields when TTS is absent.
- Use a zero endpointing delay when ASR is absent.
- Skip synthesizer setup and connection monitoring when no synthesizer tool was created.
- Preserve the existing behavior for fully configured audio conversations.

### Text routing and documented model construction

- Route text packets with `input_types["text"]`.
- Accept already-instantiated expected LLM config models in `LlmAgent`.
- Validate an instantiated ElevenLabs provider config without assuming `.get()` exists.
- Serialize helper-created tasks with Pydantic v2's `model_dump()` and an explicit `ConversationConfig`.

## Tests

Added a focused regression module covering:

- ASR + LLM + TTS;
- ASR + LLM without TTS;
- text-only LLM;
- audio with the optional text route;
- backward-compatible implicit text-only configuration;
- selection of the text pipeline sequence when audio and text routes coexist;
- task-zero initialization without ASR or TTS;
- the README's public model-instance construction style.

Validation performed:

- `pytest -q tests/tests/test_assistant_task_pipelines.py`
  - `7 passed`
- Focused assistant/tool/event selection:
  - new and unrelated passing tests completed; the known upstream event failures remained unchanged
- `ruff check ...`
  - passed
- `ruff format --check --diff ...`
  - passed
- `git diff --check`
  - passed
- Full suite:
  - `526 passed, 10 failed`
  - the same 10 audio/event failures were previously reproduced on an untouched upstream `master`; this patch introduced no additional failures

## Compatibility and risk

The full audio route is unchanged when both audio components are configured. The meaningful behavior changes are limited to configurations that were previously malformed or crashed while indexing absent components. The implicit text-only route for callers that omit a transcriber remains supported.
