### PR TITLE
Reject unsupported legacy llm_agent_graph configurations

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1809,7 +1809,7 @@ class TaskManager(BaseManager):
             llm_agent = KnowledgeBaseAgent(injected_cfg)
             logger.info("Knowledge agent created with rag-proxy-server support")
         else:
-            raise f"{agent_type} Agent type is not created yet"
+            raise ValueError(f"Unsupported runtime agent_type: {agent_type}")
         return llm_agent
 
     def __setup_tasks(self, llm=None, agent_type=None, assistant_config=None):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -346,6 +346,13 @@ class Edge(BaseModel):
 
 
 class LlmAgentGraph(BaseModel):
+    """Legacy graph schema retained for direct-import compatibility.
+
+    ``LlmAgent`` no longer accepts this schema because it has no runtime
+    implementation. New and persisted configurations should migrate to
+    ``agent_type="graph_agent"`` with ``GraphAgentConfig``.
+    """
+
     nodes: List[Node]
     edges: List[Edge]
 
@@ -523,9 +530,7 @@ class KnowledgebaseAgent(Llm):
 class LlmAgent(BaseModel):
     agent_flow_type: str
     agent_type: str
-    llm_config: Union[
-        KnowledgebaseAgent, LlmAgentGraph, MultiAgent, SimpleLlmAgent, GraphAgentConfig, KnowledgeAgentConfig
-    ]
+    llm_config: Union[KnowledgebaseAgent, MultiAgent, SimpleLlmAgent, GraphAgentConfig, KnowledgeAgentConfig]
 
     @field_validator("llm_config", mode="before")
     def validate_llm_config(cls, value, info):
@@ -534,10 +539,15 @@ class LlmAgent(BaseModel):
         valid_config_types = {
             "knowledgebase_agent": KnowledgeAgentConfig,
             "graph_agent": GraphAgentConfig,
-            "llm_agent_graph": LlmAgentGraph,
             "multiagent": MultiAgent,
             "simple_llm_agent": SimpleLlmAgent,
         }
+
+        if agent_type == "llm_agent_graph":
+            raise ValueError(
+                "agent_type 'llm_agent_graph' is not supported at runtime; "
+                "migrate this configuration to agent_type 'graph_agent'"
+            )
 
         if agent_type not in valid_config_types:
             raise ValueError(f"Unsupported agent_type: {agent_type}")

--- a/tests/tests/test_llm_agent_type_validation.py
+++ b/tests/tests/test_llm_agent_type_validation.py
@@ -1,0 +1,93 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.models import (
+    GraphAgentConfig,
+    KnowledgeAgentConfig,
+    LlmAgent,
+    MultiAgent,
+    SimpleLlmAgent,
+)
+
+
+@pytest.mark.parametrize(
+    ("agent_type", "llm_config", "expected_config_type"),
+    [
+        (
+            "simple_llm_agent",
+            {"provider": "openai", "model": "gpt-4o-mini"},
+            SimpleLlmAgent,
+        ),
+        (
+            "knowledgebase_agent",
+            {"provider": "openai", "model": "gpt-4o-mini"},
+            KnowledgeAgentConfig,
+        ),
+        (
+            "graph_agent",
+            {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "agent_information": "Test graph",
+                "nodes": [{"id": "start"}],
+                "current_node_id": "start",
+            },
+            GraphAgentConfig,
+        ),
+        (
+            "multiagent",
+            {
+                "agent_map": {"default": {"provider": "openai", "model": "gpt-4o-mini"}},
+                "agent_routing_config": {},
+                "default_agent": "default",
+            },
+            MultiAgent,
+        ),
+    ],
+)
+def test_supported_agent_types_still_validate(agent_type, llm_config, expected_config_type):
+    agent = LlmAgent(
+        agent_flow_type="streaming",
+        agent_type=agent_type,
+        llm_config=llm_config,
+    )
+
+    assert isinstance(agent.llm_config, expected_config_type)
+
+
+def test_legacy_llm_agent_graph_fails_with_migration_message():
+    with pytest.raises(ValidationError, match="migrate this configuration to agent_type 'graph_agent'"):
+        LlmAgent(
+            agent_flow_type="streaming",
+            agent_type="llm_agent_graph",
+            llm_config={},
+        )
+
+
+def test_unknown_agent_type_fails_during_validation():
+    with pytest.raises(ValidationError, match="Unsupported agent_type: made_up_agent"):
+        LlmAgent(
+            agent_flow_type="streaming",
+            agent_type="made_up_agent",
+            llm_config={},
+        )
+
+
+def test_public_schema_does_not_advertise_legacy_graph_config():
+    schema = json.dumps(LlmAgent.model_json_schema())
+
+    assert "LlmAgentGraph" not in schema
+
+
+def test_runtime_dispatch_raises_value_error_for_unsupported_type():
+    task_manager = TaskManager.__new__(TaskManager)
+
+    with pytest.raises(ValueError, match="Unsupported runtime agent_type: made_up_agent"):
+        TaskManager._TaskManager__get_agent_object(
+            task_manager,
+            llm=object(),
+            agent_type="made_up_agent",
+        )


