### PR TITLE
Keep quickstart agent IDs aligned with Redis values

### DIFF
--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -152,17 +152,21 @@ async def get_all_agents():
 
         if not agent_keys:
             return {"agents": []}
-        agents_data = []
+        agents = []
+        failed_agent_ids = []
         for key in agent_keys:
             try:
                 data = await redis_client.get(key)
-                agents_data.append(data)
-            except Exception as e:
-                logger.error(f"An error occurred with key {key}: {e}")
+                if data:
+                    agents.append({"agent_id": key, "data": json.loads(data)})
+            except Exception as exc:
+                logger.error(f"An error occurred with key {key}: {exc}")
+                failed_agent_ids.append(key)
 
-        agents = [{"agent_id": key, "data": json.loads(data)} for key, data in zip(agent_keys, agents_data) if data]
-
-        return {"agents": agents}
+        response = {"agents": agents}
+        if failed_agent_ids:
+            response["failed_agent_ids"] = failed_agent_ids
+        return response
 
     except Exception as e:
         logger.error(f"Error fetching all agents: {e}", exc_info=True)

--- a/tests/tests/test_quickstart_get_all.py
+++ b/tests/tests/test_quickstart_get_all.py
@@ -1,0 +1,132 @@
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+import pytest_asyncio
+
+
+@pytest_asyncio.fixture
+async def quickstart(monkeypatch):
+    monkeypatch.setenv("REDIS_URL", "redis://localhost:6379")
+    module_name = "quickstart_server_get_all_under_test"
+    server = sys.modules.get(module_name)
+    if server is None:
+        server_path = Path(__file__).resolve().parents[2] / "local_setup" / "quickstart_server.py"
+        spec = importlib.util.spec_from_file_location(module_name, server_path)
+        assert spec is not None and spec.loader is not None
+        server = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = server
+        spec.loader.exec_module(server)
+
+    redis_client = AsyncMock()
+    monkeypatch.setattr(server, "redis_client", redis_client)
+
+    transport = httpx.ASGITransport(app=server.app, raise_app_exceptions=False)
+    async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client, redis_client
+
+
+def _redis_get(values, failed_key=None):
+    async def get(key):
+        if key == failed_key:
+            raise RuntimeError("redis read failed")
+        return values[key]
+
+    return get
+
+
+@pytest.mark.asyncio
+async def test_all_agent_values_remain_attached_to_their_keys(quickstart):
+    client, redis_client = quickstart
+    redis_client.keys.return_value = ["agent-a", "agent-b", "agent-c"]
+    redis_client.get.side_effect = _redis_get(
+        {
+            "agent-a": json.dumps({"name": "A"}),
+            "agent-b": json.dumps({"name": "B"}),
+            "agent-c": json.dumps({"name": "C"}),
+        }
+    )
+
+    response = await client.get("/all")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "agents": [
+            {"agent_id": "agent-a", "data": {"name": "A"}},
+            {"agent_id": "agent-b", "data": {"name": "B"}},
+            {"agent_id": "agent-c", "data": {"name": "C"}},
+        ]
+    }
+
+
+@pytest.mark.parametrize("failed_key", ["agent-a", "agent-b", "agent-c"])
+@pytest.mark.asyncio
+async def test_failed_read_never_shifts_another_agents_data(quickstart, failed_key):
+    client, redis_client = quickstart
+    keys = ["agent-a", "agent-b", "agent-c"]
+    values = {
+        "agent-a": json.dumps({"name": "A"}),
+        "agent-b": json.dumps({"name": "B"}),
+        "agent-c": json.dumps({"name": "C"}),
+    }
+    redis_client.keys.return_value = keys
+    redis_client.get.side_effect = _redis_get(values, failed_key=failed_key)
+
+    response = await client.get("/all")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "agents": [{"agent_id": key, "data": json.loads(values[key])} for key in keys if key != failed_key],
+        "failed_agent_ids": [failed_key],
+    }
+
+
+@pytest.mark.asyncio
+async def test_missing_value_is_skipped_without_shifting_later_data(quickstart):
+    client, redis_client = quickstart
+    redis_client.keys.return_value = ["agent-a", "agent-b", "agent-c"]
+    redis_client.get.side_effect = _redis_get(
+        {
+            "agent-a": json.dumps({"name": "A"}),
+            "agent-b": None,
+            "agent-c": json.dumps({"name": "C"}),
+        }
+    )
+
+    response = await client.get("/all")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "agents": [
+            {"agent_id": "agent-a", "data": {"name": "A"}},
+            {"agent_id": "agent-c", "data": {"name": "C"}},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_is_reported_without_corrupting_other_mappings(quickstart):
+    client, redis_client = quickstart
+    redis_client.keys.return_value = ["agent-a", "agent-b", "agent-c"]
+    redis_client.get.side_effect = _redis_get(
+        {
+            "agent-a": json.dumps({"name": "A"}),
+            "agent-b": "not-json",
+            "agent-c": json.dumps({"name": "C"}),
+        }
+    )
+
+    response = await client.get("/all")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "agents": [
+            {"agent_id": "agent-a", "data": {"name": "A"}},
+            {"agent_id": "agent-c", "data": {"name": "C"}},
+        ],
+        "failed_agent_ids": ["agent-b"],
+    }


