### PR TITLE
Scope RAG service clients by server URL

### DIFF
--- a/bolna/helpers/rag_service_client.py
+++ b/bolna/helpers/rag_service_client.py
@@ -2,6 +2,7 @@ import aiohttp  # type: ignore
 import asyncio
 import json
 import logging
+import threading
 import time
 import uuid
 from typing import List, Dict, Any, Optional
@@ -279,11 +280,18 @@ Please respond to the user's query using the above context when relevant. If the
 
 class RAGServiceClientSingleton:
     """
-    Singleton wrapper for RAG service client to avoid creating multiple sessions.
+    URL-keyed pool of RAG service clients.
+
+    A client is reused for requests to the same normalized server URL, while
+    distinct servers receive distinct clients and aiohttp sessions.
     """
 
-    _instance = None
-    _client = None
+    _clients: Dict[str, RAGServiceClient] = {}
+    _clients_lock = threading.Lock()
+
+    @staticmethod
+    def _normalize_url(rag_server_url: str) -> str:
+        return rag_server_url.rstrip("/")
 
     @classmethod
     async def get_client(cls, rag_server_url: str) -> RAGServiceClient:
@@ -296,16 +304,29 @@ class RAGServiceClientSingleton:
         Returns:
             RAGServiceClient instance
         """
-        if cls._instance is None or cls._client is None:
-            cls._client = RAGServiceClient(rag_server_url)
-            cls._instance = cls
+        normalized_url = cls._normalize_url(rag_server_url)
+        with cls._clients_lock:
+            client = cls._clients.get(normalized_url)
+            if client is None:
+                client = RAGServiceClient(normalized_url)
+                cls._clients[normalized_url] = client
 
-        return cls._client
+        return client
+
+    @classmethod
+    async def close_all_clients(cls):
+        """Close every pooled client and empty the pool."""
+        with cls._clients_lock:
+            clients = list(cls._clients.values())
+            cls._clients.clear()
+
+        if clients:
+            await asyncio.gather(*(client.close() for client in clients))
 
     @classmethod
     async def close_client(cls):
-        """Close the client if it exists."""
-        if cls._client:
-            await cls._client.close()
-            cls._client = None
-            cls._instance = None
+        """Close all pooled clients.
+
+        Retained as a compatibility alias for callers of the former singleton.
+        """
+        await cls.close_all_clients()

--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -2,6 +2,7 @@ import os
 import asyncio
 import uuid
 import traceback
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Query, Body
 from fastapi.middleware.cors import CORSMiddleware
 import redis.asyncio as redis
@@ -12,6 +13,7 @@ from bolna.helpers.logger_config import configure_logger
 from bolna.models import *
 from bolna.llms import LiteLLM
 from bolna.agent_manager.assistant_manager import AssistantManager
+from bolna.helpers.rag_service_client import RAGServiceClientSingleton
 
 load_dotenv()
 logger = configure_logger(__name__)
@@ -20,7 +22,14 @@ redis_pool = redis.ConnectionPool.from_url(os.getenv("REDIS_URL"), decode_respon
 redis_client = redis.Redis.from_pool(redis_pool)
 active_websockets: List[WebSocket] = []
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    yield
+    await RAGServiceClientSingleton.close_all_clients()
+
+
+app = FastAPI(lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"]

--- a/tests/tests/test_rag_service_client_pool.py
+++ b/tests/tests/test_rag_service_client_pool.py
@@ -1,0 +1,93 @@
+import asyncio
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+import pytest_asyncio
+
+from bolna.helpers import rag_service_client
+from bolna.helpers.rag_service_client import RAGServiceClientSingleton
+
+
+class RecordingClient:
+    instances = []
+
+    def __init__(self, base_url):
+        time.sleep(0.01)
+        self.base_url = base_url
+        self.closed = False
+        type(self).instances.append(self)
+
+    async def close(self):
+        self.closed = True
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def reset_client_pool():
+    await RAGServiceClientSingleton.close_all_clients()
+    RecordingClient.instances = []
+    yield
+    await RAGServiceClientSingleton.close_all_clients()
+
+
+@pytest.mark.asyncio
+async def test_same_normalized_url_reuses_client():
+    first = await RAGServiceClientSingleton.get_client("https://rag.example/")
+    second = await RAGServiceClientSingleton.get_client("https://rag.example")
+
+    assert second is first
+    assert first.base_url == "https://rag.example"
+    assert len(RAGServiceClientSingleton._clients) == 1
+
+
+@pytest.mark.asyncio
+async def test_different_urls_use_different_clients():
+    first = await RAGServiceClientSingleton.get_client("https://rag-a.example")
+    second = await RAGServiceClientSingleton.get_client("https://rag-b.example")
+
+    assert second is not first
+    assert first.base_url == "https://rag-a.example"
+    assert second.base_url == "https://rag-b.example"
+
+
+@pytest.mark.asyncio
+async def test_close_all_clients_closes_every_client_and_empties_pool():
+    first = await RAGServiceClientSingleton.get_client("https://rag-a.example")
+    second = await RAGServiceClientSingleton.get_client("https://rag-b.example")
+    await first._ensure_session()
+    await second._ensure_session()
+    first_session = first.session
+    second_session = second.session
+
+    await RAGServiceClientSingleton.close_all_clients()
+
+    assert first_session.closed
+    assert second_session.closed
+    assert RAGServiceClientSingleton._clients == {}
+
+
+@pytest.mark.asyncio
+async def test_closed_client_is_replaced_when_reacquired():
+    first = await RAGServiceClientSingleton.get_client("https://rag.example")
+    await first._ensure_session()
+    await RAGServiceClientSingleton.close_client()
+
+    second = await RAGServiceClientSingleton.get_client("https://rag.example/")
+    await second._ensure_session()
+
+    assert first.session is None
+    assert second is not first
+    assert not second.session.closed
+
+
+def test_concurrent_acquisition_creates_only_one_client(monkeypatch):
+    monkeypatch.setattr(rag_service_client, "RAGServiceClient", RecordingClient)
+
+    def acquire_client():
+        return asyncio.run(RAGServiceClientSingleton.get_client("https://rag.example/"))
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        clients = list(executor.map(lambda _: acquire_client(), range(16)))
+
+    assert all(client is clients[0] for client in clients)
+    assert len(RecordingClient.instances) == 1


### PR DESCRIPTION
## Summary

`RAGServiceClientSingleton` currently stores one process-global client. The first requested RAG URL therefore determines the backend used by every later graph or knowledge-base agent, even when those agents specify a different `rag_server_url`.

This PR replaces the single client with a normalized URL-keyed pool and gives the quickstart FastAPI application explicit responsibility for closing every pooled session during shutdown.

Closes #903.

## Root cause

`get_client(rag_server_url)` only consulted `rag_server_url` while `_client` was empty:

```python
if cls._instance is None or cls._client is None:
    cls._client = RAGServiceClient(rag_server_url)
return cls._client
```

After the first acquisition, all later URLs were ignored. This conflicted with both the method signature and the per-agent URL carried by `GraphAgent` and `KnowledgeBaseAgent`.

The class also exposed `close_client()`, but no application lifecycle called it. Once a request caused the client to lazily create an `aiohttp.ClientSession`, that session could remain alive until interpreter shutdown.

## Changes

### Pool clients by normalized server URL

The wrapper now stores:

```python
_clients: Dict[str, RAGServiceClient]
```

Trailing slashes are removed before lookup, matching the normalization already performed by `RAGServiceClient`. Consequently:

- `https://rag.example` and `https://rag.example/` reuse one client
- `https://rag-a.example` and `https://rag-b.example` receive distinct clients and sessions

### Protect client creation

Pool lookup and first creation are guarded by a process-level lock. This prevents simultaneous callers from constructing duplicate clients for the same normalized URL.

The constructor performs no asynchronous work, so the lock is held only around the short in-memory lookup/construction/update section and never across network I/O or an `await`.

### Add explicit pool shutdown

`close_all_clients()` atomically takes all current clients out of the pool and then closes their sessions together. Clearing the pool before awaiting closure also ensures a later acquisition receives a new usable client instead of a closed instance.

The existing `close_client()` API remains available as a compatibility alias that closes the full pool.

### Assign lifecycle ownership

`local_setup/quickstart_server.py` now uses FastAPI's lifespan mechanism and calls `close_all_clients()` during application shutdown.

This is the application in the repository that creates and runs `AssistantManager` instances. The separate Twilio and Plivo applications only initiate calls and do not acquire RAG clients.

## Regression coverage

The new tests verify:

- equivalent normalized URLs reuse one client
- different URLs never share a client
- every real `aiohttp.ClientSession` is closed by pool shutdown
- closing and reacquiring produces a new client with a usable session
- simultaneous acquisition from multiple threads constructs exactly one client

The lifecycle tests create sessions without making external network requests.

## Validation

Passed:

```text
5 passed
```

for the new RAG client pool suite.

Also passed:

```text
ruff check
ruff format --check
python -m py_compile
git diff --check
```

The full repository suite reports:

```text
524 passed, 10 failed
```

The five new tests account for the increase over the upstream baseline. The 10 failures are pre-existing and remain confined to:

- `test_elevenlabs_close_context_eos.py` (1)
- `test_event_injection_e2e.py` (7)
- `test_split_utterance_tail_not_dropped.py` (2)

This change does not touch those areas.

## Compatibility and risk

Public acquisition remains asynchronous and retains the existing class and method names. Call sites in graph and knowledge agents require no changes.

The only semantic change is that a different normalized RAG URL now correctly produces a different client. Existing single-endpoint deployments continue to reuse one connection pool as before.

`close_client()` now closes all URL-scoped clients because there is no longer a single unambiguous client to close. New lifecycle code uses the explicit `close_all_clients()` name.
