### PR TITLE
Fail fast when graph and knowledge LLM initialization fails

### DIFF
--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -26,6 +26,7 @@ from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
+from bolna.exceptions import LLMError
 
 from typing import List, Tuple, AsyncGenerator, Optional, Dict, Any
 
@@ -123,11 +124,10 @@ class GraphAgent(BaseAgent):
 
     def _initialize_llm(self):
         """Initialize LLM with api_tools support (same pattern as KnowledgeBaseAgent)."""
+        provider = self.config.get("provider") or self.config.get("llm_provider", "openai")
         try:
-            provider = self.config.get("provider") or self.config.get("llm_provider", "openai")
             if provider not in SUPPORTED_LLM_PROVIDERS:
-                logger.warning(f"Unknown provider: {provider}, using openai")
-                provider = "openai"
+                raise ValueError(f"Unsupported LLM provider: {provider}")
 
             llm_kwargs = {
                 "model": self.llm_model,
@@ -154,9 +154,13 @@ class GraphAgent(BaseAgent):
 
             llm_class = SUPPORTED_LLM_PROVIDERS[provider]
             return llm_class(**llm_kwargs)
-        except Exception as e:
-            logger.error(f"Failed to create LLM: {e}, falling back to default OpenAiLLM")
-            return OpenAiLLM(model=self.llm_model or "gpt-4o-mini", llm_key=self.llm_key or os.getenv("OPENAI_API_KEY"))
+        except Exception as exc:
+            logger.exception(f"Failed to initialize configured LLM provider '{provider}' with model '{self.llm_model}'")
+            raise LLMError(
+                "Failed to initialize configured LLM",
+                provider=provider,
+                model=self.llm_model,
+            ) from exc
 
     @staticmethod
     def _extract_rag_collections(rag_config: Dict) -> List[str]:

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -13,6 +13,7 @@ from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.llms import OpenAiLLM
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
+from bolna.exceptions import LLMError
 
 logger = configure_logger(__name__)
 
@@ -48,12 +49,10 @@ class KnowledgeBaseAgent(BaseAgent):
 
     def _initialize_llm(self):
         """Initialize the LLM instance with all necessary config (including api_tools for function calling)."""
+        provider = self.config.get("provider") or self.config.get("llm_provider", "openai")
         try:
-            provider = self.config.get("provider") or self.config.get("llm_provider", "openai")
-
             if provider not in SUPPORTED_LLM_PROVIDERS:
-                logger.warning(f"Unknown provider: {provider}, using openai")
-                provider = "openai"
+                raise ValueError(f"Unsupported LLM provider: {provider}")
 
             llm_kwargs = {
                 "model": self.llm_model,
@@ -81,11 +80,13 @@ class KnowledgeBaseAgent(BaseAgent):
             llm_class = SUPPORTED_LLM_PROVIDERS[provider]
             return llm_class(**llm_kwargs)
 
-        except Exception as e:
-            logger.error(f"Failed to create LLM: {e}, falling back to basic OpenAI")
-            from openai import OpenAI
-
-            return OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+        except Exception as exc:
+            logger.exception(f"Failed to initialize configured LLM provider '{provider}' with model '{self.llm_model}'")
+            raise LLMError(
+                "Failed to initialize configured LLM",
+                provider=provider,
+                model=self.llm_model,
+            ) from exc
 
     def _initialize_rag_config(self) -> Dict:
         """Initialize RAG configuration from the provided config."""

--- a/tests/tests/test_agent_llm_initialization.py
+++ b/tests/tests/test_agent_llm_initialization.py
@@ -1,0 +1,79 @@
+from unittest.mock import Mock
+
+import openai
+import pytest
+
+from bolna.agent_types import graph_agent, knowledgebase_agent
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.agent_types.knowledgebase_agent import KnowledgeBaseAgent
+from bolna.exceptions import LLMError
+
+
+class FailingLLM:
+    def __init__(self, **kwargs):
+        raise RuntimeError("provider constructor failed")
+
+
+def _uninitialized_agent(agent_class, provider="azure", model="configured-model"):
+    agent = agent_class.__new__(agent_class)
+    agent.config = {"provider": provider}
+    agent.llm_model = model
+    if agent_class is GraphAgent:
+        agent.llm_key = None
+    return agent
+
+
+@pytest.mark.parametrize(
+    ("agent_class", "agent_module"),
+    [
+        (GraphAgent, graph_agent),
+        (KnowledgeBaseAgent, knowledgebase_agent),
+    ],
+)
+def test_llm_initialization_failure_is_attributed_and_preserves_cause(monkeypatch, agent_class, agent_module):
+    agent = _uninitialized_agent(agent_class)
+    monkeypatch.setitem(agent_module.SUPPORTED_LLM_PROVIDERS, "azure", FailingLLM)
+
+    with pytest.raises(LLMError) as exc_info:
+        agent._initialize_llm()
+
+    assert exc_info.value.provider == "azure"
+    assert exc_info.value.model == "configured-model"
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "provider constructor failed"
+
+
+def test_graph_agent_does_not_fall_back_to_openai(monkeypatch):
+    agent = _uninitialized_agent(GraphAgent)
+    fallback = Mock()
+    monkeypatch.setitem(graph_agent.SUPPORTED_LLM_PROVIDERS, "azure", FailingLLM)
+    monkeypatch.setattr(graph_agent, "OpenAiLLM", fallback)
+
+    with pytest.raises(LLMError):
+        agent._initialize_llm()
+
+    fallback.assert_not_called()
+
+
+def test_knowledge_agent_does_not_fall_back_to_openai(monkeypatch):
+    agent = _uninitialized_agent(KnowledgeBaseAgent)
+    fallback = Mock()
+    monkeypatch.setitem(knowledgebase_agent.SUPPORTED_LLM_PROVIDERS, "azure", FailingLLM)
+    monkeypatch.setattr(openai, "OpenAI", fallback)
+
+    with pytest.raises(LLMError):
+        agent._initialize_llm()
+
+    fallback.assert_not_called()
+
+
+@pytest.mark.parametrize("agent_class", [GraphAgent, KnowledgeBaseAgent])
+def test_unknown_provider_is_rejected_without_being_rewritten(agent_class):
+    agent = _uninitialized_agent(agent_class, provider="unknown-provider")
+
+    with pytest.raises(LLMError) as exc_info:
+        agent._initialize_llm()
+
+    assert exc_info.value.provider == "unknown-provider"
+    assert isinstance(exc_info.value.__cause__, ValueError)
+    assert str(exc_info.value.__cause__) == "Unsupported LLM provider: unknown-provider"


### PR DESCRIPTION
## Summary

Graph and knowledge-base agents currently treat any failure while constructing their configured main LLM as permission to switch to OpenAI. This PR removes that implicit provider change and makes initialization fail fast with an attributed `LLMError`.

It also rejects unknown provider names instead of silently rewriting them to `openai`.

Closes #902.

## Root cause

Both `GraphAgent._initialize_llm()` and `KnowledgeBaseAgent._initialize_llm()` wrapped provider lookup and construction in a broad `except Exception` block.

- `GraphAgent` returned a new `OpenAiLLM` after any failure.
- `KnowledgeBaseAgent` returned the synchronous OpenAI SDK client, even though its generation path expects Bolna's asynchronous `generate_stream()` interface.
- Unknown provider names were rewritten to `openai` before construction.

As a result, malformed credentials, invalid provider parameters, unsupported provider values, and provider-constructor defects could all change the selected provider without caller consent. For the knowledge agent, the incompatible fallback also deferred the failure until the first generation attempt.

## Changes

### Fail fast without changing providers

Both initialization paths now:

1. Resolve the configured provider once.
2. Reject providers absent from `SUPPORTED_LLM_PROVIDERS`.
3. Construct only the selected provider.
4. Convert lookup or constructor failures into `LLMError`.

There is no automatic OpenAI fallback.

### Preserve diagnostic context

The raised `LLMError` records:

- `component="llm"` through the existing component-error hierarchy
- the originally configured provider
- the originally configured model

The original exception is retained with Python exception chaining (`raise ... from exc`), so logs and callers can still inspect the provider constructor's underlying failure.

### Add regression coverage

The new tests cover both `GraphAgent` and `KnowledgeBaseAgent`:

- provider constructor failures raise `LLMError`
- provider and model attribution are preserved
- the original constructor exception remains available as `__cause__`
- neither agent instantiates an OpenAI fallback
- unknown providers are rejected and retain their original provider identity

The tests call the initialization boundary directly so they do not require live provider credentials or network access.

## Behavior change

Before:

- an Azure/custom/provider setup error could silently switch the main conversation model to OpenAI
- an unknown provider was treated as OpenAI
- the knowledge agent could receive a raw synchronous OpenAI client and fail later on `generate_stream()`

After:

- agent construction fails immediately
- no request can be redirected to OpenAI by this error path
- callers receive a component-specific error with provider/model metadata and the original cause

This is intentionally fail-fast rather than introducing a configurable fallback system. Explicit fallback policy, provider credentials, telemetry, and interface validation can be designed separately if the product needs that behavior.

## Validation

Passed:

```text
6 passed
```

for the new initialization regression suite.

Passed:

```text
122 passed
```

across the new tests plus the graph routing, router node, tool scope, and say-node/silence-policy suites.

Also passed:

```text
ruff check
ruff format --check
git diff --check
```

The full repository suite reports:

```text
525 passed, 10 failed
```

The 10 failures are pre-existing on the upstream base and remain confined to:

- `test_elevenlabs_close_context_eos.py` (1)
- `test_event_injection_e2e.py` (7)
- `test_split_utterance_tail_not_dropped.py` (2)

This branch adds six passing tests and does not touch those failing areas.

## Risk and compatibility

The observable compatibility change is deliberate: configurations that previously relied on an undocumented automatic OpenAI fallback will now fail during agent initialization. Valid provider configurations continue to use the same provider registry and constructor arguments as before.

No schema, persisted configuration format, or successful generation path is changed.
