### PR TITLE
Preserve intended errors in quickstart CRUD endpoints

### DIFF
--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -42,9 +42,11 @@ async def get_agent(agent_id: str):
 
         return json.loads(agent_data)
 
-    except Exception as e:
-        logger.error(f"Error fetching agent {agent_id}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error fetching agent {agent_id}: {exc}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
 @app.post("/agent")
@@ -123,9 +125,11 @@ async def edit_agent(agent_id: str, agent_data: CreateAgentPayload = Body(...)):
 
         return {"agent_id": agent_id, "state": "updated"}
 
-    except Exception as e:
-        logger.error(f"Error updating agent {agent_id}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error updating agent {agent_id}: {exc}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
 @app.delete("/agent/{agent_id}")
@@ -139,9 +143,11 @@ async def delete_agent(agent_id: str):
         await redis_client.delete(agent_id)
         return {"agent_id": agent_id, "state": "deleted"}
 
-    except Exception as e:
-        logger.error(f"Error deleting agent {agent_id}: {e}", exc_info=True)
-        raise HTTPException(status_code=500, detail="Internal server error")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error(f"Error deleting agent {agent_id}: {exc}", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal server error") from exc
 
 
 @app.get("/all")

--- a/tests/tests/test_quickstart_crud_errors.py
+++ b/tests/tests/test_quickstart_crud_errors.py
@@ -1,0 +1,119 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def quickstart(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    module_name = "quickstart_server_under_test"
+    server = sys.modules.get(module_name)
+    if server is None:
+        server_path = Path(__file__).resolve().parents[2] / "local_setup" / "quickstart_server.py"
+        spec = importlib.util.spec_from_file_location(module_name, server_path)
+        assert spec is not None and spec.loader is not None
+        server = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = server
+        spec.loader.exec_module(server)
+
+    redis_client = AsyncMock()
+    monkeypatch.setattr(server, "redis_client", redis_client)
+
+    transport = httpx.ASGITransport(app=server.app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client, redis_client
+
+
+def _agent_payload(tasks=None):
+    return {
+        "agent_config": {
+            "agent_name": "test-agent",
+            "tasks": tasks or [],
+        },
+        "agent_prompts": None,
+    }
+
+
+def _extraction_task():
+    return {
+        "task_type": "extraction",
+        "tools_config": {
+            "llm_agent": {
+                "agent_flow_type": "streaming",
+                "agent_type": "simple_llm_agent",
+                "llm_config": {"extraction_details": "Extract the caller's name"},
+            }
+        },
+        "toolchain": {"execution": "sequential", "pipelines": [["llm"]]},
+        "task_config": {},
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_get_returns_404(quickstart):
+    client, redis_client = quickstart
+    redis_client.get.return_value = None
+
+    response = await client.get("/agent/missing")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Agent not found"}
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_edit_returns_404(quickstart):
+    client, redis_client = quickstart
+    redis_client.get.return_value = None
+
+    response = await client.put("/agent/missing", json=_agent_payload())
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Agent not found"}
+
+
+@pytest.mark.asyncio
+async def test_missing_agent_delete_returns_404(quickstart):
+    client, redis_client = quickstart
+    redis_client.exists.return_value = 0
+
+    response = await client.delete("/agent/missing")
+
+    assert response.status_code == 404
+    assert response.json() == {"detail": "Agent not found"}
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "redis_method", "request_kwargs"),
+    [
+        ("get", "/agent/test", "get", {}),
+        ("put", "/agent/test", "get", {"json": _agent_payload()}),
+        ("delete", "/agent/test", "exists", {}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_redis_failures_return_500(quickstart, method, path, redis_method, request_kwargs):
+    client, redis_client = quickstart
+    getattr(redis_client, redis_method).side_effect = RuntimeError("redis unavailable")
+
+    response = await getattr(client, method)(path, **request_kwargs)
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Internal server error"}
+
+
+@pytest.mark.asyncio
+async def test_configured_extraction_error_preserves_detail(quickstart, monkeypatch):
+    client, redis_client = quickstart
+    redis_client.get.return_value = json.dumps({"agent_name": "existing"})
+    monkeypatch.delenv("EXTRACTION_PROMPT_GENERATION_MODEL", raising=False)
+
+    response = await client.put("/agent/test", json=_agent_payload([_extraction_task()]))
+
+    assert response.status_code == 500
+    assert response.json() == {"detail": "Extraction model not configured"}


### PR DESCRIPTION
## Summary

The quickstart GET, PUT, and DELETE agent endpoints intentionally raise `HTTPException` for missing resources and configuration errors, but each handler's broad `except Exception` block catches those same exceptions and replaces them with a generic HTTP 500 response.

This PR lets deliberate FastAPI HTTP errors pass through unchanged while retaining generic 500 responses for unexpected failures.

Closes #904.

## Root cause

FastAPI's `HTTPException` derives from `Exception`. The existing handlers used this structure:

```python
try:
    ...
    raise HTTPException(status_code=404, detail="Agent not found")
except Exception:
    raise HTTPException(status_code=500, detail="Internal server error")
```

That means the handler itself caught its intended 404 and converted it into a 500. `edit_agent()` did the same to its explicit `"Extraction model not configured"` error, discarding useful diagnostic detail.

The affected endpoints are:

- `GET /agent/{agent_id}`
- `PUT /agent/{agent_id}`
- `DELETE /agent/{agent_id}`

## Changes

Each affected handler now separates deliberate HTTP responses from unexpected failures:

```python
except HTTPException:
    raise
except Exception as exc:
    logger.error(..., exc_info=True)
    raise HTTPException(
        status_code=500,
        detail="Internal server error",
    ) from exc
```

This provides two distinct contracts:

- errors selected by the endpoint retain their status code and response detail
- Redis, JSON, and other unexpected exceptions remain internal HTTP 500 responses

Unexpected failures are now exception-chained so traceback tooling retains the actual cause behind the public 500 response.

## Regression coverage

The new tests run requests through the complete FastAPI ASGI stack with the Redis client mocked. They verify:

- a missing agent returns 404 from GET
- a missing agent returns 404 from PUT
- a missing agent returns 404 from DELETE
- Redis failure returns 500 from GET
- Redis failure returns 500 from PUT
- Redis failure returns 500 from DELETE
- the edit endpoint preserves the intended `500 / "Extraction model not configured"` domain error

The tests use HTTPX's `ASGITransport` because the Starlette `TestClient` version pinned transitively by this repository still passes the removed `app=` argument to the installed HTTPX client. `ASGITransport` exercises the same FastAPI routing, body validation, and exception handlers without depending on that incompatible wrapper.

No Redis server or external provider is contacted.

## Behavior

Before:

```text
missing agent -> 500 {"detail": "Internal server error"}
missing extraction model -> 500 {"detail": "Internal server error"}
Redis failure -> 500 {"detail": "Internal server error"}
```

After:

```text
missing agent -> 404 {"detail": "Agent not found"}
missing extraction model -> 500 {"detail": "Extraction model not configured"}
Redis failure -> 500 {"detail": "Internal server error"}
```

## Validation

Passed:

```text
7 passed
```

for the new quickstart CRUD error suite.

Also passed:

```text
ruff check
ruff format --check
python -m py_compile
git diff --check
```

The full repository suite reports:

```text
526 passed, 10 failed
```

The seven new tests account for the increase over the upstream baseline. The 10 failures are pre-existing and remain confined to:

- `test_elevenlabs_close_context_eos.py` (1)
- `test_event_injection_e2e.py` (7)
- `test_split_utterance_tail_not_dropped.py` (2)

This change does not touch those areas.

## Compatibility and risk

Successful CRUD behavior is unchanged. Unexpected exceptions still return the same generic 500 response, so internal details are not exposed to clients.

The intentional API correction is limited to exceptions the endpoint explicitly raises: clients now receive the status and detail selected by the handler instead of an accidental replacement response.
