### PR TITLE
feat: add Maya TTS synthesizer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ graph LR;
 1. Initiating a phone call using telephony providers like `Twilio`, `Plivo`, `Exotel` (coming soon), `Vonage` (coming soon) etc.
 2. Transcribing the conversations using `Deepgram`, `Azure` etc.
 3. Using LLMs like `OpenAI`, `DeepSeek`, `Llama`, `Cohere`, `Mistral`,  etc to handle conversations
-4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest` etc.
+4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest`, `Maya` etc.
 
 
 Refer to the [docs](https://docs.bolna.ai/providers) for a deepdive into all supported providers.
@@ -296,6 +296,7 @@ https://github.com/bolna-ai/bolna/blob/c8a0d1428793d4df29133119e354bc2f85a7ca76/
 | Deepgram   | `DEEPGRAM_AUTH_TOKEN`                            |
 | Cartesia   | `CARTESIA_API_KEY`                            |
 | Smallest   | `SMALLEST_API_KEY`                            |
+| Maya       | `MAYA_API_KEY`                            |
 
 </details>
 &nbsp;<br>

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -238,6 +238,26 @@ SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
 }
 
 # bulbul TTS requires a concrete target_language_code (no "unknown"/auto).
+# Maya matches the voice case-sensitively; "ananya" is a 400.
+MAYA_TTS_SUPPORTED_VOICES = {"Ananya", "Arjun"}
+
+# "en" is Indian English. "auto" lets Maya detect per utterance, which is what
+# romanized and mixed-script text needs.
+MAYA_TTS_SUPPORTED_LANGUAGES = {
+    "hi",
+    "bn",
+    "gu",
+    "kn",
+    "ml",
+    "mr",
+    "or",
+    "pa",
+    "ta",
+    "te",
+    "en",
+    "auto",
+}
+
 SARVAM_TTS_SUPPORTED_LANGUAGES = {
     "en-IN",
     "hi-IN",

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -238,11 +238,24 @@ SARVAM_MODEL_SAMPLING_RATE_MAPPING = {
 }
 
 # bulbul TTS requires a concrete target_language_code (no "unknown"/auto).
+SARVAM_TTS_SUPPORTED_LANGUAGES = {
+    "en-IN",
+    "hi-IN",
+    "bn-IN",
+    "ta-IN",
+    "te-IN",
+    "kn-IN",
+    "ml-IN",
+    "mr-IN",
+    "gu-IN",
+    "pa-IN",
+    "od-IN",
+}
+
 # Maya matches the voice case-sensitively; "ananya" is a 400.
 MAYA_TTS_SUPPORTED_VOICES = {"Ananya", "Arjun"}
 
-# "en" is Indian English. "auto" lets Maya detect per utterance, which is what
-# romanized and mixed-script text needs.
+# "en" is Indian English; "auto" lets Maya detect per utterance.
 MAYA_TTS_SUPPORTED_LANGUAGES = {
     "hi",
     "bn",
@@ -256,20 +269,6 @@ MAYA_TTS_SUPPORTED_LANGUAGES = {
     "te",
     "en",
     "auto",
-}
-
-SARVAM_TTS_SUPPORTED_LANGUAGES = {
-    "en-IN",
-    "hi-IN",
-    "bn-IN",
-    "ta-IN",
-    "te-IN",
-    "kn-IN",
-    "ml-IN",
-    "mr-IN",
-    "gu-IN",
-    "pa-IN",
-    "od-IN",
 }
 
 MODEL_REASONING_EFFORT_MAP = {

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -61,6 +61,7 @@ class SynthesizerProvider(str, Enum):
     SARVAM = "sarvam"
     RIME = "rime"
     PIXA = "pixa"
+    MAYA = "maya"
 
     @classmethod
     def all_values(cls):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -112,11 +112,11 @@ class PixaConfig(BaseModel):
 class MayaConfig(BaseModel):
     # "Ananya" (female) or "Arjun" (male) — the only two voices, both speak every language.
     # Case-sensitive: Maya rejects "ananya" with a 400.
-    voice: str = "Ananya"
-    model: Optional[str] = "Maya 2 Native"
-    # One of hi/bn/gu/kn/ml/mr/or/pa/ta/te/en ("en" is Indian English). Region-qualified
-    # codes ("en-IN") are reduced to the primary subtag. Set null for code-switching text,
-    # so each script keeps its own pronunciation rules instead of being forced to one.
+    voice_id: str
+    voice: str
+    model: str
+    # One of hi/bn/gu/kn/ml/mr/or/pa/ta/te/en/auto. "en" is Indian English, "auto" lets Maya
+    # detect per utterance. Region-qualified codes ("en-IN") reduce to the primary subtag.
     language: Optional[str] = "en"
 
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -109,6 +109,17 @@ class PixaConfig(BaseModel):
     repetition_penalty: Optional[float] = 1.3
 
 
+class MayaConfig(BaseModel):
+    # "Ananya" (female) or "Arjun" (male) — the only two voices, both speak every language.
+    # Case-sensitive: Maya rejects "ananya" with a 400.
+    voice: str = "Ananya"
+    model: Optional[str] = "Maya 2 Native"
+    # One of hi/bn/gu/kn/ml/mr/or/pa/ta/te/en ("en" is Indian English). Region-qualified
+    # codes ("en-IN") are reduced to the primary subtag. Set null for code-switching text,
+    # so each script keeps its own pronunciation rules instead of being forced to one.
+    language: Optional[str] = "en"
+
+
 class AzureConfig(BaseModel):
     voice: str
     model: str
@@ -156,6 +167,7 @@ class Synthesizer(BaseModel):
         CartesiaConfig,
         DeepgramConfig,
         OpenAIConfig,
+        MayaConfig,
     ] = Field(union_mode="smart")
     stream: bool = False
     buffer_size: Optional[int] = 40  # 40 characters in a buffer
@@ -199,6 +211,9 @@ class Synthesizer(BaseModel):
         elif provider == "rime":
             if isinstance(config, dict):
                 values["provider_config"] = RimeConfig(**config)
+        elif provider == "maya":
+            if isinstance(config, dict):
+                values["provider_config"] = MayaConfig(**config)
 
         return values
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -9,6 +9,7 @@ from .synthesizer import (
     SarvamSynthesizer,
     RimeSynthesizer,
     PixaSynthesizer,
+    MayaSynthesizer,
 )
 from .transcriber import (
     DeepgramTranscriber,
@@ -55,6 +56,7 @@ SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.SARVAM.value: SarvamSynthesizer,
     SynthesizerProvider.RIME.value: RimeSynthesizer,
     SynthesizerProvider.PIXA.value: PixaSynthesizer,
+    SynthesizerProvider.MAYA.value: MayaSynthesizer,
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -10,4 +10,5 @@ from .rime_synthesizer import RimeSynthesizer
 from .smallest_synthesizer import SmallestSynthesizer
 from .sarvam_synthesizer import SarvamSynthesizer
 from .pixa_synthesizer import PixaSynthesizer
+from .maya_synthesizer import MayaSynthesizer
 from .synthesizer_pool import SynthesizerPool

--- a/bolna/synthesizer/maya_synthesizer.py
+++ b/bolna/synthesizer/maya_synthesizer.py
@@ -195,13 +195,15 @@ class MayaSynthesizer(StreamSynthesizer):
 
             await self._wait_for_ws()
 
+            # The wait above can span a barge-in, which retires this sequence without
+            # cancelling the task. Re-check before anything reaches the socket, including the
+            # flush branch: priming opens an utterance, so Maya would answer it with `end`.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                await self.flush_synthesizer_stream()
+                return
+
             if text != "":
-                # The wait above can span a barge-in, which retires this sequence without
-                # cancelling the task. Re-check before anything reaches the socket.
-                if not self.should_synthesize_response(sequence_id):
-                    logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
-                    await self.flush_synthesizer_stream()
-                    return
                 try:
                     if self.ws_send_time is None:
                         self.ws_send_time = time.perf_counter()

--- a/bolna/synthesizer/maya_synthesizer.py
+++ b/bolna/synthesizer/maya_synthesizer.py
@@ -16,6 +16,7 @@ import websockets
 from websockets.exceptions import InvalidHandshake
 
 from .stream_synthesizer import StreamSynthesizer
+from bolna.constants import MAYA_TTS_SUPPORTED_LANGUAGES, MAYA_TTS_SUPPORTED_VOICES
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import pcm_to_ulaw, pcm_to_wav_bytes, resample
@@ -26,9 +27,6 @@ logger = configure_logger(__name__)
 MAYA_NATIVE_SAMPLE_RATE = 24000
 MULAW_SAMPLE_RATE = 8000
 
-MAYA_VOICES = {"Ananya", "Arjun"}
-# "en" is Indian English. Omit the field entirely for code-switching text.
-MAYA_LANGUAGES = {"hi", "bn", "gu", "kn", "ml", "mr", "or", "pa", "ta", "te", "en"}
 MAYA_DEFAULT_MODEL = "Maya 2 Native"
 
 # Maya and ISO 639-1 spell Odia "or"; bolna also carries the "od" variant.
@@ -80,7 +78,7 @@ class MayaSynthesizer(StreamSynthesizer):
     @staticmethod
     def _normalise_voice(voice):
         """Normalise to the documented casing; Maya matches case-sensitively."""
-        for known in MAYA_VOICES:
+        for known in MAYA_TTS_SUPPORTED_VOICES:
             if isinstance(voice, str) and voice.strip().lower() == known.lower():
                 return known
         return voice
@@ -94,10 +92,12 @@ class MayaSynthesizer(StreamSynthesizer):
         return _LANGUAGE_ALIASES.get(primary, primary)
 
     def _validate_options(self):
-        if self.voice not in MAYA_VOICES:
-            raise ValueError(f"Maya voice must be one of {sorted(MAYA_VOICES)}, got {self.voice!r}")
-        if self.language is not None and self.language not in MAYA_LANGUAGES:
-            raise ValueError(f"Maya language must be one of {sorted(MAYA_LANGUAGES)}, got {self.language!r}")
+        if self.voice not in MAYA_TTS_SUPPORTED_VOICES:
+            raise ValueError(f"Maya voice must be one of {sorted(MAYA_TTS_SUPPORTED_VOICES)}, got {self.voice!r}")
+        if self.language is not None and self.language not in MAYA_TTS_SUPPORTED_LANGUAGES:
+            raise ValueError(
+                f"Maya language must be one of {sorted(MAYA_TTS_SUPPORTED_LANGUAGES)}, got {self.language!r}"
+            )
 
     def get_sleep_time(self):
         return 0.01
@@ -150,7 +150,7 @@ class MayaSynthesizer(StreamSynthesizer):
         target = self._normalise_language(language)
         if target == self.language:
             return
-        if target not in MAYA_LANGUAGES:
+        if target not in MAYA_TTS_SUPPORTED_LANGUAGES:
             logger.info(f"Maya TTS: detected language {language!r} not supported, keeping {self.language!r}")
             return
         self.language = target
@@ -196,6 +196,12 @@ class MayaSynthesizer(StreamSynthesizer):
             await self._wait_for_ws()
 
             if text != "":
+                # The wait above can span a barge-in, which retires this sequence without
+                # cancelling the task. Re-check before anything reaches the socket.
+                if not self.should_synthesize_response(sequence_id):
+                    logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                    await self.flush_synthesizer_stream()
+                    return
                 try:
                     if self.ws_send_time is None:
                         self.ws_send_time = time.perf_counter()
@@ -213,7 +219,6 @@ class MayaSynthesizer(StreamSynthesizer):
                 needs_priming = not self._turn_has_text
                 self._turn_has_text = False
                 try:
-                    self._discard_audio = False
                     if needs_priming:
                         # Maya only answers a flush with `end` when an utterance is open, and an
                         # empty text frame does not open one -- whitespace does, with no audio.

--- a/bolna/synthesizer/maya_synthesizer.py
+++ b/bolna/synthesizer/maya_synthesizer.py
@@ -1,0 +1,394 @@
+"""
+Maya Research TTS: streaming WSS /v1/tts/stream, one-shot POST /v1/tts.
+
+Audio arrives as binary frames (raw 24 kHz s16le PCM); control messages are JSON.
+An utterance ends with exactly one terminator: `end`, or `cancelled` if interrupted.
+"""
+
+import asyncio
+import json
+import os
+import re
+import time
+
+import aiohttp
+import websockets
+from websockets.exceptions import InvalidHandshake
+
+from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
+from bolna.helpers.utils import pcm_to_ulaw, pcm_to_wav_bytes, resample
+from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
+
+logger = configure_logger(__name__)
+
+MAYA_NATIVE_SAMPLE_RATE = 24000
+MULAW_SAMPLE_RATE = 8000
+
+MAYA_VOICES = {"Ananya", "Arjun"}
+# "en" is Indian English. Omit the field entirely for code-switching text.
+MAYA_LANGUAGES = {"hi", "bn", "gu", "kn", "ml", "mr", "or", "pa", "ta", "te", "en"}
+MAYA_DEFAULT_MODEL = "Maya 2 Native"
+
+# Maya and ISO 639-1 spell Odia "or"; bolna also carries the "od" variant.
+_LANGUAGE_ALIASES = {"od": "or"}
+
+
+class MayaSynthesizer(StreamSynthesizer):
+    def __init__(
+        self,
+        voice="Ananya",
+        voice_id=None,
+        model=MAYA_DEFAULT_MODEL,
+        language="en",
+        sampling_rate="24000",
+        stream=False,
+        buffer_size=400,
+        synthesizer_key=None,
+        caching=True,
+        **kwargs,
+    ):
+        super().__init__(
+            stream=stream,
+            provider_name="maya",
+            buffer_size=buffer_size,
+            **kwargs,
+        )
+        self.api_key = os.environ["MAYA_API_KEY"] if synthesizer_key is None else synthesizer_key
+        # voice_id accepted so configs shaped like the other providers still resolve.
+        self.voice = self._normalise_voice(voice_id or voice)
+        self.model = model
+        self.language = self._normalise_language(language)
+        self.caching = caching
+        if caching:
+            self.cache = InmemoryScalarCache()
+
+        self.use_mulaw = kwargs.get("use_mulaw", False)
+        self.target_sample_rate = MULAW_SAMPLE_RATE if self.use_mulaw else int(sampling_rate)
+        self.sampling_rate = self.target_sample_rate
+
+        self.maya_host = os.getenv("MAYA_API_HOST", "tts.mayaresearch.ai")
+        self.api_url = f"https://{self.maya_host}/v1/tts"
+        self.ws_url = f"wss://{self.maya_host}/v1/tts/stream"
+
+        self._discard_audio = False
+        self._turn_has_text = False
+
+        self._validate_options()
+
+    @staticmethod
+    def _normalise_voice(voice):
+        """Normalise to the documented casing; Maya matches case-sensitively."""
+        for known in MAYA_VOICES:
+            if isinstance(voice, str) and voice.strip().lower() == known.lower():
+                return known
+        return voice
+
+    @staticmethod
+    def _normalise_language(language):
+        """Reduce bolna's region-qualified code ("hi-IN") to the primary subtag Maya wants."""
+        if not isinstance(language, str):
+            return language
+        primary = re.split(r"[-_]", language.strip().lower(), maxsplit=1)[0]
+        return _LANGUAGE_ALIASES.get(primary, primary)
+
+    def _validate_options(self):
+        if self.voice not in MAYA_VOICES:
+            raise ValueError(f"Maya voice must be one of {sorted(MAYA_VOICES)}, got {self.voice!r}")
+        if self.language is not None and self.language not in MAYA_LANGUAGES:
+            raise ValueError(f"Maya language must be one of {sorted(MAYA_LANGUAGES)}, got {self.language!r}")
+
+    def get_sleep_time(self):
+        return 0.01
+
+    # ------------------------------------------------------------------
+    # StreamSynthesizer hooks
+    # ------------------------------------------------------------------
+
+    def _get_audio_format(self):
+        return "mulaw" if self.use_mulaw else "pcm"
+
+    def _process_audio_chunk(self, chunk):
+        """Resample Maya's 24 kHz PCM to the target rate; mu-law encode for telephony."""
+        if not chunk:
+            return None
+        try:
+            audio = resample(
+                chunk,
+                self.target_sample_rate,
+                format="pcm",
+                original_sample_rate=MAYA_NATIVE_SAMPLE_RATE,
+            )
+        except Exception as e:
+            logger.error(f"Error resampling Maya audio: {e}")
+            return None
+        return pcm_to_ulaw(audio) if self.use_mulaw else audio
+
+    # ------------------------------------------------------------------
+    # Payload
+    # ------------------------------------------------------------------
+
+    def _config_message(self):
+        payload = {"type": "config", "voice": self.voice, "model": self.model}
+        if self.language:
+            payload["language"] = self.language
+        return payload
+
+    def form_payload(self, text):
+        """A fragment. `flush` is Maya's only terminator, so text frames are never final."""
+        return {"type": "text", "text": text, "flush": False}
+
+    # ------------------------------------------------------------------
+    # Language switching
+    # ------------------------------------------------------------------
+
+    async def set_target_language(self, language):
+        """Switch language on the live socket via a fresh config frame (no reconnect)."""
+        if not language:
+            return
+        target = self._normalise_language(language)
+        if target == self.language:
+            return
+        if target not in MAYA_LANGUAGES:
+            logger.info(f"Maya TTS: detected language {language!r} not supported, keeping {self.language!r}")
+            return
+        self.language = target
+        if self._is_ws_connected():
+            try:
+                await self._send_json(self._config_message())
+                logger.info(f"Maya TTS: switched language {language!r} -> {target}")
+            except Exception as e:
+                logger.error(f"Maya TTS: failed to send config update for {target!r}: {e}")
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
+    async def handle_interruption(self):
+        """Already-generated frames keep arriving until Maya answers with `cancelled`, so
+        audio is dropped over that window."""
+        try:
+            if not self._is_ws_connected():
+                return
+            self._discard_audio = True
+            self._turn_has_text = False
+            await self._send_json({"type": "clear"})
+            logger.info("Sent clear to Maya TTS WebSocket")
+            # A cleared turn terminates with `cancelled` rather than `end`, and that is not
+            # forwarded, so the next turn must re-detect as new.
+            self.current_turn_start_time = None
+        except Exception as e:
+            logger.error(f"Error handling Maya interruption: {e}")
+
+    # ------------------------------------------------------------------
+    # sender / receiver
+    # ------------------------------------------------------------------
+
+    async def sender(self, text, sequence_id, end_of_llm_stream=False):
+        try:
+            if self.conversation_ended:
+                return
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
+                return
+
+            await self._wait_for_ws()
+
+            if text != "":
+                try:
+                    if self.ws_send_time is None:
+                        self.ws_send_time = time.perf_counter()
+                    self._discard_audio = False
+                    await self._send_json(self.form_payload(text))
+                    self._turn_has_text = True
+                except Exception as e:
+                    logger.error(f"Error sending chunk to Maya: {e}")
+                    self.connection_error = str(e)
+                    return
+
+            if end_of_llm_stream:
+                self.last_text_sent = True
+                # Reset before sending: a stale True would make the next empty turn skip priming.
+                needs_priming = not self._turn_has_text
+                self._turn_has_text = False
+                try:
+                    self._discard_audio = False
+                    if needs_priming:
+                        # Maya only answers a flush with `end` when an utterance is open, and an
+                        # empty text frame does not open one -- whitespace does, with no audio.
+                        await self._send_json(self.form_payload(" "))
+                    await self._send_json({"type": "flush"})
+                    self._turn_has_text = False
+                except Exception as e:
+                    logger.error(f"Error sending flush to Maya: {e}")
+                    self.connection_error = str(e)
+
+        except asyncio.CancelledError:
+            logger.info("Maya sender task was cancelled.")
+        except Exception as e:
+            logger.error(f"Unexpected error in Maya sender: {e}")
+
+    async def receiver(self):
+        not_connected_since = None
+        while True:
+            try:
+                if self.conversation_ended:
+                    return
+                if not self._is_ws_connected():
+                    if self.connection_error:
+                        return
+                    now = time.perf_counter()
+                    if not_connected_since is None:
+                        not_connected_since = now
+                    elif now - not_connected_since > 30:
+                        logger.error("Maya receiver: WebSocket never connected after 30s, giving up.")
+                        self.connection_error = self.connection_error or "WebSocket never connected"
+                        return
+                    logger.info("Maya WebSocket is not connected, skipping receive.")
+                    await asyncio.sleep(0.1)
+                    continue
+                else:
+                    not_connected_since = None
+
+                response = await self.websocket.recv()
+
+                if isinstance(response, (bytes, bytearray)):
+                    if self._discard_audio:
+                        continue
+                    yield bytes(response)
+                    continue
+
+                data = self._loads_event(response)
+                if data is None:
+                    continue
+
+                event = data.get("type")
+                if event == "end":
+                    logger.info(
+                        f"Maya end of stream request_id={data.get('request_id')} session_id={data.get('session_id')}"
+                    )
+                    self._discard_audio = False
+                    yield b"\x00"
+                elif event == "cancelled":
+                    # Terminator for a turn we interrupted, sent instead of `end`. Nothing
+                    # follows it, so in-flight audio stops needing to be dropped here. No
+                    # sentinel: handle_interruption() already abandoned the turn.
+                    logger.info(f"Maya cancelled request_id={data.get('request_id')}")
+                    self._discard_audio = False
+                elif event == "error":
+                    # Not a terminator: an error rejects one frame (a bad config, say) while the
+                    # utterance still completes with its own `end`. Emitting a sentinel here
+                    # would terminate the turn twice and shift every later turn's audio onto the
+                    # wrong meta_info. The socket stays usable, so just surface it.
+                    logger.error(f"Maya TTS error response: {data}")
+                else:
+                    logger.info(f"Maya control message: {data}")
+
+            except websockets.exceptions.ConnectionClosed:
+                break
+            except Exception as e:
+                logger.error(f"Error occurred in Maya receiver - {e}")
+
+    @staticmethod
+    def _loads_event(data):
+        try:
+            parsed = json.loads(data)
+        except (TypeError, ValueError):
+            logger.error(f"Maya sent a non-JSON text frame: {data!r}")
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    async def establish_connection(self):
+        try:
+            start_time = time.perf_counter()
+            websocket = await asyncio.wait_for(
+                websockets.connect(
+                    self.ws_url,
+                    additional_headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "User-Agent": "bolna",
+                    },
+                    ssl=get_ssl_context(self.ws_url),
+                ),
+                timeout=10.0,
+            )
+            # Sent before returning so every reconnect replays it.
+            await websocket.send(json.dumps(self._config_message()))
+            self._discard_audio = False
+            if not self.connection_time:
+                self.connection_time = round((time.perf_counter() - start_time) * 1000)
+            logger.info(f"Connected to {self.ws_url}")
+            return websocket
+        except asyncio.TimeoutError:
+            logger.error("Timeout while connecting to Maya TTS websocket")
+            return None
+        except InvalidHandshake as e:
+            error_msg = str(e)
+            if "401" in error_msg or "403" in error_msg:
+                logger.error(f"Maya TTS authentication failed: {e}")
+                self.connection_error = str(e)
+            elif "404" in error_msg:
+                logger.error(f"Maya TTS endpoint not found: {e}")
+                self.connection_error = str(e)
+            else:
+                logger.error(f"Maya TTS handshake failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to connect to Maya TTS: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+
+    def _process_http_audio(self, audio):
+        """The HTTP body is the same headerless 24 kHz PCM as the WS frames."""
+        if not audio:
+            return b"\x00"
+        return self._process_audio_chunk(audio) or b"\x00"
+
+    def _get_http_audio_format(self):
+        return self._get_audio_format()
+
+    async def _generate_http(self, text):
+        payload = {"text": text, "voice": self.voice, "model": self.model}
+        if self.language:
+            payload["language"] = self.language
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+            # A default client User-Agent can trip a filter into a non-JSON 403.
+            "User-Agent": "bolna",
+        }
+        async with aiohttp.ClientSession() as session:
+            async with session.post(self.api_url, headers=headers, json=payload) as response:
+                request_id = response.headers.get("x-request-id")
+                if response.status == 200:
+                    return await response.read()
+                logger.error(
+                    f"Maya TTS HTTP error: {response.status} request_id={request_id} - {await response.text()}"
+                )
+                return None
+
+    async def synthesize_telephony_clip(self, text):
+        """Mu-law 8000 one-shot for handoff/prewarm clips, converted in-process so the
+        caller skips the pydub/ffmpeg decode. None on non-telephony configs."""
+        if not self.use_mulaw:
+            return None
+        audio = await self._generate_http(text)
+        if not audio:
+            return None
+        return self._process_audio_chunk(audio)
+
+    async def synthesize(self, text):
+        """WAV-wrapped: callers pass this to audio_to_mulaw8k() with a rate_hint guessed off
+        the synthesizer, which would decode headerless 24 kHz PCM at the wrong rate."""
+        audio = await self._generate_http(text)
+        if not audio:
+            return None
+        return pcm_to_wav_bytes(audio, sample_rate=MAYA_NATIVE_SAMPLE_RATE)

--- a/tests/tests/test_maya_synthesizer.py
+++ b/tests/tests/test_maya_synthesizer.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from bolna.models import Synthesizer
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
 from bolna.synthesizer.maya_synthesizer import MAYA_NATIVE_SAMPLE_RATE, MayaSynthesizer
 
 KEY = "maya_sk_test_dummy"
@@ -48,10 +50,30 @@ def test_voice_case_is_corrected_because_maya_matches_it_exactly():
     assert _synth(voice=" Ananya ").voice == "Ananya"
 
 
-def test_voice_id_is_accepted_as_an_alias_for_voice():
-    # Configs written against the other providers' shape use voice_id; it must not
-    # silently fall through to the default voice.
-    assert _synth(voice_id="Arjun").voice == "Arjun"
+def test_voice_id_survives_the_config_model_and_reaches_the_synthesizer():
+    """The dashboard writes voice_id for every provider. A model without the field drops it
+    silently and the caller hears the default voice, so this covers the whole path rather
+    than the constructor alone."""
+    cfg = Synthesizer(
+        provider="maya",
+        provider_config={"voice_id": "Arjun", "voice": "Arjun", "model": "Maya 2 Native", "language": "en"},
+        stream=True,
+    ).model_dump()
+    cfg.pop("caching", None)
+    cfg.pop("provider")
+    provider_config = cfg.pop("provider_config")
+    assert provider_config["voice_id"] == "Arjun"
+
+    s = SUPPORTED_SYNTHESIZER_MODELS["maya"](
+        **cfg, **provider_config, caching=True, synthesizer_key=KEY, task_manager_instance=MagicMock()
+    )
+    assert s.voice == "Arjun"
+
+
+def test_auto_lets_maya_detect_the_language_per_utterance():
+    # Advertised in Maya's own rejection frame and accepted live; raising here would fail
+    # the call at construction time, with no audio.
+    assert _synth(language="auto").language == "auto"
 
 
 @pytest.mark.parametrize(
@@ -176,6 +198,22 @@ def test_an_interrupted_turn_does_not_leave_stale_priming_state():
     s.sent.clear()
     asyncio.run(s.sender("", 2, end_of_llm_stream=True))
     assert s.sent[0] == {"type": "text", "text": " ", "flush": False}
+
+
+def test_a_barge_in_during_the_connection_wait_stops_the_sender():
+    """_wait_for_ws() can span a barge-in without the task being cancelled. Without a second
+    check the sender resumes, sends the primer and flush, and Maya answers `end` — emitting
+    end-of-stream for a sequence the pipeline already retired."""
+    s = _synth()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def wait_then_retire():
+        retired["yet"] = True  # the barge-in lands while we are parked here
+
+    s._wait_for_ws = AsyncMock(side_effect=wait_then_retire)
+    asyncio.run(s.sender("text for a turn that gets interrupted", 1, end_of_llm_stream=True))
+    assert s.sent == []
 
 
 def test_stale_sequence_sends_nothing():

--- a/tests/tests/test_maya_synthesizer.py
+++ b/tests/tests/test_maya_synthesizer.py
@@ -216,6 +216,22 @@ def test_a_barge_in_during_the_connection_wait_stops_the_sender():
     assert s.sent == []
 
 
+def test_an_empty_push_retired_during_the_wait_sends_nothing_either():
+    """The guard has to cover the flush branch too, not just the text branch: an empty final
+    push skips the text frame entirely, and priming would open an utterance that Maya answers
+    with `end` — an end-of-stream sentinel for a sequence the pipeline already dropped."""
+    s = _synth()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def wait_then_retire():
+        retired["yet"] = True
+
+    s._wait_for_ws = AsyncMock(side_effect=wait_then_retire)
+    asyncio.run(s.sender("", 1, end_of_llm_stream=True))
+    assert s.sent == []
+
+
 def test_stale_sequence_sends_nothing():
     s = _synth()
     s.task_manager_instance.is_sequence_id_in_current_ids.return_value = False

--- a/tests/tests/test_maya_synthesizer.py
+++ b/tests/tests/test_maya_synthesizer.py
@@ -1,0 +1,459 @@
+"""Maya TTS: flush semantics, 24 kHz -> telephony conversion, barge-in discard, and the
+config frame that must be replayed on every reconnect."""
+
+import asyncio
+import audioop
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.synthesizer.maya_synthesizer import MAYA_NATIVE_SAMPLE_RATE, MayaSynthesizer
+
+KEY = "maya_sk_test_dummy"
+
+
+def _synth(**kwargs):
+    """A real synthesizer with the websocket stubbed out — no env var, no network."""
+    kwargs.setdefault("voice", "Ananya")
+    kwargs.setdefault("language", "en")
+    kwargs.setdefault("stream", True)
+    kwargs.setdefault("use_mulaw", True)
+    s = MayaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock(), **kwargs)
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = True
+    s.websocket = MagicMock()
+    s.websocket.send = AsyncMock()
+    s._wait_for_ws = AsyncMock()
+    s._is_ws_connected = MagicMock(return_value=True)
+    s.sent = []
+    s._send_json = AsyncMock(side_effect=lambda p: s.sent.append(p))
+    return s
+
+
+def _pcm(seconds, rate=MAYA_NATIVE_SAMPLE_RATE):
+    """A silent-but-nonzero 16-bit mono buffer of a known length."""
+    return (b"\x10\x00") * int(seconds * rate)
+
+
+# ----------------------------------------------------------------------
+# Construction and validation
+# ----------------------------------------------------------------------
+
+
+def test_voice_case_is_corrected_because_maya_matches_it_exactly():
+    # Maya 400s on "ananya" — normalising here means a lowercase agent config still works
+    # instead of failing every turn of the call.
+    assert _synth(voice="ananya").voice == "Ananya"
+    assert _synth(voice="ARJUN").voice == "Arjun"
+    assert _synth(voice=" Ananya ").voice == "Ananya"
+
+
+def test_voice_id_is_accepted_as_an_alias_for_voice():
+    # Configs written against the other providers' shape use voice_id; it must not
+    # silently fall through to the default voice.
+    assert _synth(voice_id="Arjun").voice == "Arjun"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [{"voice": "Ananaya"}, {"voice": "Priya"}, {"voice": ""}, {"language": "fr"}],
+)
+def test_invalid_options_raise_at_construction_not_mid_call(bad):
+    # Maya rejects these too, but only once a call is live — a 400 on the HTTP path and an
+    # `error` frame on the socket. Failing at agent setup surfaces a typo before a caller
+    # hears silence.
+    with pytest.raises(ValueError):
+        _synth(**bad)
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [
+        ("en-IN", "en"),
+        ("hi-IN", "hi"),
+        ("ta_IN", "ta"),
+        ("HI-in", "hi"),
+        ("od-IN", "or"),  # bolna carries the "od" variant of Odia; Maya uses "or"
+        ("en", "en"),
+    ],
+)
+def test_region_qualified_codes_are_reduced_to_mayas_primary_subtag(given, expected):
+    """bolna's ASR reports "hi-IN", and agent configs are commonly written the same way.
+    Without this the configured language fails validation outright and every auto-detected
+    switch is silently dropped, so the feature would look wired up but never fire."""
+    assert _synth(language=given).language == expected
+
+
+def test_mulaw_is_off_unless_task_manager_asks_for_it():
+    """task_manager injects use_mulaw=True for telephony and False for web/freeswitch, but
+    injects nothing for the "default" output handler — which plays raw PCM. Defaulting to
+    mulaw would emit 8k into a 24k player."""
+    s = MayaSynthesizer(voice="Ananya", stream=True, synthesizer_key=KEY, task_manager_instance=MagicMock())
+    assert s.use_mulaw is False
+    assert s._get_audio_format() == "pcm"
+
+
+def test_telephony_pins_8k_mulaw_and_web_keeps_native_24k():
+    tel = _synth(use_mulaw=True)
+    assert (tel.target_sample_rate, tel._get_audio_format()) == (8000, "mulaw")
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert (web.target_sample_rate, web._get_audio_format()) == (24000, "pcm")
+
+
+# ----------------------------------------------------------------------
+# Payloads
+# ----------------------------------------------------------------------
+
+
+def test_text_frames_are_explicitly_non_final():
+    # flush is Maya's only terminator, so every text frame must say flush=False or the
+    # server would speak each fragment as its own utterance.
+    assert _synth().form_payload("hello") == {"type": "text", "text": "hello", "flush": False}
+
+
+def test_config_frame_carries_voice_model_and_language():
+    # No region — Maya resolves the inference region server-side.
+    assert _synth(voice="Arjun", language="ta")._config_message() == {
+        "type": "config",
+        "voice": "Arjun",
+        "model": "Maya 2 Native",
+        "language": "ta",
+    }
+
+
+def test_config_frame_omits_language_when_unset_so_code_switching_works():
+    # Mixed-script text must not be forced to one language's pronunciation rules.
+    assert "language" not in _synth(language=None)._config_message()
+
+
+# ----------------------------------------------------------------------
+# sender
+# ----------------------------------------------------------------------
+
+
+def test_sender_sends_text_then_flush_on_end_of_llm_stream():
+    s = _synth()
+    asyncio.run(s.sender("Sure, I can", 1, end_of_llm_stream=False))
+    assert s.sent == [{"type": "text", "text": "Sure, I can", "flush": False}]
+    assert s.last_text_sent is False
+
+    asyncio.run(s.sender(" help with that.", 1, end_of_llm_stream=True))
+    assert s.sent[-2] == {"type": "text", "text": " help with that.", "flush": False}
+    assert s.sent[-1] == {"type": "flush"}
+    assert s.last_text_sent is True
+
+
+def test_an_empty_final_push_is_primed_so_the_turn_still_terminates():
+    """Maya emits `end` only when an utterance is open, and an empty-string text frame
+    does not open one — a bare flush is silently ignored (verified against the live API).
+    bolna's final push can be empty, so whitespace primes the buffer: `end` with zero
+    audio frames, instead of a turn that never closes."""
+    s = _synth()
+    asyncio.run(s.sender("", 1, end_of_llm_stream=True))
+    assert s.sent == [{"type": "text", "text": " ", "flush": False}, {"type": "flush"}]
+
+
+def test_a_turn_that_already_sent_text_is_not_primed():
+    s = _synth()
+    asyncio.run(s.sender("real text", 1, end_of_llm_stream=True))
+    assert s.sent == [{"type": "text", "text": "real text", "flush": False}, {"type": "flush"}]
+
+
+def test_priming_state_resets_between_turns():
+    s = _synth()
+    asyncio.run(s.sender("turn one", 1, end_of_llm_stream=True))
+    s.sent.clear()
+    # Next turn is empty from the start, so it needs priming again.
+    asyncio.run(s.sender("", 2, end_of_llm_stream=True))
+    assert s.sent == [{"type": "text", "text": " ", "flush": False}, {"type": "flush"}]
+
+
+def test_an_interrupted_turn_does_not_leave_stale_priming_state():
+    s = _synth()
+    asyncio.run(s.sender("some text", 1))
+    asyncio.run(s.handle_interruption())
+    s.sent.clear()
+    asyncio.run(s.sender("", 2, end_of_llm_stream=True))
+    assert s.sent[0] == {"type": "text", "text": " ", "flush": False}
+
+
+def test_stale_sequence_sends_nothing():
+    s = _synth()
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = False
+    asyncio.run(s.sender("dropped", 7, end_of_llm_stream=True))
+    assert s.sent == []
+
+
+def test_sender_stamps_ws_send_time_once_per_turn():
+    s = _synth()
+    asyncio.run(s.sender("first", 1))
+    first = s.ws_send_time
+    asyncio.run(s.sender("second", 1))
+    assert s.ws_send_time == first  # TTFB is measured from the first frame of the turn
+
+
+def test_sending_a_new_turn_stops_discarding_leftover_audio():
+    s = _synth()
+    s._discard_audio = True
+    asyncio.run(s.sender("a new turn supersedes the cleared one", 2))
+    assert s._discard_audio is False
+
+
+# ----------------------------------------------------------------------
+# receiver
+# ----------------------------------------------------------------------
+
+
+def _drain(s, frames):
+    """Feed `frames` through receiver() and collect what it yields.
+
+    receiver() loops forever by design, so once the scripted frames run out we raise
+    CancelledError — it is a BaseException, so the receiver's broad `except Exception`
+    does not swallow it and the loop unwinds instead of spinning on a dead mock.
+    """
+    remaining = list(frames)
+    out = []
+
+    async def recv():
+        if not remaining:
+            raise asyncio.CancelledError
+        return remaining.pop(0)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        async for item in s.receiver():
+            out.append(item)
+
+    try:
+        asyncio.run(asyncio.wait_for(go(), timeout=5))
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+    return out
+
+
+def test_receiver_yields_binary_audio_and_maps_end_to_the_eos_sentinel():
+    s = _synth()
+    out = _drain(
+        s,
+        [
+            b"\x01\x02",
+            b"\x03\x04",
+            json.dumps({"type": "end", "request_id": "r1", "session_id": "s1"}),
+        ],
+    )
+    assert out == [b"\x01\x02", b"\x03\x04", b"\x00"]
+
+
+def test_receiver_drops_in_flight_audio_after_a_clear():
+    # Maya sends no `end` for a cleared utterance and keeps delivering ~1s of frames.
+    s = _synth()
+    s._discard_audio = True
+    out = _drain(s, [b"stale", b"stale", json.dumps({"type": "end"})])
+    assert out == [b"\x00"]  # audio dropped, the terminal event still lands
+
+
+def test_cancelled_ends_the_discard_window_without_emitting_a_sentinel():
+    """A cleared turn terminates with `cancelled`, never `end`. handle_interruption() has
+    already abandoned it, so forwarding a sentinel would stamp end-of-stream on a turn the
+    pipeline dropped -- but it is the exact point in-flight audio stops arriving."""
+    s = _synth()
+    s._discard_audio = True
+    out = _drain(s, [b"stale", json.dumps({"type": "cancelled", "request_id": "r1"}), b"fresh"])
+    assert out == [b"fresh"]
+    assert s._discard_audio is False
+
+
+def test_end_event_clears_the_discard_flag():
+    s = _synth()
+    s._discard_audio = True
+    _drain(s, [json.dumps({"type": "end"})])
+    assert s._discard_audio is False
+
+
+def test_an_error_is_not_treated_as_a_terminator():
+    """An error rejects a single frame — a bad config, say — while the utterance it landed
+    beside still completes with its own `end` (verified on the wire: error at t=0.03s, then
+    7 audio frames and `end` at t=0.69s). Emitting a sentinel here would terminate that turn
+    twice and shift every later turn's audio onto the wrong meta_info."""
+    s = _synth()
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "error", "error": "invalid 'model'"}),
+            b"\x01\x02",
+            json.dumps({"type": "end"}),
+        ],
+    )
+    assert out == [b"\x01\x02", b"\x00"]  # exactly one terminator, from `end`
+    assert s.connection_error is None  # and the synthesizer stays alive
+
+
+def test_receiver_survives_an_unexpected_or_malformed_control_frame():
+    s = _synth()
+    out = _drain(s, ["not json at all", json.dumps({"type": "something_new"}), json.dumps({"type": "end"})])
+    assert out == [b"\x00"]
+    assert s.connection_error is None
+
+
+# ----------------------------------------------------------------------
+# Audio conversion
+# ----------------------------------------------------------------------
+
+
+def test_telephony_chunks_are_resampled_to_8k_and_mulaw_encoded():
+    s = _synth(use_mulaw=True)
+    out = s._process_audio_chunk(_pcm(1.0))
+    # 24k 16-bit in -> 8k 8-bit out: one sixth of the bytes, and decodable as mu-law.
+    assert len(out) == 8000
+    assert len(audioop.ulaw2lin(out, 2)) == 16000
+
+
+def test_web_chunks_pass_through_untouched_at_native_rate():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    chunk = _pcm(0.5)
+    assert s._process_audio_chunk(chunk) == chunk  # no resample, no encode
+
+
+def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
+    s = _synth()
+    assert s._process_audio_chunk(b"") is None
+    # An odd-length buffer can't be whole 16-bit samples; drop it instead of raising
+    # inside the audio path.
+    assert s._process_audio_chunk(b"\x01") is None
+
+
+def test_http_body_uses_the_same_conversion_and_guards_an_empty_response():
+    s = _synth(use_mulaw=True)
+    assert len(s._process_http_audio(_pcm(1.0))) == 8000
+    assert s._process_http_audio(None) == b"\x00"
+    assert s._get_http_audio_format() == "mulaw"
+
+
+# ----------------------------------------------------------------------
+# One-shot clips (prewarm / handoff)
+# ----------------------------------------------------------------------
+
+
+def test_telephony_one_shot_returns_native_mulaw_and_skips_the_transcode():
+    s = _synth(use_mulaw=True)
+    s._generate_http = AsyncMock(return_value=_pcm(1.0))
+    clip = asyncio.run(s.synthesize_telephony_clip("hi"))
+    assert len(clip) == 8000  # 1s of mu-law @8k, no pydub/ffmpeg involved
+
+
+def test_telephony_one_shot_defers_to_synthesize_on_non_telephony_configs():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    assert asyncio.run(s.synthesize_telephony_clip("hi")) is None
+
+
+def test_synthesize_wraps_pcm_in_wav_so_the_rate_is_self_describing():
+    """The handoff path calls audio_to_mulaw8k(rate_hint=getattr(synth, 'sampling_rate')).
+    Headerless 24 kHz PCM would be decoded at the hinted rate and play at a third speed,
+    so synthesize() carries a RIFF header and the hint stops mattering."""
+    from bolna.helpers.utils import audio_to_mulaw8k
+
+    s = _synth(use_mulaw=True)
+    s._generate_http = AsyncMock(return_value=_pcm(1.0))
+    out = asyncio.run(s.synthesize("hi"))
+    assert out[:4] == b"RIFF"
+
+    # One second in must stay one second out (8000 mu-law bytes) even with a wrong hint.
+    clip = audio_to_mulaw8k(out, rate_hint=8000, format_hint="")
+    assert len(clip) == 8000
+
+
+def test_one_shot_paths_return_none_when_the_api_returns_nothing():
+    s = _synth()
+    s._generate_http = AsyncMock(return_value=None)
+    assert asyncio.run(s.synthesize("hi")) is None
+    assert asyncio.run(s.synthesize_telephony_clip("hi")) is None
+
+
+# ----------------------------------------------------------------------
+# Interruption
+# ----------------------------------------------------------------------
+
+
+def test_interruption_sends_clear_and_starts_discarding():
+    s = _synth()
+    s.current_turn_start_time = 123.0
+    asyncio.run(s.handle_interruption())
+    assert s.sent == [{"type": "clear"}]
+    assert s._discard_audio is True
+    # The cleared turn's end-of-stream never arrives, so the next turn must be re-detected
+    # as new for stale text_queue entries to be pruned.
+    assert s.current_turn_start_time is None
+
+
+def test_interruption_on_a_dead_socket_is_a_no_op():
+    s = _synth()
+    s._is_ws_connected = MagicMock(return_value=False)
+    asyncio.run(s.handle_interruption())
+    assert s.sent == []
+
+
+# ----------------------------------------------------------------------
+# Connection / language switching
+# ----------------------------------------------------------------------
+
+
+def test_config_is_sent_before_establish_connection_returns():
+    """Reconnect safety: monitor_connection() only publishes self.websocket after this
+    method returns, so config sent here can never be raced by a text frame."""
+    s = _synth()
+    sent = []
+    ws = MagicMock()
+    ws.send = AsyncMock(side_effect=lambda p: sent.append(json.loads(p)))
+
+    async def fake_connect(*a, **kw):
+        return ws
+
+    import bolna.synthesizer.maya_synthesizer as mod
+
+    original = mod.websockets.connect
+    mod.websockets.connect = fake_connect
+    try:
+        result = asyncio.run(s.establish_connection())
+    finally:
+        mod.websockets.connect = original
+
+    assert result is ws
+    assert sent == [s._config_message()]
+    assert sent[0]["type"] == "config"
+
+
+def test_language_switch_resends_config_without_reconnecting():
+    s = _synth(language="en")
+    asyncio.run(s.set_target_language("ta"))
+    assert s.language == "ta"
+    assert s.sent == [{"type": "config", "voice": "Ananya", "model": "Maya 2 Native", "language": "ta"}]
+
+
+def test_language_switch_accepts_the_region_qualified_code_the_asr_reports():
+    # _maybe_update_tts_language passes detected_language_code straight through ("hi-IN").
+    s = _synth(language="en")
+    asyncio.run(s.set_target_language("hi-IN"))
+    assert s.language == "hi"
+    assert s.sent == [{"type": "config", "voice": "Ananya", "model": "Maya 2 Native", "language": "hi"}]
+
+
+def test_language_switch_is_a_no_op_when_the_code_only_differs_by_region():
+    s = _synth(language="hi")
+    asyncio.run(s.set_target_language("hi-IN"))
+    assert s.sent == []
+
+
+def test_unsupported_language_is_ignored_rather_than_breaking_the_call():
+    s = _synth(language="en")
+    asyncio.run(s.set_target_language("fr-FR"))
+    assert s.language == "en"
+    assert s.sent == []
+
+
+def test_switching_to_the_current_language_is_a_no_op():
+    s = _synth(language="hi")
+    asyncio.run(s.set_target_language("hi"))
+    assert s.sent == []


### PR DESCRIPTION
MayaSynthesizer adds Maya Research's Maya 2 Native as a TTS provider — eleven Indian languages including Indian English, with voices Ananya and Arjun, each covering all eleven. A conversation runs on one persistent WebSocket; a one-shot HTTP call covers prewarm clips.

- Sentence segmentation happens on Maya's side, so LLM fragments go out as they arrive with no client-side chunking
- Output is 24 kHz throughout — downsampled and mu-law encoded for telephony, left native for web
- ASR codes like `hi-IN` are trimmed to `hi`, which also lets language switch mid-call without reconnecting
- Interrupt sends a clear frame, then drops frames until `cancelled` lands
- A whitespace primer is added when the final push is empty, otherwise the flush returns nothing and the turn never closes
- Handoff and prewarm clips go over HTTP, with a direct mu-law path that skips the transcode
- Registered in enums, providers, models (MayaConfig) and README
- Unit tests included
