### PR TITLE
Protect follow-up webhooks with outbound SSRF validation

### DIFF
--- a/bolna/agent_types/webhook_agent.py
+++ b/bolna/agent_types/webhook_agent.py
@@ -1,8 +1,11 @@
 import aiohttp
 from .base_agent import BaseAgent
+from bolna.helpers.function_calling_helpers import SSRFError, validate_outbound_url
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
+
+WEBHOOK_TIMEOUT_SECONDS = 10
 
 
 class WebhookAgent(BaseAgent):
@@ -14,21 +17,26 @@ class WebhookAgent(BaseAgent):
     async def __send_payload(self, payload):
         try:
             logger.info(f"Sending a webhook post request {payload}")
-            async with aiohttp.ClientSession() as session:
-                if payload is not None:
-                    async with session.post(self.webhook_url, json=payload) as response:
-                        if response.status == 200:
-                            # need to check if the returned response is json or not
-                            # data = await response.json()
-                            return True
-                        else:
-                            logger.error(f"Error: {response.status} - {await response.text()}")
-                            return None
-                else:
-                    logger.info("Payload was null")
+            if payload is None:
+                logger.info("Payload was null")
+                return None
+
+            await validate_outbound_url(self.webhook_url)
+            timeout = aiohttp.ClientTimeout(total=WEBHOOK_TIMEOUT_SECONDS)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(self.webhook_url, json=payload, allow_redirects=False) as response:
+                    if response.status == 200:
+                        # need to check if the returned response is json or not
+                        # data = await response.json()
+                        return True
+                    logger.error(f"Error: {response.status} - {await response.text()}")
+            return None
+        except SSRFError as e:
+            logger.warning(f"Blocked outbound webhook URL: {e}")
             return None
         except Exception as e:
             logger.error(f"Something went wrong with webhook {self.webhook_url}, {payload}, {str(e)}")
+            return None
 
     async def execute(self, payload):
         if not self.webhook_url:

--- a/tests/tests/test_webhook_agent_ssrf.py
+++ b/tests/tests/test_webhook_agent_ssrf.py
@@ -1,0 +1,129 @@
+from unittest.mock import AsyncMock
+
+import aiohttp
+import pytest
+
+import bolna.agent_types.webhook_agent as webhook_module
+import bolna.helpers.function_calling_helpers as function_calling_helpers
+from bolna.agent_types.webhook_agent import WEBHOOK_TIMEOUT_SECONDS, WebhookAgent
+from bolna.helpers.function_calling_helpers import SSRFError
+
+
+class _FakeResponse:
+    def __init__(self, status=200, body=""):
+        self.status = status
+        self.body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def text(self):
+        return self.body
+
+
+class _FakeSession:
+    def __init__(self, response, requests, timeout):
+        self.response = response
+        self.requests = requests
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    def post(self, url, **kwargs):
+        self.requests.append((url, kwargs, self.timeout))
+        return self.response
+
+
+def _install_fake_session(monkeypatch, response):
+    requests = []
+
+    def session_factory(*, timeout):
+        return _FakeSession(response, requests, timeout)
+
+    monkeypatch.setattr(webhook_module.aiohttp, "ClientSession", session_factory)
+    return requests
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/internal",
+        "http://10.0.0.5/internal",
+        "http://169.254.169.254/latest/meta-data/",
+        "http://[::1]/internal",
+        "file:///etc/passwd",
+    ],
+)
+async def test_webhook_agent_blocks_unsafe_targets_before_opening_session(monkeypatch, url):
+    session_factory = AsyncMock()
+    monkeypatch.setattr(webhook_module.aiohttp, "ClientSession", session_factory)
+
+    result = await WebhookAgent(url).execute({"event": "test"})
+
+    assert result is None
+    session_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_agent_blocks_hostname_resolving_to_private_ip(monkeypatch):
+    async def reject_private_dns(_url):
+        raise SSRFError("blocked private DNS result")
+
+    session_factory = AsyncMock()
+    monkeypatch.setattr(webhook_module, "validate_outbound_url", reject_private_dns)
+    monkeypatch.setattr(webhook_module.aiohttp, "ClientSession", session_factory)
+
+    result = await WebhookAgent("https://public-looking.example/hook").execute({"event": "test"})
+
+    assert result is None
+    session_factory.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_webhook_agent_disables_redirects_and_uses_bounded_timeout(monkeypatch):
+    validate = AsyncMock()
+    requests = _install_fake_session(monkeypatch, _FakeResponse(status=302, body="redirect"))
+    monkeypatch.setattr(webhook_module, "validate_outbound_url", validate)
+
+    result = await WebhookAgent("https://example.com/hook").execute({"event": "test"})
+
+    assert result is None
+    validate.assert_awaited_once_with("https://example.com/hook")
+    assert len(requests) == 1
+    url, kwargs, timeout = requests[0]
+    assert url == "https://example.com/hook"
+    assert kwargs == {"json": {"event": "test"}, "allow_redirects": False}
+    assert isinstance(timeout, aiohttp.ClientTimeout)
+    assert timeout.total == WEBHOOK_TIMEOUT_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_webhook_agent_allows_explicitly_allowlisted_internal_host(monkeypatch):
+    monkeypatch.setattr(function_calling_helpers, "_ALLOWLISTED_HOSTS", frozenset({"internal.example"}))
+    requests = _install_fake_session(monkeypatch, _FakeResponse(status=200))
+
+    result = await WebhookAgent("http://internal.example/hook").execute({"event": "test"})
+
+    assert result is True
+    assert len(requests) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("status", "expected"), [(200, True), (500, None)])
+async def test_webhook_agent_preserves_success_and_error_results(monkeypatch, status, expected):
+    validate = AsyncMock()
+    requests = _install_fake_session(monkeypatch, _FakeResponse(status=status, body="response"))
+    monkeypatch.setattr(webhook_module, "validate_outbound_url", validate)
+
+    result = await WebhookAgent("https://example.com/hook").execute({"event": "test"})
+
+    assert result is expected
+    assert len(requests) == 1


