### PR TITLE
Propagate active SynthesizerPool provider failures

### DIFF
--- a/bolna/synthesizer/synthesizer_pool.py
+++ b/bolna/synthesizer/synthesizer_pool.py
@@ -1,10 +1,21 @@
 import asyncio
+from dataclasses import dataclass
+
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
 
 # Sentinel pushed into _output_queue to unblock generate() on switch
 _SWITCH_SENTINEL = object()
+_CLEANUP_SENTINEL = object()
+
+
+@dataclass(frozen=True)
+class _GenerationResult:
+    label: str
+    generation: int
+    message: object | None = None
+    error: BaseException | None = None
 
 
 class SynthesizerPool:
@@ -16,12 +27,11 @@ class SynthesizerPool:
     maintain one connection per voice. Standby synths keep their connection
     alive via monitor_connection() but receive no text, so no billing occurs.
 
-    Audio output funnels through a single _output_queue. A per-synth
-    _run_generate task iterates that synth's generate() and puts results
-    into the shared queue. On switch(), the old task is cancelled and a new
-    one started; a SENTINEL is pushed so the pool's generate() returns,
-    letting __listen_synthesizer's outer while-loop re-enter and pick up
-    the new active synth.
+    Audio output and provider failures funnel through a single _output_queue.
+    Every result carries its source generation so work left behind by a retired
+    synth can be discarded safely. On switch(), the old task is cancelled and
+    a new one started; a sentinel makes the pool's generate() return, letting
+    __listen_synthesizer's outer loop re-enter for the new active synth.
     """
 
     def __init__(self, synthesizers, active_label, multilingual_config):
@@ -41,6 +51,8 @@ class SynthesizerPool:
         self._monitor_tasks = {}  # label -> monitor task
         self._multilingual_config = multilingual_config
         self._switch_lock = asyncio.Lock()
+        self._generation = 0
+        self._closed = False
 
     # ------------------------------------------------------------------
     # Properties
@@ -103,32 +115,47 @@ class SynthesizerPool:
             logger.info(f"SynthesizerPool: monitor started for '{label}'")
 
         # Start the generate-forwarding task for the active synth
-        self._gen_task = asyncio.create_task(self._run_generate(self.active_label))
+        self._gen_task = asyncio.create_task(self._run_generate(self.active_label, self._generation))
         logger.info(f"SynthesizerPool: generate task started for active='{self.active_label}'")
 
-    async def _run_generate(self, label):
-        """Iterate synth.generate() and forward results into the shared _output_queue."""
+    async def _run_generate(self, label, generation=None):
+        """Forward a provider's messages or failure with generation identity."""
+        generation = self._generation if generation is None else generation
         try:
             synth = self.synthesizers[label]
             async for message in synth.generate():
-                self._output_queue.put_nowait(message)
+                self._output_queue.put_nowait(_GenerationResult(label=label, generation=generation, message=message))
         except asyncio.CancelledError:
             logger.info(f"SynthesizerPool: _run_generate cancelled for '{label}'")
         except Exception as e:
             logger.error(f"SynthesizerPool: error in _run_generate for '{label}': {e}", exc_info=True)
+            self._output_queue.put_nowait(_GenerationResult(label=label, generation=generation, error=e))
 
     async def generate(self):
         """Async generator that yields audio packets from the active synthesizer.
 
         Returns (stops iteration) when a _SWITCH_SENTINEL is encountered,
         which signals __listen_synthesizer to re-enter via the outer while loop.
+        Provider failures from the active generation are re-raised to that
+        consumer; results from retired generations are discarded.
         """
         while True:
             message = await self._output_queue.get()
             if message is _SWITCH_SENTINEL:
                 logger.info("SynthesizerPool: generate() received SWITCH_SENTINEL, returning")
                 return
-            yield message
+            if message is _CLEANUP_SENTINEL:
+                logger.info("SynthesizerPool: generate() received CLEANUP_SENTINEL, returning")
+                return
+            if message.generation != self._generation or message.label != self.active_label:
+                logger.info(
+                    f"SynthesizerPool: ignoring stale result for '{message.label}' "
+                    f"(generation={message.generation}, active={self.active_label}, current={self._generation})"
+                )
+                continue
+            if message.error is not None:
+                raise message.error
+            yield message.message
 
     # ------------------------------------------------------------------
     # Switching