### PR DESCRIPTION
## Summary

Stop accepting and advertising `agent_type="llm_agent_graph"`, which has no runtime implementation, and replace TaskManager's invalid string raise with a clear `ValueError`.

Closes #901.

## Resolution chosen

This PR takes the explicit deprecation/removal path rather than attempting to revive the legacy runtime.

Repository inspection found:

- `LlmAgent` accepted `llm_agent_graph` and exposed `LlmAgentGraph` in its Pydantic union.
- `TaskManager.__get_agent_object()` had no matching runtime branch.
- `GraphBasedConversationAgent` is exported but has no runtime references.
- Its non-preprocessed path calls `_get_next_formulaic_agent_next_step()`, which is still `pass`.
- The legacy graph schema (`Node`/`Edge`) does not map directly to the current `GraphAgentConfig` node-routing model.

Wiring that class into production would therefore advertise partially implemented behavior and require a migration design for nodes, edges, prompts, preprocessing, and persisted configurations. Failing early is safer and makes the current contract truthful.

## Changes

### Validation and generated schema

- Remove `LlmAgentGraph` from the `LlmAgent.llm_config` union.
- Remove `llm_agent_graph` from the accepted config-type dispatch.
- Add an explicit validation error:

```text
agent_type 'llm_agent_graph' is not supported at runtime;
migrate this configuration to agent_type 'graph_agent'
```

- Retain the legacy `LlmAgentGraph`, `Node`, `Edge`, and `GraphBasedConversationAgent` Python classes for direct-import compatibility. They are no longer presented as a valid `LlmAgent` configuration.
- Document the legacy schema's status in its class docstring.

This removes `LlmAgentGraph` from `LlmAgent.model_json_schema()`, so generated API/client schemas no longer imply that the unusable configuration is supported.

### Runtime fallback

Replace:

```python
raise f"{agent_type} Agent type is not created yet"
```

with:

```python
raise ValueError(f"Unsupported runtime agent_type: {agent_type}")
```

The old expression raised `TypeError: exceptions must derive from BaseException`, hiding the actual configuration problem.

## Behavior

| Configuration | Before | After |
| --- | --- | --- |
| `simple_llm_agent` | Valid | Unchanged |
| `graph_agent` | Valid/current graph runtime | Unchanged |
| `knowledgebase_agent` | Valid | Unchanged |
| `multiagent` | Valid | Unchanged |
| `llm_agent_graph` | Schema-valid, runtime failure | Validation error with migration guidance |
| Unknown agent type | Validation error | Validation error naming the type |
| Unsupported runtime dispatch | Unrelated `TypeError` | Clear `ValueError` naming the type |

## Migration

Persisted configurations using:

```json
{"agent_type": "llm_agent_graph"}
```

must be migrated to:

```json
{"agent_type": "graph_agent"}
```

The `llm_config` must use the current `GraphAgentConfig` shape (`agent_information`, `nodes`, `current_node_id`, and current `GraphNode`/`GraphEdge` definitions). This PR deliberately does not guess an automatic mapping from the incomplete legacy schema.

## Tests

Added regression coverage for:

- all four still-supported `LlmAgent` agent types validating with their expected config model;
- `llm_agent_graph` failing during Pydantic validation;
- the validation message identifying `graph_agent` as the migration target;
- arbitrary unsupported types failing during validation and naming the supplied type;
- the generated public schema excluding `LlmAgentGraph`;
- unsupported runtime dispatch raising `ValueError` rather than a string-raise `TypeError`.

Validation performed:

- Agent validation plus current graph router/expression suite:
  - `83 passed`
- `ruff check bolna/models.py bolna/agent_manager/task_manager.py tests/tests/test_llm_agent_type_validation.py`
  - passed
- `ruff format --check --diff bolna/models.py bolna/agent_manager/task_manager.py tests/tests/test_llm_agent_type_validation.py`
  - passed
- `git diff --check`
  - passed
- Full suite:
  - `527 passed, 10 failed`
  - the same 10 audio/event failures were previously reproduced on untouched upstream `master`; this patch introduced no additional failures

## Compatibility and risk

Supported runtime configurations are unchanged. The intentional breaking behavior is limited to a configuration that could already never run successfully. Keeping the legacy classes importable reduces impact for code that performs offline migration or schema conversion.