### PR DESCRIPTION
## Summary

Apply Bolna's existing outbound URL security policy to follow-up webhook tasks before they create an HTTP session.

Closes #899.

## Vulnerability

`WebhookAgent` accepted a configured URL and posted to it directly:

```python
async with aiohttp.ClientSession() as session:
    async with session.post(webhook_url, json=payload) as response:
        ...
```

Unlike function-call requests and direct pre-call webhooks, this path did not call `validate_outbound_url()` and allowed aiohttp to follow redirects. A tenant-controlled follow-up task could therefore target loopback, RFC-1918, link-local/cloud metadata, IPv6 local addresses, or a public endpoint that redirects to an internal service.

The request also relied on aiohttp's default timeout, allowing a slow or unreachable target to keep the follow-up task open for substantially longer than the other protected outbound paths.

## Changes

- Validate `self.webhook_url` with the shared `validate_outbound_url()` guard before creating `ClientSession`.
- Set `allow_redirects=False` on the POST so an already-validated public endpoint cannot redirect the client to an unvalidated internal destination.
- Use `aiohttp.ClientTimeout(total=10)`, matching the bounded timeout used by the function-call and pre-call webhook paths.
- Handle `SSRFError` separately:
  - the server log records why the target was blocked;
  - the existing downstream contract remains `None`, so DNS/internal-address details are not returned to task consumers.
- Preserve the existing result behavior:
  - HTTP 200 returns `True`;
  - non-200 responses and request failures return `None`;
  - a null payload does not open a network session.

Deployments that intentionally call internal services continue to use the existing `BOLNA_TOOL_URL_HOST_ALLOWLIST`; the webhook path does not introduce a separate bypass.

## Security behavior

| Target/response | Result |
| --- | --- |
| Public HTTP(S), status 200 | Request sent, returns `True` |
| Public HTTP(S), non-200 | Request sent, returns `None` |
| Loopback/private/link-local/metadata IP | Blocked before session creation |
| Hostname resolving to a private IP | Blocked before session creation |
| Non-HTTP(S) scheme | Blocked before session creation |
| Explicitly allowlisted internal hostname | Request permitted |
| HTTP redirect | Returned as non-200; redirect is not followed |
| Request exceeding 10 seconds | Cancelled by the total client timeout |

## Tests

Added focused WebhookAgent coverage for:

- IPv4 loopback;
- RFC-1918 addresses;
- the `169.254.169.254` metadata endpoint;
- IPv6 loopback;
- non-HTTP schemes;
- a hostname rejected after private DNS resolution;
- session creation only after validation;
- disabled redirects;
- the 10-second total timeout;
- the explicit internal-host allowlist;
- unchanged HTTP 200 and HTTP 500 results.

Validation performed:

- `pytest -q tests/tests/test_webhook_agent_ssrf.py tests/tests/test_ssrf_validation.py tests/tests/test_pre_call_webhook.py`
  - `44 passed`
- `ruff check bolna/agent_types/webhook_agent.py tests/tests/test_webhook_agent_ssrf.py`
  - passed
- `ruff format --check --diff bolna/agent_types/webhook_agent.py tests/tests/test_webhook_agent_ssrf.py`
  - passed
- `bandit -q bolna/agent_types/webhook_agent.py`
  - passed
- `git diff --check`
  - passed
- Full suite:
  - `529 passed, 10 failed`
  - the same 10 audio/event failures were previously reproduced on untouched upstream `master`; this patch introduced no additional failures

## Compatibility and risk

The response contract is unchanged. The only requests that stop working are targets already prohibited by Bolna's shared outbound URL policy and redirect-dependent webhook endpoints. Redirect blocking is intentional because redirect destinations are not revalidated.