@@ -148,6 +175,9 @@ class SynthesizerPool:
         """
         # Serialize: concurrent switches would each start a _run_generate (dual recv on one ws).
         async with self._switch_lock:
+            if self._closed:
+                raise RuntimeError("Cannot switch a closed SynthesizerPool")
+
             if label == self.active_label:
                 logger.info(f"SynthesizerPool: already active on '{label}', no-op")
                 return
@@ -156,6 +186,8 @@ class SynthesizerPool:
                 raise ValueError(f"Unknown synthesizer label '{label}'. Available: {list(self.synthesizers.keys())}")
 
             old = self.active_label
+            self._generation += 1
+            generation = self._generation
 
             if self._gen_task and not self._gen_task.done():
                 self._gen_task.cancel()
@@ -166,7 +198,7 @@ class SynthesizerPool:
                 logger.info(f"SynthesizerPool: cancelled generate task for '{old}'")
 
             self.active_label = label
-            self._gen_task = asyncio.create_task(self._run_generate(label))
+            self._gen_task = asyncio.create_task(self._run_generate(label, generation))
             logger.info(f"SynthesizerPool: started generate task for '{label}'")
 
             self._output_queue.put_nowait(_SWITCH_SENTINEL)
@@ -192,6 +224,9 @@ class SynthesizerPool:
 
     async def cleanup(self):
         """Clean up all synthesizers and cancel all tasks."""
+        self._closed = True
+        self._generation += 1
+
         # Cancel generate task
         if self._gen_task and not self._gen_task.done():
             self._gen_task.cancel()
@@ -214,5 +249,9 @@ class SynthesizerPool:
         for label, synth in self.synthesizers.items():
             logger.info(f"SynthesizerPool: cleaning up '{label}'")
             await synth.cleanup()
+
+        while not self._output_queue.empty():
+            self._output_queue.get_nowait()
+        self._output_queue.put_nowait(_CLEANUP_SENTINEL)
 
         logger.info("SynthesizerPool: cleanup complete")

--- a/tests/tests/test_synthesizer_pool_errors.py
+++ b/tests/tests/test_synthesizer_pool_errors.py
@@ -1,0 +1,144 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.enums import HangupReason
+from bolna.exceptions import SynthesizerError
+from bolna.synthesizer.synthesizer_pool import SynthesizerPool
+
+
+class _BaseSynth:
+    connection_time = 0
+    turn_latencies = []
+
+    def __init__(self):
+        self.cleanup = AsyncMock()
+
+
+class _ErrorSynth(_BaseSynth):
+    async def generate(self):
+        raise RuntimeError("provider generation failed")
+        yield  # pragma: no cover - keeps this method an async generator
+
+
+class _BlockingSynth(_BaseSynth):
+    def __init__(self):
+        super().__init__()
+        self.started = asyncio.Event()
+
+    async def generate(self):
+        self.started.set()
+        await asyncio.Event().wait()
+        yield  # pragma: no cover - the task is cancelled while waiting
+
+
+class _ErrorOnCancellationSynth(_BlockingSynth):
+    async def generate(self):
+        self.started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            raise RuntimeError("stale provider failure") from exc
+        yield  # pragma: no cover - the task is cancelled while waiting
+
+
+class _MessageSynth(_BaseSynth):
+    async def generate(self):
+        yield {"data": b"new", "meta_info": {"sequence_id": 1}}
+        await asyncio.Event().wait()
+
+
+def _pool(synthesizers, active="en"):
+    return SynthesizerPool(synthesizers, active, {})
+
+
+@pytest.mark.asyncio
+async def test_active_provider_error_propagates_from_pool_generate():
+    pool = _pool({"en": _ErrorSynth()})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en", pool._generation))
+
+    with pytest.raises(RuntimeError, match="provider generation failed"):
+        await anext(pool.generate())
+
+    await pool.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_old_generator_does_not_surface_during_switch():
+    old_synth = _BlockingSynth()
+    pool = _pool({"en": old_synth, "hi": _MessageSynth()})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en", pool._generation))
+    await old_synth.started.wait()
+
+    await pool.switch("hi")
+
+    with pytest.raises(StopAsyncIteration):
+        await anext(pool.generate())
+    message = await asyncio.wait_for(anext(pool.generate()), timeout=1)
+    assert message["data"] == b"new"
+
+    await pool.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_stale_old_generation_error_does_not_kill_new_generator():
+    old_synth = _ErrorOnCancellationSynth()
+    pool = _pool({"en": old_synth, "hi": _MessageSynth()})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en", pool._generation))
+    await old_synth.started.wait()
+
+    await pool.switch("hi")
+
+    # The old provider turns cancellation into an error. The pool consumes and
+    # discards that stale envelope before honoring the switch boundary.
+    with pytest.raises(StopAsyncIteration):
+        await anext(pool.generate())
+    message = await asyncio.wait_for(anext(pool.generate()), timeout=1)
+    assert message["data"] == b"new"
+
+    await pool.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_unblocks_waiting_consumer():
+    synth = _BlockingSynth()
+    pool = _pool({"en": synth})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en", pool._generation))
+    await synth.started.wait()
+    waiting_consumer = asyncio.create_task(anext(pool.generate()))
+    await asyncio.sleep(0)
+
+    await pool.cleanup()
+
+    with pytest.raises(StopAsyncIteration):
+        await asyncio.wait_for(waiting_consumer, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_task_manager_converts_pool_error_to_synthesizer_error():
+    synth = _ErrorSynth()
+    pool = _pool({"en": synth})
+    pool._gen_task = asyncio.create_task(pool._run_generate("en", pool._generation))
+    task_manager = SimpleNamespace(
+        conversation_ended=False,
+        tools={"synthesizer": pool},
+        _turn_audio_flushed=asyncio.Event(),
+        _end_call_on_component_error=AsyncMock(),
+        synthesizer_provider="test-provider",
+        _component_model=lambda _component: "test-model",
+    )
+
+    await TaskManager._TaskManager__listen_synthesizer(task_manager)
+
+    assert task_manager._turn_audio_flushed.is_set()
+    task_manager._end_call_on_component_error.assert_awaited_once()
+    error, reason = task_manager._end_call_on_component_error.await_args.args
+    assert isinstance(error, SynthesizerError)
+    assert str(error) == "provider generation failed"
+    assert error.provider == "test-provider"
+    assert error.model == "test-model"
+    assert reason == HangupReason.SYNTHESIZER_ERROR
+    synth.cleanup.assert_awaited_once()


### PR DESCRIPTION
## Summary

Propagate active synthesizer-provider failures through `SynthesizerPool.generate()` so TaskManager can enter its existing `SynthesizerError` and controlled-hangup path.

Closes #900.

## Root cause

Each provider is consumed in a background `_run_generate()` task. That task forwarded audio packets into the pool queue, but its generic exception handler only logged provider failures:

```python
except Exception as exc:
    logger.error(...)
```

The background task then completed normally. The pool-level async generator remained blocked on `_output_queue.get()`, so `TaskManager.__listen_synthesizer()` received neither a final audio packet nor an exception.

The existing switch sentinel could wake the consumer, but it could not carry an error or identify which provider generation produced a queued item. Reusing it for failures would also make stale failures from a retired provider indistinguishable from a failure in the newly active provider.

## Design

The pool now uses generation-tagged result envelopes:

```text
provider generate()
        |
        v
_GenerationResult(label, generation, message | error)
        |
        v
shared output queue
        |
        +-- current generation message --> yield unchanged packet
        +-- current generation error ----> re-raise original exception
        +-- retired generation result ---> discard
        +-- switch sentinel -------------> stop this iterator
        +-- cleanup sentinel ------------> stop waiting iterator
```

Every switch increments the generation before cancelling the old provider task. This makes any error emitted while that cancellation unwinds stale by construction. The consumer checks both generation and label before yielding or raising.

## Changes

- Add `_GenerationResult` for provider messages and exceptions.
- Tag every forwarded provider result with its label and generation.
- Re-raise the original exception only when it belongs to the currently active generation.
- Increment the generation at switch start, before awaiting old-task cancellation.
- Ignore stale audio and stale errors from retired generations.
- Keep `asyncio.CancelledError` as a normal cancellation signal; it never becomes a provider error.
- Keep the switch sentinel distinct from result and error envelopes.
- Add a separate cleanup sentinel.
- Mark the pool closed during cleanup, invalidate the current generation, drain stale queued results, and wake a consumer blocked on the queue.
- Reject attempts to switch a closed pool.

No TaskManager production change is required: `TaskManager.__listen_synthesizer()` already catches exceptions from `generate()`, sets `_turn_audio_flushed`, wraps the failure as `SynthesizerError`, and calls `_end_call_on_component_error(..., HangupReason.SYNTHESIZER_ERROR)`. The pool now preserves the contract needed to reach that code.

## Tests

Added direct regression coverage for:

- active provider exceptions propagating from `SynthesizerPool.generate()`;
- TaskManager converting the propagated failure into a provider/model-attributed `SynthesizerError`;
- `_turn_audio_flushed` being set on the TaskManager error path;
- ordinary old-provider cancellation during `switch()` remaining non-fatal;
- an old provider that raises while cancellation unwinds not killing the new active generator;
- the new provider continuing to yield normally after a stale error;
- cleanup unblocking a consumer waiting on an empty output queue.

Validation performed:

- Pool, TaskManager audio-flush, and existing switch suite:
  - `23 passed`
- Pool plus surrounding language-switch/handoff suite:
  - `26 passed`
- `ruff check bolna/synthesizer/synthesizer_pool.py tests/tests/test_synthesizer_pool_errors.py`
  - passed
- `ruff format --check --diff bolna/synthesizer/synthesizer_pool.py tests/tests/test_synthesizer_pool_errors.py`
  - passed
- `git diff --check`
  - passed
- Full suite:
  - `524 passed, 10 failed`
  - the same 10 audio/event failures were previously reproduced on untouched upstream `master`; this patch introduced no additional failures

## Compatibility and risk

Packets yielded by the public pool generator are unchanged; the generation envelope is internal to the pool queue. Switch behavior retains the existing iterator boundary. The main behavior change is intentional: a failure in the current provider is no longer converted into an indefinitely empty queue.