### PR DESCRIPTION
## Summary

`GET /all` currently fetches Redis keys and values into separate lists. If any individual `GET` fails, the key remains in the first list while no corresponding value is added to the second. The final `zip()` then shifts every later value onto the wrong agent ID.

This PR constructs each response entry from its key and decoded value inside the same guarded operation, making positional drift impossible.

It also makes partial results visible through `failed_agent_ids` without exposing backend exception details.

Closes #905.

## Root cause

The existing flow maintains two collections with different failure behavior:

```python
agent_keys = [A, B, C]
agents_data = []

for key in agent_keys:
    try:
        agents_data.append(await redis.get(key))
    except Exception:
        pass

zip(agent_keys, agents_data)
```

If reading `B` fails, `agents_data` becomes `[data_A, data_C]`. Zipping produces:

```text
A -> data_A
B -> data_C
```

The endpoint therefore returns a valid-looking but corrupted identity/data mapping. This is more dangerous than a simple missing result because a caller can act on one agent ID while viewing another agent's configuration.

JSON decoding happened after the per-key `try` block as part of the final comprehension. An invalid value consequently failed the entire endpoint instead of being isolated to the affected key.

## Changes

### Construct key/value records atomically

The endpoint now builds the final response entries directly:

```python
for key in agent_keys:
    try:
        data = await redis_client.get(key)
        if data:
            agents.append({
                "agent_id": key,
                "data": json.loads(data),
            })
    except Exception:
        ...
```

The key and its value never travel through separate positional lists, so a skipped value cannot change any other record's identity.

### Isolate invalid values

`json.loads()` now runs inside the same per-key guard as the Redis read. Malformed JSON skips and reports only that key; valid later records remain correctly mapped.

### Communicate partial results

When a Redis read or JSON decode fails, the response includes:

```json
{
  "agents": [...],
  "failed_agent_ids": ["agent-b"]
}
```

The field is omitted when every attempted read succeeds, preserving the existing successful response shape. A missing/`None` Redis value remains an ordinary skipped item and is not reported as a backend failure.

Raw Redis or JSON exception messages are logged server-side and are not returned to clients.

## Regression coverage

The new ASGI endpoint tests verify:

- all successful values remain attached to their own keys
- a failed first read cannot shift later data
- a failed middle read cannot shift later data
- a failed last read cannot affect earlier data
- a missing/`None` value is skipped without shifting subsequent data
- invalid JSON is isolated and reported without corrupting other mappings

The Redis client is fully mocked; no external Redis server is used.

## Behavior example

For keys `[A, B, C]` where `B` fails:

Before:

```json
{
  "agents": [
    {"agent_id": "A", "data": "data_A"},
    {"agent_id": "B", "data": "data_C"}
  ]
}
```

After:

```json
{
  "agents": [
    {"agent_id": "A", "data": "data_A"},
    {"agent_id": "C", "data": "data_C"}
  ],
  "failed_agent_ids": ["B"]
}
```

## Validation

Passed:

```text
6 passed
```

for the new quickstart `GET /all` regression suite.

Also passed:

```text
ruff check
ruff format --check
python -m py_compile
git diff --check
```

The full repository suite reports:

```text
525 passed, 10 failed
```

The six new tests account for the increase over the upstream baseline. The 10 failures are pre-existing and remain confined to:

- `test_elevenlabs_close_context_eos.py` (1)
- `test_event_injection_e2e.py` (7)
- `test_split_utterance_tail_not_dropped.py` (2)

This change does not touch those areas.

## Scope and compatibility

The endpoint still returns partial successful results and keeps the existing `agents` field unchanged. `failed_agent_ids` is additive and only appears when the result is incomplete due to a read or decode failure.

This PR intentionally does not replace `KEYS *` with namespaced `SCAN` or `MGET`; that is a separate storage-schema and scalability decision. The change here is limited to preserving identity correctness under the endpoint's current retrieval strategy.
