### PR TITLE
feat: speech-to-speech agents with OpenAI Realtime and Gemini Live

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.198"
+__version__ = "0.10.199"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -715,8 +715,8 @@ class TaskManager(BaseManager):
                 )
 
                 if self.__is_s2s():
-                    # The s2s result below asks for the goodbye, so telling the model to say
-                    # one before the call too produced two goodbyes on every hangup.
+                    # The end_call result asks for the goodbye, so asking for one here too
+                    # would have the model say it twice.
                     end_call_description = (
                         "End the current call. Do not say goodbye before calling this "
                         "function; you will be prompted to say it afterwards."
@@ -7196,9 +7196,8 @@ class TaskManager(BaseManager):
                     )
 
                     if self.__is_s2s():
-                        # The model owns the audio stream and there is no synthesizer to
-                        # render this. Pushing a packet through the path below left the
-                        # transcript claiming the agent spoke while the caller heard nothing.
+                        # The model owns the audio stream and there is no synthesizer to render
+                        # this, so the path below would log speech the caller never hears.
                         await self.tools["s2s"].trigger_response(
                             instructions=f"Say exactly this, and nothing else: {user_online_message}"
                         )
@@ -7479,9 +7478,8 @@ class TaskManager(BaseManager):
         try:
             await s2s.connect()
         except asyncio.CancelledError:
-            # CancelledError is a BaseException, so it skips the handler below and the one
-            # in run() swallows it. Without this line a call torn down mid-handshake ends
-            # with no error anywhere: no S2S start line, no exception, just a clean finish.
+            # CancelledError is a BaseException, so it skips the handler below and run()
+            # swallows it, leaving a call torn down mid-handshake with no error recorded.
             logger.error(
                 f"S2S connect cancelled after {round((time.time() - self._s2s_started_at) * 1000)}ms | "
                 f"provider={self.s2s_provider_name} model={self.s2s_model}"
@@ -7516,8 +7514,8 @@ class TaskManager(BaseManager):
                 welcome = ""
 
         if welcome:
-            # Gate clock starts with the greeting: measured connects run 400ms to 1600ms
-            # against a 1500ms gate, so timing it earlier spent the barge-in protection.
+            # Gate clock starts with the greeting: a connect can take longer than the gate
+            # itself, so timing it from before connect leaves no barge-in protection.
             self._s2s_started_at = time.time()
             self._s2s_welcome_sent = True
             await s2s.trigger_response(
@@ -7535,9 +7533,8 @@ class TaskManager(BaseManager):
             asyncio.create_task(self._s2s_event_loop()),
         ]
         try:
-            # Either loop finishing ends the call: the caller hung up, or the provider
-            # socket closed. Waiting on both would park here for the rest of the session:
-            # a provider that has stopped being spoken to sends nothing to wake its reader.
+            # Either loop finishing ends the call. Waiting on both would park here: a
+            # provider that has stopped being spoken to sends nothing to wake its reader.
             done, _ = await asyncio.wait(loops, return_when=asyncio.FIRST_COMPLETED)
             for task in done:
                 task.result()
@@ -7700,14 +7697,9 @@ class TaskManager(BaseManager):
                 if self._s2s_within_welcome_gate():
                     continue
                 # The provider reports every speech start here, so this is only a barge-in
-                # when the agent still had the floor.
-                #
-                # InterruptionManager is used for accounting only, never to veto: by the
-                # time this event arrives the provider's own VAD has already stopped
-                # generating, so nothing decided here can give the agent the floor back.
-                # Whether a cough counts as a barge-in is tuned at the provider instead,
-                # via semantic_vad eagerness on OpenAI and endOfSpeechSensitivity on Gemini,
-                # both of which classify better than a word count and a phrase list.
+                # when the agent still had the floor. InterruptionManager is accounting only:
+                # the provider's VAD has already stopped generating, so nothing decided here
+                # can give the agent the floor back. Barge-in sensitivity is tuned provider-side.
                 self.interruption_manager.on_user_speech_started()
                 if self._s2s_agent_has_floor():
                     logger.info("S2S: caller barged in, dropping queued audio")
@@ -7769,8 +7761,7 @@ class TaskManager(BaseManager):
             meta["message_category"] = "agent_hangup"
         elif self._s2s_turn_seq == 0 and self._s2s_welcome_sent:
             # The model speaks the greeting itself, so nothing else marks it. The output
-            # handlers stamp welcome_message_sent_ts off this, which is what
-            # time_to_first_audio reports.
+            # handlers stamp welcome_message_sent_ts off this, which time_to_first_audio reads.
             meta["message_category"] = "agent_welcome_message"
         meta.update(extra)
         return meta
@@ -7803,9 +7794,8 @@ class TaskManager(BaseManager):
             )
 
         if event.transcript or usage:
-            # A turn whose usage never arrived must stay distinguishable from one that
-            # genuinely spent nothing: passing zeros stamps it api_reported and billing
-            # then trusts a number the provider never sent.
+            # A turn whose usage never arrived must stay distinguishable from one that spent
+            # nothing: zeros would stamp it api_reported and billing would trust that.
             split = (usage or s2s_events.S2SUsage()).modality_split()
             convert_to_request_log(
                 event.transcript,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7870,7 +7870,9 @@ class TaskManager(BaseManager):
                     (
                         "transcriber_task",
                         TranscriberError,
-                        self.task_config.get("tools_config", {}).get("transcriber", {}).get("provider"),
+                        # An s2s task stores transcriber as an explicit None, so the key is
+                        # present and a default on .get() never fires.
+                        (self.task_config.get("tools_config", {}).get("transcriber") or {}).get("provider"),
                     ),
                 ]:
                     task = getattr(self, attr, None)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7411,6 +7411,8 @@ class TaskManager(BaseManager):
         self._s2s_pending_results = 0
         self._s2s_welcome_gate_ms = self.s2s.welcome_audio_gate_ms
         self._s2s_started_at = time.time()
+        self._s2s_agent_speaking = False
+        self._s2s_turn_seq = 0
 
         try:
             await s2s.connect()
@@ -7514,6 +7516,9 @@ class TaskManager(BaseManager):
                 break
 
             if isinstance(event, s2s_events.AudioDelta):
+                if not self._s2s_agent_speaking:
+                    self._s2s_agent_speaking = True
+                    self.interruption_manager.on_agent_speech_started(self._s2s_turn_seq)
                 await self.buffered_output_queue.put(
                     {"data": self._s2s_encode_output(event.data), "meta_info": self._s2s_meta()}
                 )
@@ -7529,6 +7534,7 @@ class TaskManager(BaseManager):
                     logger.info(f"S2S caller: {event.content[:200]}")
                     self.conversation_history.append_user(event.content)
                     self.time_since_last_spoken_human_word = time.time()
+                    self.interruption_manager.on_user_speech_ended()
 
             elif isinstance(event, s2s_events.FunctionCall):
                 task = asyncio.create_task(self._s2s_execute_tool(event))
@@ -7538,7 +7544,13 @@ class TaskManager(BaseManager):
             elif isinstance(event, s2s_events.Interrupted):
                 if self._s2s_within_welcome_gate():
                     continue
-                logger.info("S2S: caller barged in, dropping queued audio")
+                # The provider reports every speech start here, so this is only a barge-in
+                # when the agent actually had the floor.
+                self.interruption_manager.on_user_speech_started()
+                if self._s2s_agent_speaking:
+                    logger.info("S2S: caller barged in, dropping queued audio")
+                    self.interruption_manager.on_interruption_triggered()
+                    self._s2s_agent_speaking = False
                 await self._s2s_drop_queued_audio()
 
             elif isinstance(event, s2s_events.ResponseDone):
@@ -7602,6 +7614,11 @@ class TaskManager(BaseManager):
                 break
 
     async def _s2s_finish_turn(self, event):
+        if self._s2s_agent_speaking:
+            self.interruption_manager.on_agent_speech_ended()
+            self._s2s_agent_speaking = False
+        self._s2s_turn_seq += 1
+
         usage = event.usage
         if usage and self.task_id == 0 and self.on_turn_usage:
             task = asyncio.create_task(self.on_turn_usage(usage.input_tokens, usage.output_tokens, usage.cached_tokens))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7582,15 +7582,31 @@ class TaskManager(BaseManager):
             self._s2s_tool_tasks.add(task)
             task.add_done_callback(self._s2s_tool_tasks.discard)
 
-        if event.transcript:
+        usage = event.usage or {}
+        if event.transcript or usage:
             convert_to_request_log(
                 event.transcript,
-                {"request_id": self.task_id, "sequence_id": -1},
+                {
+                    "request_id": self.task_id,
+                    "sequence_id": -1,
+                    "s2s_usage": {
+                        key: usage.get(key, 0)
+                        for key in (
+                            "input_audio_tokens",
+                            "input_text_tokens",
+                            "output_audio_tokens",
+                            "output_text_tokens",
+                        )
+                    },
+                },
                 model=self.s2s_model,
                 component=LogComponent.S2S,
                 direction=LogDirection.RESPONSE,
                 is_cached=False,
                 run_id=self.run_id,
+                input_tokens=usage.get("input_tokens", 0),
+                output_tokens=usage.get("output_tokens", 0),
+                cached_tokens=usage.get("cached_tokens", 0),
             )
 
         # The end-of-stream sentinel makes the output handler emit its final mark, which is

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1306,7 +1306,12 @@ class TaskManager(BaseManager):
             tasks.append(self.tools["input"].handle())
 
             if not self.turn_based_conversation and not self.is_web_based_call:
-                tasks.append(self.__forced_first_message())
+                # An s2s model speaks its own greeting, so it takes the stream id but not
+                # the pre-rendered welcome audio it has no synthesizer to produce.
+                if self.__is_s2s():
+                    tasks.append(self._s2s_await_stream_sid())
+                else:
+                    tasks.append(self.__forced_first_message())
 
         if tasks:
             await asyncio.gather(*tasks)
@@ -1360,6 +1365,42 @@ class TaskManager(BaseManager):
             # masked the missing-freeswitch-handler case when a PyPI bolna shadowed the branch
             raise ValueError(f"Unsupported input provider: {self.task_config['tools_config']['input']['provider']}")
 
+    async def __await_stream_sid(self, timeout=10.0):
+        """Wait for the carrier's stream id and hand it to the output handler.
+
+        Nothing reaches the caller until the output handler holds this: it drops every
+        packet while stream_sid is None. Returns whether the id arrived in time.
+        """
+        # output_handler_set is not part of the wait: __setup_output_handlers runs in __init__,
+        # so it is already true by the time this task exists.
+        logger.info("Waiting for stream_sid before sending the welcome message")
+        try:
+            await asyncio.wait_for(self.tools["input"].stream_sid_ready.wait(), timeout)
+        except asyncio.TimeoutError:
+            logger.warning(f"Timeout reached while waiting for stream_sid after {timeout}s")
+            await self.__process_end_of_conversation()
+            return False
+
+        self.stream_sid_ts = time.time() * 1000
+        await self._report_stream_connect()
+        self.stream_sid = self.tools["input"].get_stream_sid()
+        await self.tools["output"].set_stream_sid(self.stream_sid)
+        return True
+
+    async def _s2s_await_stream_sid(self):
+        """Claim the stream id for an s2s call, which has no welcome audio to play.
+
+        The model speaks its own greeting, so the welcome path below is skipped — but it
+        was also the only thing propagating the stream id, and without it the output
+        handler silently discards the whole conversation.
+        """
+        try:
+            if await self.__await_stream_sid():
+                logger.info(f"Got stream sid for s2s conversation {self.stream_sid}")
+                self.tools["input"].is_welcome_message_played = True
+        except Exception as e:
+            logger.error(f"Exception in _s2s_await_stream_sid {str(e)}")
+
     async def __forced_first_message(self, timeout=10.0):
         logger.info(f"Executing the first message task")
         try:
@@ -1367,16 +1408,8 @@ class TaskManager(BaseManager):
             if delay_ms > 0:
                 logger.info(f"Welcome message delay set to {delay_ms} ms")
                 await asyncio.sleep(delay_ms / 1000)
-            # output_handler_set is not part of the wait: __setup_output_handlers runs in __init__,
-            # so it is already true by the time this task exists.
-            logger.info("Waiting for stream_sid before sending the welcome message")
-            try:
-                await asyncio.wait_for(self.tools["input"].stream_sid_ready.wait(), timeout)
-            except asyncio.TimeoutError:
-                logger.warning(f"Timeout reached while waiting for stream_sid after {timeout}s")
-                await self.__process_end_of_conversation()
+            if not await self.__await_stream_sid(timeout=timeout):
                 return
-            stream_sid = self.tools["input"].get_stream_sid()
 
             text = self.kwargs.get("agent_welcome_message", None)
             meta_info = {
@@ -1417,11 +1450,7 @@ class TaskManager(BaseManager):
             meta_info["is_final_chunk_of_entire_response"] = True
             message = create_ws_data_packet(audio_chunk, meta_info)
 
-            self.stream_sid_ts = time.time() * 1000
-            await self._report_stream_connect()
-            logger.info(f"Got stream sid and hence sending the first message {stream_sid}")
-            self.stream_sid = stream_sid
-            await self.tools["output"].set_stream_sid(stream_sid)
+            logger.info(f"Got stream sid and hence sending the first message {self.stream_sid}")
 
             if audio_chunk is None:
                 # No welcome message to play - mark as played immediately

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7147,8 +7147,7 @@ class TaskManager(BaseManager):
                     f"(audio_playing=False, no pending generation, response_in_pipeline={self.response_in_pipeline}) "
                     f"- forcing hangup"
                 )
-                self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
-                await self.process_call_hangup()
+                await self._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
                 break
 
             # Draining audio needs no term here: every branch below is gated on
@@ -7176,8 +7175,7 @@ class TaskManager(BaseManager):
                 logger.info(
                     f"{time_since_last_spoken_ai_word} seconds since AI last spoke and {time_since_user_last_spoke} seconds since user last spoke, both exceed {self.hang_conversation_after}s timeout - hanging up"
                 )
-                self.hangup_detail = HangupReason.INACTIVITY_TIMEOUT
-                await self.process_call_hangup()
+                await self._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
                 break
 
             elif (
@@ -7545,6 +7543,22 @@ class TaskManager(BaseManager):
             await asyncio.gather(*loops, return_exceptions=True)
             await s2s.disconnect()
         logger.info("S2S conversation completed")
+
+    async def _hangup_after_goodbye(self, reason) -> None:
+        """End the call, letting an s2s model speak the configured goodbye first.
+
+        process_call_hangup cannot do this itself: the post-response hangup it would arm
+        routes straight back into it, so the second entry hits the in-progress guard and
+        the call never ends. Arming it here lets the model finish the goodbye and the
+        ordinary end-of-turn path close the call exactly once.
+        """
+        self.hangup_detail = reason
+        message = self.call_hangup_message if not self.voicemail_handler.detected else ""
+        if self.__is_s2s() and message and message.strip():
+            self._s2s_hangup_after_response = True
+            await self.tools["s2s"].trigger_response(instructions=f"Say exactly this, and nothing else: {message}")
+            return
+        await self.process_call_hangup()
 
     def _s2s_track_task(self, task, call_id=None) -> None:
         """Hold a reference to a background task and surface its failure.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4102,16 +4102,15 @@ class TaskManager(BaseManager):
 
         self._hangup_processing = True
         self.hangup_triggered = True
-        message = self.call_hangup_message if not self.voicemail_handler.detected else ""
         if self.__is_s2s():
-            # The model already spoke the goodbye, prompted by the end_call result below,
-            # and there is no synthesizer to render one here. Queueing this would push a
-            # packet the caller never hears and leave the call waiting on its mark.
+            # The model has already spoken the goodbye by now, prompted by the end_call result
+            # or _hangup_after_goodbye, and there is no synthesizer to render one here anyway.
             self.hangup_message_queued = False
             self.hangup_triggered_at = time.time()
             await self.__process_end_of_conversation()
             return
 
+        message = self.call_hangup_message if not self.voicemail_handler.detected else ""
         if not message or message.strip() == "":
             self.hangup_message_queued = False  # No hangup message to wait for
             self.hangup_triggered_at = time.time()
@@ -7407,7 +7406,7 @@ class TaskManager(BaseManager):
         if self.turn_based_conversation or self.is_web_based_call:
             return None
         provider = self.task_config["tools_config"]["input"]["provider"]
-        return provider if provider in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS else None
+        return provider if provider in SUPPORTED_INPUT_TELEPHONY_HANDLERS else None
 
     def _s2s_is_carrier_leg(self):
         return self._s2s_telephony_provider() is not None
@@ -7944,8 +7943,10 @@ class TaskManager(BaseManager):
         await s2s.send_function_result(event.call_id, event.name, result)
         await s2s.commit_function_results()
         if ends_call:
-            # Armed only once the commit returns. commit waits on the tool-call turn's own
-            # response.done, so the next turn to complete is the goodbye, not this one.
+            # Armed only once the commit returns, so the next turn to complete is the goodbye.
+            # OpenAI guarantees that by awaiting the tool-call turn's response.done inside
+            # commit; Gemini sends its toolResponse and returns, so a turnComplete arriving
+            # between the two would hang up before the goodbye is spoken.
             self._s2s_hangup_after_response = True
 
     async def _s2s_before_tool_request(self, event, args, params, meta_info):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7941,8 +7941,7 @@ class TaskManager(BaseManager):
                         # Typed component errors were only ever written to the request log, so
                         # a failed provider connect left nothing in the app log to find.
                         logger.error(
-                            f"Component error | component={e.component} provider={e.provider} "
-                            f"model={e.model} error={e}"
+                            f"Component error | component={e.component} provider={e.provider} model={e.model} error={e}"
                         )
                     if self.run_id and not self._error_logged:
                         if isinstance(e, BolnaComponentError):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -56,6 +56,7 @@ from .base_manager import BaseManager
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
+from bolna.s2s import events as s2s_events
 from bolna.enums import (
     TelephonyProvider,
     LogComponent,
@@ -97,6 +98,7 @@ from bolna.helpers.utils import (
     process_task_cancellation,
     audio_to_mulaw8k,
     pcm_to_ulaw,
+    ulaw_to_pcm,
     format_error_message,
     enrich_context_with_time_variables,
 )
@@ -312,8 +314,11 @@ class TaskManager(BaseManager):
         if task["tools_config"].get("api_tools", None) is not None:
             self.kwargs["api_tools"] = task["tools_config"]["api_tools"]
 
+        # Speech-to-speech agents carry no llm_agent/transcriber/synthesizer at all.
+        self.s2s_config = task["tools_config"].get("s2s")
+
         if (
-            task["tools_config"]["llm_agent"]
+            task["tools_config"].get("llm_agent")
             and task["tools_config"]["llm_agent"]["llm_config"].get("assistant_id", None) is not None
         ):
             self.kwargs["assistant_id"] = task["tools_config"]["llm_agent"]["llm_config"]["assistant_id"]
@@ -790,10 +795,13 @@ class TaskManager(BaseManager):
                 self._speech_started_before_welcome = False
 
         # setting transcriber and synthesizer in parallel
-        self.__setup_transcriber()
-        self.__setup_synthesizer(self.llm_config)
-        if not self.turn_based_conversation and task_id == 0:
-            self.synthesizer_monitor_task = asyncio.create_task(self.tools["synthesizer"].monitor_connection())
+        if self.__is_s2s():
+            self.__setup_s2s()
+        else:
+            self.__setup_transcriber()
+            self.__setup_synthesizer(self.llm_config)
+            if not self.turn_based_conversation and task_id == 0:
+                self.synthesizer_monitor_task = asyncio.create_task(self.tools["synthesizer"].monitor_connection())
 
         # Language switching, gated per call by the LANGUAGE_SWITCH feature flag
         # (tools_config["llm_language_switch"], see __language_switch_enabled):
@@ -1138,17 +1146,20 @@ class TaskManager(BaseManager):
         agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
         return agent_type == "multiagent"
 
-    def __is_knowledgebase_agent(self):
+    def __agent_type(self):
+        """Configured llm_agent type, or None for webhook and speech-to-speech tasks."""
         if self.task_config["task_type"] == "webhook":
-            return False
-        agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
-        return agent_type == "knowledgebase_agent"
+            return None
+        return (self.task_config["tools_config"].get("llm_agent") or {}).get("agent_type", None)
+
+    def __is_knowledgebase_agent(self):
+        return self.__agent_type() == "knowledgebase_agent"
 
     def __is_graph_agent(self):
-        if self.task_config["task_type"] == "webhook":
-            return False
-        agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
-        return agent_type == "graph_agent"
+        return self.__agent_type() == "graph_agent"
+
+    def __is_s2s(self):
+        return bool(self.s2s_config) and self._is_conversation_task()
 
     # def __is_knowledge_agent(self):
     #     if self.task_config["task_type"] == "webhook":
@@ -1844,6 +1855,19 @@ class TaskManager(BaseManager):
         else:
             raise f"{agent_type} Agent type is not created yet"
         return llm_agent
+
+    def __setup_s2s(self):
+        """Validate the S2S config. The provider itself is built once prompts are loaded."""
+        provider = (self.s2s_config or {}).get("provider")
+        if provider not in SUPPORTED_S2S_PROVIDERS:
+            raise ValueError(f"Unsupported S2S provider '{provider}'. Supported: {list(SUPPORTED_S2S_PROVIDERS)}")
+        self.s2s_provider_name = provider
+        self.s2s_provider_config = dict(self.s2s_config.get("provider_config") or {})
+        self.s2s_model = self.s2s_provider_config.get("model")
+        # A goodbye message would need TTS, which an S2S agent has no synthesizer for.
+        # The model speaks its own goodbye before end_call instead.
+        self.call_hangup_message_config = None
+        logger.info(f"S2S agent configured | provider={provider} model={self.s2s_model}")
 
     def __setup_tasks(self, llm=None, agent_type=None, assistant_config=None):
         if self.task_config["task_type"] == "conversation" and not self.__is_multiagent():
@@ -3159,212 +3183,8 @@ class TaskManager(BaseManager):
                     meta_info,
                     tool_conf.get("pre_call_webhook_param"),
                 )
-            await asyncio.sleep(2)
-            try:
-                from_number = self.context_data["recipient_data"]["from_number"]
-            except Exception as e:
-                from_number = None
-
-            call_sid = None
-            call_transfer_number = None
-            payload = {
-                "call_sid": call_sid,
-                "provider": self.tools["input"].io_provider,
-                "stream_sid": self.stream_sid,
-                "from_number": from_number,
-                "execution_id": self.run_id,
-                **(self.transfer_call_params or {}),
-            }
-
-            if self.tools["input"].io_provider != "default":
-                call_sid = self.tools["input"].get_call_sid()
-                payload["call_sid"] = call_sid
-
-            if url is None:
-                url = os.getenv("CALL_TRANSFER_WEBHOOK_URL")
-
-                try:
-                    json_function_call_params = copy.deepcopy(param)
-                    if isinstance(param, str):
-                        json_function_call_params = json.loads(param)
-                    call_transfer_number = json_function_call_params["call_transfer_number"]
-                    if call_transfer_number:
-                        payload["call_transfer_number"] = call_transfer_number
-                except Exception as e:
-                    logger.error(f"Error in __execute_function_call {e}")
-
-            if param is not None:
-                logger.info(f"Gotten response {resp}")
-                payload = {**payload, **resp}
-
-            if self.tools["input"].io_provider != "default":
-                payload["call_sid"] = self.tools["input"].get_call_sid()
-
-            self.transfer_call_events.append(
-                {
-                    "type": "transfer_start",
-                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                    "tool_name": called_fun,
-                    "tool_call_id": resp.get("tool_call_id", ""),
-                    "turn_id": meta_info.get("turn_id"),
-                    "sequence_id": meta_info.get("sequence_id"),
-                    "transfer_number": payload.get("call_transfer_number"),
-                    "provider": self.tools["input"].io_provider,
-                }
-            )
-
-            if self.tools["input"].io_provider == "default":
-                mock_response = (
-                    f"This is a mocked response demonstrating a successful transfer of call to {call_transfer_number}"
-                )
-                function_call_log = self._start_api_call_detail(
-                    called_fun=called_fun,
-                    url=url,
-                    method="POST",
-                    param=param,
-                    headers={"Content-Type": "application/json"},
-                    meta_info=meta_info,
-                    runtime_args={
-                        **self._extract_api_call_runtime_args(resp),
-                        "tool_call_id": resp.get("tool_call_id", ""),
-                    },
-                    request_body=payload,
-                    api_params=payload,
-                )
-                convert_to_request_log(
-                    str(payload),
-                    meta_info,
-                    None,
-                    LogComponent.FUNCTION_CALL,
-                    direction=LogDirection.REQUEST,
-                    run_id=self.run_id,
-                )
-                convert_to_request_log(
-                    mock_response,
-                    meta_info,
-                    None,
-                    LogComponent.FUNCTION_CALL,
-                    direction=LogDirection.RESPONSE,
-                    run_id=self.run_id,
-                )
-                self._finalize_api_call_detail(
-                    function_call_log, response=mock_response, status_code=200, content_type="text/plain"
-                )
-                self.transfer_call_events.append(
-                    {
-                        "type": "transfer_end",
-                        "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                        "tool_call_id": resp.get("tool_call_id", ""),
-                        "turn_id": meta_info.get("turn_id"),
-                        "sequence_id": meta_info.get("sequence_id"),
-                        "status_code": 200,
-                        "latency_ms": function_call_log.get("latency_ms"),
-                        "success": True,
-                    }
-                )
-
-                bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
-                await self.tools["output"].handle(bos_packet)
-                await self.tools["output"].handle(create_ws_data_packet(mock_response, meta_info))
-                eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
-                await self.tools["output"].handle(eos_packet)
-                return
-
-            async with aiohttp.ClientSession() as session:
-                logger.info(f"Sending the payload to stop the conversation {payload} url {url}")
-                while self.tools["input"].is_audio_being_played_to_user():
-                    await asyncio.sleep(1)
-                function_call_log = self._start_api_call_detail(
-                    called_fun=called_fun,
-                    url=url,
-                    method="POST",
-                    param=param,
-                    headers={"Content-Type": "application/json"},
-                    meta_info=meta_info,
-                    runtime_args={
-                        **self._extract_api_call_runtime_args(resp),
-                        "tool_call_id": resp.get("tool_call_id", ""),
-                    },
-                    request_body=payload,
-                    api_params=payload,
-                )
-                convert_to_request_log(
-                    str(payload),
-                    meta_info,
-                    None,
-                    LogComponent.FUNCTION_CALL,
-                    direction=LogDirection.REQUEST,
-                    is_cached=False,
-                    run_id=self.run_id,
-                )
-                _transfer_end_recorded = False
-                try:
-                    async with session.post(url, json=payload) as response:
-                        response_text = await response.text()
-                        logger.info(f"Response from the server after call transfer: {response_text}")
-                        convert_to_request_log(
-                            str(response_text),
-                            meta_info,
-                            None,
-                            LogComponent.FUNCTION_CALL,
-                            direction=LogDirection.RESPONSE,
-                            is_cached=False,
-                            run_id=self.run_id,
-                        )
-                        self._finalize_api_call_detail(
-                            function_call_log,
-                            response=response_text,
-                            status_code=response.status,
-                            content_type=response.headers.get("Content-Type"),
-                        )
-                        self.transfer_call_events.append(
-                            {
-                                "type": "transfer_end",
-                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                                "tool_call_id": resp.get("tool_call_id", ""),
-                                "turn_id": meta_info.get("turn_id"),
-                                "sequence_id": meta_info.get("sequence_id"),
-                                "status_code": response.status,
-                                "latency_ms": function_call_log.get("latency_ms"),
-                                "success": response.status < 400,
-                            }
-                        )
-                        _transfer_end_recorded = True
-                except Exception as transfer_exc:
-                    logger.warning(f"Transfer webhook did not respond (call likely redirected): {transfer_exc}")
-                    self._finalize_api_call_detail(function_call_log, error=transfer_exc)
-                    self.transfer_call_events.append(
-                        {
-                            "type": "transfer_end",
-                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                            "tool_call_id": resp.get("tool_call_id", ""),
-                            "turn_id": meta_info.get("turn_id"),
-                            "sequence_id": meta_info.get("sequence_id"),
-                            "status_code": None,
-                            "latency_ms": function_call_log.get("latency_ms"),
-                            "success": None,
-                        }
-                    )
-                    _transfer_end_recorded = True
-                finally:
-                    # CancelledError (BaseException) bypasses except — ensure transfer_end is
-                    # always recorded so it appears in progression_data even if the task is
-                    # cancelled mid-flight when Plivo terminates the call.
-                    if not _transfer_end_recorded:
-                        self._finalize_api_call_detail(function_call_log, error="cancelled")
-                        self.transfer_call_events.append(
-                            {
-                                "type": "transfer_end",
-                                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
-                                "tool_call_id": resp.get("tool_call_id", ""),
-                                "turn_id": meta_info.get("turn_id"),
-                                "sequence_id": meta_info.get("sequence_id"),
-                                "status_code": None,
-                                "latency_ms": function_call_log.get("latency_ms"),
-                                "success": None,
-                            }
-                        )
-                return
+            await self._execute_transfer_call_webhook(called_fun, url, param, resp, meta_info)
+            return
 
         # switch_language tool handler (injected in BOTH flows): waits for in-flight
         if called_fun == "switch_language":
@@ -4253,6 +4073,219 @@ class TaskManager(BaseManager):
             # Stamp after goodbye is queued — actual disconnect happens after it plays
             self.hangup_triggered_at = time.time()
         return
+
+    async def _execute_transfer_call_webhook(self, called_fun, url, param, resp, meta_info):
+        """POST the transfer payload to the telephony webhook and record transfer_start/end.
+
+        Split out of __execute_function_call so the speech-to-speech path can hand off a call
+        without duplicating the payload, mock-provider and event-recording behaviour.
+        """
+        await asyncio.sleep(2)
+        try:
+            from_number = self.context_data["recipient_data"]["from_number"]
+        except Exception as e:
+            from_number = None
+
+        call_sid = None
+        call_transfer_number = None
+        payload = {
+            "call_sid": call_sid,
+            "provider": self.tools["input"].io_provider,
+            "stream_sid": self.stream_sid,
+            "from_number": from_number,
+            "execution_id": self.run_id,
+            **(self.transfer_call_params or {}),
+        }
+
+        if self.tools["input"].io_provider != "default":
+            call_sid = self.tools["input"].get_call_sid()
+            payload["call_sid"] = call_sid
+
+        if url is None:
+            url = os.getenv("CALL_TRANSFER_WEBHOOK_URL")
+
+            try:
+                json_function_call_params = copy.deepcopy(param)
+                if isinstance(param, str):
+                    json_function_call_params = json.loads(param)
+                call_transfer_number = json_function_call_params["call_transfer_number"]
+                if call_transfer_number:
+                    payload["call_transfer_number"] = call_transfer_number
+            except Exception as e:
+                logger.error(f"Error in __execute_function_call {e}")
+
+        if param is not None:
+            logger.info(f"Gotten response {resp}")
+            payload = {**payload, **resp}
+
+        if self.tools["input"].io_provider != "default":
+            payload["call_sid"] = self.tools["input"].get_call_sid()
+
+        self.transfer_call_events.append(
+            {
+                "type": "transfer_start",
+                "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                "tool_name": called_fun,
+                "tool_call_id": resp.get("tool_call_id", ""),
+                "turn_id": meta_info.get("turn_id"),
+                "sequence_id": meta_info.get("sequence_id"),
+                "transfer_number": payload.get("call_transfer_number"),
+                "provider": self.tools["input"].io_provider,
+            }
+        )
+
+        if self.tools["input"].io_provider == "default":
+            mock_response = (
+                f"This is a mocked response demonstrating a successful transfer of call to {call_transfer_number}"
+            )
+            function_call_log = self._start_api_call_detail(
+                called_fun=called_fun,
+                url=url,
+                method="POST",
+                param=param,
+                headers={"Content-Type": "application/json"},
+                meta_info=meta_info,
+                runtime_args={
+                    **self._extract_api_call_runtime_args(resp),
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                },
+                request_body=payload,
+                api_params=payload,
+            )
+            convert_to_request_log(
+                str(payload),
+                meta_info,
+                None,
+                LogComponent.FUNCTION_CALL,
+                direction=LogDirection.REQUEST,
+                run_id=self.run_id,
+            )
+            convert_to_request_log(
+                mock_response,
+                meta_info,
+                None,
+                LogComponent.FUNCTION_CALL,
+                direction=LogDirection.RESPONSE,
+                run_id=self.run_id,
+            )
+            self._finalize_api_call_detail(
+                function_call_log, response=mock_response, status_code=200, content_type="text/plain"
+            )
+            self.transfer_call_events.append(
+                {
+                    "type": "transfer_end",
+                    "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                    "turn_id": meta_info.get("turn_id"),
+                    "sequence_id": meta_info.get("sequence_id"),
+                    "status_code": 200,
+                    "latency_ms": function_call_log.get("latency_ms"),
+                    "success": True,
+                }
+            )
+
+            bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
+            await self.tools["output"].handle(bos_packet)
+            await self.tools["output"].handle(create_ws_data_packet(mock_response, meta_info))
+            eos_packet = create_ws_data_packet("<end_of_stream>", meta_info)
+            await self.tools["output"].handle(eos_packet)
+            return
+
+        async with aiohttp.ClientSession() as session:
+            logger.info(f"Sending the payload to stop the conversation {payload} url {url}")
+            while self.tools["input"].is_audio_being_played_to_user():
+                await asyncio.sleep(1)
+            function_call_log = self._start_api_call_detail(
+                called_fun=called_fun,
+                url=url,
+                method="POST",
+                param=param,
+                headers={"Content-Type": "application/json"},
+                meta_info=meta_info,
+                runtime_args={
+                    **self._extract_api_call_runtime_args(resp),
+                    "tool_call_id": resp.get("tool_call_id", ""),
+                },
+                request_body=payload,
+                api_params=payload,
+            )
+            convert_to_request_log(
+                str(payload),
+                meta_info,
+                None,
+                LogComponent.FUNCTION_CALL,
+                direction=LogDirection.REQUEST,
+                is_cached=False,
+                run_id=self.run_id,
+            )
+            _transfer_end_recorded = False
+            try:
+                async with session.post(url, json=payload) as response:
+                    response_text = await response.text()
+                    logger.info(f"Response from the server after call transfer: {response_text}")
+                    convert_to_request_log(
+                        str(response_text),
+                        meta_info,
+                        None,
+                        LogComponent.FUNCTION_CALL,
+                        direction=LogDirection.RESPONSE,
+                        is_cached=False,
+                        run_id=self.run_id,
+                    )
+                    self._finalize_api_call_detail(
+                        function_call_log,
+                        response=response_text,
+                        status_code=response.status,
+                        content_type=response.headers.get("Content-Type"),
+                    )
+                    self.transfer_call_events.append(
+                        {
+                            "type": "transfer_end",
+                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                            "tool_call_id": resp.get("tool_call_id", ""),
+                            "turn_id": meta_info.get("turn_id"),
+                            "sequence_id": meta_info.get("sequence_id"),
+                            "status_code": response.status,
+                            "latency_ms": function_call_log.get("latency_ms"),
+                            "success": response.status < 400,
+                        }
+                    )
+                    _transfer_end_recorded = True
+            except Exception as transfer_exc:
+                logger.warning(f"Transfer webhook did not respond (call likely redirected): {transfer_exc}")
+                self._finalize_api_call_detail(function_call_log, error=transfer_exc)
+                self.transfer_call_events.append(
+                    {
+                        "type": "transfer_end",
+                        "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                        "tool_call_id": resp.get("tool_call_id", ""),
+                        "turn_id": meta_info.get("turn_id"),
+                        "sequence_id": meta_info.get("sequence_id"),
+                        "status_code": None,
+                        "latency_ms": function_call_log.get("latency_ms"),
+                        "success": None,
+                    }
+                )
+                _transfer_end_recorded = True
+            finally:
+                # CancelledError (BaseException) bypasses except — ensure transfer_end is
+                # always recorded so it appears in progression_data even if the task is
+                # cancelled mid-flight when Plivo terminates the call.
+                if not _transfer_end_recorded:
+                    self._finalize_api_call_detail(function_call_log, error="cancelled")
+                    self.transfer_call_events.append(
+                        {
+                            "type": "transfer_end",
+                            "ts_ms": round(time.time() * 1000 - self.conversation_start_init_ts, 2),
+                            "tool_call_id": resp.get("tool_call_id", ""),
+                            "turn_id": meta_info.get("turn_id"),
+                            "sequence_id": meta_info.get("sequence_id"),
+                            "status_code": None,
+                            "latency_ms": function_call_log.get("latency_ms"),
+                            "success": None,
+                        }
+                    )
+            return
 
     async def _listen_llm_input_queue(self):
         logger.info(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -40,6 +40,8 @@ from bolna.constants import (
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
     RESPONSES_API_MODEL_PREFIXES,
+    S2S_GOODBYE_TIMEOUT_S,
+    S2S_STREAM_SID_TIMEOUT_S,
     STALL_HANGUP_FLOOR_S,
     STUCK_AUDIO_GATE_RELEASE_S,
     WEB_BASED_CALL_PROVIDER,
@@ -781,8 +783,8 @@ class TaskManager(BaseManager):
                     minimum_wait_duration=self.minimum_wait_duration,
                 )
 
-                # Backchanneling
-                self.should_backchannel = self.conversation_config.get("backchanneling", False)
+                # Backchanneling presets are keyed on a synthesizer voice, which s2s has none of.
+                self.should_backchannel = self.conversation_config.get("backchanneling", False) and not self.__is_s2s()
                 self.backchanneling_task = None
                 self.backchanneling_start_delay = self.conversation_config.get("backchanneling_start_delay", 5)
                 self.backchanneling_message_gap = self.conversation_config.get(
@@ -1398,6 +1400,7 @@ class TaskManager(BaseManager):
             if await self.__await_stream_sid():
                 logger.info(f"Got stream sid for s2s conversation {self.stream_sid}")
                 self.tools["input"].is_welcome_message_played = True
+                self._s2s_stream_ready.set()
         except Exception as e:
             logger.error(f"Exception in _s2s_await_stream_sid {str(e)}")
 
@@ -1913,9 +1916,8 @@ class TaskManager(BaseManager):
         self.s2s = S2SConfig(**self.s2s_config)
         self.s2s_provider_name = self.s2s.provider
         self.s2s_model = self.s2s.provider_config.model
-        # A goodbye message would need TTS, which an S2S agent has no synthesizer for.
-        # The model speaks its own goodbye before end_call instead.
-        self.call_hangup_message_config = None
+        # Not in _run_s2s_conversation: message_task_new sets this and is scheduled first.
+        self._s2s_stream_ready = asyncio.Event()
         logger.info(f"S2S agent configured | provider={self.s2s_provider_name} model={self.s2s_model}")
 
     def __setup_tasks(self, llm=None, agent_type=None, assistant_config=None):
@@ -7502,13 +7504,20 @@ class TaskManager(BaseManager):
             f"model_in={s2s.input_sample_rate} model_out={s2s.output_sample_rate}"
         )
 
-        # Restart the gate clock now the handshake is done. Measured connects run 400ms to
-        # 1600ms against a 1500ms gate, so timing it from before connect left the welcome
-        # message with most of its barge-in protection already spent.
-        self._s2s_started_at = time.time()
-
         welcome = (self.kwargs.get("agent_welcome_message") or "").strip()
+        if welcome and not self.turn_based_conversation and not self.is_web_based_call:
+            # The output handler drops every packet until it holds the stream id, so a
+            # greeting sent before that loses its opening words.
+            try:
+                await asyncio.wait_for(self._s2s_stream_ready.wait(), timeout=S2S_STREAM_SID_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning("S2S: no stream_sid before the greeting, skipping it")
+                welcome = ""
+
         if welcome:
+            # Gate clock starts with the greeting: measured connects run 400ms to 1600ms
+            # against a 1500ms gate, so timing it earlier spent the barge-in protection.
+            self._s2s_started_at = time.time()
             await s2s.trigger_response(
                 instructions=f"Open the conversation by saying exactly this, and nothing else: {welcome}"
             )
@@ -7557,8 +7566,18 @@ class TaskManager(BaseManager):
         if self.__is_s2s() and message and message.strip():
             self._s2s_hangup_after_response = True
             await self.tools["s2s"].trigger_response(instructions=f"Say exactly this, and nothing else: {message}")
+            # Our caller stops watching the call once this returns.
+            self._s2s_track_task(asyncio.create_task(self._s2s_hangup_if_goodbye_never_comes()))
             return
         await self.process_call_hangup()
+
+    async def _s2s_hangup_if_goodbye_never_comes(self) -> None:
+        """Close the call if the armed goodbye never arrives."""
+        await asyncio.sleep(S2S_GOODBYE_TIMEOUT_S)
+        if self._s2s_hangup_after_response and not self.conversation_ended:
+            logger.warning(f"S2S goodbye not delivered in {S2S_GOODBYE_TIMEOUT_S}s, hanging up without it")
+            self._s2s_hangup_after_response = False
+            await self.process_call_hangup()
 
     def _s2s_track_task(self, task, call_id=None) -> None:
         """Hold a reference to a background task and surface its failure.
@@ -7621,6 +7640,11 @@ class TaskManager(BaseManager):
 
             # The agent's own greeting would otherwise echo back and trip the provider's VAD.
             if self._s2s_within_welcome_gate():
+                discarded += 1
+                continue
+
+            # Same gate the transcriber path uses: no answering over a handed-off call.
+            if self._should_ignore_transcriber_input():
                 discarded += 1
                 continue
 
@@ -7803,17 +7827,19 @@ class TaskManager(BaseManager):
 
         if self._s2s_hangup_after_response:
             self._s2s_hangup_after_response = False
-            self.hangup_detail = HangupReason.END_CALL_TOOL
+            # _hangup_after_goodbye already stamped its own reason before arming this.
+            if self.hangup_detail is None:
+                self.hangup_detail = HangupReason.END_CALL_TOOL
             await self.process_call_hangup()
 
     async def _s2s_output_loop(self):
-        try:
-            while not self.conversation_ended:
-                try:
-                    message = await asyncio.wait_for(self.buffered_output_queue.get(), timeout=1.0)
-                except asyncio.TimeoutError:
-                    continue
+        while not self.conversation_ended:
+            try:
+                message = await asyncio.wait_for(self.buffered_output_queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
 
+            try:
                 self.tools["input"].update_is_audio_being_played(True)
                 await self.tools["output"].handle(message)
 
@@ -7829,10 +7855,9 @@ class TaskManager(BaseManager):
                             ),
                         }
                     )
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            logger.error(f"S2S output loop error: {e}")
+            except Exception as e:
+                # Nothing re-creates this task, so exiting leaves the caller in silence.
+                logger.error(f"S2S output loop error, dropped one packet: {e}")
 
     async def _s2s_dtmf_loop(self):
         """Forward carrier keypad digits to the model as text; no provider sees our media leg."""

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7615,6 +7615,11 @@ class TaskManager(BaseManager):
         }
         if self._s2s_hangup_after_response:
             meta["message_category"] = "agent_hangup"
+        elif self._s2s_turn_seq == 0:
+            # The model speaks the greeting itself, so nothing else marks it. The output
+            # handlers stamp welcome_message_sent_ts off this, which is what
+            # time_to_first_audio reports.
+            meta["message_category"] = "agent_welcome_message"
         meta.update(extra)
         return meta
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7470,6 +7470,7 @@ class TaskManager(BaseManager):
         self._s2s_hangup_after_response = False
         self._s2s_pending_results = 0
         self._s2s_welcome_gate_ms = self.s2s.welcome_audio_gate_ms
+        self._s2s_welcome_sent = False
         self._s2s_started_at = time.time()
         self._s2s_agent_speaking = False
         self._s2s_turn_seq = 0
@@ -7495,6 +7496,7 @@ class TaskManager(BaseManager):
             await self._report_provider_health(
                 "s2s", self.s2s_provider_name, self.s2s_model, False, phase="connect", blocking=True
             )
+            self.hangup_detail = HangupReason.S2S_ERROR
             raise LLMError(str(e), provider=self.s2s_provider_name, model=self.s2s_model)
 
         logger.info(
@@ -7518,6 +7520,7 @@ class TaskManager(BaseManager):
             # Gate clock starts with the greeting: measured connects run 400ms to 1600ms
             # against a 1500ms gate, so timing it earlier spent the barge-in protection.
             self._s2s_started_at = time.time()
+            self._s2s_welcome_sent = True
             await s2s.trigger_response(
                 instructions=f"Open the conversation by saying exactly this, and nothing else: {welcome}"
             )
@@ -7616,7 +7619,8 @@ class TaskManager(BaseManager):
         return time.time() < self._s2s_playout_until
 
     def _s2s_within_welcome_gate(self):
-        return (time.time() - self._s2s_started_at) * 1000 < self._s2s_welcome_gate_ms
+        # No greeting means no echo of one to guard against, so the caller is never gated.
+        return self._s2s_welcome_sent and (time.time() - self._s2s_started_at) * 1000 < self._s2s_welcome_gate_ms
 
     async def _s2s_audio_ingest_loop(self):
         """Caller audio to the model, resampled to whatever rate the provider declares."""
@@ -7744,6 +7748,7 @@ class TaskManager(BaseManager):
                     await self._report_provider_health(
                         "s2s", self.s2s_provider_name, self.s2s_model, False, blocking=True
                     )
+                    self.hangup_detail = HangupReason.S2S_ERROR
                     raise LLMError(event.message, provider=self.s2s_provider_name, model=self.s2s_model)
 
     def _s2s_encode_output(self, pcm):
@@ -7763,7 +7768,7 @@ class TaskManager(BaseManager):
         }
         if self._s2s_hangup_after_response:
             meta["message_category"] = "agent_hangup"
-        elif self._s2s_turn_seq == 0:
+        elif self._s2s_turn_seq == 0 and self._s2s_welcome_sent:
             # The model speaks the greeting itself, so nothing else marks it. The output
             # handlers stamp welcome_message_sent_ts off this, which is what
             # time_to_first_audio reports.
@@ -7915,6 +7920,7 @@ class TaskManager(BaseManager):
                 result = json.dumps({"status": "success", "message": "Transfer already in progress; wait silently."})
             else:
                 self.has_transfer = True
+                await self._s2s_before_tool_request(event, args, params, meta_info)
                 # param is the configured tool body, which is where call_transfer_number
                 # lives; the model's own arguments go in as the response, same as the llm
                 # path. Passing the arguments as both leaves the webhook no destination.
@@ -7923,11 +7929,7 @@ class TaskManager(BaseManager):
                 )
                 result = json.dumps({"status": "success", "message": "Transfer initiated; wait silently."})
         else:
-            # Without this the caller hears dead air for as long as the endpoint takes, and
-            # the are-you-still-there watchdog fires into the gap.
-            filler = compute_function_pre_call_message(self.language, event.name, params.get("pre_call_message"))
-            if filler:
-                await s2s.trigger_response(instructions=f"Say exactly this, and nothing else: {filler}")
+            await self._s2s_before_tool_request(event, args, params, meta_info)
             result = await self._s2s_call_api_tool(event, args, params, meta_info)
 
         convert_to_request_log(
@@ -7945,6 +7947,17 @@ class TaskManager(BaseManager):
             # Armed only once the commit returns. commit waits on the tool-call turn's own
             # response.done, so the next turn to complete is the goodbye, not this one.
             self._s2s_hangup_after_response = True
+
+    async def _s2s_before_tool_request(self, event, args, params, meta_info):
+        """Pre-call webhook and filler, the same two things the llm path does before a tool."""
+        webhook_url = params.get("pre_call_webhook_url")
+        if webhook_url:
+            self.fire_pre_call_webhook(webhook_url, event.name, args, meta_info, params.get("pre_call_webhook_param"))
+        # Without this the caller hears dead air for as long as the tool takes, and the
+        # are-you-still-there watchdog fires into the gap.
+        filler = compute_function_pre_call_message(self.language, event.name, params.get("pre_call_message"))
+        if filler:
+            await self.tools["s2s"].trigger_response(instructions=f"Say exactly this, and nothing else: {filler}")
 
     async def _s2s_call_api_tool(self, event, args, params, meta_info):
         url = params.get("url")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7125,8 +7125,12 @@ class TaskManager(BaseManager):
             # window as busy so we don't synthesize "are you still there" over the
             # upcoming follow-up response. hang_conversation_after intentionally remains
             # ungated so a truly hung task still triggers the inactivity hangup.
-            has_pending_generation = (self.llm_task is not None and not self.llm_task.done()) or (
-                self.execute_function_call_task is not None and not self.execute_function_call_task.done()
+            has_pending_generation = (
+                (self.llm_task is not None and not self.llm_task.done())
+                or (self.execute_function_call_task is not None and not self.execute_function_call_task.done())
+                # An s2s tool call lives here instead, and outlasting the floor would otherwise
+                # read as no forward progress and hang up mid-tool.
+                or any(not task.done() for task in getattr(self, "_s2s_tool_tasks", ()))
             )
 
             time_since_last_spoken_ai_word = time.time() - self.compute_last_ai_audio_timestamp()
@@ -7688,6 +7692,9 @@ class TaskManager(BaseManager):
                     logger.info(f"S2S caller: {event.content[:200]}")
                     self.conversation_history.append_user(event.content)
                     self.time_since_last_spoken_human_word = time.time()
+                    # Cleared here rather than in the output loop: the prompt's audio is not
+                    # distinguishable from any other turn, but the caller answering is.
+                    self.asked_if_user_is_still_there = False
                     self.interruption_manager.on_user_speech_ended()
 
             elif isinstance(event, s2s_events.FunctionCall):
@@ -7938,6 +7945,7 @@ class TaskManager(BaseManager):
             # commit; Gemini sends its toolResponse and returns, so a turnComplete arriving
             # between the two would hang up before the goodbye is spoken.
             self._s2s_hangup_after_response = True
+            self._s2s_track_task(asyncio.create_task(self._s2s_hangup_if_goodbye_never_comes()))
 
     async def _s2s_before_tool_request(self, event, args, params, meta_info):
         """Pre-call webhook and filler, the same two things the llm path does before a tool."""

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -105,6 +105,7 @@ from bolna.helpers.utils import (
 from bolna.helpers.logger_config import configure_logger
 from ..helpers.mark_event_meta_data import MarkEventMetaData
 from ..helpers.observable_variable import ObservableVariable
+from bolna.models import S2SConfig
 from .models import ComponentLatencies
 from .voicemail_handler import VoicemailHandler
 
@@ -1863,16 +1864,13 @@ class TaskManager(BaseManager):
 
     def __setup_s2s(self):
         """Validate the S2S config. The provider itself is built once prompts are loaded."""
-        provider = (self.s2s_config or {}).get("provider")
-        if provider not in SUPPORTED_S2S_PROVIDERS:
-            raise ValueError(f"Unsupported S2S provider '{provider}'. Supported: {list(SUPPORTED_S2S_PROVIDERS)}")
-        self.s2s_provider_name = provider
-        self.s2s_provider_config = dict(self.s2s_config.get("provider_config") or {})
-        self.s2s_model = self.s2s_provider_config.get("model")
+        self.s2s = S2SConfig(**self.s2s_config)
+        self.s2s_provider_name = self.s2s.provider
+        self.s2s_model = self.s2s.provider_config.model
         # A goodbye message would need TTS, which an S2S agent has no synthesizer for.
         # The model speaks its own goodbye before end_call instead.
         self.call_hangup_message_config = None
-        logger.info(f"S2S agent configured | provider={provider} model={self.s2s_model}")
+        logger.info(f"S2S agent configured | provider={self.s2s_provider_name} model={self.s2s_model}")
 
     def __setup_tasks(self, llm=None, agent_type=None, assistant_config=None):
         if self.task_config["task_type"] == "conversation" and not self.__is_multiagent():
@@ -7346,23 +7344,25 @@ class TaskManager(BaseManager):
         return self.task_config["tools_config"]["input"]["provider"] in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
 
     def _s2s_input_format(self):
-        """(encoding, sample_rate) of the caller audio arriving on audio_queue.
+        """Format of the caller audio arriving on audio_queue.
 
         Mirrors what the transcriber path selects, so a config that works for the ASR
         pipeline behaves identically here. Every carrier bridge streams 8k mu-law; the
         browser and FreeSWITCH legs carry linear PCM at 16k.
         """
-        return ("mulaw", 8000) if self._s2s_is_carrier_leg() else ("pcm", 16000)
+        if self._s2s_is_carrier_leg():
+            return s2s_events.AudioFormat(s2s_events.AudioEncoding.MULAW, 8000)
+        return s2s_events.AudioFormat(s2s_events.AudioEncoding.PCM, 16000)
 
     def _s2s_output_format(self):
-        """(encoding, sample_rate) the output handler expects.
+        """Format the output handler expects.
 
         Not the mirror of the input: a web call sends 16k up and plays 24k back, so the
         two legs are resolved separately.
         """
         if self._s2s_is_carrier_leg():
-            return "mulaw", 8000
-        return "pcm", self.sampling_rate
+            return s2s_events.AudioFormat(s2s_events.AudioEncoding.MULAW, 8000)
+        return s2s_events.AudioFormat(s2s_events.AudioEncoding.PCM, self.sampling_rate)
 
     def _build_s2s_provider(self):
         system_prompt = self.system_prompt
@@ -7376,27 +7376,28 @@ class TaskManager(BaseManager):
         api_key = self.kwargs.get("s2s_key") or os.getenv(
             "GOOGLE_API_KEY" if self.s2s_provider_name == S2SProvider.GEMINI_LIVE.value else "OPENAI_API_KEY"
         )
-        config = {k: v for k, v in self.s2s_provider_config.items() if v is not None}
-        config.pop("model", None)
-        config.pop("voice", None)
+        # mode="json" so enum fields (reasoning_effort) reach the provider as plain strings.
+        options = self.s2s.provider_config.model_dump(exclude_none=True, mode="json")
+        options.pop("model")
+        voice = options.pop("voice")
         return SUPPORTED_S2S_PROVIDERS[self.s2s_provider_name](
             system_prompt=system_prompt or "",
-            voice=self.s2s_provider_config.get("voice"),
+            voice=voice,
             model=self.s2s_model,
             api_key=api_key,
             tools=tools,
-            **config,
+            **options,
         )
 
     async def _run_s2s_conversation(self):
         s2s = self._build_s2s_provider()
         self.tools["s2s"] = s2s
-        self._s2s_in_encoding, self._s2s_in_rate = self._s2s_input_format()
-        self._s2s_out_encoding, self._s2s_out_rate = self._s2s_output_format()
+        self._s2s_input = self._s2s_input_format()
+        self._s2s_output = self._s2s_output_format()
         self._s2s_tool_tasks = set()
         self._s2s_hangup_after_response = False
         self._s2s_pending_results = 0
-        self._s2s_welcome_gate_ms = int((self.s2s_config or {}).get("welcome_audio_gate_ms") or 1500)
+        self._s2s_welcome_gate_ms = self.s2s.welcome_audio_gate_ms
         self._s2s_started_at = time.time()
 
         try:
@@ -7409,7 +7410,8 @@ class TaskManager(BaseManager):
 
         logger.info(
             f"S2S conversation started | provider={self.s2s_provider_name} model={self.s2s_model} "
-            f"leg_in={self._s2s_in_encoding}@{self._s2s_in_rate} leg_out={self._s2s_out_encoding}@{self._s2s_out_rate} "
+            f"leg_in={self._s2s_input.encoding.value}@{self._s2s_input.sample_rate} "
+            f"leg_out={self._s2s_output.encoding.value}@{self._s2s_output.sample_rate} "
             f"model_in={s2s.input_sample_rate} model_out={s2s.output_sample_rate}"
         )
 
@@ -7469,9 +7471,11 @@ class TaskManager(BaseManager):
                 discarded += 1
                 continue
 
-            pcm = ulaw_to_pcm(data) if self._s2s_in_encoding == "mulaw" else data
-            if self._s2s_in_rate != s2s.input_sample_rate:
-                pcm = resample(pcm, s2s.input_sample_rate, format="pcm", original_sample_rate=self._s2s_in_rate)
+            pcm = ulaw_to_pcm(data) if self._s2s_input.encoding is s2s_events.AudioEncoding.MULAW else data
+            if self._s2s_input.sample_rate != s2s.input_sample_rate:
+                pcm = resample(
+                    pcm, s2s.input_sample_rate, format="pcm", original_sample_rate=self._s2s_input.sample_rate
+                )
 
             try:
                 await s2s.send_audio(pcm)
@@ -7546,15 +7550,15 @@ class TaskManager(BaseManager):
 
     def _s2s_encode_output(self, pcm):
         s2s = self.tools["s2s"]
-        if self._s2s_out_rate != s2s.output_sample_rate:
-            pcm = resample(pcm, self._s2s_out_rate, format="pcm", original_sample_rate=s2s.output_sample_rate)
-        return pcm_to_ulaw(pcm) if self._s2s_out_encoding == "mulaw" else pcm
+        if self._s2s_output.sample_rate != s2s.output_sample_rate:
+            pcm = resample(pcm, self._s2s_output.sample_rate, format="pcm", original_sample_rate=s2s.output_sample_rate)
+        return pcm_to_ulaw(pcm) if self._s2s_output.encoding is s2s_events.AudioEncoding.MULAW else pcm
 
     def _s2s_meta(self, **extra):
         meta = {
             "io": self.tools["output"].get_provider() if not self.default_io else "default",
             "sequence_id": -1,
-            "format": self._s2s_out_encoding,
+            "format": self._s2s_output.encoding.value,
         }
         if self._s2s_hangup_after_response:
             meta["message_category"] = "agent_hangup"
@@ -7571,42 +7575,25 @@ class TaskManager(BaseManager):
                 break
 
     async def _s2s_finish_turn(self, event):
-        if event.usage and self.task_id == 0 and self.on_turn_usage:
-            task = asyncio.create_task(
-                self.on_turn_usage(
-                    event.usage.get("input_tokens", 0),
-                    event.usage.get("output_tokens", 0),
-                    event.usage.get("cached_tokens", 0),
-                )
-            )
+        usage = event.usage
+        if usage and self.task_id == 0 and self.on_turn_usage:
+            task = asyncio.create_task(self.on_turn_usage(usage.input_tokens, usage.output_tokens, usage.cached_tokens))
             self._s2s_tool_tasks.add(task)
             task.add_done_callback(self._s2s_tool_tasks.discard)
 
-        usage = event.usage or {}
         if event.transcript or usage:
+            usage = usage or s2s_events.S2SUsage()
             convert_to_request_log(
                 event.transcript,
-                {
-                    "request_id": self.task_id,
-                    "sequence_id": -1,
-                    "s2s_usage": {
-                        key: usage.get(key, 0)
-                        for key in (
-                            "input_audio_tokens",
-                            "input_text_tokens",
-                            "output_audio_tokens",
-                            "output_text_tokens",
-                        )
-                    },
-                },
+                {"request_id": self.task_id, "sequence_id": -1, "s2s_usage": usage.modality_split()},
                 model=self.s2s_model,
                 component=LogComponent.S2S,
                 direction=LogDirection.RESPONSE,
                 is_cached=False,
                 run_id=self.run_id,
-                input_tokens=usage.get("input_tokens", 0),
-                output_tokens=usage.get("output_tokens", 0),
-                cached_tokens=usage.get("cached_tokens", 0),
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cached_tokens=usage.cached_tokens,
             )
 
         # The end-of-stream sentinel makes the output handler emit its final mark, which is
@@ -7640,7 +7627,9 @@ class TaskManager(BaseManager):
                             "data": message["data"],
                             "start_time": time.time(),
                             "duration": calculate_audio_duration(
-                                len(message["data"]), self._s2s_out_rate, format=self._s2s_out_encoding
+                                len(message["data"]),
+                                self._s2s_output.sample_rate,
+                                format=self._s2s_output.encoding.value,
                             ),
                         }
                     )

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7187,6 +7187,16 @@ class TaskManager(BaseManager):
                         self.check_user_online_message_config, self.language
                     )
 
+                    if self.__is_s2s():
+                        # The model owns the audio stream and there is no synthesizer to
+                        # render this. Pushing a packet through the path below left the
+                        # transcript claiming the agent spoke while the caller heard nothing.
+                        await self.tools["s2s"].trigger_response(
+                            instructions=f"Say exactly this, and nothing else: {user_online_message}"
+                        )
+                        self.conversation_history.append_assistant(user_online_message, exclude_from_llm=True)
+                        continue
+
                     self.tools["input"].reset_response_heard_by_user()
 
                     if self.should_record:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7752,18 +7752,21 @@ class TaskManager(BaseManager):
             )
 
         if event.transcript or usage:
-            usage = usage or s2s_events.S2SUsage()
+            # A turn whose usage never arrived must stay distinguishable from one that
+            # genuinely spent nothing: passing zeros stamps it api_reported and billing
+            # then trusts a number the provider never sent.
+            split = (usage or s2s_events.S2SUsage()).modality_split()
             convert_to_request_log(
                 event.transcript,
-                {"request_id": self.task_id, "sequence_id": -1, "s2s_usage": usage.modality_split()},
+                {"request_id": self.task_id, "sequence_id": -1, "s2s_usage": split},
                 model=self.s2s_model,
                 component=LogComponent.S2S,
                 direction=LogDirection.RESPONSE,
                 is_cached=False,
                 run_id=self.run_id,
-                input_tokens=usage.input_tokens,
-                output_tokens=usage.output_tokens,
-                cached_tokens=usage.cached_tokens,
+                input_tokens=usage.input_tokens if usage else None,
+                output_tokens=usage.output_tokens if usage else None,
+                cached_tokens=usage.cached_tokens if usage else None,
             )
 
         # The end-of-stream sentinel makes the output handler emit its final mark, which is

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7633,6 +7633,9 @@ class TaskManager(BaseManager):
     async def _s2s_finish_turn(self, event):
         if self._s2s_agent_speaking:
             self.interruption_manager.on_agent_speech_ended()
+            # A turn that produced audio and ran to completion is the agent recovering
+            # from whatever interrupted the previous one.
+            self.interruption_manager.on_successful_response_delivered(self._s2s_turn_seq)
             self._s2s_agent_speaking = False
         self._s2s_turn_seq += 1
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -709,6 +709,15 @@ class TaskManager(BaseManager):
                     else None
                 )
 
+                if self.__is_s2s():
+                    # The s2s result below asks for the goodbye, so telling the model to say
+                    # one before the call too produced two goodbyes on every hangup.
+                    end_call_description = (
+                        "End the current call. Do not say goodbye before calling this "
+                        "function; you will be prompted to say it afterwards."
+                        + (f"\nCriteria for when to end: {cancellation_prompt}" if cancellation_prompt else "")
+                    )
+
                 self.end_call_primary = (
                     self.conversation_config.get("end_call_tool_mode") in ("primary", "primary_with_shadow_hangup")
                     and self.use_llm_to_determine_hangup

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -632,7 +632,10 @@ class TaskManager(BaseManager):
 
             # Enable DTMF flow
             dtmf_enabled = self.conversation_config.get("dtmf_enabled", False)
-            if dtmf_enabled:
+            # An s2s task starts its own consumer in _run_s2s_conversation. Starting this one
+            # too would race it for the same queue, and this one wins by being first: the
+            # digits get injected into the transcriber/LLM pipeline an s2s agent does not have.
+            if dtmf_enabled and not self.__is_s2s():
                 self.tools["input"].is_dtmf_active = True
                 self.dtmf_task = asyncio.create_task(self.inject_digits_to_conversation())
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7532,6 +7532,27 @@ class TaskManager(BaseManager):
             await s2s.disconnect()
         logger.info("S2S conversation completed")
 
+    def _s2s_track_task(self, task, call_id=None) -> None:
+        """Hold a reference to a background task and surface its failure.
+
+        A bare discard callback drops the exception along with the task, so a tool result
+        that never reached the model looked exactly like one that succeeded.
+        """
+        task.s2s_call_id = call_id
+        self._s2s_tool_tasks.add(task)
+        task.add_done_callback(self._s2s_on_task_done)
+
+    def _s2s_on_task_done(self, task) -> None:
+        self._s2s_tool_tasks.discard(task)
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(
+                f"S2S background task failed | call_id={getattr(task, 's2s_call_id', None)} "
+                f"error={type(exception).__name__}: {exception}"
+            )
+
     def _s2s_extend_playout(self, chunk: bytes) -> None:
         """Advance the estimate of when the caller will have heard everything sent so far."""
         duration = calculate_audio_duration(
@@ -7618,9 +7639,7 @@ class TaskManager(BaseManager):
                     self.interruption_manager.on_user_speech_ended()
 
             elif isinstance(event, s2s_events.FunctionCall):
-                task = asyncio.create_task(self._s2s_execute_tool(event))
-                self._s2s_tool_tasks.add(task)
-                task.add_done_callback(self._s2s_tool_tasks.discard)
+                self._s2s_track_task(asyncio.create_task(self._s2s_execute_tool(event)), call_id=event.call_id)
 
             elif isinstance(event, s2s_events.Interrupted):
                 if self._s2s_within_welcome_gate():
@@ -7654,6 +7673,11 @@ class TaskManager(BaseManager):
 
             elif isinstance(event, s2s_events.FunctionCallCancelled):
                 logger.info(f"S2S: provider cancelled tool calls {event.call_ids}")
+                # The provider has discarded these ids. Letting the task run would fire a
+                # real side effect and then answer a call_id the model no longer knows.
+                for task in list(self._s2s_tool_tasks):
+                    if getattr(task, "s2s_call_id", None) in event.call_ids:
+                        task.cancel()
 
             elif isinstance(event, s2s_events.S2SError):
                 logger.error(f"S2S error: {event.message} (code={event.code})")
@@ -7711,9 +7735,9 @@ class TaskManager(BaseManager):
 
         usage = event.usage
         if usage and self.task_id == 0 and self.on_turn_usage:
-            task = asyncio.create_task(self.on_turn_usage(usage.input_tokens, usage.output_tokens, usage.cached_tokens))
-            self._s2s_tool_tasks.add(task)
-            task.add_done_callback(self._s2s_tool_tasks.discard)
+            self._s2s_track_task(
+                asyncio.create_task(self.on_turn_usage(usage.input_tokens, usage.output_tokens, usage.cached_tokens))
+            )
 
         if event.transcript or usage:
             usage = usage or s2s_events.S2SUsage()

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7495,6 +7495,11 @@ class TaskManager(BaseManager):
             f"model_in={s2s.input_sample_rate} model_out={s2s.output_sample_rate}"
         )
 
+        # Restart the gate clock now the handshake is done. Measured connects run 400ms to
+        # 1600ms against a 1500ms gate, so timing it from before connect left the welcome
+        # message with most of its barge-in protection already spent.
+        self._s2s_started_at = time.time()
+
         welcome = (self.kwargs.get("agent_welcome_message") or "").strip()
         if welcome:
             await s2s.trigger_response(
@@ -7646,6 +7651,13 @@ class TaskManager(BaseManager):
                     continue
                 # The provider reports every speech start here, so this is only a barge-in
                 # when the agent still had the floor.
+                #
+                # InterruptionManager is used for accounting only, never to veto: by the
+                # time this event arrives the provider's own VAD has already stopped
+                # generating, so nothing decided here can give the agent the floor back.
+                # Whether a cough counts as a barge-in is tuned at the provider instead,
+                # via semantic_vad eagerness on OpenAI and endOfSpeechSensitivity on Gemini,
+                # both of which classify better than a word count and a phrase list.
                 self.interruption_manager.on_user_speech_started()
                 if self._s2s_agent_has_floor():
                     logger.info("S2S: caller barged in, dropping queued audio")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1231,14 +1231,20 @@ class TaskManager(BaseManager):
                     self.task_config["tools_config"]["output"]["provider"]
                 )
 
+                # A speech-to-speech agent has no synthesizer config to stamp; its run loop
+                # encodes straight to the rate chosen here.
+                is_s2s_output = self.__is_s2s()
+                synth_config = None if is_s2s_output else self.task_config["tools_config"]["synthesizer"]
                 if self.task_config["tools_config"]["output"]["provider"] in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS.keys():
                     output_kwargs["mark_event_meta_data"] = self.mark_event_meta_data
                     logger.info(f"Making sure that the sampling rate for output handler is 8000")
-                    self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"] = 8000
+                    if synth_config:
+                        synth_config["provider_config"]["sampling_rate"] = 8000
                     # sip-trunk (Asterisk) uses ulaw; other telephony use pcm (handler converts to mulaw)
                     if self.task_config["tools_config"]["output"]["provider"] == TelephonyProvider.SIP_TRUNK.value:
-                        self.task_config["tools_config"]["synthesizer"]["audio_format"] = "ulaw"
-                        logger.info(f"Setting synthesizer audio format to ulaw for Asterisk sip-trunk")
+                        if synth_config:
+                            synth_config["audio_format"] = "ulaw"
+                            logger.info(f"Setting synthesizer audio format to ulaw for Asterisk sip-trunk")
                         # Pass input handler to output handler so it can simulate mark events
                         input_handler = self.tools.get("input")
                         output_kwargs["input_handler"] = input_handler
@@ -1247,12 +1253,14 @@ class TaskManager(BaseManager):
                         logger.info(
                             f"Passing input_handler to sip-trunk output handler for mark event simulation: {input_handler is not None}"
                         )
-                    else:
-                        self.task_config["tools_config"]["synthesizer"]["audio_format"] = "pcm"
+                    elif synth_config:
+                        synth_config["audio_format"] = "pcm"
+                    self.sampling_rate = 8000
                 else:
-                    self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"] = 24000
+                    if synth_config:
+                        synth_config["provider_config"]["sampling_rate"] = WEBCALL_TTS_SAMPLE_RATE
                     output_kwargs["queue"] = output_queue
-                self.sampling_rate = self.task_config["tools_config"]["synthesizer"]["provider_config"]["sampling_rate"]
+                    self.sampling_rate = WEBCALL_TTS_SAMPLE_RATE
 
             if self.task_config["tools_config"]["output"]["provider"] == "default":
                 output_kwargs["is_web_based_call"] = self.is_web_based_call
@@ -7331,28 +7339,30 @@ class TaskManager(BaseManager):
     # Speech-to-speech conversation
     ########################
 
-    def _s2s_io_format(self):
-        """(encoding, sample_rate) of the audio on both legs of the media stream.
+    def _s2s_is_carrier_leg(self):
+        """True when the media stream is a telephony bridge rather than a browser leg."""
+        if self.turn_based_conversation or self.is_web_based_call:
+            return False
+        return self.task_config["tools_config"]["input"]["provider"] in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
 
-        Mirrors the encoding the transcriber path selects, so a config that works for the
-        ASR pipeline behaves identically here. Every carrier bridge streams 8k mu-law;
-        only the browser and FreeSWITCH legs carry linear PCM.
+    def _s2s_input_format(self):
+        """(encoding, sample_rate) of the caller audio arriving on audio_queue.
+
+        Mirrors what the transcriber path selects, so a config that works for the ASR
+        pipeline behaves identically here. Every carrier bridge streams 8k mu-law; the
+        browser and FreeSWITCH legs carry linear PCM at 16k.
         """
-        if self.turn_based_conversation:
-            provider = "playground"
-        elif self.is_web_based_call:
-            provider = WEB_BASED_CALL_PROVIDER
-        else:
-            provider = self.task_config["tools_config"]["input"]["provider"]
+        return ("mulaw", 8000) if self._s2s_is_carrier_leg() else ("pcm", 16000)
 
-        if provider in (
-            WEB_BASED_CALL_PROVIDER,
-            TelephonyProvider.FREESWITCH.value,
-            TelephonyProvider.DEFAULT.value,
-            "playground",
-        ):
-            return "pcm", 16000
-        return "mulaw", 8000
+    def _s2s_output_format(self):
+        """(encoding, sample_rate) the output handler expects.
+
+        Not the mirror of the input: a web call sends 16k up and plays 24k back, so the
+        two legs are resolved separately.
+        """
+        if self._s2s_is_carrier_leg():
+            return "mulaw", 8000
+        return "pcm", self.sampling_rate
 
     def _build_s2s_provider(self):
         system_prompt = self.system_prompt
@@ -7381,8 +7391,8 @@ class TaskManager(BaseManager):
     async def _run_s2s_conversation(self):
         s2s = self._build_s2s_provider()
         self.tools["s2s"] = s2s
-        self._s2s_encoding, self._s2s_rate = self._s2s_io_format()
-        self.sampling_rate = self._s2s_rate
+        self._s2s_in_encoding, self._s2s_in_rate = self._s2s_input_format()
+        self._s2s_out_encoding, self._s2s_out_rate = self._s2s_output_format()
         self._s2s_tool_tasks = set()
         self._s2s_hangup_after_response = False
         self._s2s_pending_results = 0
@@ -7399,7 +7409,8 @@ class TaskManager(BaseManager):
 
         logger.info(
             f"S2S conversation started | provider={self.s2s_provider_name} model={self.s2s_model} "
-            f"io={self._s2s_encoding}@{self._s2s_rate} in={s2s.input_sample_rate} out={s2s.output_sample_rate}"
+            f"leg_in={self._s2s_in_encoding}@{self._s2s_in_rate} leg_out={self._s2s_out_encoding}@{self._s2s_out_rate} "
+            f"model_in={s2s.input_sample_rate} model_out={s2s.output_sample_rate}"
         )
 
         welcome = (self.kwargs.get("agent_welcome_message") or "").strip()
@@ -7458,9 +7469,9 @@ class TaskManager(BaseManager):
                 discarded += 1
                 continue
 
-            pcm = ulaw_to_pcm(data) if self._s2s_encoding == "mulaw" else data
-            if self._s2s_rate != s2s.input_sample_rate:
-                pcm = resample(pcm, s2s.input_sample_rate, format="pcm", original_sample_rate=self._s2s_rate)
+            pcm = ulaw_to_pcm(data) if self._s2s_in_encoding == "mulaw" else data
+            if self._s2s_in_rate != s2s.input_sample_rate:
+                pcm = resample(pcm, s2s.input_sample_rate, format="pcm", original_sample_rate=self._s2s_in_rate)
 
             try:
                 await s2s.send_audio(pcm)
@@ -7535,15 +7546,15 @@ class TaskManager(BaseManager):
 
     def _s2s_encode_output(self, pcm):
         s2s = self.tools["s2s"]
-        if self._s2s_rate != s2s.output_sample_rate:
-            pcm = resample(pcm, self._s2s_rate, format="pcm", original_sample_rate=s2s.output_sample_rate)
-        return pcm_to_ulaw(pcm) if self._s2s_encoding == "mulaw" else pcm
+        if self._s2s_out_rate != s2s.output_sample_rate:
+            pcm = resample(pcm, self._s2s_out_rate, format="pcm", original_sample_rate=s2s.output_sample_rate)
+        return pcm_to_ulaw(pcm) if self._s2s_out_encoding == "mulaw" else pcm
 
     def _s2s_meta(self, **extra):
         meta = {
             "io": self.tools["output"].get_provider() if not self.default_io else "default",
             "sequence_id": -1,
-            "format": self._s2s_encoding,
+            "format": self._s2s_out_encoding,
         }
         if self._s2s_hangup_after_response:
             meta["message_category"] = "agent_hangup"
@@ -7613,7 +7624,7 @@ class TaskManager(BaseManager):
                             "data": message["data"],
                             "start_time": time.time(),
                             "duration": calculate_audio_duration(
-                                len(message["data"]), self.sampling_rate, format=self._s2s_encoding
+                                len(message["data"]), self._s2s_out_rate, format=self._s2s_out_encoding
                             ),
                         }
                     )

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1390,7 +1390,7 @@ class TaskManager(BaseManager):
     async def _s2s_await_stream_sid(self):
         """Claim the stream id for an s2s call, which has no welcome audio to play.
 
-        The model speaks its own greeting, so the welcome path below is skipped — but it
+        The model speaks its own greeting, so the welcome path below is skipped, but it
         was also the only thing propagating the stream id, and without it the output
         handler silently discards the whole conversation.
         """
@@ -4326,7 +4326,7 @@ class TaskManager(BaseManager):
                 )
                 _transfer_end_recorded = True
             finally:
-                # CancelledError (BaseException) bypasses except — ensure transfer_end is
+                # CancelledError (BaseException) bypasses except, so ensure transfer_end is
                 # always recorded so it appears in progression_data even if the task is
                 # cancelled mid-flight when Plivo terminates the call.
                 if not _transfer_end_recorded:
@@ -7524,7 +7524,7 @@ class TaskManager(BaseManager):
             asyncio.create_task(self._s2s_event_loop()),
         ]
         try:
-            # Either loop finishing ends the call — the caller hung up, or the provider
+            # Either loop finishing ends the call: the caller hung up, or the provider
             # socket closed. Waiting on both would park here for the rest of the session:
             # a provider that has stopped being spoken to sends nothing to wake its reader.
             done, _ = await asyncio.wait(loops, return_when=asyncio.FIRST_COMPLETED)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7806,8 +7806,11 @@ class TaskManager(BaseManager):
                 result = json.dumps({"status": "success", "message": "Transfer already in progress; wait silently."})
             else:
                 self.has_transfer = True
+                # param is the configured tool body, which is where call_transfer_number
+                # lives; the model's own arguments go in as the response, same as the llm
+                # path. Passing the arguments as both leaves the webhook no destination.
                 await self._execute_transfer_call_webhook(
-                    event.name, params.get("url"), json.dumps(args), args, meta_info
+                    event.name, params.get("url"), params.get("param"), args, meta_info
                 )
                 result = json.dumps({"status": "success", "message": "Transfer initiated; wait silently."})
         else:
@@ -7840,7 +7843,7 @@ class TaskManager(BaseManager):
             url=url,
             method=method,
             param=params.get("param"),
-            headers=params.get("header"),
+            headers=params.get("headers"),
             meta_info=meta_info,
             runtime_args=args,
             request_body=params.get("param"),
@@ -7852,7 +7855,7 @@ class TaskManager(BaseManager):
                 method=method,
                 param=params.get("param"),
                 api_token=params.get("api_token"),
-                headers_data=params.get("header"),
+                headers_data=params.get("headers"),
                 meta_info=meta_info,
                 run_id=self.run_id,
                 return_response_metadata=True,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7444,7 +7444,12 @@ class TaskManager(BaseManager):
             asyncio.create_task(self._s2s_event_loop()),
         ]
         try:
-            await asyncio.gather(*loops)
+            # Either loop finishing ends the call — the caller hung up, or the provider
+            # socket closed. Waiting on both would park here for the rest of the session:
+            # a provider that has stopped being spoken to sends nothing to wake its reader.
+            done, _ = await asyncio.wait(loops, return_when=asyncio.FIRST_COMPLETED)
+            for task in done:
+                task.result()
         except asyncio.CancelledError:
             pass
         finally:
@@ -7455,6 +7460,7 @@ class TaskManager(BaseManager):
                 task.cancel()
             if self._s2s_tool_tasks:
                 await asyncio.gather(*self._s2s_tool_tasks, return_exceptions=True)
+            await asyncio.gather(*loops, return_exceptions=True)
             await s2s.disconnect()
         logger.info("S2S conversation completed")
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -613,8 +613,10 @@ class TaskManager(BaseManager):
         self.conversation_config = None
 
         if task_id == 0:
-            provider_config = self.task_config["tools_config"]["synthesizer"].get("provider_config")
-            self.synthesizer_voice = provider_config["voice"]
+            # An S2S task carries no synthesizer block; its voice lives on the s2s config.
+            synthesizer_config = self.task_config["tools_config"].get("synthesizer") or {}
+            provider_config = synthesizer_config.get("provider_config") or {}
+            self.synthesizer_voice = provider_config.get("voice")
             self.hangup_detail = None
             self.end_call_primary = False  # set below if task_config opts in
 
@@ -659,7 +661,10 @@ class TaskManager(BaseManager):
             # for long pauses and rushing
             if self.conversation_config is not None:
                 # TODO need to get this for azure - for azure the subtraction would not happen
-                self.minimum_wait_duration = self.task_config["tools_config"]["transcriber"]["endpointing"]
+                # No transcriber on an S2S task: the provider owns endpointing.
+                self.minimum_wait_duration = (self.task_config["tools_config"].get("transcriber") or {}).get(
+                    "endpointing"
+                )
                 self.last_spoken_timestamp = time.time() * 1000
                 self.incremental_delay = self.conversation_config.get("incremental_delay", 100)
 
@@ -7337,28 +7342,35 @@ class TaskManager(BaseManager):
     # Speech-to-speech conversation
     ########################
 
-    def _s2s_is_carrier_leg(self):
-        """True when the media stream is a telephony bridge rather than a browser leg."""
+    def _s2s_telephony_provider(self):
+        """Carrier behind the media stream, or None for browser and playground legs."""
         if self.turn_based_conversation or self.is_web_based_call:
-            return False
-        return self.task_config["tools_config"]["input"]["provider"] in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
+            return None
+        provider = self.task_config["tools_config"]["input"]["provider"]
+        return provider if provider in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS else None
+
+    def _s2s_is_carrier_leg(self):
+        return self._s2s_telephony_provider() is not None
 
     def _s2s_input_format(self):
         """Format of the caller audio arriving on audio_queue.
 
-        Mirrors what the transcriber path selects, so a config that works for the ASR
-        pipeline behaves identically here. Every carrier bridge streams 8k mu-law; the
-        browser and FreeSWITCH legs carry linear PCM at 16k.
+        Reads the same TelephonyProvider.mulaw_values() the transcribers use, so a carrier
+        that streams linear16 (plivo, exotel, vobiz) is not decoded as mu-law. Browser and
+        playground legs carry linear PCM at 16k.
         """
-        if self._s2s_is_carrier_leg():
+        provider = self._s2s_telephony_provider()
+        if provider is None:
+            return s2s_events.AudioFormat(s2s_events.AudioEncoding.PCM, 16000)
+        if provider in TelephonyProvider.mulaw_values():
             return s2s_events.AudioFormat(s2s_events.AudioEncoding.MULAW, 8000)
-        return s2s_events.AudioFormat(s2s_events.AudioEncoding.PCM, 16000)
+        return s2s_events.AudioFormat(s2s_events.AudioEncoding.PCM, 8000)
 
     def _s2s_output_format(self):
         """Format the output handler expects.
 
-        Not the mirror of the input: a web call sends 16k up and plays 24k back, so the
-        two legs are resolved separately.
+        Not the mirror of the input: plivo accepts mu-law while streaming linear16 up, and
+        a web call sends 16k up but plays 24k back, so the two legs resolve separately.
         """
         if self._s2s_is_carrier_leg():
             return s2s_events.AudioFormat(s2s_events.AudioEncoding.MULAW, 8000)
@@ -7463,6 +7475,9 @@ class TaskManager(BaseManager):
             if data is None:
                 if message.get("meta_info", {}).get("eos"):
                     logger.info(f"S2S ingest: EOS received | sent={sent} discarded={discarded}")
+                    # The provider goes quiet once audio stops, so the event loop would park
+                    # on its socket forever unless the hangup is published here.
+                    self.conversation_ended = True
                     break
                 continue
 
@@ -7556,6 +7571,9 @@ class TaskManager(BaseManager):
 
     def _s2s_meta(self, **extra):
         meta = {
+            # DefaultOutputHandler.handle indexes meta_info["type"] before anything else and
+            # swallows the KeyError by closing itself, silencing the whole browser leg.
+            "type": "audio",
             "io": self.tools["output"].get_provider() if not self.default_io else "default",
             "sequence_id": -1,
             "format": self._s2s_output.encoding.value,
@@ -7568,6 +7586,9 @@ class TaskManager(BaseManager):
     async def _s2s_drop_queued_audio(self):
         if "output" in self.tools:
             await self.tools["output"].handle_interruption()
+        # handle_interruption clears the pending final-chunk mark, and that mark's echo is
+        # the only thing that would otherwise flip this flag back off.
+        self.tools["input"].update_is_audio_being_played(False)
         while not self.buffered_output_queue.empty():
             try:
                 self.buffered_output_queue.get_nowait()
@@ -7674,8 +7695,8 @@ class TaskManager(BaseManager):
             run_id=self.run_id,
         )
 
-        if event.name.startswith(END_CALL_FUNCTION_PREFIX):
-            self._s2s_hangup_after_response = True
+        ends_call = event.name.startswith(END_CALL_FUNCTION_PREFIX)
+        if ends_call:
             result = json.dumps({"status": "success", "message": "Call is ending now. Say a brief goodbye."})
         elif event.name.startswith("transfer_call"):
             if self.has_transfer:
@@ -7700,6 +7721,10 @@ class TaskManager(BaseManager):
         )
         await s2s.send_function_result(event.call_id, event.name, result)
         await s2s.commit_function_results()
+        if ends_call:
+            # Armed only once the commit returns. commit waits on the tool-call turn's own
+            # response.done, so the next turn to complete is the goodbye, not this one.
+            self._s2s_hangup_after_response = True
 
     async def _s2s_call_api_tool(self, event, args, params, meta_info):
         url = params.get("url")
@@ -7945,12 +7970,20 @@ class TaskManager(BaseManager):
                 if hasattr(self, "transcriber_task") and self.transcriber_task is not None:
                     tasks_to_cancel.append(process_task_cancellation(self.transcriber_task, "transcriber_task"))
 
-            if self._is_conversation_task() and "transcriber" in self.tools and "synthesizer" in self.tools:
-                self.transcriber_latencies.connection_latency_ms = self.tools["transcriber"].connection_time
-                self.synthesizer_latencies.connection_latency_ms = self.tools["synthesizer"].connection_time
+            # An S2S task has neither transcriber nor synthesizer, but still owes the caller
+            # a conversation payload: transcript, hangup detail, recording, progression.
+            _has_asr_tts = "transcriber" in self.tools and "synthesizer" in self.tools
+            if self._is_conversation_task() and (_has_asr_tts or "s2s" in self.tools):
+                if _has_asr_tts:
+                    self.transcriber_latencies.connection_latency_ms = self.tools["transcriber"].connection_time
+                    self.synthesizer_latencies.connection_latency_ms = self.tools["synthesizer"].connection_time
 
-                self.transcriber_latencies.turn_latencies = self.tools["transcriber"].turn_latencies
-                self.synthesizer_latencies.turn_latencies = self.tools["synthesizer"].turn_latencies
+                    self.transcriber_latencies.turn_latencies = self.tools["transcriber"].turn_latencies
+                    self.synthesizer_latencies.turn_latencies = self.tools["synthesizer"].turn_latencies
+                elif "s2s" in self.tools:
+                    # One socket covers both legs, so its timings land on the LLM component.
+                    self.llm_latencies.connection_latency_ms = self.tools["s2s"].connection_time
+                    self.llm_latencies.turn_latencies = self.tools["s2s"].turn_latencies
 
                 # Annotate each transcriber turn with was_interrupted so callers
                 # can see which ASR turns had a user barge-in without cross-referencing
@@ -8020,7 +8053,9 @@ class TaskManager(BaseManager):
                     "call_sid": self.call_sid,
                     "stream_sid": self.stream_sid,
                     "transcriber_duration": self.transcriber_duration,
-                    "synthesizer_characters": self.tools["synthesizer"].get_synthesized_characters(),
+                    "synthesizer_characters": (
+                        self.tools["synthesizer"].get_synthesized_characters() if _has_asr_tts else 0
+                    ),
                     "ended_by_assistant": self.ended_by_assistant,
                     "latency_dict": {
                         "llm_latencies": self.llm_latencies.model_dump(),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -521,7 +521,7 @@ class TaskManager(BaseManager):
                     "buffer_size"
                 ]
         else:
-            if self.task_config["tools_config"]["llm_agent"] is not None:
+            if self.task_config["tools_config"].get("llm_agent") is not None:
                 if self.__is_knowledgebase_agent():
                     self.llm_agent_config = self.task_config["tools_config"]["llm_agent"]
                     self.llm_config = {
@@ -1141,10 +1141,7 @@ class TaskManager(BaseManager):
         return select_message_by_language(self.call_hangup_message_config, self.language)
 
     def __is_multiagent(self):
-        if self.task_config["task_type"] == "webhook":
-            return False
-        agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", None)
-        return agent_type == "multiagent"
+        return self.__agent_type() == "multiagent"
 
     def __agent_type(self):
         """Configured llm_agent type, or None for webhook and speech-to-speech tasks."""
@@ -1902,7 +1899,7 @@ class TaskManager(BaseManager):
         if self.task_config["task_type"] == "webhook":
             return
 
-        agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", "simple_llm_agent")
+        agent_type = (self.task_config["tools_config"].get("llm_agent") or {}).get("agent_type", "simple_llm_agent")
         self.is_local = local
         if task_id == 0:
             if (
@@ -7330,6 +7327,409 @@ class TaskManager(BaseManager):
         except Exception as e:
             logger.error(f"Error occurred in handling init event - {e}")
 
+    ########################
+    # Speech-to-speech conversation
+    ########################
+
+    def _s2s_io_format(self):
+        """(encoding, sample_rate) of the audio on both legs of the media stream.
+
+        Mirrors the encoding the transcriber path selects, so a config that works for the
+        ASR pipeline behaves identically here. Every carrier bridge streams 8k mu-law;
+        only the browser and FreeSWITCH legs carry linear PCM.
+        """
+        if self.turn_based_conversation:
+            provider = "playground"
+        elif self.is_web_based_call:
+            provider = WEB_BASED_CALL_PROVIDER
+        else:
+            provider = self.task_config["tools_config"]["input"]["provider"]
+
+        if provider in (
+            WEB_BASED_CALL_PROVIDER,
+            TelephonyProvider.FREESWITCH.value,
+            TelephonyProvider.DEFAULT.value,
+            "playground",
+        ):
+            return "pcm", 16000
+        return "mulaw", 8000
+
+    def _build_s2s_provider(self):
+        system_prompt = self.system_prompt
+        if isinstance(system_prompt, dict):
+            system_prompt = system_prompt.get("content", "")
+
+        tools = self.kwargs.get("api_tools", {}).get("tools") or []
+        if isinstance(tools, str):
+            tools = json.loads(tools)
+
+        api_key = self.kwargs.get("s2s_key") or os.getenv(
+            "GOOGLE_API_KEY" if self.s2s_provider_name == S2SProvider.GEMINI_LIVE.value else "OPENAI_API_KEY"
+        )
+        config = {k: v for k, v in self.s2s_provider_config.items() if v is not None}
+        config.pop("model", None)
+        config.pop("voice", None)
+        return SUPPORTED_S2S_PROVIDERS[self.s2s_provider_name](
+            system_prompt=system_prompt or "",
+            voice=self.s2s_provider_config.get("voice"),
+            model=self.s2s_model,
+            api_key=api_key,
+            tools=tools,
+            **config,
+        )
+
+    async def _run_s2s_conversation(self):
+        s2s = self._build_s2s_provider()
+        self.tools["s2s"] = s2s
+        self._s2s_encoding, self._s2s_rate = self._s2s_io_format()
+        self.sampling_rate = self._s2s_rate
+        self._s2s_tool_tasks = set()
+        self._s2s_hangup_after_response = False
+        self._s2s_pending_results = 0
+        self._s2s_welcome_gate_ms = int((self.s2s_config or {}).get("welcome_audio_gate_ms") or 1500)
+        self._s2s_started_at = time.time()
+
+        try:
+            await s2s.connect()
+        except Exception as e:
+            await self._report_provider_health(
+                "s2s", self.s2s_provider_name, self.s2s_model, False, phase="connect", blocking=True
+            )
+            raise LLMError(str(e), provider=self.s2s_provider_name, model=self.s2s_model)
+
+        logger.info(
+            f"S2S conversation started | provider={self.s2s_provider_name} model={self.s2s_model} "
+            f"io={self._s2s_encoding}@{self._s2s_rate} in={s2s.input_sample_rate} out={s2s.output_sample_rate}"
+        )
+
+        welcome = (self.kwargs.get("agent_welcome_message") or "").strip()
+        if welcome:
+            await s2s.trigger_response(
+                instructions=f"Open the conversation by saying exactly this, and nothing else: {welcome}"
+            )
+
+        self.output_task = asyncio.create_task(self._s2s_output_loop())
+        self.hangup_task = asyncio.create_task(self.__check_for_completion())
+        if self.conversation_config.get("dtmf_enabled", False):
+            self.tools["input"].is_dtmf_active = True
+            self.dtmf_task = asyncio.create_task(self._s2s_dtmf_loop())
+
+        loops = [
+            asyncio.create_task(self._s2s_audio_ingest_loop()),
+            asyncio.create_task(self._s2s_event_loop()),
+        ]
+        try:
+            await asyncio.gather(*loops)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            self.conversation_ended = True
+            for task in loops:
+                task.cancel()
+            for task in list(self._s2s_tool_tasks):
+                task.cancel()
+            if self._s2s_tool_tasks:
+                await asyncio.gather(*self._s2s_tool_tasks, return_exceptions=True)
+            await s2s.disconnect()
+        logger.info("S2S conversation completed")
+
+    def _s2s_within_welcome_gate(self):
+        return (time.time() - self._s2s_started_at) * 1000 < self._s2s_welcome_gate_ms
+
+    async def _s2s_audio_ingest_loop(self):
+        """Caller audio to the model, resampled to whatever rate the provider declares."""
+        s2s = self.tools["s2s"]
+        sent = discarded = 0
+        while not self.conversation_ended:
+            try:
+                message = await asyncio.wait_for(self.audio_queue.get(), timeout=1.0)
+            except asyncio.TimeoutError:
+                continue
+
+            data = message.get("data")
+            if data is None:
+                if message.get("meta_info", {}).get("eos"):
+                    logger.info(f"S2S ingest: EOS received | sent={sent} discarded={discarded}")
+                    break
+                continue
+
+            # The agent's own greeting would otherwise echo back and trip the provider's VAD.
+            if self._s2s_within_welcome_gate():
+                discarded += 1
+                continue
+
+            pcm = ulaw_to_pcm(data) if self._s2s_encoding == "mulaw" else data
+            if self._s2s_rate != s2s.input_sample_rate:
+                pcm = resample(pcm, s2s.input_sample_rate, format="pcm", original_sample_rate=self._s2s_rate)
+
+            try:
+                await s2s.send_audio(pcm)
+            except Exception as e:
+                logger.error(f"S2S ingest: send_audio failed, ending conversation: {e}")
+                self.conversation_ended = True
+                break
+            sent += 1
+        logger.info(f"S2S ingest loop exited | sent={sent} discarded={discarded}")
+
+    async def _s2s_event_loop(self):
+        s2s = self.tools["s2s"]
+        async for event in s2s.receive_events():
+            if self.conversation_ended:
+                break
+
+            if isinstance(event, s2s_events.AudioDelta):
+                await self.buffered_output_queue.put(
+                    {"data": self._s2s_encode_output(event.data), "meta_info": self._s2s_meta()}
+                )
+                self.last_transmitted_timestamp = time.time()
+
+            elif isinstance(event, s2s_events.TranscriptDelta):
+                if event.is_final and event.content:
+                    logger.info(f"S2S agent: {event.content[:200]}")
+                    self.conversation_history.append_assistant(event.content)
+
+            elif isinstance(event, s2s_events.InputTranscript):
+                if event.is_final and event.content:
+                    logger.info(f"S2S caller: {event.content[:200]}")
+                    self.conversation_history.append_user(event.content)
+                    self.time_since_last_spoken_human_word = time.time()
+
+            elif isinstance(event, s2s_events.FunctionCall):
+                task = asyncio.create_task(self._s2s_execute_tool(event))
+                self._s2s_tool_tasks.add(task)
+                task.add_done_callback(self._s2s_tool_tasks.discard)
+
+            elif isinstance(event, s2s_events.Interrupted):
+                if self._s2s_within_welcome_gate():
+                    continue
+                logger.info("S2S: caller barged in, dropping queued audio")
+                await self._s2s_drop_queued_audio()
+
+            elif isinstance(event, s2s_events.ResponseDone):
+                await self._s2s_finish_turn(event)
+
+            elif isinstance(event, s2s_events.SessionReady):
+                await self._report_provider_health(
+                    "s2s", self.s2s_provider_name, self.s2s_model, True, event.connection_time_ms, phase="connect"
+                )
+
+            elif isinstance(event, s2s_events.SessionExpiring):
+                logger.info(f"S2S session expiring in {event.time_left_ms}ms, provider will resume it")
+
+            elif isinstance(event, s2s_events.SessionResumed):
+                logger.info(f"S2S session resumed in {event.reconnect_ms:.0f}ms")
+                await self._report_provider_health(
+                    "s2s", self.s2s_provider_name, self.s2s_model, True, event.reconnect_ms, phase="connect"
+                )
+
+            elif isinstance(event, s2s_events.FunctionCallCancelled):
+                logger.info(f"S2S: provider cancelled tool calls {event.call_ids}")
+
+            elif isinstance(event, s2s_events.S2SError):
+                logger.error(f"S2S error: {event.message} (code={event.code})")
+                if event.fatal:
+                    await self._report_provider_health(
+                        "s2s", self.s2s_provider_name, self.s2s_model, False, blocking=True
+                    )
+                    raise LLMError(event.message, provider=self.s2s_provider_name, model=self.s2s_model)
+
+    def _s2s_encode_output(self, pcm):
+        s2s = self.tools["s2s"]
+        if self._s2s_rate != s2s.output_sample_rate:
+            pcm = resample(pcm, self._s2s_rate, format="pcm", original_sample_rate=s2s.output_sample_rate)
+        return pcm_to_ulaw(pcm) if self._s2s_encoding == "mulaw" else pcm
+
+    def _s2s_meta(self, **extra):
+        meta = {
+            "io": self.tools["output"].get_provider() if not self.default_io else "default",
+            "sequence_id": -1,
+            "format": self._s2s_encoding,
+        }
+        if self._s2s_hangup_after_response:
+            meta["message_category"] = "agent_hangup"
+        meta.update(extra)
+        return meta
+
+    async def _s2s_drop_queued_audio(self):
+        if "output" in self.tools:
+            await self.tools["output"].handle_interruption()
+        while not self.buffered_output_queue.empty():
+            try:
+                self.buffered_output_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+    async def _s2s_finish_turn(self, event):
+        if event.usage and self.task_id == 0 and self.on_turn_usage:
+            task = asyncio.create_task(
+                self.on_turn_usage(
+                    event.usage.get("input_tokens", 0),
+                    event.usage.get("output_tokens", 0),
+                    event.usage.get("cached_tokens", 0),
+                )
+            )
+            self._s2s_tool_tasks.add(task)
+            task.add_done_callback(self._s2s_tool_tasks.discard)
+
+        if event.transcript:
+            convert_to_request_log(
+                event.transcript,
+                {"request_id": self.task_id, "sequence_id": -1},
+                model=self.s2s_model,
+                component=LogComponent.S2S,
+                direction=LogDirection.RESPONSE,
+                is_cached=False,
+                run_id=self.run_id,
+            )
+
+        # The end-of-stream sentinel makes the output handler emit its final mark, which is
+        # how the hangup path learns the audio actually reached the caller.
+        await self.buffered_output_queue.put(
+            {
+                "data": b"\x00",
+                "meta_info": self._s2s_meta(end_of_llm_stream=True, end_of_synthesizer_stream=True),
+            }
+        )
+
+        if self._s2s_hangup_after_response:
+            self._s2s_hangup_after_response = False
+            self.hangup_detail = HangupReason.END_CALL_TOOL
+            await self.process_call_hangup()
+
+    async def _s2s_output_loop(self):
+        try:
+            while not self.conversation_ended:
+                try:
+                    message = await asyncio.wait_for(self.buffered_output_queue.get(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+
+                self.tools["input"].update_is_audio_being_played(True)
+                await self.tools["output"].handle(message)
+
+                if self.should_record and isinstance(message["data"], bytes) and message["data"] != b"\x00":
+                    self.conversation_recording["output"].append(
+                        {
+                            "data": message["data"],
+                            "start_time": time.time(),
+                            "duration": calculate_audio_duration(
+                                len(message["data"]), self.sampling_rate, format=self._s2s_encoding
+                            ),
+                        }
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"S2S output loop error: {e}")
+
+    async def _s2s_dtmf_loop(self):
+        """Forward carrier keypad digits to the model as text; no provider sees our media leg."""
+        while not self.conversation_ended:
+            digits = await self.queues["dtmf"].get()
+            logger.info(f"S2S DTMF collected: {digits}")
+            ts_ms = round(time.time() * 1000 - self.conversation_start_init_ts, 2)
+            for digit in digits:
+                self.dtmf_events.append({"digit": digit, "ts_ms": ts_ms})
+            try:
+                await self.tools["s2s"].send_dtmf(digits)
+            except NotImplementedError:
+                logger.warning(f"{self.s2s_provider_name} cannot accept DTMF; digits dropped")
+            except Exception as e:
+                logger.error(f"S2S DTMF forward failed: {e}")
+
+    async def _s2s_execute_tool(self, event):
+        s2s = self.tools["s2s"]
+        meta_info = {"request_id": self.task_id, "sequence_id": -1, "turn_id": None}
+        tools_params = self.kwargs.get("api_tools", {}).get("tools_params", {}) or {}
+        params = tools_params.get(event.name, {}) or {}
+        try:
+            args = json.loads(event.arguments or "{}")
+        except ValueError:
+            args = {}
+
+        logger.info(f"S2S tool call: {event.name} args={args}")
+        convert_to_request_log(
+            json.dumps({"called_fun": event.name, **args}),
+            meta_info,
+            self.s2s_model,
+            LogComponent.FUNCTION_CALL,
+            direction=LogDirection.REQUEST,
+            is_cached=False,
+            run_id=self.run_id,
+        )
+
+        if event.name.startswith(END_CALL_FUNCTION_PREFIX):
+            self._s2s_hangup_after_response = True
+            result = json.dumps({"status": "success", "message": "Call is ending now. Say a brief goodbye."})
+        elif event.name.startswith("transfer_call"):
+            if self.has_transfer:
+                result = json.dumps({"status": "success", "message": "Transfer already in progress; wait silently."})
+            else:
+                self.has_transfer = True
+                await self._execute_transfer_call_webhook(
+                    event.name, params.get("url"), json.dumps(args), args, meta_info
+                )
+                result = json.dumps({"status": "success", "message": "Transfer initiated; wait silently."})
+        else:
+            result = await self._s2s_call_api_tool(event, args, params, meta_info)
+
+        convert_to_request_log(
+            result,
+            meta_info,
+            self.s2s_model,
+            LogComponent.FUNCTION_CALL,
+            direction=LogDirection.RESPONSE,
+            is_cached=False,
+            run_id=self.run_id,
+        )
+        await s2s.send_function_result(event.call_id, event.name, result)
+        await s2s.commit_function_results()
+
+    async def _s2s_call_api_tool(self, event, args, params, meta_info):
+        url = params.get("url")
+        if not url:
+            return json.dumps({"status": "error", "message": f"Tool '{event.name}' has no URL configured."})
+
+        method = (params.get("method") or "POST").lower()
+        call_log = self._start_api_call_detail(
+            called_fun=event.name,
+            url=url,
+            method=method,
+            param=params.get("param"),
+            headers=params.get("header"),
+            meta_info=meta_info,
+            runtime_args=args,
+            request_body=params.get("param"),
+            api_params=args,
+        )
+        try:
+            response = await trigger_api(
+                url=url,
+                method=method,
+                param=params.get("param"),
+                api_token=params.get("api_token"),
+                headers_data=params.get("header"),
+                meta_info=meta_info,
+                run_id=self.run_id,
+                return_response_metadata=True,
+                **args,
+            )
+        except asyncio.CancelledError:
+            self._finalize_api_call_detail(call_log, error="cancelled")
+            raise
+        except Exception as e:
+            self._finalize_api_call_detail(call_log, error=e)
+            return json.dumps({"status": "error", "message": str(e)})
+
+        self._finalize_api_call_detail(
+            call_log,
+            response=response.get("body"),
+            status_code=response.get("status_code"),
+            content_type=response.get("content_type"),
+            error=response.get("error"),
+        )
+        return str(response.get("body"))
+
     async def run(self):
         self._component_error = None  # Reset for each run
         self._error_logged = False
@@ -7340,39 +7740,48 @@ class TaskManager(BaseManager):
                 tasks = []
                 # tasks = [asyncio.create_task(self.tools['input'].handle())]
 
-                # In the case of web call we would play the first message once we receive the init event
-                if self.turn_based_conversation:
-                    self.first_message_task = asyncio.create_task(self.__first_message())
+                if self.__is_s2s():
+                    # One socket replaces the transcriber, LLM and synthesizer legs; the S2S
+                    # runner owns its own output, hangup and DTMF tasks.
+                    tasks.append(asyncio.create_task(self._run_s2s_conversation()))
+                else:
+                    # In the case of web call we would play the first message once we receive the init event
+                    if self.turn_based_conversation:
+                        self.first_message_task = asyncio.create_task(self.__first_message())
 
-                if not self.turn_based_conversation:
-                    self.first_message_passing_time = None
-                    self.handle_accumulated_message_task = asyncio.create_task(self.__handle_accumulated_message())
-                if "transcriber" in self.tools:
-                    tasks.append(asyncio.create_task(self._listen_transcriber()))
-                    self.transcriber_task = asyncio.create_task(self.tools["transcriber"].run())
+                    if not self.turn_based_conversation:
+                        self.first_message_passing_time = None
+                        self.handle_accumulated_message_task = asyncio.create_task(self.__handle_accumulated_message())
+                    if "transcriber" in self.tools:
+                        tasks.append(asyncio.create_task(self._listen_transcriber()))
+                        self.transcriber_task = asyncio.create_task(self.tools["transcriber"].run())
 
-                if self.turn_based_conversation and self._is_conversation_task():
-                    logger.info(
-                        "Since it's connected through dashboard, I'll run listen_llm_tas too in case user wants to simply text"
-                    )
-                    self.llm_queue_task = asyncio.create_task(self._listen_llm_input_queue())
+                    if self.turn_based_conversation and self._is_conversation_task():
+                        logger.info(
+                            "Since it's connected through dashboard, I'll run listen_llm_tas too in case user wants to simply text"
+                        )
+                        self.llm_queue_task = asyncio.create_task(self._listen_llm_input_queue())
 
-                if "synthesizer" in self.tools and self._is_conversation_task() and not self.turn_based_conversation:
-                    try:
-                        self.synthesizer_task = asyncio.create_task(self.__listen_synthesizer())
-                    except asyncio.CancelledError as e:
-                        logger.error(f"Synth task got cancelled {e}")
-                        traceback.print_exc()
+                    if (
+                        "synthesizer" in self.tools
+                        and self._is_conversation_task()
+                        and not self.turn_based_conversation
+                    ):
+                        try:
+                            self.synthesizer_task = asyncio.create_task(self.__listen_synthesizer())
+                        except asyncio.CancelledError as e:
+                            logger.error(f"Synth task got cancelled {e}")
+                            traceback.print_exc()
 
-                self.output_task = asyncio.create_task(self.__process_output_loop())
-                if not self.turn_based_conversation or self.enforce_streaming:
-                    self.hangup_task = asyncio.create_task(self.__check_for_completion())
+                    self.output_task = asyncio.create_task(self.__process_output_loop())
+                    if not self.turn_based_conversation or self.enforce_streaming:
+                        self.hangup_task = asyncio.create_task(self.__check_for_completion())
 
-                    if self.should_backchannel:
-                        self.backchanneling_task = asyncio.create_task(self.__check_for_backchanneling())
+                        if self.should_backchannel:
+                            self.backchanneling_task = asyncio.create_task(self.__check_for_backchanneling())
 
-                    if self.__is_graph_agent():
-                        self.event_listener_task = asyncio.create_task(self._listen_events())
+                        if self.__is_graph_agent():
+                            self.event_listener_task = asyncio.create_task(self._listen_events())
 
                 try:
                     await asyncio.gather(*tasks)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7413,6 +7413,7 @@ class TaskManager(BaseManager):
         self._s2s_started_at = time.time()
         self._s2s_agent_speaking = False
         self._s2s_turn_seq = 0
+        self._s2s_playout_until = 0.0
 
         try:
             await s2s.connect()
@@ -7465,6 +7466,21 @@ class TaskManager(BaseManager):
             await asyncio.gather(*loops, return_exceptions=True)
             await s2s.disconnect()
         logger.info("S2S conversation completed")
+
+    def _s2s_extend_playout(self, chunk: bytes) -> None:
+        """Advance the estimate of when the caller will have heard everything sent so far."""
+        duration = calculate_audio_duration(
+            len(chunk), self._s2s_output.sample_rate, format=self._s2s_output.encoding.value
+        )
+        self._s2s_playout_until = max(self._s2s_playout_until, time.time()) + duration
+
+    def _s2s_agent_has_floor(self) -> bool:
+        """Whether the caller is still hearing the agent.
+
+        The model finishes generating a turn seconds before its audio finishes playing, so
+        the generation window alone would miss barge-ins over the tail of a response.
+        """
+        return time.time() < self._s2s_playout_until
 
     def _s2s_within_welcome_gate(self):
         return (time.time() - self._s2s_started_at) * 1000 < self._s2s_welcome_gate_ms
@@ -7519,9 +7535,9 @@ class TaskManager(BaseManager):
                 if not self._s2s_agent_speaking:
                     self._s2s_agent_speaking = True
                     self.interruption_manager.on_agent_speech_started(self._s2s_turn_seq)
-                await self.buffered_output_queue.put(
-                    {"data": self._s2s_encode_output(event.data), "meta_info": self._s2s_meta()}
-                )
+                chunk = self._s2s_encode_output(event.data)
+                self._s2s_extend_playout(chunk)
+                await self.buffered_output_queue.put({"data": chunk, "meta_info": self._s2s_meta()})
                 self.last_transmitted_timestamp = time.time()
 
             elif isinstance(event, s2s_events.TranscriptDelta):
@@ -7545,12 +7561,13 @@ class TaskManager(BaseManager):
                 if self._s2s_within_welcome_gate():
                     continue
                 # The provider reports every speech start here, so this is only a barge-in
-                # when the agent actually had the floor.
+                # when the agent still had the floor.
                 self.interruption_manager.on_user_speech_started()
-                if self._s2s_agent_speaking:
+                if self._s2s_agent_has_floor():
                     logger.info("S2S: caller barged in, dropping queued audio")
                     self.interruption_manager.on_interruption_triggered()
                     self._s2s_agent_speaking = False
+                self._s2s_playout_until = 0.0
                 await self._s2s_drop_queued_audio()
 
             elif isinstance(event, s2s_events.ResponseDone):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7427,9 +7427,23 @@ class TaskManager(BaseManager):
         self._s2s_turn_seq = 0
         self._s2s_playout_until = 0.0
 
+        logger.info(f"S2S connecting | provider={self.s2s_provider_name} model={self.s2s_model}")
         try:
             await s2s.connect()
+        except asyncio.CancelledError:
+            # CancelledError is a BaseException, so it skips the handler below and the one
+            # in run() swallows it. Without this line a call torn down mid-handshake ends
+            # with no error anywhere: no S2S start line, no exception, just a clean finish.
+            logger.error(
+                f"S2S connect cancelled after {round((time.time() - self._s2s_started_at) * 1000)}ms | "
+                f"provider={self.s2s_provider_name} model={self.s2s_model}"
+            )
+            raise
         except Exception as e:
+            logger.error(
+                f"S2S connect failed after {round((time.time() - self._s2s_started_at) * 1000)}ms | "
+                f"provider={self.s2s_provider_name} model={self.s2s_model} error={type(e).__name__}: {e}"
+            )
             await self._report_provider_health(
                 "s2s", self.s2s_provider_name, self.s2s_model, False, phase="connect", blocking=True
             )
@@ -7887,10 +7901,20 @@ class TaskManager(BaseManager):
                 try:
                     await asyncio.gather(*tasks)
                 except asyncio.CancelledError:
-                    pass
+                    # Cancellation is a normal hangup, but it also lands here when a task is
+                    # torn down before it ever got going, which is indistinguishable from a
+                    # clean finish in the log otherwise.
+                    logger.info(f"Conversation tasks cancelled | pending={sum(1 for t in tasks if not t.done())}")
                 except Exception as e:
                     if not isinstance(e, BolnaComponentError):
                         logger.error(f"Error: {e}")
+                    else:
+                        # Typed component errors were only ever written to the request log, so
+                        # a failed provider connect left nothing in the app log to find.
+                        logger.error(
+                            f"Component error | component={e.component} provider={e.provider} "
+                            f"model={e.model} error={e}"
+                        )
                     if self.run_id and not self._error_logged:
                         if isinstance(e, BolnaComponentError):
                             error_msg = format_error_message(e.component, e.provider or e.model or "-", str(e))

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4101,6 +4101,15 @@ class TaskManager(BaseManager):
         self._hangup_processing = True
         self.hangup_triggered = True
         message = self.call_hangup_message if not self.voicemail_handler.detected else ""
+        if self.__is_s2s():
+            # The model already spoke the goodbye, prompted by the end_call result below,
+            # and there is no synthesizer to render one here. Queueing this would push a
+            # packet the caller never hears and leave the call waiting on its mark.
+            self.hangup_message_queued = False
+            self.hangup_triggered_at = time.time()
+            await self.__process_end_of_conversation()
+            return
+
         if not message or message.strip() == "":
             self.hangup_message_queued = False  # No hangup message to wait for
             self.hangup_triggered_at = time.time()
@@ -7849,7 +7858,19 @@ class TaskManager(BaseManager):
 
         ends_call = event.name.startswith(END_CALL_FUNCTION_PREFIX)
         if ends_call:
-            result = json.dumps({"status": "success", "message": "Call is ending now. Say a brief goodbye."})
+            # A configured hangup message is the goodbye for an s2s call: there is no
+            # synthesizer to play it separately, so the model has to speak it.
+            goodbye = self.call_hangup_message
+            result = json.dumps(
+                {
+                    "status": "success",
+                    "message": (
+                        f"Call is ending now. Say exactly this, and nothing else: {goodbye}"
+                        if goodbye and goodbye.strip()
+                        else "Call is ending now. Say a brief goodbye."
+                    ),
+                }
+            )
         elif event.name.startswith("transfer_call"):
             if self.has_transfer:
                 result = json.dumps({"status": "success", "message": "Transfer already in progress; wait silently."})
@@ -7863,6 +7884,11 @@ class TaskManager(BaseManager):
                 )
                 result = json.dumps({"status": "success", "message": "Transfer initiated; wait silently."})
         else:
+            # Without this the caller hears dead air for as long as the endpoint takes, and
+            # the are-you-still-there watchdog fires into the gap.
+            filler = compute_function_pre_call_message(self.language, event.name, params.get("pre_call_message"))
+            if filler:
+                await s2s.trigger_response(instructions=f"Say exactly this, and nothing else: {filler}")
             result = await self._s2s_call_api_tool(event, args, params, meta_info)
 
         convert_to_request_log(

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -52,6 +52,11 @@ LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 # healthy turn within utterance_end_ms (1s floor), so a real speaker stays well inside this.
 STUCK_AUDIO_GATE_RELEASE_S = 3.0
 
+# Above __await_stream_sid's own 10s timeout, so that path is what ends the call.
+S2S_STREAM_SID_TIMEOUT_S = 12.0
+# How long an armed goodbye gets before the call is closed without it.
+S2S_GOODBYE_TIMEOUT_S = 10.0
+
 # Soniox real-time STT
 SONIOX_WEBSOCKET_HOST = "stt-rt.soniox.com"
 SONIOX_ENDPOINT_TOKEN = "<end>"  # sentinel token emitted when the speaker stops

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -317,6 +317,10 @@ MODEL_REASONING_EFFORT_MAP = {
     "gpt-5.6-sol": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.6-terra": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
     "gpt-5.6-luna": [RE.NONE, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    # Realtime speech-to-speech. gpt-realtime-1.5 has no reasoning and is deliberately absent.
+    "gpt-realtime-2": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-realtime-2.1": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
+    "gpt-realtime-2.1-mini": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH, RE.XHIGH],
 }
 
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -199,6 +199,7 @@ class HangupReason(str, Enum):
     SYNTHESIZER_ERROR = "synthesizer_error"
     LLM_ERROR = "llm_error"
     END_CALL_TOOL = "end_call_tool"
+    S2S_ERROR = "s2s_error"
 
     @classmethod
     def all_values(cls):
@@ -216,6 +217,7 @@ class LogComponent(str, Enum):
     LLM_LANGUAGE_DETECTION = "llm_language_detection"
     LLM_LANGUAGE_SWITCH = "llm_language_switch"
     LLM_VOICEMAIL = "llm_voicemail"
+    S2S = "s2s"
     SYNTHESIZER = "synthesizer"
     TRANSCRIBER = "transcriber"
     WARNING = "warning"
@@ -291,6 +293,17 @@ class NodeType(str, Enum):
     LLM = "llm"
     STATIC = "static"
     ROUTER = "router"
+
+
+class S2SProvider(str, Enum):
+    """Enum for speech-to-speech providers."""
+
+    OPENAI_REALTIME = "openai_realtime"
+    GEMINI_LIVE = "gemini_live"
+
+    @classmethod
+    def all_values(cls):
+        return [p.value for p in cls]
 
 
 class ToolScope(str, Enum):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -263,6 +263,13 @@ def get_required_input_types(task):
     return input_types
 
 
+def is_s2s_agent(task):
+    """True when a task runs speech-to-speech instead of the transcriber/LLM/synthesizer chain."""
+    if not isinstance(task, dict):
+        return False
+    return bool((task.get("tools_config") or {}).get("s2s"))
+
+
 def format_messages(messages, use_system_prompt=False, include_tools=False):
     formatted_string = ""
     for message in messages:

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -1027,6 +1027,23 @@ def timestamp_ms() -> float:
     return time.time() * 1000
 
 
+def clean_gemini_schema(schema):
+    """Strip JSON Schema keys Gemini's proto-based Schema rejects.
+
+    Both the Gemini LLM and the Live API refuse a function declaration carrying
+    additionalProperties, and the Live API rejects the whole setup frame for it.
+    """
+    if not isinstance(schema, dict):
+        return schema
+    cleaned = {k: v for k, v in schema.items() if k != "additionalProperties"}
+    for k, v in cleaned.items():
+        if isinstance(v, dict):
+            cleaned[k] = clean_gemini_schema(v)
+        elif isinstance(v, list):
+            cleaned[k] = [clean_gemini_schema(i) if isinstance(i, dict) else i for i in v]
+    return cleaned
+
+
 def structure_system_prompt(
     system_prompt, run_id, assistant_id, call_sid, context_data, timezone, is_web_based_call=False
 ):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -256,7 +256,8 @@ def get_required_input_types(task):
     input_types = dict()
     for i, chain in enumerate(task["toolchain"]["pipelines"]):
         first_model = chain[0]
-        if chain[0] == "transcriber":
+        # An s2s pipeline takes caller audio directly, with no transcriber in front of it.
+        if chain[0] in ("transcriber", "s2s"):
             input_types["audio"] = i
         elif chain[0] == "synthesizer" or chain[0] == "llm":
             input_types["text"] = i

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -621,6 +621,18 @@ async def write_request_logs(message, run_id):
             None,
         ]
         metadata = message.get("graph_routing_metadata", {})
+    elif message["component"] == LogComponent.S2S:
+        component_details = [
+            message_data,
+            message.get("input_tokens", 0),
+            message.get("output_tokens", 0),
+            None,
+            message.get("latency", None),
+            False,
+            None,
+            None,
+        ]
+        metadata = message.get("s2s_metadata", {})
     elif message["component"] == LogComponent.ERROR:
         component_details = [message_data, None, None, None, message.get("latency", None), False, None, None]
         metadata = message.get("error_metadata", {})
@@ -813,6 +825,21 @@ def convert_to_request_log(
                     else UsageSource.ESTIMATED.value
                 )
                 log["llm_metadata"] = llm_metadata
+        case LogComponent.S2S:
+            log["latency"] = meta_info.get("s2s_latency", None) if direction == LogDirection.RESPONSE else None
+            if direction == LogDirection.RESPONSE:
+                log["input_tokens"] = input_tokens or 0
+                log["output_tokens"] = output_tokens or 0
+                # Audio and text are priced apart, so the split has to survive to billing.
+                s2s_metadata = dict(meta_info.get("s2s_usage") or {})
+                if cached_tokens:
+                    s2s_metadata["cached_tokens"] = cached_tokens
+                s2s_metadata["usage_source"] = (
+                    UsageSource.API_REPORTED.value
+                    if (input_tokens is not None or output_tokens is not None)
+                    else UsageSource.ESTIMATED.value
+                )
+                log["s2s_metadata"] = s2s_metadata
         case LogComponent.SYNTHESIZER:
             log["latency"] = meta_info.get("synthesizer_latency", None) if direction == LogDirection.RESPONSE else None
         case LogComponent.TRANSCRIBER:

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -913,6 +913,11 @@ def pcm_to_ulaw(pcm_bytes):
     return ulaw_bytes
 
 
+def ulaw_to_pcm(ulaw_bytes):
+    """Convert 8-bit ulaw audio to 16-bit signed linear PCM."""
+    return audioop.ulaw2lin(ulaw_bytes, 2)  # 2 = sample width in bytes (16-bit)
+
+
 def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
     """One-shot synth output (base64 str / WAV / raw PCM) → mono 16-bit 8kHz mu-law.
     Undecodable compressed containers (MP3/Ogg/FLAC) return None — never raw noise."""

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -7,7 +7,12 @@ from google import genai
 from google.genai import types
 from bolna.constants import default_thinking_level
 from bolna.helpers.logger_config import configure_logger
-from bolna.helpers.utils import now_ms, compute_function_pre_call_message, convert_to_request_log
+from bolna.helpers.utils import (
+    now_ms,
+    compute_function_pre_call_message,
+    convert_to_request_log,
+    clean_gemini_schema,
+)
 from .llm import BaseLLM
 from .types import LLMStreamChunk, LatencyData, FunctionCallPayload
 
@@ -29,18 +34,6 @@ def _usage_kwargs(usage) -> dict:
 
 
 class GeminiLLM(BaseLLM):
-    def _clean_schema(self, schema):
-        """Gemini Protos don't support additionalProperties."""
-        if not isinstance(schema, dict):
-            return schema
-        cleaned = {k: v for k, v in schema.items() if k != "additionalProperties"}
-        for k, v in cleaned.items():
-            if isinstance(v, dict):
-                cleaned[k] = self._clean_schema(v)
-            elif isinstance(v, list):
-                cleaned[k] = [self._clean_schema(i) if isinstance(i, dict) else i for i in v]
-        return cleaned
-
     def __init__(self, max_tokens=100, buffer_size=40, model="gemini-2.5-flash", temperature=0.1, **kwargs):
         super().__init__(max_tokens, buffer_size)
 
@@ -74,7 +67,7 @@ class GeminiLLM(BaseLLM):
                         types.FunctionDeclaration(
                             name=func["name"],
                             description=func["description"],
-                            parameters=self._clean_schema(func["parameters"]),
+                            parameters=clean_gemini_schema(func["parameters"]),
                         )
                     )
                 elif "name" in tool and "parameters" in tool:
@@ -82,7 +75,7 @@ class GeminiLLM(BaseLLM):
                         types.FunctionDeclaration(
                             name=tool["name"],
                             description=tool.get("description", ""),
-                            parameters=self._clean_schema(tool["parameters"]),
+                            parameters=clean_gemini_schema(tool["parameters"]),
                         )
                     )
 

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -605,6 +605,7 @@ class OpenAIRealtimeConfig(BaseModel):
     reasoning_effort: Optional[ReasoningEffort] = None
     max_output_tokens: Optional[int] = None
     transcription_model: Optional[str] = "gpt-4o-mini-transcribe"
+    language: Optional[str] = None
 
     @model_validator(mode="after")
     def validate_reasoning(self):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -639,7 +639,7 @@ class S2SConfig(BaseModel):
     provider: str
     provider_config: Union[OpenAIRealtimeConfig, GeminiLiveConfig]
     # Suppresses inbound audio while the agent opens, so its own greeting cannot trip provider VAD.
-    welcome_audio_gate_ms: Optional[int] = 1500
+    welcome_audio_gate_ms: int = 1500
 
     @model_validator(mode="before")
     def preprocess(cls, values):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -7,6 +7,7 @@ from .enums import (
     TelephonyProvider,
     SynthesizerProvider,
     TranscriberProvider,
+    S2SProvider,
     ReasoningEffort,
     Verbosity,
     ExpressionOperator,
@@ -594,6 +595,65 @@ class ToolModel(BaseModel):
     tools_params: Dict[str, APIParams]
 
 
+class OpenAIRealtimeConfig(BaseModel):
+    model: str = "gpt-realtime-2.1"
+    voice: str = "marin"
+    turn_detection_type: str = "server_vad"
+    vad_threshold: Optional[float] = 0.5
+    vad_silence_duration_ms: Optional[int] = 500
+    vad_prefix_padding_ms: Optional[int] = 300
+    reasoning_effort: Optional[ReasoningEffort] = None
+    max_output_tokens: Optional[int] = None
+    transcription_model: Optional[str] = "gpt-4o-mini-transcribe"
+
+    @model_validator(mode="after")
+    def validate_reasoning(self):
+        if self.reasoning_effort:
+            if self.model not in MODEL_REASONING_EFFORT_MAP:
+                raise ValueError(f"reasoning_effort is not supported for realtime model '{self.model}'.")
+            validate_reasoning_effort_for_model(self.model, self.reasoning_effort.value)
+        return self
+
+
+class GeminiLiveConfig(BaseModel):
+    model: str = "gemini-3.1-flash-live-preview"
+    voice: str = "Kore"
+    language: Optional[str] = None
+    temperature: Optional[float] = None
+    start_sensitivity: Optional[str] = None
+    end_sensitivity: Optional[str] = None
+    vad_silence_duration_ms: Optional[int] = None
+    vad_prefix_padding_ms: Optional[int] = None
+    # Gemini closes an audio session at ~15 minutes, so both stay on unless explicitly disabled.
+    enable_session_resumption: bool = True
+    enable_context_compression: bool = True
+
+
+S2S_PROVIDER_CONFIGS = {
+    S2SProvider.OPENAI_REALTIME.value: OpenAIRealtimeConfig,
+    S2SProvider.GEMINI_LIVE.value: GeminiLiveConfig,
+}
+
+
+class S2SConfig(BaseModel):
+    provider: str
+    provider_config: Union[OpenAIRealtimeConfig, GeminiLiveConfig]
+    # Suppresses inbound audio while the agent opens, so its own greeting cannot trip provider VAD.
+    welcome_audio_gate_ms: Optional[int] = 1500
+
+    @model_validator(mode="before")
+    def preprocess(cls, values):
+        if not isinstance(values, dict):
+            return values
+        provider = values.get("provider")
+        validate_attribute(provider, S2SProvider.all_values())
+        config = values.get("provider_config") or {}
+        if isinstance(config, BaseModel):
+            config = config.model_dump()
+        values["provider_config"] = S2S_PROVIDER_CONFIGS[provider](**config)
+        return values
+
+
 class ToolsConfig(BaseModel):
     llm_agent: Optional[Union[LlmAgent, SimpleLlmAgent]] = None
     synthesizer: Optional[Synthesizer] = None
@@ -601,6 +661,7 @@ class ToolsConfig(BaseModel):
     input: Optional[IOModel] = None
     output: Optional[IOModel] = None
     api_tools: Optional[ToolModel] = None
+    s2s: Optional[S2SConfig] = None
     switch_tool_description: Optional[str] = None
     switch_handoff_messages: Optional[Dict[str, str]] = None
     agent_names: Optional[Dict[str, str]] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -598,7 +598,13 @@ class ToolModel(BaseModel):
 class OpenAIRealtimeConfig(BaseModel):
     model: str = "gpt-realtime-2.1"
     voice: str = "marin"
-    turn_detection_type: str = "server_vad"
+    # semantic_vad scores whether the caller has actually finished from what they said, so
+    # it waits longer on a trailing "ummm" than on a finished sentence. That is the job the
+    # llm pipeline does with a word count and a phrase list, done by a model instead.
+    turn_detection_type: str = "semantic_vad"
+    # auto | low | medium | high. Lower gives the caller longer before the model takes over.
+    eagerness: Optional[str] = "auto"
+    # server_vad only; ignored under semantic_vad.
     vad_threshold: Optional[float] = 0.5
     vad_silence_duration_ms: Optional[int] = 500
     vad_prefix_padding_ms: Optional[int] = 300
@@ -623,7 +629,9 @@ class GeminiLiveConfig(BaseModel):
     temperature: Optional[float] = None
     start_sensitivity: Optional[str] = None
     end_sensitivity: Optional[str] = None
-    vad_silence_duration_ms: Optional[int] = None
+    # Gemini's guide puts the usable band at 500-800ms: below it utterances fragment and
+    # transcription quality drops, above it the caller waits on every reply.
+    vad_silence_duration_ms: Optional[int] = 600
     vad_prefix_padding_ms: Optional[int] = None
     # Gemini closes an audio session at ~15 minutes, so both stay on unless explicitly disabled.
     enable_session_resumption: bool = True

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -44,7 +44,8 @@ from .output_handlers import (
     FreeSwitchOutputHandler,
 )
 from .llms import OpenAiLLM, LiteLLM, AzureLLM, GeminiLLM
-from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider
+from .s2s import GeminiLiveS2S, OpenAIRealtimeS2S
+from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider, S2SProvider
 
 
 def elevenlabs_synthesizer(**kwargs):
@@ -137,4 +138,8 @@ SUPPORTED_OUTPUT_TELEPHONY_HANDLERS = {
     TelephonyProvider.PLIVO.value: PlivoOutputHandler,
     TelephonyProvider.VOBIZ.value: VobizOutputHandler,
     TelephonyProvider.SIP_TRUNK.value: SipTrunkOutputHandler,
+}
+SUPPORTED_S2S_PROVIDERS = {
+    S2SProvider.OPENAI_REALTIME.value: OpenAIRealtimeS2S,
+    S2SProvider.GEMINI_LIVE.value: GeminiLiveS2S,
 }

--- a/bolna/s2s/__init__.py
+++ b/bolna/s2s/__init__.py
@@ -1,0 +1,5 @@
+from .base_s2s import BaseS2SProvider
+from .gemini_live_s2s import GeminiLiveS2S
+from .openai_realtime_s2s import OpenAIRealtimeS2S
+
+__all__ = ["BaseS2SProvider", "GeminiLiveS2S", "OpenAIRealtimeS2S"]

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -22,9 +22,6 @@ class BaseS2SProvider(ABC):
     input_sample_rate: int
     output_sample_rate: int = 24000
 
-    # DTMF is telephony-only and not offered by every provider.
-    supports_dtmf: bool = False
-
     def __init__(
         self,
         *,

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -4,6 +4,11 @@ from typing import AsyncGenerator, List, Optional
 
 from .events import S2SUsage
 
+# Without a cap, a provider that closes every connection is re-dialled for the whole call.
+# The first retry skips the delay so a single transient drop costs the caller nothing extra.
+MAX_RECONNECT_ATTEMPTS = 5
+RECONNECT_DELAY_S = 0.5
+
 
 class BaseS2SProvider(ABC):
     """Provider-agnostic interface for speech-to-speech models.

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -1,3 +1,4 @@
+import time
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
 
@@ -38,10 +39,51 @@ class BaseS2SProvider(ABC):
         self.turn_latencies: list = []
         self.first_audio_latencies: list = []
         self.usage_total = S2SUsage()
+        self._turn_start_time: Optional[float] = None
+        self._turn_first_audio_ms: Optional[float] = None
 
     def _accumulate_usage(self, usage: S2SUsage) -> S2SUsage:
         self.usage_total = self.usage_total + usage
         return usage
+
+    def start_turn(self) -> None:
+        """Open the latency clock for one model response."""
+        self._turn_start_time = time.time()
+        self._turn_first_audio_ms = None
+
+    def cancel_turn(self) -> None:
+        """Drop the open turn: the caller barged in, so its timings never completed."""
+        self._turn_start_time = None
+        self._turn_first_audio_ms = None
+
+    def record_first_audio(self) -> None:
+        if self._turn_start_time is None or self._turn_first_audio_ms is not None:
+            return
+        self._turn_first_audio_ms = round((time.time() - self._turn_start_time) * 1000, 2)
+        self.first_audio_latencies.append(self._turn_first_audio_ms)
+
+    def end_turn(self, usage: Optional[S2SUsage] = None) -> None:
+        """Close the turn as an LLM-shaped latency entry.
+
+        Downstream observability reads turn_latencies as dicts keyed like the LLM
+        pipeline's, so an s2s turn has to arrive in that shape rather than as a
+        bare duration.
+        """
+        if self._turn_start_time is None:
+            return
+        entry = {
+            "sequence_id": len(self.turn_latencies),
+            "turn_id": len(self.turn_latencies),
+            "model": self.model,
+            "first_token_latency_ms": self._turn_first_audio_ms,
+            "total_stream_duration_ms": round((time.time() - self._turn_start_time) * 1000, 2),
+        }
+        if usage is not None:
+            entry["input_tokens"] = usage.input_tokens
+            entry["output_tokens"] = usage.output_tokens
+            entry["cached_tokens"] = usage.cached_tokens
+        self.turn_latencies.append(entry)
+        self.cancel_turn()
 
     @abstractmethod
     async def connect(self) -> None:

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -1,0 +1,83 @@
+from abc import ABC, abstractmethod
+from typing import AsyncGenerator, List, Optional
+
+
+class BaseS2SProvider(ABC):
+    """Provider-agnostic interface for speech-to-speech models.
+
+    TaskManager interacts only through this contract, so a new provider drops in by
+    subclassing and declaring its audio rates. Rates are declared per provider rather
+    than assumed: OpenAI Realtime takes 24kHz input, Gemini Live takes 16kHz, and both
+    emit 24kHz. Callers resample against these attributes instead of hardcoding.
+    """
+
+    input_sample_rate: int
+    output_sample_rate: int = 24000
+
+    # DTMF is telephony-only and not offered by every provider.
+    supports_dtmf: bool = False
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str,
+        voice: str,
+        model: str,
+        api_key: str,
+        tools: Optional[List[dict]] = None,
+        **kwargs,
+    ):
+        self.system_prompt = system_prompt
+        self.voice = voice
+        self.model = model
+        self.api_key = api_key
+        self.tools = tools or []
+        self.connection_time: Optional[float] = None
+        self.turn_latencies: list = []
+        self.first_audio_latencies: list = []
+        self.usage_total: dict = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cached_tokens": 0,
+            "input_audio_tokens": 0,
+            "output_audio_tokens": 0,
+            "input_text_tokens": 0,
+            "output_text_tokens": 0,
+        }
+
+    def _accumulate_usage(self, usage: dict) -> None:
+        for key, value in usage.items():
+            if key in self.usage_total:
+                self.usage_total[key] += value or 0
+
+    @abstractmethod
+    async def connect(self) -> None:
+        """Open the session and block until the provider accepts the config."""
+
+    @abstractmethod
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        """Send PCM-16 mono audio at input_sample_rate."""
+
+    @abstractmethod
+    async def receive_events(self) -> AsyncGenerator:
+        """Yield provider-agnostic events until the session ends."""
+
+    @abstractmethod
+    async def send_function_result(self, call_id: str, name: str, result: str) -> None:
+        """Queue one tool result for the model."""
+
+    @abstractmethod
+    async def commit_function_results(self) -> None:
+        """Flush queued tool results and let the model continue."""
+
+    @abstractmethod
+    async def trigger_response(self, instructions: Optional[str] = None) -> None:
+        """Ask the model to speak without new user audio, used for the welcome message."""
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Close the session."""
+
+    async def send_dtmf(self, digits: str) -> None:
+        """Forward telephony keypad digits to the model."""
+        raise NotImplementedError(f"{type(self).__name__} does not support DTMF")

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -5,7 +5,7 @@ from typing import AsyncGenerator, List, Optional
 from .events import S2SUsage
 
 # Without a cap, a provider that closes every connection is re-dialled for the whole call.
-# The first retry skips the delay so a single transient drop costs the caller nothing extra.
+# The first retry skips the delay, so a single transient drop costs the caller nothing.
 MAX_RECONNECT_ATTEMPTS = 5
 RECONNECT_DELAY_S = 0.5
 
@@ -13,10 +13,8 @@ RECONNECT_DELAY_S = 0.5
 class BaseS2SProvider(ABC):
     """Provider-agnostic interface for speech-to-speech models.
 
-    TaskManager interacts only through this contract, so a new provider drops in by
-    subclassing and declaring its audio rates. Rates are declared per provider rather
-    than assumed: OpenAI Realtime takes 24kHz input, Gemini Live takes 16kHz, and both
-    emit 24kHz. Callers resample against these attributes instead of hardcoding.
+    Each provider declares its own audio rates; callers resample against those attributes
+    rather than hardcoding, since the two providers differ on input rate.
     """
 
     input_sample_rate: int
@@ -65,12 +63,7 @@ class BaseS2SProvider(ABC):
         self.first_audio_latencies.append(self._turn_first_audio_ms)
 
     def end_turn(self, usage: Optional[S2SUsage] = None) -> None:
-        """Close the turn as an LLM-shaped latency entry.
-
-        Downstream observability reads turn_latencies as dicts keyed like the LLM
-        pipeline's, so an s2s turn has to arrive in that shape rather than as a
-        bare duration.
-        """
+        """Close the turn as an LLM-shaped latency entry, which is the shape observability reads."""
         if self._turn_start_time is None:
             return
         entry = {

--- a/bolna/s2s/base_s2s.py
+++ b/bolna/s2s/base_s2s.py
@@ -1,6 +1,8 @@
 from abc import ABC, abstractmethod
 from typing import AsyncGenerator, List, Optional
 
+from .events import S2SUsage
+
 
 class BaseS2SProvider(ABC):
     """Provider-agnostic interface for speech-to-speech models.
@@ -35,20 +37,11 @@ class BaseS2SProvider(ABC):
         self.connection_time: Optional[float] = None
         self.turn_latencies: list = []
         self.first_audio_latencies: list = []
-        self.usage_total: dict = {
-            "input_tokens": 0,
-            "output_tokens": 0,
-            "cached_tokens": 0,
-            "input_audio_tokens": 0,
-            "output_audio_tokens": 0,
-            "input_text_tokens": 0,
-            "output_text_tokens": 0,
-        }
+        self.usage_total = S2SUsage()
 
-    def _accumulate_usage(self, usage: dict) -> None:
-        for key, value in usage.items():
-            if key in self.usage_total:
-                self.usage_total[key] += value or 0
+    def _accumulate_usage(self, usage: S2SUsage) -> S2SUsage:
+        self.usage_total = self.usage_total + usage
+        return usage
 
     @abstractmethod
     async def connect(self) -> None:

--- a/bolna/s2s/events.py
+++ b/bolna/s2s/events.py
@@ -1,0 +1,84 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass
+class SessionReady:
+    """Provider accepted the session config and is ready for audio."""
+
+    connection_time_ms: float
+
+
+@dataclass
+class AudioDelta:
+    """A chunk of output audio, PCM-16 at the provider's output_sample_rate."""
+
+    data: bytes
+
+
+@dataclass
+class TranscriptDelta:
+    """Assistant speech transcript."""
+
+    content: str
+    is_final: bool
+
+
+@dataclass
+class InputTranscript:
+    """User speech transcript from the provider's built-in transcription."""
+
+    content: str
+    is_final: bool
+
+
+@dataclass
+class FunctionCall:
+    """The provider wants to invoke a tool."""
+
+    name: str
+    call_id: str
+    arguments: str  # JSON string
+
+
+@dataclass
+class FunctionCallCancelled:
+    """Provider withdrew tool calls it had previously requested."""
+
+    call_ids: list
+
+
+@dataclass
+class ResponseDone:
+    """A full model response (turn) has completed."""
+
+    transcript: str
+    usage: Optional[dict] = field(default=None)
+
+
+@dataclass
+class Interrupted:
+    """User barged in, provider stopped generating."""
+
+
+@dataclass
+class SessionExpiring:
+    """The provider will close this session soon and it must be resumed."""
+
+    time_left_ms: Optional[int] = None
+
+
+@dataclass
+class SessionResumed:
+    """A dropped session was transparently re-established mid-call."""
+
+    reconnect_ms: float
+
+
+@dataclass
+class S2SError:
+    """An error from the S2S provider."""
+
+    message: str
+    code: str = ""
+    fatal: bool = True

--- a/bolna/s2s/events.py
+++ b/bolna/s2s/events.py
@@ -1,5 +1,50 @@
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, replace
+from enum import Enum
 from typing import Optional
+
+
+class AudioEncoding(str, Enum):
+    MULAW = "mulaw"
+    PCM = "pcm"
+
+
+@dataclass(frozen=True)
+class AudioFormat:
+    """How audio is carried on one leg of the media stream."""
+
+    encoding: AudioEncoding
+    sample_rate: int
+
+
+@dataclass(frozen=True)
+class S2SUsage:
+    """Tokens for one turn. Audio and text bill at different rates, so they stay apart."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_tokens: int = 0
+    input_audio_tokens: int = 0
+    input_text_tokens: int = 0
+    output_audio_tokens: int = 0
+    output_text_tokens: int = 0
+
+    def __add__(self, other: "S2SUsage") -> "S2SUsage":
+        return replace(self, **{f: getattr(self, f) + getattr(other, f) for f in _USAGE_FIELDS})
+
+    def modality_split(self) -> dict:
+        """The audio/text breakdown that has to reach billing."""
+        return {
+            "input_audio_tokens": self.input_audio_tokens,
+            "input_text_tokens": self.input_text_tokens,
+            "output_audio_tokens": self.output_audio_tokens,
+            "output_text_tokens": self.output_text_tokens,
+        }
+
+    def as_dict(self) -> dict:
+        return asdict(self)
+
+
+_USAGE_FIELDS = tuple(S2SUsage.__dataclass_fields__)
 
 
 @dataclass
@@ -53,7 +98,7 @@ class ResponseDone:
     """A full model response (turn) has completed."""
 
     transcript: str
-    usage: Optional[dict] = field(default=None)
+    usage: Optional[S2SUsage] = field(default=None)
 
 
 @dataclass

--- a/bolna/s2s/events.py
+++ b/bolna/s2s/events.py
@@ -88,7 +88,7 @@ class FunctionCall:
 
 @dataclass
 class FunctionCallCancelled:
-    """Provider withdrew tool calls it had previously requested."""
+    """Provider withdrew tool calls it requested."""
 
     call_ids: list
 

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -316,9 +316,7 @@ class GeminiLiveS2S(BaseS2SProvider):
         await self._send(
             {
                 "clientContent": {
-                    "turns": [
-                        {"role": "user", "parts": [{"text": f"[The user pressed the keypad digits: {digits}]"}]}
-                    ],
+                    "turns": [{"role": "user", "parts": [{"text": f"[The user pressed the keypad digits: {digits}]"}]}],
                     "turnComplete": True,
                 }
             }

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -7,6 +7,7 @@ from typing import AsyncGenerator, List, Optional
 import websockets
 
 from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.utils import clean_gemini_schema
 from .base_s2s import BaseS2SProvider
 from .events import (
     AudioDelta,
@@ -160,7 +161,9 @@ class GeminiLiveS2S(BaseS2SProvider):
             declaration = {"name": spec["name"], "description": spec.get("description", "")}
             parameters = spec.get("parameters")
             if parameters:
-                declaration["parameters"] = parameters
+                # An unsupported schema key does not just drop the tool: Gemini rejects the
+                # whole setup frame, so the call ends before the model ever connects.
+                declaration["parameters"] = clean_gemini_schema(parameters)
             declarations.append(declaration)
         return declarations
 

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -104,8 +104,8 @@ class GeminiLiveS2S(BaseS2SProvider):
         url = f"{GEMINI_LIVE_URL}?key={self.api_key}"
         started = time.time()
         self._ws = await websockets.connect(url, max_size=None)
-        # The handshake has three stages that fail differently — a blocked socket, a
-        # rejected setup, and a model that never acknowledges — and they are
+        # The handshake has three stages that fail differently: a blocked socket, a
+        # rejected setup, and a model that never acknowledges, and they are
         # indistinguishable from one another once the call has already ended.
         logger.debug(f"Gemini Live socket open in {round((time.time() - started) * 1000)}ms")
         await self._send({"setup": self._build_setup()})

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -16,6 +16,7 @@ from .events import (
     Interrupted,
     ResponseDone,
     S2SError,
+    S2SUsage,
     SessionExpiring,
     SessionReady,
     SessionResumed,
@@ -82,6 +83,7 @@ class GeminiLiveS2S(BaseS2SProvider):
         self._resumption_handle: Optional[str] = None
         self._reconnecting = False
         self._pending_tool_results: list = []
+        self._turn_usage = S2SUsage()
         self._current_response_transcript = ""
         self._turn_start_time: Optional[float] = None
         self._first_audio_recorded_this_turn = False
@@ -244,7 +246,11 @@ class GeminiLiveS2S(BaseS2SProvider):
                 continue
 
             if "usageMetadata" in message:
-                self._accumulate_usage(_map_usage(message["usageMetadata"]))
+                # Gemini reports usage in its own message, not on turnComplete, so hold it
+                # until the turn closes or the tokens never reach billing.
+                usage = _map_usage(message["usageMetadata"])
+                self._turn_usage = self._turn_usage + usage
+                self._accumulate_usage(usage)
 
             server_content = message.get("serverContent")
             if not server_content:
@@ -287,7 +293,8 @@ class GeminiLiveS2S(BaseS2SProvider):
                 self._current_response_transcript = ""
                 self._turn_start_time = None
                 self._first_audio_recorded_this_turn = False
-                yield ResponseDone(transcript=transcript, usage=None)
+                turn_usage, self._turn_usage = self._turn_usage, S2SUsage()
+                yield ResponseDone(transcript=transcript, usage=turn_usage)
 
     async def send_function_result(self, call_id: str, name: str, result: str) -> None:
         # Gemini wants a JSON object per response, and batches them in one toolResponse.
@@ -362,16 +369,17 @@ def _duration_to_ms(duration) -> Optional[int]:
         return None
 
 
-def _map_usage(usage: dict) -> dict:
+def _map_usage(usage: dict) -> S2SUsage:
     """Flatten Gemini usageMetadata, keeping the audio/text split that billing prices apart."""
-    mapped = {
-        "input_tokens": usage.get("promptTokenCount", 0) or 0,
-        "output_tokens": usage.get("responseTokenCount", 0) or 0,
-        "cached_tokens": usage.get("cachedContentTokenCount", 0) or 0,
-    }
+    by_modality = {}
     for prefix, field in (("input", "promptTokensDetails"), ("output", "responseTokensDetails")):
         for entry in usage.get(field) or []:
             modality = (entry.get("modality") or "").lower()
             if modality in ("audio", "text"):
-                mapped[f"{prefix}_{modality}_tokens"] = entry.get("tokenCount", 0) or 0
-    return mapped
+                by_modality[f"{prefix}_{modality}_tokens"] = entry.get("tokenCount", 0) or 0
+    return S2SUsage(
+        input_tokens=usage.get("promptTokenCount", 0) or 0,
+        output_tokens=usage.get("responseTokenCount", 0) or 0,
+        cached_tokens=usage.get("cachedContentTokenCount", 0) or 0,
+        **by_modality,
+    )

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -258,6 +258,9 @@ class GeminiLiveS2S(BaseS2SProvider):
 
             transcription = server_content.get("inputTranscription")
             if transcription and transcription.get("text"):
+                # Gemini has no response.created, so the caller's transcript is the earliest
+                # signal that a turn is under way and is what first-audio latency measures from.
+                self._start_turn_clock()
                 yield InputTranscript(content=transcription["text"], is_final=True)
 
             transcription = server_content.get("outputTranscription")
@@ -270,9 +273,7 @@ class GeminiLiveS2S(BaseS2SProvider):
                 inline_data = part.get("inlineData")
                 if not inline_data or not inline_data.get("data"):
                     continue
-                if self._turn_start_time is None:
-                    self._turn_start_time = time.time()
-                if not self._first_audio_recorded_this_turn:
+                if self._turn_start_time and not self._first_audio_recorded_this_turn:
                     self.first_audio_latencies.append((time.time() - self._turn_start_time) * 1000)
                     self._first_audio_recorded_this_turn = True
                 yield AudioDelta(data=base64.b64decode(inline_data["data"]))
@@ -298,15 +299,23 @@ class GeminiLiveS2S(BaseS2SProvider):
             payload = {"result": result}
         self._pending_tool_results.append({"id": call_id, "name": name, "response": payload})
 
+    def _start_turn_clock(self) -> None:
+        """Mark the point a turn was requested, for first-audio and turn latency."""
+        if self._turn_start_time is None:
+            self._turn_start_time = time.time()
+            self._first_audio_recorded_this_turn = False
+
     async def commit_function_results(self) -> None:
         if not self._pending_tool_results:
             return
+        self._start_turn_clock()
         responses, self._pending_tool_results = self._pending_tool_results, []
         # Gemini resumes generating on its own once the results land, so there is no
         # separate trigger the way OpenAI needs response.create.
         await self._send({"toolResponse": {"functionResponses": responses}})
 
     async def trigger_response(self, instructions: Optional[str] = None) -> None:
+        self._start_turn_clock()
         text = instructions or "Greet the user as instructed."
         await self._send(
             {"clientContent": {"turns": [{"role": "user", "parts": [{"text": text}]}], "turnComplete": True}}
@@ -354,8 +363,15 @@ def _duration_to_ms(duration) -> Optional[int]:
 
 
 def _map_usage(usage: dict) -> dict:
-    return {
+    """Flatten Gemini usageMetadata, keeping the audio/text split that billing prices apart."""
+    mapped = {
         "input_tokens": usage.get("promptTokenCount", 0) or 0,
         "output_tokens": usage.get("responseTokenCount", 0) or 0,
         "cached_tokens": usage.get("cachedContentTokenCount", 0) or 0,
     }
+    for prefix, field in (("input", "promptTokensDetails"), ("output", "responseTokensDetails")):
+        for entry in usage.get(field) or []:
+            modality = (entry.get("modality") or "").lower()
+            if modality in ("audio", "text"):
+                mapped[f"{prefix}_{modality}_tokens"] = entry.get("tokenCount", 0) or 0
+    return mapped

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -1,0 +1,363 @@
+import asyncio
+import base64
+import json
+import time
+from typing import AsyncGenerator, List, Optional
+
+import websockets
+
+from bolna.helpers.logger_config import configure_logger
+from .base_s2s import BaseS2SProvider
+from .events import (
+    AudioDelta,
+    FunctionCall,
+    FunctionCallCancelled,
+    InputTranscript,
+    Interrupted,
+    ResponseDone,
+    S2SError,
+    SessionExpiring,
+    SessionReady,
+    SessionResumed,
+    TranscriptDelta,
+)
+
+logger = configure_logger(__name__)
+
+GEMINI_LIVE_URL = (
+    "wss://generativelanguage.googleapis.com/ws/"
+    "google.ai.generativelanguage.v1beta.GenerativeService.BidiGenerateContent"
+)
+
+
+class GeminiLiveS2S(BaseS2SProvider):
+    """Gemini Live API speech-to-speech provider.
+
+    Gemini caps an audio-only session at roughly 15 minutes, which is well inside the
+    length of a normal call. The session is therefore resumed transparently: the server
+    hands out a resumption handle, warns via goAway before it closes, and the reconnect
+    restores conversation state so the caller never notices.
+    """
+
+    input_sample_rate = 16000
+    output_sample_rate = 24000
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str,
+        voice: str,
+        model: str,
+        api_key: str,
+        tools: Optional[List[dict]] = None,
+        language: Optional[str] = None,
+        temperature: Optional[float] = None,
+        start_sensitivity: Optional[str] = None,
+        end_sensitivity: Optional[str] = None,
+        vad_silence_duration_ms: Optional[int] = None,
+        vad_prefix_padding_ms: Optional[int] = None,
+        enable_session_resumption: bool = True,
+        enable_context_compression: bool = True,
+        **kwargs,
+    ):
+        super().__init__(
+            system_prompt=system_prompt,
+            voice=voice,
+            model=model,
+            api_key=api_key,
+            tools=tools,
+            **kwargs,
+        )
+        self.language = language
+        self.temperature = temperature
+        self.start_sensitivity = start_sensitivity
+        self.end_sensitivity = end_sensitivity
+        self.vad_silence_duration_ms = vad_silence_duration_ms
+        self.vad_prefix_padding_ms = vad_prefix_padding_ms
+        self.enable_session_resumption = enable_session_resumption
+        self.enable_context_compression = enable_context_compression
+
+        self._ws = None
+        self._closed = False
+        self._resumption_handle: Optional[str] = None
+        self._reconnecting = False
+        self._pending_tool_results: list = []
+        self._current_response_transcript = ""
+        self._turn_start_time: Optional[float] = None
+        self._first_audio_recorded_this_turn = False
+
+    async def connect(self) -> None:
+        started = time.time()
+        await self._open_session()
+        self.connection_time = (time.time() - started) * 1000
+        logger.info(f"Gemini Live connected in {self.connection_time:.0f}ms | model={self.model}")
+
+    async def _open_session(self) -> None:
+        url = f"{GEMINI_LIVE_URL}?key={self.api_key}"
+        self._ws = await websockets.connect(url, max_size=None)
+        await self._send({"setup": self._build_setup()})
+
+        # Gemini requires setupComplete before any other client message.
+        raw = await asyncio.wait_for(self._ws.recv(), timeout=10)
+        message = json.loads(raw)
+        if "setupComplete" not in message:
+            error = message.get("error", {})
+            raise ConnectionError(f"Gemini Live setup failed: {error.get('message', json.dumps(message)[:200])}")
+
+    def _build_setup(self) -> dict:
+        generation_config: dict = {
+            "responseModalities": ["AUDIO"],
+            "speechConfig": {"voiceConfig": {"prebuiltVoiceConfig": {"voiceName": self.voice}}},
+        }
+        if self.language:
+            generation_config["speechConfig"]["languageCode"] = self.language
+        if self.temperature is not None:
+            generation_config["temperature"] = self.temperature
+
+        setup: dict = {
+            "model": self.model if self.model.startswith("models/") else f"models/{self.model}",
+            "generationConfig": generation_config,
+            "systemInstruction": {"parts": [{"text": self.system_prompt}]},
+            "inputAudioTranscription": {},
+            "outputAudioTranscription": {},
+        }
+
+        automatic_vad = {
+            key: value
+            for key, value in (
+                ("startOfSpeechSensitivity", self.start_sensitivity),
+                ("endOfSpeechSensitivity", self.end_sensitivity),
+                ("silenceDurationMs", self.vad_silence_duration_ms),
+                ("prefixPaddingMs", self.vad_prefix_padding_ms),
+            )
+            if value is not None
+        }
+        if automatic_vad:
+            setup["realtimeInputConfig"] = {"automaticActivityDetection": automatic_vad}
+
+        if self.tools:
+            setup["tools"] = [{"functionDeclarations": self._format_tools()}]
+        if self.enable_session_resumption:
+            # An empty handle asks the server to start issuing them for this session.
+            setup["sessionResumption"] = {"handle": self._resumption_handle} if self._resumption_handle else {}
+        if self.enable_context_compression:
+            setup["contextWindowCompression"] = {"slidingWindow": {}}
+        return setup
+
+    def _format_tools(self) -> list:
+        declarations = []
+        for tool in self.tools:
+            spec = tool.get("function") if isinstance(tool, dict) and "function" in tool else tool
+            if not isinstance(spec, dict) or "name" not in spec:
+                logger.warning(f"S2S: dropping malformed tool entry: {tool!r}")
+                continue
+            declaration = {"name": spec["name"], "description": spec.get("description", "")}
+            parameters = spec.get("parameters")
+            if parameters:
+                declaration["parameters"] = parameters
+            declarations.append(declaration)
+        return declarations
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        if self._reconnecting:
+            return  # Brief gap while the session is restored; dropping is better than raising.
+        await self._send(
+            {
+                "realtimeInput": {
+                    "audio": {
+                        "data": base64.b64encode(pcm_bytes).decode("ascii"),
+                        "mimeType": f"audio/pcm;rate={self.input_sample_rate}",
+                    }
+                }
+            }
+        )
+
+    async def receive_events(self) -> AsyncGenerator:
+        yield SessionReady(connection_time_ms=self.connection_time or 0.0)
+        while not self._closed:
+            try:
+                async for event in self._receive_events_impl():
+                    yield event
+                # Clean server close: resume if we still have a handle.
+                if self._closed:
+                    return
+            except websockets.ConnectionClosed as e:
+                if self._closed:
+                    return
+                logger.warning(f"Gemini Live connection closed: code={e.code} reason={e.reason!r}")
+
+            if not self._can_resume():
+                yield S2SError(message="Gemini Live session ended and cannot be resumed", code="session_ended")
+                return
+            try:
+                started = time.time()
+                await self._resume_session()
+                yield SessionResumed(reconnect_ms=(time.time() - started) * 1000)
+            except Exception as e:
+                yield S2SError(message=f"Gemini Live resume failed: {e}", code="resume_failed")
+                return
+
+    def _can_resume(self) -> bool:
+        return self.enable_session_resumption and bool(self._resumption_handle) and not self._closed
+
+    async def _resume_session(self) -> None:
+        self._reconnecting = True
+        try:
+            if self._ws:
+                try:
+                    await self._ws.close()
+                except Exception:
+                    pass
+            await self._open_session()
+            logger.info("Gemini Live session resumed")
+        finally:
+            self._reconnecting = False
+
+    async def _receive_events_impl(self) -> AsyncGenerator:
+        async for raw in self._ws:
+            if isinstance(raw, bytes):
+                raw = raw.decode("utf-8")
+            message = json.loads(raw)
+
+            if "sessionResumptionUpdate" in message:
+                update = message["sessionResumptionUpdate"]
+                if update.get("resumable") and update.get("newHandle"):
+                    self._resumption_handle = update["newHandle"]
+                continue
+
+            if "goAway" in message:
+                time_left = message["goAway"].get("timeLeft")
+                yield SessionExpiring(time_left_ms=_duration_to_ms(time_left))
+                continue
+
+            if "toolCall" in message:
+                for call in message["toolCall"].get("functionCalls", []):
+                    yield FunctionCall(
+                        name=call.get("name", ""),
+                        call_id=call.get("id", ""),
+                        arguments=json.dumps(call.get("args", {})),
+                    )
+                continue
+
+            if "toolCallCancellation" in message:
+                yield FunctionCallCancelled(call_ids=message["toolCallCancellation"].get("ids", []))
+                continue
+
+            if "usageMetadata" in message:
+                self._accumulate_usage(_map_usage(message["usageMetadata"]))
+
+            server_content = message.get("serverContent")
+            if not server_content:
+                continue
+
+            if server_content.get("interrupted"):
+                self._current_response_transcript = ""
+                self._turn_start_time = None
+                yield Interrupted()
+                continue
+
+            transcription = server_content.get("inputTranscription")
+            if transcription and transcription.get("text"):
+                yield InputTranscript(content=transcription["text"], is_final=True)
+
+            transcription = server_content.get("outputTranscription")
+            if transcription and transcription.get("text"):
+                text = transcription["text"]
+                self._current_response_transcript += text
+                yield TranscriptDelta(content=text, is_final=False)
+
+            for part in (server_content.get("modelTurn") or {}).get("parts", []):
+                inline_data = part.get("inlineData")
+                if not inline_data or not inline_data.get("data"):
+                    continue
+                if self._turn_start_time is None:
+                    self._turn_start_time = time.time()
+                if not self._first_audio_recorded_this_turn:
+                    self.first_audio_latencies.append((time.time() - self._turn_start_time) * 1000)
+                    self._first_audio_recorded_this_turn = True
+                yield AudioDelta(data=base64.b64decode(inline_data["data"]))
+
+            if server_content.get("turnComplete"):
+                transcript = self._current_response_transcript.strip()
+                if transcript:
+                    yield TranscriptDelta(content=transcript, is_final=True)
+                if self._turn_start_time:
+                    self.turn_latencies.append((time.time() - self._turn_start_time) * 1000)
+                self._current_response_transcript = ""
+                self._turn_start_time = None
+                self._first_audio_recorded_this_turn = False
+                yield ResponseDone(transcript=transcript, usage=None)
+
+    async def send_function_result(self, call_id: str, name: str, result: str) -> None:
+        # Gemini wants a JSON object per response, and batches them in one toolResponse.
+        try:
+            payload = json.loads(result)
+            if not isinstance(payload, dict):
+                payload = {"result": payload}
+        except (ValueError, TypeError):
+            payload = {"result": result}
+        self._pending_tool_results.append({"id": call_id, "name": name, "response": payload})
+
+    async def commit_function_results(self) -> None:
+        if not self._pending_tool_results:
+            return
+        responses, self._pending_tool_results = self._pending_tool_results, []
+        # Gemini resumes generating on its own once the results land, so there is no
+        # separate trigger the way OpenAI needs response.create.
+        await self._send({"toolResponse": {"functionResponses": responses}})
+
+    async def trigger_response(self, instructions: Optional[str] = None) -> None:
+        text = instructions or "Greet the user as instructed."
+        await self._send(
+            {"clientContent": {"turns": [{"role": "user", "parts": [{"text": text}]}], "turnComplete": True}}
+        )
+
+    async def send_dtmf(self, digits: str) -> None:
+        await self._send(
+            {
+                "clientContent": {
+                    "turns": [
+                        {"role": "user", "parts": [{"text": f"[The user pressed the keypad digits: {digits}]"}]}
+                    ],
+                    "turnComplete": True,
+                }
+            }
+        )
+
+    async def disconnect(self) -> None:
+        self._closed = True
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception as e:
+                logger.warning(f"Error closing Gemini Live WS: {e}")
+            self._ws = None
+
+    async def _send(self, payload: dict) -> None:
+        if not self._ws:
+            return
+        try:
+            await self._ws.send(json.dumps(payload))
+        except Exception as e:
+            logger.error(f"Error sending to Gemini Live: {e}")
+            raise
+
+
+def _duration_to_ms(duration) -> Optional[int]:
+    """Convert a protobuf duration string such as '9.5s' to milliseconds."""
+    if duration is None:
+        return None
+    if isinstance(duration, (int, float)):
+        return int(duration * 1000)
+    try:
+        return int(float(str(duration).rstrip("s")) * 1000)
+    except ValueError:
+        return None
+
+
+def _map_usage(usage: dict) -> dict:
+    return {
+        "input_tokens": usage.get("promptTokenCount", 0) or 0,
+        "output_tokens": usage.get("responseTokenCount", 0) or 0,
+        "cached_tokens": usage.get("cachedContentTokenCount", 0) or 0,
+    }

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -8,7 +8,7 @@ import websockets
 
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import clean_gemini_schema
-from .base_s2s import BaseS2SProvider
+from .base_s2s import MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY_S, BaseS2SProvider
 from .events import (
     AudioDelta,
     FunctionCall,
@@ -190,9 +190,11 @@ class GeminiLiveS2S(BaseS2SProvider):
 
     async def receive_events(self) -> AsyncGenerator:
         yield SessionReady(connection_time_ms=self.connection_time or 0.0)
+        attempts = 0
         while not self._closed:
             try:
                 async for event in self._receive_events_impl():
+                    attempts = 0  # the session is producing traffic again
                     yield event
                 # Clean server close: resume if we still have a handle.
                 if self._closed:
@@ -205,6 +207,16 @@ class GeminiLiveS2S(BaseS2SProvider):
             if not self._can_resume():
                 yield S2SError(message="Gemini Live session ended and cannot be resumed", code="session_ended")
                 return
+
+            attempts += 1
+            if attempts > MAX_RECONNECT_ATTEMPTS:
+                yield S2SError(
+                    message=f"Gemini Live closed {attempts} times without recovering",
+                    code="reconnect_exhausted",
+                )
+                return
+            if attempts > 1:
+                await asyncio.sleep(RECONNECT_DELAY_S)
             try:
                 started = time.time()
                 await self._resume_session()

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -82,7 +82,7 @@ class GeminiLiveS2S(BaseS2SProvider):
         self._resumption_handle: Optional[str] = None
         self._reconnecting = False
         self._pending_tool_results: list = []
-        self._turn_usage = S2SUsage()
+        self._turn_usage: Optional[S2SUsage] = None
         self._current_response_transcript = ""
         self._current_input_transcript = ""
 
@@ -269,7 +269,7 @@ class GeminiLiveS2S(BaseS2SProvider):
                 # Gemini reports usage in its own message, not on turnComplete, so hold it
                 # until the turn closes or the tokens never reach billing.
                 usage = _map_usage(message["usageMetadata"])
-                self._turn_usage = self._turn_usage + usage
+                self._turn_usage = (self._turn_usage or S2SUsage()) + usage
                 self._accumulate_usage(usage)
 
             server_content = message.get("serverContent")
@@ -326,7 +326,7 @@ class GeminiLiveS2S(BaseS2SProvider):
                 transcript = self._current_response_transcript.strip()
                 if transcript:
                     yield TranscriptDelta(content=transcript, is_final=True)
-                turn_usage, self._turn_usage = self._turn_usage, S2SUsage()
+                turn_usage, self._turn_usage = self._turn_usage, None
                 self.end_turn(turn_usage)
                 self._current_response_transcript = ""
                 yield ResponseDone(transcript=transcript, usage=turn_usage)

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -85,8 +85,6 @@ class GeminiLiveS2S(BaseS2SProvider):
         self._pending_tool_results: list = []
         self._turn_usage = S2SUsage()
         self._current_response_transcript = ""
-        self._turn_start_time: Optional[float] = None
-        self._first_audio_recorded_this_turn = False
 
     async def connect(self) -> None:
         started = time.time()
@@ -258,7 +256,7 @@ class GeminiLiveS2S(BaseS2SProvider):
 
             if server_content.get("interrupted"):
                 self._current_response_transcript = ""
-                self._turn_start_time = None
+                self.cancel_turn()
                 yield Interrupted()
                 continue
 
@@ -279,21 +277,16 @@ class GeminiLiveS2S(BaseS2SProvider):
                 inline_data = part.get("inlineData")
                 if not inline_data or not inline_data.get("data"):
                     continue
-                if self._turn_start_time and not self._first_audio_recorded_this_turn:
-                    self.first_audio_latencies.append((time.time() - self._turn_start_time) * 1000)
-                    self._first_audio_recorded_this_turn = True
+                self.record_first_audio()
                 yield AudioDelta(data=base64.b64decode(inline_data["data"]))
 
             if server_content.get("turnComplete"):
                 transcript = self._current_response_transcript.strip()
                 if transcript:
                     yield TranscriptDelta(content=transcript, is_final=True)
-                if self._turn_start_time:
-                    self.turn_latencies.append((time.time() - self._turn_start_time) * 1000)
-                self._current_response_transcript = ""
-                self._turn_start_time = None
-                self._first_audio_recorded_this_turn = False
                 turn_usage, self._turn_usage = self._turn_usage, S2SUsage()
+                self.end_turn(turn_usage)
+                self._current_response_transcript = ""
                 yield ResponseDone(transcript=transcript, usage=turn_usage)
 
     async def send_function_result(self, call_id: str, name: str, result: str) -> None:
@@ -307,10 +300,9 @@ class GeminiLiveS2S(BaseS2SProvider):
         self._pending_tool_results.append({"id": call_id, "name": name, "response": payload})
 
     def _start_turn_clock(self) -> None:
-        """Mark the point a turn was requested, for first-audio and turn latency."""
+        """Gemini can be prompted from several places; only the first one opens the turn."""
         if self._turn_start_time is None:
-            self._turn_start_time = time.time()
-            self._first_audio_recorded_this_turn = False
+            self.start_turn()
 
     async def commit_function_results(self) -> None:
         if not self._pending_tool_results:

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -86,6 +86,13 @@ class GeminiLiveS2S(BaseS2SProvider):
         self._pending_tool_results: list = []
         self._turn_usage = S2SUsage()
         self._current_response_transcript = ""
+        self._current_input_transcript = ""
+
+    def _take_input_transcript(self) -> str:
+        """Return the caller's accumulated words and reset, so they are emitted once."""
+        text = self._current_input_transcript.strip()
+        self._current_input_transcript = ""
+        return text
 
     async def connect(self) -> None:
         started = time.time()
@@ -264,8 +271,14 @@ class GeminiLiveS2S(BaseS2SProvider):
                 continue
 
             if server_content.get("interrupted"):
+                partial = self._current_response_transcript.strip()
                 self._current_response_transcript = ""
                 self.cancel_turn()
+                if partial:
+                    # The final transcript is only emitted at turnComplete, which never
+                    # arrives for an interrupted turn, so what the caller actually heard
+                    # before barging in would go unrecorded.
+                    yield TranscriptDelta(content=partial, is_final=True)
                 yield Interrupted()
                 continue
 
@@ -274,7 +287,18 @@ class GeminiLiveS2S(BaseS2SProvider):
                 # Gemini has no response.created, so the caller's transcript is the earliest
                 # signal that a turn is under way and is what first-audio latency measures from.
                 self._start_turn_clock()
-                yield InputTranscript(content=transcription["text"], is_final=True)
+                # Gemini streams the caller's words in fragments with no finality flag.
+                # Marking each one final would record a single sentence as several turns.
+                self._current_input_transcript += transcription["text"]
+                yield InputTranscript(content=transcription["text"], is_final=False)
+
+            # The caller's utterance is complete once the model starts answering it.
+            if (server_content.get("outputTranscription") or {}).get("text") or (
+                server_content.get("modelTurn") or {}
+            ).get("parts"):
+                caller = self._take_input_transcript()
+                if caller:
+                    yield InputTranscript(content=caller, is_final=True)
 
             transcription = server_content.get("outputTranscription")
             if transcription and transcription.get("text"):
@@ -290,6 +314,10 @@ class GeminiLiveS2S(BaseS2SProvider):
                 yield AudioDelta(data=base64.b64decode(inline_data["data"]))
 
             if server_content.get("turnComplete"):
+                # Backstop for a turn that completed without the model ever answering.
+                caller = self._take_input_transcript()
+                if caller:
+                    yield InputTranscript(content=caller, is_final=True)
                 transcript = self._current_response_transcript.strip()
                 if transcript:
                     yield TranscriptDelta(content=transcript, is_final=True)

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -94,7 +94,12 @@ class GeminiLiveS2S(BaseS2SProvider):
 
     async def _open_session(self) -> None:
         url = f"{GEMINI_LIVE_URL}?key={self.api_key}"
+        started = time.time()
         self._ws = await websockets.connect(url, max_size=None)
+        # The handshake has three stages that fail differently — a blocked socket, a
+        # rejected setup, and a model that never acknowledges — and they are
+        # indistinguishable from one another once the call has already ended.
+        logger.debug(f"Gemini Live socket open in {round((time.time() - started) * 1000)}ms")
         await self._send({"setup": self._build_setup()})
 
         # Gemini requires setupComplete before any other client message.
@@ -103,6 +108,7 @@ class GeminiLiveS2S(BaseS2SProvider):
         if "setupComplete" not in message:
             error = message.get("error", {})
             raise ConnectionError(f"Gemini Live setup failed: {error.get('message', json.dumps(message)[:200])}")
+        logger.debug(f"Gemini Live setup acknowledged in {round((time.time() - started) * 1000)}ms")
 
     def _build_setup(self) -> dict:
         generation_config: dict = {

--- a/bolna/s2s/gemini_live_s2s.py
+++ b/bolna/s2s/gemini_live_s2s.py
@@ -35,10 +35,8 @@ GEMINI_LIVE_URL = (
 class GeminiLiveS2S(BaseS2SProvider):
     """Gemini Live API speech-to-speech provider.
 
-    Gemini caps an audio-only session at roughly 15 minutes, which is well inside the
-    length of a normal call. The session is therefore resumed transparently: the server
-    hands out a resumption handle, warns via goAway before it closes, and the reconnect
-    restores conversation state so the caller never notices.
+    Gemini caps an audio-only session at roughly 15 minutes, well inside a normal call, so
+    the session is resumed transparently off the handle the server issues.
     """
 
     input_sample_rate = 16000
@@ -104,9 +102,6 @@ class GeminiLiveS2S(BaseS2SProvider):
         url = f"{GEMINI_LIVE_URL}?key={self.api_key}"
         started = time.time()
         self._ws = await websockets.connect(url, max_size=None)
-        # The handshake has three stages that fail differently: a blocked socket, a
-        # rejected setup, and a model that never acknowledges, and they are
-        # indistinguishable from one another once the call has already ended.
         logger.debug(f"Gemini Live socket open in {round((time.time() - started) * 1000)}ms")
         await self._send({"setup": self._build_setup()})
 
@@ -196,7 +191,6 @@ class GeminiLiveS2S(BaseS2SProvider):
                 async for event in self._receive_events_impl():
                     attempts = 0  # the session is producing traffic again
                     yield event
-                # Clean server close: resume if we still have a handle.
                 if self._closed:
                     return
             except websockets.ConnectionClosed as e:
@@ -287,9 +281,8 @@ class GeminiLiveS2S(BaseS2SProvider):
                 self._current_response_transcript = ""
                 self.cancel_turn()
                 if partial:
-                    # The final transcript is only emitted at turnComplete, which never
-                    # arrives for an interrupted turn, so what the caller actually heard
-                    # before barging in would go unrecorded.
+                    # turnComplete never arrives for an interrupted turn, so without this
+                    # what the caller heard before barging in goes unrecorded.
                     yield TranscriptDelta(content=partial, is_final=True)
                 yield Interrupted()
                 continue

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -173,9 +173,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         return formatted
 
     async def send_audio(self, pcm_bytes: bytes) -> None:
-        await self._send(
-            {"type": "input_audio_buffer.append", "audio": base64.b64encode(pcm_bytes).decode("ascii")}
-        )
+        await self._send({"type": "input_audio_buffer.append", "audio": base64.b64encode(pcm_bytes).decode("ascii")})
 
     async def receive_events(self) -> AsyncGenerator:
         yield SessionReady(connection_time_ms=self.connection_time or 0.0)

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -17,6 +17,7 @@ from .events import (
     S2SError,
     S2SUsage,
     SessionReady,
+    SessionResumed,
     TranscriptDelta,
 )
 
@@ -85,6 +86,8 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         self.language = language
 
         self._ws = None
+        self._closed = False
+        self._history: list = []
         self._current_response_transcript = ""
         self._response_done_event = asyncio.Event()
         self._response_done_event.set()
@@ -111,6 +114,18 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         await self._await_session_updated()
         self.connection_time = (time.time() - started) * 1000
         logger.info(f"OpenAI Realtime connected in {self.connection_time:.0f}ms | model={self.model}")
+
+    def _instructions(self) -> str:
+        """The system prompt, plus what has already been said when this is a reconnect."""
+        if not self._history:
+            return self.system_prompt
+        spoken = "\n".join(f"{role}: {text}" for role, text in self._history)
+        return (
+            f"{self.system_prompt}\n\n"
+            "The call is already in progress and was briefly interrupted. "
+            "Continue naturally without greeting the caller again. "
+            f"Conversation so far:\n{spoken}"
+        )
 
     async def _await_session_updated(self, timeout: float = 5.0) -> None:
         # A rejected session.update must surface at connect time; mid-call is too late to fall back.
@@ -145,7 +160,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         config: dict = {
             "type": "realtime",
             "output_modalities": ["audio"],
-            "instructions": self.system_prompt,
+            "instructions": self._instructions(),
             "audio": {
                 "input": {
                     "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
@@ -195,11 +210,38 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
 
     async def receive_events(self) -> AsyncGenerator:
         yield SessionReady(connection_time_ms=self.connection_time or 0.0)
-        try:
-            async for event in self._receive_events_impl():
-                yield event
-        except websockets.ConnectionClosed as e:
-            yield S2SError(message=f"WebSocket closed: code={e.code} reason={e.reason!r}", code="connection_closed")
+        while True:
+            try:
+                async for event in self._receive_events_impl():
+                    yield event
+                return
+            except websockets.ConnectionClosed as e:
+                if self._closed:
+                    return
+                logger.warning(f"OpenAI Realtime connection closed: code={e.code} reason={e.reason!r}")
+
+            # A drop mid-call used to end the call outright. Reconnecting costs the caller
+            # the in-flight turn, which the model regenerates from the replayed history.
+            try:
+                started = time.time()
+                await self._reconnect()
+                yield SessionResumed(reconnect_ms=(time.time() - started) * 1000)
+            except Exception as e:
+                yield S2SError(message=f"OpenAI Realtime reconnect failed: {e}", code="reconnect_failed")
+                return
+
+    async def _reconnect(self) -> None:
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception:
+                pass
+            self._ws = None
+        # connect() rebuilds the session config, which carries the transcript so far in the
+        # instructions. OpenAI has no server-side resumption handle like Gemini's, and the
+        # shape for replaying an assistant turn as a conversation item is undocumented,
+        # so the prompt is the one surface that cannot be rejected mid-call.
+        await self.connect()
 
     async def _receive_events_impl(self) -> AsyncGenerator:
         async for raw in self._ws:
@@ -216,10 +258,15 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             elif event_type == "response.output_audio_transcript.done":
                 transcript = event.get("transcript", "")
                 self._current_response_transcript += transcript + " "
+                if transcript:
+                    self._history.append(("assistant", transcript))
                 yield TranscriptDelta(content=transcript, is_final=True)
 
             elif event_type == "conversation.item.input_audio_transcription.completed":
-                yield InputTranscript(content=event.get("transcript", ""), is_final=True)
+                transcript = event.get("transcript", "")
+                if transcript:
+                    self._history.append(("user", transcript))
+                yield InputTranscript(content=transcript, is_final=True)
 
             elif event_type == "response.function_call_arguments.done":
                 yield FunctionCall(
@@ -304,6 +351,8 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         await self.commit_function_results()
 
     async def disconnect(self) -> None:
+        # Marks the close as intentional so the reader does not treat it as a drop to recover from.
+        self._closed = True
         if self._ws:
             try:
                 await self._ws.close()

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -15,6 +15,7 @@ from .events import (
     Interrupted,
     ResponseDone,
     S2SError,
+    S2SUsage,
     SessionReady,
     TranscriptDelta,
 )
@@ -301,20 +302,20 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             logger.error(f"Error sending to OpenAI Realtime: {e}")
             raise
 
-    def _extract_usage(self, event: dict) -> Optional[dict]:
+    def _extract_usage(self, event: dict) -> Optional[S2SUsage]:
         raw = (event.get("response") or {}).get("usage")
         if not raw:
             return None
         input_details = raw.get("input_token_details") or {}
         output_details = raw.get("output_token_details") or {}
-        usage = {
-            "input_tokens": raw.get("input_tokens", 0),
-            "output_tokens": raw.get("output_tokens", 0),
-            "cached_tokens": (input_details.get("cached_tokens") or 0),
-            "input_audio_tokens": input_details.get("audio_tokens", 0),
-            "output_audio_tokens": output_details.get("audio_tokens", 0),
-            "input_text_tokens": input_details.get("text_tokens", 0),
-            "output_text_tokens": output_details.get("text_tokens", 0),
-        }
-        self._accumulate_usage(usage)
-        return usage
+        return self._accumulate_usage(
+            S2SUsage(
+                input_tokens=raw.get("input_tokens", 0) or 0,
+                output_tokens=raw.get("output_tokens", 0) or 0,
+                cached_tokens=input_details.get("cached_tokens", 0) or 0,
+                input_audio_tokens=input_details.get("audio_tokens", 0) or 0,
+                input_text_tokens=input_details.get("text_tokens", 0) or 0,
+                output_audio_tokens=output_details.get("audio_tokens", 0) or 0,
+                output_text_tokens=output_details.get("text_tokens", 0) or 0,
+            )
+        )

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -64,6 +64,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         reasoning_effort: Optional[str] = None,
         max_output_tokens: Optional[int] = None,
         transcription_model: str = "gpt-4o-mini-transcribe",
+        language: Optional[str] = None,
         **kwargs,
     ):
         super().__init__(
@@ -81,6 +82,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         self.reasoning_effort = reasoning_effort
         self.max_output_tokens = max_output_tokens
         self.transcription_model = transcription_model
+        self.language = language
 
         self._ws = None
         self._current_response_transcript = ""
@@ -148,7 +150,13 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 "input": {
                     "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
                     "turn_detection": turn_detection,
-                    "transcription": {"model": self.transcription_model},
+                    # Without a language the model auto-detects per utterance and can
+                    # transcribe a caller into the wrong script mid-call.
+                    "transcription": (
+                        {"model": self.transcription_model, "language": self.language}
+                        if self.language
+                        else {"model": self.transcription_model}
+                    ),
                 },
                 "output": {
                     "format": {"type": "audio/pcm", "rate": self.output_sample_rate},

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -1,0 +1,322 @@
+import asyncio
+import base64
+import json
+import time
+from typing import AsyncGenerator, List, Optional
+
+import websockets
+
+from bolna.helpers.logger_config import configure_logger
+from .base_s2s import BaseS2SProvider
+from .events import (
+    AudioDelta,
+    FunctionCall,
+    InputTranscript,
+    Interrupted,
+    ResponseDone,
+    S2SError,
+    SessionReady,
+    TranscriptDelta,
+)
+
+logger = configure_logger(__name__)
+
+OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
+
+# gpt-realtime-2 and its point releases accept reasoning.effort; 1.5 rejects it.
+REASONING_MODEL_PREFIXES = ("gpt-realtime-2",)
+
+
+class OpenAIRealtimeS2S(BaseS2SProvider):
+    """OpenAI Realtime API speech-to-speech provider.
+
+    Targets the GA protocol only. The Realtime beta was removed from the API on
+    2026-05-12, so the beta event aliases (response.audio.*) are gone.
+    """
+
+    input_sample_rate = 24000
+    output_sample_rate = 24000
+
+    def __init__(
+        self,
+        *,
+        system_prompt: str,
+        voice: str,
+        model: str,
+        api_key: str,
+        tools: Optional[List[dict]] = None,
+        turn_detection_type: str = "server_vad",
+        vad_threshold: float = 0.5,
+        vad_silence_duration_ms: int = 500,
+        vad_prefix_padding_ms: int = 300,
+        reasoning_effort: Optional[str] = None,
+        max_output_tokens: Optional[int] = None,
+        transcription_model: str = "gpt-4o-mini-transcribe",
+        **kwargs,
+    ):
+        super().__init__(
+            system_prompt=system_prompt,
+            voice=voice,
+            model=model,
+            api_key=api_key,
+            tools=tools,
+            **kwargs,
+        )
+        self.turn_detection_type = turn_detection_type
+        self.vad_threshold = vad_threshold
+        self.vad_silence_duration_ms = vad_silence_duration_ms
+        self.vad_prefix_padding_ms = vad_prefix_padding_ms
+        self.reasoning_effort = reasoning_effort
+        self.max_output_tokens = max_output_tokens
+        self.transcription_model = transcription_model
+
+        self._ws = None
+        self._current_response_transcript = ""
+        self._turn_start_time: Optional[float] = None
+        self._first_audio_recorded_this_turn = False
+        self._response_done_event = asyncio.Event()
+        self._response_done_event.set()
+
+    @property
+    def is_reasoning_model(self) -> bool:
+        return self.model.startswith(REASONING_MODEL_PREFIXES)
+
+    async def connect(self) -> None:
+        url = f"{OPENAI_REALTIME_URL}?model={self.model}"
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+
+        started = time.time()
+        self._ws = await websockets.connect(url, additional_headers=headers, max_size=None)
+
+        event = json.loads(await self._ws.recv())
+        if event.get("type") != "session.created":
+            error = event.get("error", {})
+            raise ConnectionError(
+                f"OpenAI Realtime handshake failed: {error.get('message', event.get('type', 'unknown'))}"
+            )
+
+        await self._send({"type": "session.update", "session": self._build_session_config()})
+        await self._await_session_updated()
+        self.connection_time = (time.time() - started) * 1000
+        logger.info(f"OpenAI Realtime connected in {self.connection_time:.0f}ms | model={self.model}")
+
+    async def _await_session_updated(self, timeout: float = 5.0) -> None:
+        # A rejected session.update must surface at connect time; mid-call is too late to fall back.
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            try:
+                raw = await asyncio.wait_for(self._ws.recv(), timeout=max(0.05, deadline - time.time()))
+            except asyncio.TimeoutError:
+                logger.warning(f"OpenAI Realtime: no session.updated within {timeout}s, continuing")
+                return
+            event = json.loads(raw)
+            if event.get("type") == "session.updated":
+                return
+            if event.get("type") == "error":
+                error = event.get("error", {})
+                raise ConnectionError(
+                    f"OpenAI Realtime rejected session.update: "
+                    f"{error.get('message', 'unknown')} (code={error.get('code', '')})"
+                )
+
+    def _build_session_config(self) -> dict:
+        turn_detection: dict = {"type": self.turn_detection_type}
+        if self.turn_detection_type == "server_vad":
+            turn_detection.update(
+                {
+                    "threshold": self.vad_threshold,
+                    "prefix_padding_ms": self.vad_prefix_padding_ms,
+                    "silence_duration_ms": self.vad_silence_duration_ms,
+                }
+            )
+
+        config: dict = {
+            "type": "realtime",
+            "output_modalities": ["audio"],
+            "instructions": self.system_prompt,
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": self.input_sample_rate},
+                    "turn_detection": turn_detection,
+                    "transcription": {"model": self.transcription_model},
+                },
+                "output": {
+                    "format": {"type": "audio/pcm", "rate": self.output_sample_rate},
+                    "voice": self.voice,
+                },
+            },
+        }
+        if self.reasoning_effort and self.is_reasoning_model:
+            config["reasoning"] = {"effort": self.reasoning_effort}
+        if self.max_output_tokens is not None:
+            config["max_output_tokens"] = self.max_output_tokens
+        if self.tools:
+            config["tools"] = self._format_tools()
+            config["tool_choice"] = "auto"
+        return config
+
+    def _format_tools(self) -> list:
+        formatted = []
+        for tool in self.tools:
+            spec = tool.get("function") if isinstance(tool, dict) and "function" in tool else tool
+            if not isinstance(spec, dict) or "name" not in spec:
+                logger.warning(f"S2S: dropping malformed tool entry: {tool!r}")
+                continue
+            formatted.append(
+                {
+                    "type": "function",
+                    "name": spec["name"],
+                    "description": spec.get("description", ""),
+                    "parameters": spec.get("parameters", {}),
+                }
+            )
+        return formatted
+
+    async def send_audio(self, pcm_bytes: bytes) -> None:
+        await self._send(
+            {"type": "input_audio_buffer.append", "audio": base64.b64encode(pcm_bytes).decode("ascii")}
+        )
+
+    async def receive_events(self) -> AsyncGenerator:
+        yield SessionReady(connection_time_ms=self.connection_time or 0.0)
+        try:
+            async for event in self._receive_events_impl():
+                yield event
+        except websockets.ConnectionClosed as e:
+            yield S2SError(message=f"WebSocket closed: code={e.code} reason={e.reason!r}", code="connection_closed")
+
+    async def _receive_events_impl(self) -> AsyncGenerator:
+        async for raw in self._ws:
+            event = json.loads(raw)
+            event_type = event.get("type", "")
+
+            if event_type == "response.output_audio.delta":
+                if not self._first_audio_recorded_this_turn and self._turn_start_time:
+                    self.first_audio_latencies.append((time.time() - self._turn_start_time) * 1000)
+                    self._first_audio_recorded_this_turn = True
+                yield AudioDelta(data=base64.b64decode(event["delta"]))
+
+            elif event_type == "response.output_audio_transcript.delta":
+                yield TranscriptDelta(content=event.get("delta", ""), is_final=False)
+
+            elif event_type == "response.output_audio_transcript.done":
+                transcript = event.get("transcript", "")
+                self._current_response_transcript += transcript + " "
+                yield TranscriptDelta(content=transcript, is_final=True)
+
+            elif event_type == "conversation.item.input_audio_transcription.completed":
+                yield InputTranscript(content=event.get("transcript", ""), is_final=True)
+
+            elif event_type == "response.function_call_arguments.done":
+                yield FunctionCall(
+                    name=event.get("name", ""),
+                    call_id=event.get("call_id", ""),
+                    arguments=event.get("arguments", "{}"),
+                )
+
+            elif event_type == "response.created":
+                self._turn_start_time = time.time()
+                self._first_audio_recorded_this_turn = False
+                self._response_done_event.clear()
+
+            elif event_type == "response.done":
+                if self._turn_start_time:
+                    self.turn_latencies.append((time.time() - self._turn_start_time) * 1000)
+                    self._turn_start_time = None
+                transcript = self._current_response_transcript.strip()
+                self._current_response_transcript = ""
+                self._response_done_event.set()
+                yield ResponseDone(transcript=transcript, usage=self._extract_usage(event))
+
+            elif event_type == "input_audio_buffer.speech_started":
+                # Keep the transcript accumulated so far: the caller already heard that much,
+                # and response.done still needs to report it before clearing.
+                self._turn_start_time = None
+                yield Interrupted()
+
+            elif event_type == "error":
+                error = event.get("error", {})
+                # A failed response frees the turn; without this the next commit would stall.
+                self._response_done_event.set()
+                yield S2SError(message=error.get("message", "Unknown error"), code=error.get("code", ""))
+
+            else:
+                logger.debug(f"OpenAI Realtime unhandled event: {event_type}")
+
+    async def send_function_result(self, call_id: str, name: str, result: str) -> None:
+        await self._send(
+            {
+                "type": "conversation.item.create",
+                "item": {"type": "function_call_output", "call_id": call_id, "output": result},
+            }
+        )
+
+    async def commit_function_results(self) -> None:
+        await self._wait_for_response_done()
+        await self._send({"type": "response.create"})
+
+    async def _wait_for_response_done(self, timeout: float = 5.0) -> None:
+        # OpenAI rejects response.create while a response is still active.
+        if self._response_done_event.is_set():
+            return
+        try:
+            await asyncio.wait_for(self._response_done_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            logger.warning("Timed out waiting for response.done before commit, sending anyway")
+
+    async def trigger_response(self, instructions: Optional[str] = None) -> None:
+        payload: dict = {"type": "response.create"}
+        if instructions:
+            payload["response"] = {"instructions": instructions}
+        await self._wait_for_response_done()
+        await self._send(payload)
+
+    async def send_dtmf(self, digits: str) -> None:
+        # bolna terminates telephony itself, so the provider never sees the carrier's DTMF
+        # frames. Inject the digits as user text instead.
+        await self._send(
+            {
+                "type": "conversation.item.create",
+                "item": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": f"[The user pressed the keypad digits: {digits}]"}],
+                },
+            }
+        )
+        await self.commit_function_results()
+
+    async def disconnect(self) -> None:
+        if self._ws:
+            try:
+                await self._ws.close()
+            except Exception as e:
+                logger.warning(f"Error closing OpenAI Realtime WS: {e}")
+            self._ws = None
+
+    async def _send(self, payload: dict) -> None:
+        if not self._ws:
+            return
+        try:
+            await self._ws.send(json.dumps(payload))
+        except Exception as e:
+            logger.error(f"Error sending to OpenAI Realtime: {e}")
+            raise
+
+    def _extract_usage(self, event: dict) -> Optional[dict]:
+        raw = (event.get("response") or {}).get("usage")
+        if not raw:
+            return None
+        input_details = raw.get("input_token_details") or {}
+        output_details = raw.get("output_token_details") or {}
+        usage = {
+            "input_tokens": raw.get("input_tokens", 0),
+            "output_tokens": raw.get("output_tokens", 0),
+            "cached_tokens": (input_details.get("cached_tokens") or 0),
+            "input_audio_tokens": input_details.get("audio_tokens", 0),
+            "output_audio_tokens": output_details.get("audio_tokens", 0),
+            "input_text_tokens": input_details.get("text_tokens", 0),
+            "output_text_tokens": output_details.get("text_tokens", 0),
+        }
+        self._accumulate_usage(usage)
+        return usage

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -84,8 +84,6 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
 
         self._ws = None
         self._current_response_transcript = ""
-        self._turn_start_time: Optional[float] = None
-        self._first_audio_recorded_this_turn = False
         self._response_done_event = asyncio.Event()
         self._response_done_event.set()
 
@@ -201,9 +199,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             event_type = event.get("type", "")
 
             if event_type == "response.output_audio.delta":
-                if not self._first_audio_recorded_this_turn and self._turn_start_time:
-                    self.first_audio_latencies.append((time.time() - self._turn_start_time) * 1000)
-                    self._first_audio_recorded_this_turn = True
+                self.record_first_audio()
                 yield AudioDelta(data=base64.b64decode(event["delta"]))
 
             elif event_type == "response.output_audio_transcript.delta":
@@ -225,23 +221,21 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 )
 
             elif event_type == "response.created":
-                self._turn_start_time = time.time()
-                self._first_audio_recorded_this_turn = False
+                self.start_turn()
                 self._response_done_event.clear()
 
             elif event_type == "response.done":
-                if self._turn_start_time:
-                    self.turn_latencies.append((time.time() - self._turn_start_time) * 1000)
-                    self._turn_start_time = None
+                usage = self._extract_usage(event)
+                self.end_turn(usage)
                 transcript = self._current_response_transcript.strip()
                 self._current_response_transcript = ""
                 self._response_done_event.set()
-                yield ResponseDone(transcript=transcript, usage=self._extract_usage(event))
+                yield ResponseDone(transcript=transcript, usage=usage)
 
             elif event_type == "input_audio_buffer.speech_started":
                 # Keep the transcript accumulated so far: the caller already heard that much,
                 # and response.done still needs to report it before clearing.
-                self._turn_start_time = None
+                self.cancel_turn()
                 yield Interrupted()
 
             elif event_type == "error":

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -27,6 +27,17 @@ OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 # gpt-realtime-2 and its point releases accept reasoning.effort; 1.5 rejects it.
 REASONING_MODEL_PREFIXES = ("gpt-realtime-2",)
 
+# Turn-level complaints the session survives. Cancelling a response that already finished
+# and racing response.create against an active response both land here, and neither is a
+# reason to drop a live call or mark the provider unhealthy.
+RECOVERABLE_ERROR_CODES = frozenset(
+    {
+        "response_cancel_not_active",
+        "conversation_already_has_active_response",
+        "invalid_request_error",
+    }
+)
+
 
 class OpenAIRealtimeS2S(BaseS2SProvider):
     """OpenAI Realtime API speech-to-speech provider.
@@ -237,7 +248,12 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 error = event.get("error", {})
                 # A failed response frees the turn; without this the next commit would stall.
                 self._response_done_event.set()
-                yield S2SError(message=error.get("message", "Unknown error"), code=error.get("code", ""))
+                code = error.get("code", "") or ""
+                yield S2SError(
+                    message=error.get("message", "Unknown error"),
+                    code=code,
+                    fatal=code not in RECOVERABLE_ERROR_CODES,
+                )
 
             else:
                 logger.debug(f"OpenAI Realtime unhandled event: {event_type}")

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -217,7 +217,9 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 async for event in self._receive_events_impl():
                     attempts = 0  # the session is producing traffic again
                     yield event
-                return
+                # A normal close ends the iterator without raising, so this is a drop too.
+                if self._closed:
+                    return
             except websockets.ConnectionClosed as e:
                 if self._closed:
                     return

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -58,7 +58,8 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         model: str,
         api_key: str,
         tools: Optional[List[dict]] = None,
-        turn_detection_type: str = "server_vad",
+        turn_detection_type: str = "semantic_vad",
+        eagerness: Optional[str] = "auto",
         vad_threshold: float = 0.5,
         vad_silence_duration_ms: int = 500,
         vad_prefix_padding_ms: int = 300,
@@ -77,6 +78,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             **kwargs,
         )
         self.turn_detection_type = turn_detection_type
+        self.eagerness = eagerness
         self.vad_threshold = vad_threshold
         self.vad_silence_duration_ms = vad_silence_duration_ms
         self.vad_prefix_padding_ms = vad_prefix_padding_ms
@@ -156,6 +158,9 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                     "silence_duration_ms": self.vad_silence_duration_ms,
                 }
             )
+        elif self.eagerness:
+            # How long the classifier lets a hesitant caller keep the floor.
+            turn_detection["eagerness"] = self.eagerness
 
         config: dict = {
             "type": "realtime",

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -7,7 +7,7 @@ from typing import AsyncGenerator, List, Optional
 import websockets
 
 from bolna.helpers.logger_config import configure_logger
-from .base_s2s import BaseS2SProvider
+from .base_s2s import MAX_RECONNECT_ATTEMPTS, RECONNECT_DELAY_S, BaseS2SProvider
 from .events import (
     AudioDelta,
     FunctionCall,
@@ -35,9 +35,10 @@ RECOVERABLE_ERROR_CODES = frozenset(
     {
         "response_cancel_not_active",
         "conversation_already_has_active_response",
-        "invalid_request_error",
     }
 )
+# A rejected field or a malformed tool schema arrives as a type, with no code to match above.
+RECOVERABLE_ERROR_TYPES = frozenset({"invalid_request_error"})
 
 
 class OpenAIRealtimeS2S(BaseS2SProvider):
@@ -215,15 +216,27 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
 
     async def receive_events(self) -> AsyncGenerator:
         yield SessionReady(connection_time_ms=self.connection_time or 0.0)
+        attempts = 0
         while True:
             try:
                 async for event in self._receive_events_impl():
+                    attempts = 0  # the session is producing traffic again
                     yield event
                 return
             except websockets.ConnectionClosed as e:
                 if self._closed:
                     return
                 logger.warning(f"OpenAI Realtime connection closed: code={e.code} reason={e.reason!r}")
+
+            attempts += 1
+            if attempts > MAX_RECONNECT_ATTEMPTS:
+                yield S2SError(
+                    message=f"OpenAI Realtime closed {attempts} times without recovering",
+                    code="reconnect_exhausted",
+                )
+                return
+            if attempts > 1:
+                await asyncio.sleep(RECONNECT_DELAY_S)
 
             # A drop mid-call used to end the call outright. Reconnecting costs the caller
             # the in-flight turn, which the model regenerates from the replayed history.
@@ -302,12 +315,11 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 error = event.get("error", {})
                 # A failed response frees the turn; without this the next commit would stall.
                 self._response_done_event.set()
-                code = error.get("code", "") or ""
-                yield S2SError(
-                    message=error.get("message", "Unknown error"),
-                    code=code,
-                    fatal=code not in RECOVERABLE_ERROR_CODES,
-                )
+                code = error.get("code") or ""
+                error_type = error.get("type") or ""
+                # A codeless error is not worth a dropped call; a dead session closes its socket.
+                fatal = bool(code) and code not in RECOVERABLE_ERROR_CODES and error_type not in RECOVERABLE_ERROR_TYPES
+                yield S2SError(message=error.get("message", "Unknown error"), code=code, fatal=fatal)
 
             else:
                 logger.debug(f"OpenAI Realtime unhandled event: {event_type}")

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -28,9 +28,8 @@ OPENAI_REALTIME_URL = "wss://api.openai.com/v1/realtime"
 # gpt-realtime-2 and its point releases accept reasoning.effort; 1.5 rejects it.
 REASONING_MODEL_PREFIXES = ("gpt-realtime-2",)
 
-# Turn-level complaints the session survives. Cancelling a response that already finished
-# and racing response.create against an active response both land here, and neither is a
-# reason to drop a live call or mark the provider unhealthy.
+# Turn-level complaints the session survives: neither is a reason to drop a live call or
+# mark the provider unhealthy.
 RECOVERABLE_ERROR_CODES = frozenset(
     {
         "response_cancel_not_active",
@@ -42,11 +41,7 @@ RECOVERABLE_ERROR_TYPES = frozenset({"invalid_request_error"})
 
 
 class OpenAIRealtimeS2S(BaseS2SProvider):
-    """OpenAI Realtime API speech-to-speech provider.
-
-    Targets the GA protocol only. The Realtime beta was removed from the API on
-    2026-05-12, so the beta event aliases (response.audio.*) are gone.
-    """
+    """OpenAI Realtime API speech-to-speech provider, GA protocol only."""
 
     input_sample_rate = 24000
     output_sample_rate = 24000
@@ -238,8 +233,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             if attempts > 1:
                 await asyncio.sleep(RECONNECT_DELAY_S)
 
-            # A drop mid-call used to end the call outright. Reconnecting costs the caller
-            # the in-flight turn, which the model regenerates from the replayed history.
+            # Costs the caller the in-flight turn, which the model regenerates from history.
             try:
                 started = time.time()
                 await self._reconnect()
@@ -255,10 +249,8 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
             except Exception:
                 pass
             self._ws = None
-        # connect() rebuilds the session config, which carries the transcript so far in the
-        # instructions. OpenAI has no server-side resumption handle like Gemini's, and the
-        # shape for replaying an assistant turn as a conversation item is undocumented,
-        # so the prompt is the one surface that cannot be rejected mid-call.
+        # OpenAI has no resumption handle like Gemini's, so state is restored by rebuilding
+        # the session config, whose instructions carry the transcript so far.
         await self.connect()
 
     async def _receive_events_impl(self) -> AsyncGenerator:
@@ -353,8 +345,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         await self._send(payload)
 
     async def send_dtmf(self, digits: str) -> None:
-        # bolna terminates telephony itself, so the provider never sees the carrier's DTMF
-        # frames. Inject the digits as user text instead.
+        # bolna terminates telephony, so the provider never sees the carrier's DTMF frames.
         await self._send(
             {
                 "type": "conversation.item.create",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.198"
+version = "0.10.199"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_pre_call_webhook.py
+++ b/tests/tests/test_pre_call_webhook.py
@@ -359,6 +359,9 @@ def _make_transfer_self(tool_conf):
         _extract_api_call_runtime_args=MagicMock(return_value={}),
         _finalize_api_call_detail=MagicMock(),
     )
+    # The POST itself lives in _execute_transfer_call_webhook; bind the real one so the
+    # branch still runs end to end.
+    me._execute_transfer_call_webhook = types.MethodType(TaskManager._execute_transfer_call_webhook, me)
     return me
 
 
@@ -414,10 +417,12 @@ async def test_transfer_call_skips_pre_call_webhook_when_no_url():
 
 
 def test_transfer_branch_fires_before_transfer_post():
-    """Source guard: the transfer_call branch must call fire_pre_call_webhook, and do so
-    before the transfer POST (session.post), so the webhook genuinely precedes the transfer."""
+    """Source guard: the transfer_call branch must call fire_pre_call_webhook before it
+    hands off to the webhook POST, so the webhook genuinely precedes the transfer."""
     src = inspect.getsource(TaskManager._TaskManager__execute_function_call)
     transfer_idx = src.index('if called_fun.startswith("transfer_call")')
     fire_idx = src.index("fire_pre_call_webhook", transfer_idx)
-    post_idx = src.index("session.post", transfer_idx)
-    assert transfer_idx < fire_idx < post_idx, "pre-call webhook must fire inside transfer branch, before the POST"
+    handoff_idx = src.index("_execute_transfer_call_webhook", transfer_idx)
+    assert transfer_idx < fire_idx < handoff_idx, "pre-call webhook must fire before the transfer POST"
+    # The POST now lives in the extracted helper.
+    assert "session.post" in inspect.getsource(TaskManager._execute_transfer_call_webhook)

--- a/tests/tests/test_routing_reasoning_effort_default.py
+++ b/tests/tests/test_routing_reasoning_effort_default.py
@@ -9,9 +9,11 @@ import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bolna.agent_types.graph_agent import GraphAgent
-from bolna.constants import MODEL_REASONING_EFFORT_MAP
+from bolna.constants import GPT5_MODEL_PREFIX, MODEL_REASONING_EFFORT_MAP
 
-GPT5_MODELS = sorted(MODEL_REASONING_EFFORT_MAP)
+# Routing only sends reasoning_effort for the gpt-5 family. The map also carries the
+# realtime speech-to-speech models, which accept an effort but are never a routing model.
+GPT5_MODELS = sorted(m for m in MODEL_REASONING_EFFORT_MAP if m.startswith(GPT5_MODEL_PREFIX))
 AZURE_DEPLOYMENT_FORMS = ["azure/gpt-5.4-mini", "ptu-gpt-5.4-mini"]
 
 

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -169,18 +169,35 @@ class TestOpenAISessionConfig:
         assert audio["output"]["voice"] == "marin"
 
     def test_server_vad_carries_tuning_params(self):
-        turn_detection = make_openai(vad_threshold=0.7, vad_silence_duration_ms=250)._build_session_config()["audio"][
-            "input"
-        ]["turn_detection"]
+        turn_detection = make_openai(
+            turn_detection_type="server_vad", vad_threshold=0.7, vad_silence_duration_ms=250
+        )._build_session_config()["audio"]["input"]["turn_detection"]
         assert turn_detection["type"] == "server_vad"
         assert turn_detection["threshold"] == 0.7
         assert turn_detection["silence_duration_ms"] == 250
 
+    def test_semantic_vad_is_the_default_and_carries_eagerness(self):
+        # A semantic classifier decides whether the caller actually finished, which the
+        # llm pipeline approximates with a word count and a phrase list.
+        turn_detection = make_openai()._build_session_config()["audio"]["input"]["turn_detection"]
+        assert turn_detection == {"type": "semantic_vad", "eagerness": "auto"}
+
     def test_semantic_vad_omits_threshold_tuning(self):
-        turn_detection = make_openai(turn_detection_type="semantic_vad")._build_session_config()["audio"]["input"][
+        turn_detection = make_openai(turn_detection_type="semantic_vad", eagerness=None)._build_session_config()[
+            "audio"
+        ]["input"]["turn_detection"]
+        assert turn_detection == {"type": "semantic_vad"}
+
+    def test_eagerness_is_tunable(self):
+        turn_detection = make_openai(eagerness="low")._build_session_config()["audio"]["input"]["turn_detection"]
+        assert turn_detection["eagerness"] == "low"
+
+    def test_server_vad_still_supported_for_explicit_opt_in(self):
+        turn_detection = make_openai(turn_detection_type="server_vad")._build_session_config()["audio"]["input"][
             "turn_detection"
         ]
-        assert turn_detection == {"type": "semantic_vad"}
+        assert turn_detection["type"] == "server_vad"
+        assert "eagerness" not in turn_detection
 
     def test_reasoning_sent_only_for_reasoning_models(self):
         assert "reasoning" in make_openai(model="gpt-realtime-2.1", reasoning_effort="low")._build_session_config()

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -1,0 +1,453 @@
+import base64
+import json
+
+import pytest
+import websockets
+
+from bolna.models import GeminiLiveConfig, OpenAIRealtimeConfig, S2SConfig
+from bolna.providers import SUPPORTED_S2S_PROVIDERS
+from bolna.s2s import GeminiLiveS2S, OpenAIRealtimeS2S
+from bolna.s2s.events import (
+    AudioDelta,
+    FunctionCall,
+    InputTranscript,
+    Interrupted,
+    ResponseDone,
+    S2SError,
+    SessionExpiring,
+    SessionReady,
+    SessionResumed,
+    TranscriptDelta,
+)
+
+
+class FakeWS:
+    """Minimal websockets stand-in that replays scripted server frames."""
+
+    def __init__(self, incoming=None):
+        self.incoming = list(incoming or [])
+        self.sent = []
+        self.closed = False
+        self.close_after_drain = False
+        self.on_drain = None
+
+    async def send(self, payload):
+        self.sent.append(json.loads(payload))
+
+    async def recv(self):
+        if not self.incoming:
+            raise websockets.ConnectionClosed(None, None)
+        return json.dumps(self.incoming.pop(0))
+
+    async def close(self):
+        self.closed = True
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self.incoming:
+            if self.on_drain:
+                self.on_drain()
+            if self.close_after_drain:
+                raise websockets.ConnectionClosed(None, None)
+            raise StopAsyncIteration
+        return json.dumps(self.incoming.pop(0))
+
+    def sent_of_type(self, event_type):
+        return [m for m in self.sent if m.get("type") == event_type]
+
+
+def make_openai(**overrides):
+    defaults = {
+        "system_prompt": "be helpful",
+        "voice": "marin",
+        "model": "gpt-realtime-2.1",
+        "api_key": "sk-test",
+    }
+    defaults.update(overrides)
+    return OpenAIRealtimeS2S(**defaults)
+
+
+def make_gemini(**overrides):
+    defaults = {
+        "system_prompt": "be helpful",
+        "voice": "Kore",
+        "model": "gemini-3.1-flash-live-preview",
+        "api_key": "gm-test",
+    }
+    defaults.update(overrides)
+    return GeminiLiveS2S(**defaults)
+
+
+def attach_ws(provider, frames):
+    """Attach a socket that ends the provider's resume loop once the frames run out."""
+    ws = FakeWS(frames)
+    ws.on_drain = lambda: setattr(provider, "_closed", True)
+    provider._ws = ws
+    return ws
+
+
+async def drain(provider):
+    return [event async for event in provider.receive_events()]
+
+
+class TestProviderRegistry:
+    def test_both_providers_registered(self):
+        assert set(SUPPORTED_S2S_PROVIDERS) == {"openai_realtime", "gemini_live"}
+
+    def test_providers_declare_their_own_input_rate(self):
+        # The pipeline resamples against these, so they must not silently share a default.
+        assert OpenAIRealtimeS2S.input_sample_rate == 24000
+        assert GeminiLiveS2S.input_sample_rate == 16000
+        assert OpenAIRealtimeS2S.output_sample_rate == GeminiLiveS2S.output_sample_rate == 24000
+
+
+class TestOpenAISessionConfig:
+    def test_uses_ga_field_names_only(self):
+        config = make_openai(max_output_tokens=500)._build_session_config()
+        assert config["type"] == "realtime"
+        assert config["output_modalities"] == ["audio"]
+        assert config["max_output_tokens"] == 500
+        # max_response_output_tokens was the beta spelling and is rejected by the GA API.
+        assert "max_response_output_tokens" not in config
+
+    def test_audio_format_is_the_ga_object_form(self):
+        audio = make_openai()._build_session_config()["audio"]
+        assert audio["input"]["format"] == {"type": "audio/pcm", "rate": 24000}
+        assert audio["output"]["format"] == {"type": "audio/pcm", "rate": 24000}
+        assert audio["output"]["voice"] == "marin"
+
+    def test_server_vad_carries_tuning_params(self):
+        turn_detection = make_openai(vad_threshold=0.7, vad_silence_duration_ms=250)._build_session_config()[
+            "audio"
+        ]["input"]["turn_detection"]
+        assert turn_detection["type"] == "server_vad"
+        assert turn_detection["threshold"] == 0.7
+        assert turn_detection["silence_duration_ms"] == 250
+
+    def test_semantic_vad_omits_threshold_tuning(self):
+        turn_detection = make_openai(turn_detection_type="semantic_vad")._build_session_config()["audio"]["input"][
+            "turn_detection"
+        ]
+        assert turn_detection == {"type": "semantic_vad"}
+
+    def test_reasoning_sent_only_for_reasoning_models(self):
+        assert "reasoning" in make_openai(model="gpt-realtime-2.1", reasoning_effort="low")._build_session_config()
+        assert "reasoning" in make_openai(model="gpt-realtime-2", reasoning_effort="low")._build_session_config()
+        # gpt-realtime-1.5 has no reasoning and rejects the field.
+        assert (
+            "reasoning" not in make_openai(model="gpt-realtime-1.5", reasoning_effort="low")._build_session_config()
+        )
+
+    def test_tools_are_flattened_and_malformed_entries_dropped(self):
+        provider = make_openai(
+            tools=[
+                {"function": {"name": "book", "description": "d", "parameters": {"type": "object"}}},
+                {"name": "cancel", "parameters": {}},
+                {"nonsense": True},
+            ]
+        )
+        config = provider._build_session_config()
+        assert [t["name"] for t in config["tools"]] == ["book", "cancel"]
+        assert all(t["type"] == "function" for t in config["tools"])
+        assert config["tool_choice"] == "auto"
+
+
+class TestOpenAIEventMapping:
+    @pytest.mark.asyncio
+    async def test_maps_ga_events(self):
+        provider = make_openai()
+        provider.connection_time = 12.0
+        provider._ws = FakeWS(
+            [
+                {"type": "response.created"},
+                {"type": "response.output_audio.delta", "delta": base64.b64encode(b"pcm").decode()},
+                {"type": "response.output_audio_transcript.done", "transcript": "hello"},
+                {"type": "conversation.item.input_audio_transcription.completed", "transcript": "hi there"},
+                {
+                    "type": "response.function_call_arguments.done",
+                    "name": "book",
+                    "call_id": "c1",
+                    "arguments": '{"day":"mon"}',
+                },
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "response.done", "response": {"usage": {"input_tokens": 5, "output_tokens": 7}}},
+            ]
+        )
+        events = await drain(provider)
+        kinds = [type(e) for e in events]
+
+        assert kinds[0] is SessionReady
+        assert AudioDelta in kinds and Interrupted in kinds and ResponseDone in kinds
+        assert next(e for e in events if isinstance(e, AudioDelta)).data == b"pcm"
+        assert next(e for e in events if isinstance(e, InputTranscript)).content == "hi there"
+
+        call = next(e for e in events if isinstance(e, FunctionCall))
+        assert (call.name, call.call_id, call.arguments) == ("book", "c1", '{"day":"mon"}')
+
+        done = next(e for e in events if isinstance(e, ResponseDone))
+        assert done.transcript == "hello"
+        assert done.usage["input_tokens"] == 5
+        assert provider.usage_total["output_tokens"] == 7
+
+    @pytest.mark.asyncio
+    async def test_barge_in_preserves_what_the_agent_already_said(self):
+        # speech_started arrives before the cancelled response.done. Clearing the accumulated
+        # transcript there would drop the spoken text from the turn log on every barge-in.
+        provider = make_openai()
+        provider._ws = FakeWS(
+            [
+                {"type": "response.created"},
+                {"type": "response.output_audio_transcript.done", "transcript": "your balance is"},
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "response.done", "response": {}},
+            ]
+        )
+        events = await drain(provider)
+        assert next(e for e in events if isinstance(e, ResponseDone)).transcript == "your balance is"
+
+    @pytest.mark.asyncio
+    async def test_beta_audio_event_is_no_longer_understood(self):
+        # The Realtime beta was removed on 2026-05-12; keeping its aliases would be dead code.
+        provider = make_openai()
+        provider._ws = FakeWS([{"type": "response.audio.delta", "delta": base64.b64encode(b"x").decode()}])
+        assert not [e for e in await drain(provider) if isinstance(e, AudioDelta)]
+
+    @pytest.mark.asyncio
+    async def test_closed_socket_surfaces_as_error(self):
+        provider = make_openai()
+        ws = FakeWS([])
+        ws.close_after_drain = True
+        provider._ws = ws
+        errors = [e for e in await drain(provider) if isinstance(e, S2SError)]
+        assert errors and errors[0].code == "connection_closed"
+
+    @pytest.mark.asyncio
+    async def test_error_event_releases_the_turn_gate(self):
+        # Without this the next commit_function_results would block for the full timeout.
+        provider = make_openai()
+        provider._ws = FakeWS([{"type": "response.created"}, {"type": "error", "error": {"message": "boom"}}])
+        events = await drain(provider)
+        assert any(isinstance(e, S2SError) for e in events)
+        assert provider._response_done_event.is_set()
+
+
+class TestOpenAIClientMessages:
+    @pytest.mark.asyncio
+    async def test_send_audio_base64_encodes(self):
+        provider = make_openai()
+        provider._ws = FakeWS()
+        await provider.send_audio(b"raw-pcm")
+        sent = provider._ws.sent_of_type("input_audio_buffer.append")[0]
+        assert base64.b64decode(sent["audio"]) == b"raw-pcm"
+
+    @pytest.mark.asyncio
+    async def test_function_result_then_commit(self):
+        provider = make_openai()
+        provider._ws = FakeWS()
+        await provider.send_function_result("c1", "book", '{"ok":true}')
+        await provider.commit_function_results()
+        item = provider._ws.sent_of_type("conversation.item.create")[0]["item"]
+        assert item == {"type": "function_call_output", "call_id": "c1", "output": '{"ok":true}'}
+        assert provider._ws.sent_of_type("response.create")
+
+    @pytest.mark.asyncio
+    async def test_dtmf_is_injected_as_user_text(self):
+        # bolna terminates telephony, so OpenAI never sees carrier DTMF frames.
+        provider = make_openai()
+        provider._ws = FakeWS()
+        await provider.send_dtmf("42#")
+        item = provider._ws.sent_of_type("conversation.item.create")[0]["item"]
+        assert item["role"] == "user"
+        assert "42#" in item["content"][0]["text"]
+        assert provider._ws.sent_of_type("response.create")
+
+
+class TestGeminiSetup:
+    def test_setup_shape(self):
+        setup = make_gemini()._build_setup()
+        assert setup["model"] == "models/gemini-3.1-flash-live-preview"
+        assert setup["generationConfig"]["responseModalities"] == ["AUDIO"]
+        assert setup["generationConfig"]["speechConfig"]["voiceConfig"]["prebuiltVoiceConfig"]["voiceName"] == "Kore"
+        assert setup["inputAudioTranscription"] == {}
+        assert setup["outputAudioTranscription"] == {}
+
+    def test_model_prefix_not_doubled(self):
+        assert make_gemini(model="models/gemini-3.1-flash-live-preview")._build_setup()["model"] == (
+            "models/gemini-3.1-flash-live-preview"
+        )
+
+    def test_resumption_and_compression_on_by_default(self):
+        setup = make_gemini()._build_setup()
+        assert setup["sessionResumption"] == {}
+        assert setup["contextWindowCompression"] == {"slidingWindow": {}}
+
+    def test_resumption_handle_is_replayed_on_reconnect(self):
+        provider = make_gemini()
+        provider._resumption_handle = "handle-abc"
+        assert provider._build_setup()["sessionResumption"] == {"handle": "handle-abc"}
+
+    def test_features_can_be_disabled(self):
+        setup = make_gemini(enable_session_resumption=False, enable_context_compression=False)._build_setup()
+        assert "sessionResumption" not in setup and "contextWindowCompression" not in setup
+
+    def test_vad_block_only_present_when_configured(self):
+        assert "realtimeInputConfig" not in make_gemini()._build_setup()
+        vad = make_gemini(vad_silence_duration_ms=120)._build_setup()["realtimeInputConfig"][
+            "automaticActivityDetection"
+        ]
+        assert vad == {"silenceDurationMs": 120}
+
+    def test_tools_use_function_declarations(self):
+        provider = make_gemini(tools=[{"function": {"name": "book", "description": "d", "parameters": {}}}])
+        assert provider._build_setup()["tools"] == [{"functionDeclarations": [{"name": "book", "description": "d"}]}]
+
+
+class TestGeminiEventMapping:
+    @pytest.mark.asyncio
+    async def test_maps_server_content(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"serverContent": {"inputTranscription": {"text": "hi"}}},
+                {"serverContent": {"outputTranscription": {"text": "hello"}}},
+                {
+                    "serverContent": {
+                        "modelTurn": {"parts": [{"inlineData": {"data": base64.b64encode(b"aud").decode()}}]}
+                    }
+                },
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        events = await drain(provider)
+        assert next(e for e in events if isinstance(e, InputTranscript)).content == "hi"
+        assert next(e for e in events if isinstance(e, AudioDelta)).data == b"aud"
+        assert next(e for e in events if isinstance(e, ResponseDone)).transcript == "hello"
+
+    @pytest.mark.asyncio
+    async def test_interrupted_and_go_away(self):
+        provider = make_gemini()
+        attach_ws(provider, [{"serverContent": {"interrupted": True}}, {"goAway": {"timeLeft": "9.5s"}}])
+        events = await drain(provider)
+        assert any(isinstance(e, Interrupted) for e in events)
+        assert next(e for e in events if isinstance(e, SessionExpiring)).time_left_ms == 9500
+
+    @pytest.mark.asyncio
+    async def test_tool_call_args_are_json_encoded(self):
+        provider = make_gemini()
+        attach_ws(provider, [{"toolCall": {"functionCalls": [{"name": "book", "id": "c1", "args": {"d": 1}}]}}])
+        call = next(e for e in await drain(provider) if isinstance(e, FunctionCall))
+        assert (call.name, call.call_id) == ("book", "c1")
+        assert json.loads(call.arguments) == {"d": 1}
+
+    @pytest.mark.asyncio
+    async def test_resumption_handle_is_captured(self):
+        provider = make_gemini()
+        attach_ws(provider, [{"sessionResumptionUpdate": {"newHandle": "h1", "resumable": True}}])
+        await drain(provider)
+        assert provider._resumption_handle == "h1"
+
+    @pytest.mark.asyncio
+    async def test_usage_metadata_accumulates(self):
+        provider = make_gemini()
+        attach_ws(provider, [{"usageMetadata": {"promptTokenCount": 3, "responseTokenCount": 4}}])
+        await drain(provider)
+        assert provider.usage_total["input_tokens"] == 3
+        assert provider.usage_total["output_tokens"] == 4
+
+
+class TestGeminiSessionResumption:
+    @pytest.mark.asyncio
+    async def test_dropped_session_is_resumed_transparently(self, monkeypatch):
+        provider = make_gemini()
+        dropped = FakeWS([{"sessionResumptionUpdate": {"newHandle": "h1", "resumable": True}}])
+        dropped.close_after_drain = True
+        provider._ws = dropped
+
+        opened = {"count": 0}
+
+        async def fake_open():
+            opened["count"] += 1
+            attach_ws(provider, [{"serverContent": {"turnComplete": True}}])
+
+        monkeypatch.setattr(provider, "_open_session", fake_open)
+
+        events = await drain(provider)
+        assert opened["count"] == 1
+        assert any(isinstance(e, SessionResumed) for e in events)
+        assert any(isinstance(e, ResponseDone) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_drop_without_handle_is_a_hard_error(self):
+        provider = make_gemini()
+        ws = FakeWS([])
+        ws.close_after_drain = True
+        provider._ws = ws
+        errors = [e for e in await drain(provider) if isinstance(e, S2SError)]
+        assert errors and errors[0].code == "session_ended"
+
+    @pytest.mark.asyncio
+    async def test_audio_is_dropped_while_reconnecting(self):
+        provider = make_gemini()
+        provider._ws = FakeWS()
+        provider._reconnecting = True
+        await provider.send_audio(b"pcm")
+        assert provider._ws.sent == []
+
+
+class TestGeminiClientMessages:
+    @pytest.mark.asyncio
+    async def test_audio_declares_16k_mime(self):
+        provider = make_gemini()
+        provider._ws = FakeWS()
+        await provider.send_audio(b"pcm")
+        audio = provider._ws.sent[0]["realtimeInput"]["audio"]
+        assert audio["mimeType"] == "audio/pcm;rate=16000"
+        assert base64.b64decode(audio["data"]) == b"pcm"
+
+    @pytest.mark.asyncio
+    async def test_tool_results_batch_into_one_response(self):
+        provider = make_gemini()
+        provider._ws = FakeWS()
+        await provider.send_function_result("c1", "book", '{"ok":true}')
+        await provider.send_function_result("c2", "cancel", "plain text")
+        assert provider._ws.sent == []  # Buffered until commit.
+
+        await provider.commit_function_results()
+        responses = provider._ws.sent[0]["toolResponse"]["functionResponses"]
+        assert [r["id"] for r in responses] == ["c1", "c2"]
+        assert responses[0]["response"] == {"ok": True}
+        assert responses[1]["response"] == {"result": "plain text"}
+
+    @pytest.mark.asyncio
+    async def test_commit_without_pending_results_sends_nothing(self):
+        provider = make_gemini()
+        provider._ws = FakeWS()
+        await provider.commit_function_results()
+        assert provider._ws.sent == []
+
+
+class TestS2SConfigModel:
+    def test_provider_selects_its_config_class(self):
+        assert isinstance(S2SConfig(provider="openai_realtime", provider_config={}).provider_config, OpenAIRealtimeConfig)
+        assert isinstance(S2SConfig(provider="gemini_live", provider_config={}).provider_config, GeminiLiveConfig)
+
+    def test_defaults_track_the_current_recommended_models(self):
+        assert S2SConfig(provider="openai_realtime", provider_config={}).provider_config.model == "gpt-realtime-2.1"
+        assert (
+            S2SConfig(provider="gemini_live", provider_config={}).provider_config.model
+            == "gemini-3.1-flash-live-preview"
+        )
+
+    def test_unknown_provider_rejected(self):
+        with pytest.raises(Exception):
+            S2SConfig(provider="whisper_realtime", provider_config={})
+
+    def test_reasoning_effort_rejected_for_non_reasoning_model(self):
+        with pytest.raises(Exception):
+            OpenAIRealtimeConfig(model="gpt-realtime-1.5", reasoning_effort="low")
+
+    def test_reasoning_effort_accepted_for_reasoning_model(self):
+        assert OpenAIRealtimeConfig(model="gpt-realtime-2.1", reasoning_effort="low").reasoning_effort == "low"

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -285,14 +285,15 @@ class TestOpenAIEventMapping:
         # mid-call complaints. Treating them as fatal hung up live calls and marked the
         # provider unhealthy in the circuit breaker.
         provider = make_openai()
-        provider._ws = FakeWS(
+        attach_ws(
+            provider,
             [
                 {"type": "error", "error": {"message": "Cancellation failed", "code": "response_cancel_not_active"}},
                 {
                     "type": "error",
                     "error": {"message": "active response", "code": "conversation_already_has_active_response"},
                 },
-            ]
+            ],
         )
         errors = [e for e in await drain(provider) if isinstance(e, S2SError)]
         assert len(errors) == 2

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -376,6 +376,72 @@ class TestGeminiSetup:
         assert provider._build_setup()["tools"] == [{"functionDeclarations": [{"name": "book", "description": "d"}]}]
 
 
+class TestGeminiTranscriptBoundaries:
+    """Gemini streams both transcripts in fragments and only finalises the agent's at
+    turnComplete, so naive mapping splits one caller sentence into many turns and loses
+    every barged-in agent turn."""
+
+    @pytest.mark.asyncio
+    async def test_caller_fragments_become_one_final_turn(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"serverContent": {"inputTranscription": {"text": "I want "}}},
+                {"serverContent": {"inputTranscription": {"text": "to book "}}},
+                {"serverContent": {"inputTranscription": {"text": "a table"}}},
+                {"serverContent": {"outputTranscription": {"text": "Sure"}}},
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        finals = [e for e in await drain(provider) if isinstance(e, InputTranscript) and e.is_final]
+        assert [e.content for e in finals] == ["I want to book a table"]
+
+    @pytest.mark.asyncio
+    async def test_caller_turn_finalises_without_model_output(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"serverContent": {"inputTranscription": {"text": "hello?"}}},
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        finals = [e for e in await drain(provider) if isinstance(e, InputTranscript) and e.is_final]
+        assert [e.content for e in finals] == ["hello?"]
+
+    @pytest.mark.asyncio
+    async def test_barged_in_agent_turn_is_still_recorded(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"serverContent": {"outputTranscription": {"text": "Your order is "}}},
+                {"serverContent": {"outputTranscription": {"text": "on its way"}}},
+                {"serverContent": {"interrupted": True}},
+            ],
+        )
+        events = await drain(provider)
+        finals = [e for e in events if isinstance(e, TranscriptDelta) and e.is_final]
+        assert [e.content for e in finals] == ["Your order is on its way"]
+        assert any(isinstance(e, Interrupted) for e in events)
+
+    @pytest.mark.asyncio
+    async def test_interrupted_turn_does_not_leak_into_the_next_one(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"serverContent": {"outputTranscription": {"text": "first"}}},
+                {"serverContent": {"interrupted": True}},
+                {"serverContent": {"outputTranscription": {"text": "second"}}},
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        finals = [e.content for e in await drain(provider) if isinstance(e, TranscriptDelta) and e.is_final]
+        assert finals == ["first", "second"]
+
+
 class TestGeminiEventMapping:
     @pytest.mark.asyncio
     async def test_maps_server_content(self):

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -616,3 +616,89 @@ class TestS2SConfigModel:
 
     def test_reasoning_effort_accepted_for_reasoning_model(self):
         assert OpenAIRealtimeConfig(model="gpt-realtime-2.1", reasoning_effort="low").reasoning_effort == "low"
+
+
+class TestTurnLatencyRecords:
+    """turn_latencies feeds the same observability path as the LLM pipeline's, which
+    indexes each entry by key. Appending bare durations crashed post-call processing."""
+
+    @pytest.mark.asyncio
+    async def test_openai_turn_is_recorded_as_a_dict(self):
+        provider = make_openai()
+        attach_ws(
+            provider,
+            [
+                {"type": "response.created"},
+                {"type": "response.output_audio.delta", "delta": _b64(b"aud")},
+                {
+                    "type": "response.done",
+                    "response": {
+                        "usage": {
+                            "input_tokens": 30,
+                            "output_tokens": 12,
+                            "input_token_details": {"cached_tokens": 8},
+                        }
+                    },
+                },
+            ],
+        )
+        await drain(provider)
+
+        assert len(provider.turn_latencies) == 1
+        turn = provider.turn_latencies[0]
+        assert turn["sequence_id"] == 0
+        assert turn["model"] == provider.model
+        assert turn["first_token_latency_ms"] is not None
+        assert turn["total_stream_duration_ms"] >= turn["first_token_latency_ms"]
+        assert (turn["input_tokens"], turn["output_tokens"], turn["cached_tokens"]) == (30, 12, 8)
+
+    @pytest.mark.asyncio
+    async def test_gemini_turn_is_recorded_as_a_dict(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                # The caller speaking is what opens the turn; a model turn never arrives cold.
+                {"serverContent": {"inputTranscription": {"text": "hello"}}},
+                {"serverContent": {"modelTurn": {"parts": [{"inlineData": {"data": _b64(b"aud")}}]}}},
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        await drain(provider)
+
+        assert len(provider.turn_latencies) == 1
+        turn = provider.turn_latencies[0]
+        assert turn["sequence_id"] == 0
+        assert turn["model"] == provider.model
+        assert "total_stream_duration_ms" in turn
+
+    @pytest.mark.asyncio
+    async def test_barge_in_drops_the_turn_instead_of_recording_a_partial(self):
+        provider = make_openai()
+        attach_ws(
+            provider,
+            [
+                {"type": "response.created"},
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "response.done", "response": {}},
+            ],
+        )
+        await drain(provider)
+
+        assert provider.turn_latencies == []
+
+    @pytest.mark.asyncio
+    async def test_sequence_ids_increment_across_turns(self):
+        provider = make_openai()
+        attach_ws(
+            provider,
+            [
+                {"type": "response.created"},
+                {"type": "response.done", "response": {}},
+                {"type": "response.created"},
+                {"type": "response.done", "response": {}},
+            ],
+        )
+        await drain(provider)
+
+        assert [t["sequence_id"] for t in provider.turn_latencies] == [0, 1]

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -80,6 +80,10 @@ def make_gemini(**overrides):
     return GeminiLiveS2S(**defaults)
 
 
+def _b64(data):
+    return base64.b64encode(data).decode()
+
+
 def attach_ws(provider, frames):
     """Attach a socket that ends the provider's resume loop once the frames run out."""
     ws = FakeWS(frames)
@@ -354,6 +358,56 @@ class TestGeminiEventMapping:
         await drain(provider)
         assert provider.usage_total["input_tokens"] == 3
         assert provider.usage_total["output_tokens"] == 4
+
+    @pytest.mark.asyncio
+    async def test_usage_keeps_the_audio_text_split(self):
+        # Verbatim shape returned by gemini-3.1-flash-live-preview. Audio and text are
+        # priced ~4x apart, so collapsing the modalities would misprice every call.
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {
+                    "usageMetadata": {
+                        "promptTokenCount": 363,
+                        "responseTokenCount": 35,
+                        "totalTokenCount": 398,
+                        "promptTokensDetails": [
+                            {"modality": "TEXT", "tokenCount": 137},
+                            {"modality": "AUDIO", "tokenCount": 201},
+                        ],
+                        "responseTokensDetails": [{"modality": "AUDIO", "tokenCount": 35}],
+                    }
+                }
+            ],
+        )
+        await drain(provider)
+        assert provider.usage_total["input_text_tokens"] == 137
+        assert provider.usage_total["input_audio_tokens"] == 201
+        assert provider.usage_total["output_audio_tokens"] == 35
+
+    @pytest.mark.asyncio
+    async def test_first_audio_latency_measured_from_turn_start(self):
+        # The clock has to start when the turn is requested. Stamping it on the first audio
+        # part instead reported a flat 0ms against the live API.
+        provider = make_gemini()
+        provider._ws = FakeWS()
+        await provider.trigger_response(instructions="say hi")
+        assert provider._turn_start_time is not None
+
+        attach_ws(
+            provider,
+            [{"serverContent": {"modelTurn": {"parts": [{"inlineData": {"data": _b64(b"aud")}}]}}}],
+        )
+        await drain(provider)
+        assert provider.first_audio_latencies and provider.first_audio_latencies[0] > 0
+
+    @pytest.mark.asyncio
+    async def test_caller_transcript_starts_the_turn_clock(self):
+        provider = make_gemini()
+        attach_ws(provider, [{"serverContent": {"inputTranscription": {"text": "hello"}}}])
+        await drain(provider)
+        assert provider._turn_start_time is not None
 
 
 class TestGeminiSessionResumption:

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -119,9 +119,9 @@ class TestOpenAISessionConfig:
         assert audio["output"]["voice"] == "marin"
 
     def test_server_vad_carries_tuning_params(self):
-        turn_detection = make_openai(vad_threshold=0.7, vad_silence_duration_ms=250)._build_session_config()[
-            "audio"
-        ]["input"]["turn_detection"]
+        turn_detection = make_openai(vad_threshold=0.7, vad_silence_duration_ms=250)._build_session_config()["audio"][
+            "input"
+        ]["turn_detection"]
         assert turn_detection["type"] == "server_vad"
         assert turn_detection["threshold"] == 0.7
         assert turn_detection["silence_duration_ms"] == 250
@@ -136,9 +136,7 @@ class TestOpenAISessionConfig:
         assert "reasoning" in make_openai(model="gpt-realtime-2.1", reasoning_effort="low")._build_session_config()
         assert "reasoning" in make_openai(model="gpt-realtime-2", reasoning_effort="low")._build_session_config()
         # gpt-realtime-1.5 has no reasoning and rejects the field.
-        assert (
-            "reasoning" not in make_openai(model="gpt-realtime-1.5", reasoning_effort="low")._build_session_config()
-        )
+        assert "reasoning" not in make_openai(model="gpt-realtime-1.5", reasoning_effort="low")._build_session_config()
 
     def test_tools_are_flattened_and_malformed_entries_dropped(self):
         provider = make_openai(
@@ -431,7 +429,9 @@ class TestGeminiClientMessages:
 
 class TestS2SConfigModel:
     def test_provider_selects_its_config_class(self):
-        assert isinstance(S2SConfig(provider="openai_realtime", provider_config={}).provider_config, OpenAIRealtimeConfig)
+        assert isinstance(
+            S2SConfig(provider="openai_realtime", provider_config={}).provider_config, OpenAIRealtimeConfig
+        )
         assert isinstance(S2SConfig(provider="gemini_live", provider_config={}).provider_config, GeminiLiveConfig)
 
     def test_defaults_track_the_current_recommended_models(self):

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -262,6 +262,31 @@ class TestOpenAIEventMapping:
         assert not [e for e in await drain(provider) if isinstance(e, AudioDelta)]
 
     @pytest.mark.asyncio
+    async def test_recoverable_errors_do_not_kill_the_call(self):
+        # Cancelling an already-finished response and racing response.create are routine
+        # mid-call complaints. Treating them as fatal hung up live calls and marked the
+        # provider unhealthy in the circuit breaker.
+        provider = make_openai()
+        provider._ws = FakeWS(
+            [
+                {"type": "error", "error": {"message": "Cancellation failed", "code": "response_cancel_not_active"}},
+                {
+                    "type": "error",
+                    "error": {"message": "active response", "code": "conversation_already_has_active_response"},
+                },
+            ]
+        )
+        errors = [e for e in await drain(provider) if isinstance(e, S2SError)]
+        assert len(errors) == 2
+        assert all(not e.fatal for e in errors)
+
+    @pytest.mark.asyncio
+    async def test_unknown_errors_stay_fatal(self):
+        provider = make_openai()
+        provider._ws = FakeWS([{"type": "error", "error": {"message": "boom", "code": "server_error"}}])
+        assert next(e for e in await drain(provider) if isinstance(e, S2SError)).fatal is True
+
+    @pytest.mark.asyncio
     async def test_closed_socket_surfaces_as_error(self):
         provider = make_openai()
         ws = FakeWS([])

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -702,3 +702,29 @@ class TestTurnLatencyRecords:
         await drain(provider)
 
         assert [t["sequence_id"] for t in provider.turn_latencies] == [0, 1]
+
+
+class TestLanguagePinning:
+    """Without a pinned language the provider auto-detects per utterance, which put a
+    caller's speech into the wrong script mid-call."""
+
+    def test_openai_sends_the_language_to_transcription(self):
+        transcription = make_openai(language="hi")._build_session_config()["audio"]["input"]["transcription"]
+        assert transcription["language"] == "hi"
+        assert transcription["model"] == "gpt-4o-mini-transcribe"
+
+    def test_openai_omits_language_when_unset(self):
+        transcription = make_openai()._build_session_config()["audio"]["input"]["transcription"]
+        assert "language" not in transcription
+
+    def test_gemini_sends_the_language_code(self):
+        setup = make_gemini(language="hi-IN")._build_setup()
+        assert setup["generationConfig"]["speechConfig"]["languageCode"] == "hi-IN"
+
+    def test_gemini_omits_language_when_unset(self):
+        setup = make_gemini()._build_setup()
+        assert "languageCode" not in setup["generationConfig"]["speechConfig"]
+
+    def test_language_is_exposed_on_both_provider_configs(self):
+        assert OpenAIRealtimeConfig(language="hi").language == "hi"
+        assert GeminiLiveConfig(language="hi-IN").language == "hi-IN"

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -728,3 +728,54 @@ class TestLanguagePinning:
     def test_language_is_exposed_on_both_provider_configs(self):
         assert OpenAIRealtimeConfig(language="hi").language == "hi"
         assert GeminiLiveConfig(language="hi-IN").language == "hi-IN"
+
+
+class TestGeminiToolSchema:
+    """Gemini rejects the entire setup frame over one unsupported schema key, so an
+    agent with tools never connected and the call ended before the first word."""
+
+    def _params(self, declarations):
+        return declarations[0]["parameters"]
+
+    def test_additional_properties_is_stripped_from_declarations(self):
+        tool = {
+            "name": "end_call",
+            "description": "End the call",
+            "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+        }
+        setup = make_gemini(tools=[tool])._build_setup()
+        assert "additionalProperties" not in self._params(setup["tools"][0]["functionDeclarations"])
+
+    def test_nested_schemas_are_cleaned_too(self):
+        tool = {
+            "name": "book",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "slot": {"type": "object", "properties": {}, "additionalProperties": False},
+                    "guests": {
+                        "type": "array",
+                        "items": {"type": "object", "properties": {}, "additionalProperties": False},
+                    },
+                },
+                "additionalProperties": False,
+            },
+        }
+        params = self._params(make_gemini(tools=[tool])._build_setup()["tools"][0]["functionDeclarations"])
+        assert "additionalProperties" not in params
+        assert "additionalProperties" not in params["properties"]["slot"]
+        assert "additionalProperties" not in params["properties"]["guests"]["items"]
+
+    def test_supported_schema_content_survives(self):
+        tool = {
+            "name": "lookup",
+            "parameters": {
+                "type": "object",
+                "properties": {"order_id": {"type": "string", "description": "the order"}},
+                "required": ["order_id"],
+                "additionalProperties": False,
+            },
+        }
+        params = self._params(make_gemini(tools=[tool])._build_setup()["tools"][0]["functionDeclarations"])
+        assert params["required"] == ["order_id"]
+        assert params["properties"]["order_id"] == {"type": "string", "description": "the order"}

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -2,6 +2,7 @@ import base64
 import json
 
 import pytest
+from unittest.mock import AsyncMock
 import websockets
 
 from bolna.models import GeminiLiveConfig, OpenAIRealtimeConfig, S2SConfig
@@ -287,13 +288,59 @@ class TestOpenAIEventMapping:
         assert next(e for e in await drain(provider) if isinstance(e, S2SError)).fatal is True
 
     @pytest.mark.asyncio
-    async def test_closed_socket_surfaces_as_error(self):
+    async def test_closed_socket_is_recovered_by_reconnecting(self):
         provider = make_openai()
         ws = FakeWS([])
         ws.close_after_drain = True
         provider._ws = ws
+
+        async def fake_connect():
+            provider._ws = FakeWS([])
+            provider._ws.close_after_drain = True
+            provider._closed = True  # second drop is treated as intentional, ending the loop
+
+        provider.connect = fake_connect
+        events = await drain(provider)
+        assert any(isinstance(e, SessionResumed) for e in events)
+        assert not [e for e in events if isinstance(e, S2SError)]
+
+    @pytest.mark.asyncio
+    async def test_intentional_disconnect_does_not_reconnect(self):
+        provider = make_openai()
+        ws = FakeWS([])
+        ws.close_after_drain = True
+        provider._ws = ws
+        provider._closed = True
+        provider.connect = AsyncMock()
+
+        events = await drain(provider)
+        assert not [e for e in events if isinstance(e, (S2SError, SessionResumed))]
+        provider.connect.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failed_reconnect_is_fatal(self):
+        provider = make_openai()
+        ws = FakeWS([])
+        ws.close_after_drain = True
+        provider._ws = ws
+        provider.connect = AsyncMock(side_effect=ConnectionError("refused"))
+
         errors = [e for e in await drain(provider) if isinstance(e, S2SError)]
-        assert errors and errors[0].code == "connection_closed"
+        assert errors and errors[0].code == "reconnect_failed"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_carries_the_transcript_into_the_new_prompt(self):
+        provider = make_openai()
+        provider._history = [("user", "my order is late"), ("assistant", "let me check")]
+        instructions = provider._build_session_config()["instructions"]
+        assert "my order is late" in instructions and "let me check" in instructions
+        # Otherwise the model greets the caller a second time after the drop.
+        assert "without greeting the caller again" in instructions
+
+    @pytest.mark.asyncio
+    async def test_first_connect_sends_the_bare_system_prompt(self):
+        provider = make_openai()
+        assert provider._build_session_config()["instructions"] == provider.system_prompt
 
     @pytest.mark.asyncio
     async def test_error_event_releases_the_turn_gate(self):

--- a/tests/tests/test_s2s_providers.py
+++ b/tests/tests/test_s2s_providers.py
@@ -8,12 +8,15 @@ from bolna.models import GeminiLiveConfig, OpenAIRealtimeConfig, S2SConfig
 from bolna.providers import SUPPORTED_S2S_PROVIDERS
 from bolna.s2s import GeminiLiveS2S, OpenAIRealtimeS2S
 from bolna.s2s.events import (
+    AudioEncoding,
+    AudioFormat,
     AudioDelta,
     FunctionCall,
     InputTranscript,
     Interrupted,
     ResponseDone,
     S2SError,
+    S2SUsage,
     SessionExpiring,
     SessionReady,
     SessionResumed,
@@ -94,6 +97,48 @@ def attach_ws(provider, frames):
 
 async def drain(provider):
     return [event async for event in provider.receive_events()]
+
+
+class TestS2SUsage:
+    def test_adds_field_by_field(self):
+        total = S2SUsage(input_tokens=1, input_audio_tokens=2) + S2SUsage(input_tokens=10, output_text_tokens=5)
+        assert total.input_tokens == 11
+        assert total.input_audio_tokens == 2
+        assert total.output_text_tokens == 5
+
+    def test_modality_split_is_exactly_what_billing_reads(self):
+        usage = S2SUsage(
+            input_tokens=99,
+            cached_tokens=7,
+            input_audio_tokens=1,
+            input_text_tokens=2,
+            output_audio_tokens=3,
+            output_text_tokens=4,
+        )
+        # Flat totals travel in their own log columns, so the split must not repeat them.
+        assert usage.modality_split() == {
+            "input_audio_tokens": 1,
+            "input_text_tokens": 2,
+            "output_audio_tokens": 3,
+            "output_text_tokens": 4,
+        }
+
+    def test_starts_at_zero(self):
+        assert S2SUsage() + S2SUsage() == S2SUsage()
+
+    def test_is_immutable(self):
+        with pytest.raises(Exception):
+            S2SUsage().input_tokens = 5
+
+
+class TestAudioFormat:
+    def test_compares_by_value(self):
+        assert AudioFormat(AudioEncoding.MULAW, 8000) == AudioFormat(AudioEncoding.MULAW, 8000)
+        assert AudioFormat(AudioEncoding.PCM, 16000) != AudioFormat(AudioEncoding.PCM, 24000)
+
+    def test_encoding_serialises_to_the_string_the_output_handler_expects(self):
+        assert AudioEncoding.MULAW.value == "mulaw"
+        assert AudioEncoding.PCM.value == "pcm"
 
 
 class TestProviderRegistry:
@@ -190,8 +235,8 @@ class TestOpenAIEventMapping:
 
         done = next(e for e in events if isinstance(e, ResponseDone))
         assert done.transcript == "hello"
-        assert done.usage["input_tokens"] == 5
-        assert provider.usage_total["output_tokens"] == 7
+        assert done.usage.input_tokens == 5
+        assert provider.usage_total.output_tokens == 7
 
     @pytest.mark.asyncio
     async def test_barge_in_preserves_what_the_agent_already_said(self):
@@ -356,8 +401,49 @@ class TestGeminiEventMapping:
         provider = make_gemini()
         attach_ws(provider, [{"usageMetadata": {"promptTokenCount": 3, "responseTokenCount": 4}}])
         await drain(provider)
-        assert provider.usage_total["input_tokens"] == 3
-        assert provider.usage_total["output_tokens"] == 4
+        assert provider.usage_total.input_tokens == 3
+        assert provider.usage_total.output_tokens == 4
+
+    @pytest.mark.asyncio
+    async def test_turn_usage_reaches_response_done(self):
+        # Gemini reports usage in its own message, not on turnComplete. Leaving it off the
+        # turn event means billing sees zero tokens for every Gemini call.
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {
+                    "usageMetadata": {
+                        "promptTokenCount": 363,
+                        "responseTokenCount": 35,
+                        "promptTokensDetails": [{"modality": "AUDIO", "tokenCount": 201}],
+                        "responseTokensDetails": [{"modality": "AUDIO", "tokenCount": 35}],
+                    }
+                },
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        done = next(e for e in await drain(provider) if isinstance(e, ResponseDone))
+        assert done.usage is not None
+        assert done.usage.input_tokens == 363
+        assert done.usage.input_audio_tokens == 201
+        assert done.usage.output_audio_tokens == 35
+
+    @pytest.mark.asyncio
+    async def test_turn_usage_resets_between_turns(self):
+        provider = make_gemini()
+        attach_ws(
+            provider,
+            [
+                {"usageMetadata": {"promptTokenCount": 10, "responseTokenCount": 1}},
+                {"serverContent": {"turnComplete": True}},
+                {"usageMetadata": {"promptTokenCount": 20, "responseTokenCount": 2}},
+                {"serverContent": {"turnComplete": True}},
+            ],
+        )
+        turns = [e for e in await drain(provider) if isinstance(e, ResponseDone)]
+        assert [t.usage.input_tokens for t in turns] == [10, 20]
+        assert provider.usage_total.input_tokens == 30
 
     @pytest.mark.asyncio
     async def test_usage_keeps_the_audio_text_split(self):
@@ -382,9 +468,9 @@ class TestGeminiEventMapping:
             ],
         )
         await drain(provider)
-        assert provider.usage_total["input_text_tokens"] == 137
-        assert provider.usage_total["input_audio_tokens"] == 201
-        assert provider.usage_total["output_audio_tokens"] == 35
+        assert provider.usage_total.input_text_tokens == 137
+        assert provider.usage_total.input_audio_tokens == 201
+        assert provider.usage_total.output_audio_tokens == 35
 
     @pytest.mark.asyncio
     async def test_first_audio_latency_measured_from_turn_start(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -54,6 +54,7 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm._s2s_hangup_after_response = False
     tm._s2s_started_at = 0  # welcome gate already elapsed
     tm._s2s_welcome_gate_ms = 0
+    tm._s2s_welcome_sent = True
     tm._s2s_agent_speaking = False
     tm._s2s_turn_seq = 0
     tm._s2s_playout_until = 0.0

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from bolna.agent_manager.task_manager import TaskManager
-from bolna.enums import HangupReason
+from bolna.enums import HangupReason, TelephonyProvider
 from bolna.helpers.utils import pcm_to_ulaw
 from bolna.s2s import events as s2s_events
 from bolna.s2s.events import AudioEncoding, AudioFormat
@@ -76,12 +76,24 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
 
 
 class TestIOFormatSelection:
-    @pytest.mark.parametrize("provider", ["plivo", "twilio", "exotel", "vobiz", "sip-trunk"])
-    def test_every_carrier_leg_is_8k_mulaw_both_ways(self, provider):
-        # Plivo is the primary carrier and streams mu-law like the rest; treating it as
-        # linear PCM would send noise to the model.
+    @pytest.mark.parametrize("provider", ["twilio", "sip-trunk"])
+    def test_mulaw_carriers_are_mulaw_both_ways(self, provider):
         tm = make_tm(io_provider=provider)
         assert tm._s2s_input_format() == AudioFormat(AudioEncoding.MULAW, 8000)
+        assert tm._s2s_output_format() == AudioFormat(AudioEncoding.MULAW, 8000)
+
+    @pytest.mark.parametrize("provider", ["plivo", "twilio", "exotel", "vobiz", "sip-trunk"])
+    def test_input_encoding_matches_what_the_transcribers_use(self, provider):
+        # TelephonyProvider.mulaw_providers() is the single source of truth. Assuming every
+        # carrier is mu-law fed linear PCM through ulaw_to_pcm and sent the model noise.
+        tm = make_tm(io_provider=provider)
+        expected = AudioEncoding.MULAW if provider in TelephonyProvider.mulaw_values() else AudioEncoding.PCM
+        assert tm._s2s_input_format() == AudioFormat(expected, 8000)
+
+    @pytest.mark.parametrize("provider", ["plivo", "exotel", "vobiz"])
+    def test_linear_carriers_stream_pcm_up_and_take_mulaw_down(self, provider):
+        tm = make_tm(io_provider=provider)
+        assert tm._s2s_input_format() == AudioFormat(AudioEncoding.PCM, 8000)
         assert tm._s2s_output_format() == AudioFormat(AudioEncoding.MULAW, 8000)
 
     def test_web_call_sends_16k_and_plays_back_24k(self):
@@ -131,10 +143,40 @@ class TestOutputHandlerSetup:
         assert self._setup("default", web=True).sampling_rate == 24000
 
 
+class TestLinearCarrierIngest:
+    @pytest.mark.asyncio
+    async def test_plivo_pcm_is_not_decoded_as_mulaw(self):
+        # The bug: ulaw_to_pcm() over linear PCM expands each 2-byte sample into two
+        # garbage samples, so the model heard noise at double duration on the primary carrier.
+        tm = make_tm(io_provider="plivo", in_rate=24000)
+        pcm_8k = _silence_pcm(160)  # 20ms @ 8kHz linear
+        await tm.audio_queue.put({"data": pcm_8k, "meta_info": {}})
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        sent = tm.tools["s2s"].send_audio.await_args.args[0]
+        # 160 samples @8k -> 480 samples @24k -> 960 bytes. Mis-decoding would give 1920.
+        assert len(sent) == 960
+
+
+class TestLoopTermination:
+    @pytest.mark.asyncio
+    async def test_eos_ends_the_conversation_so_the_event_loop_can_exit(self):
+        # The event loop parks on the provider socket, which goes quiet after hangup. If EOS
+        # does not publish conversation_ended, gather() never returns and teardown stalls.
+        tm = make_tm()
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        assert tm.conversation_ended is True
+
+
 class TestAudioIngest:
     @pytest.mark.asyncio
     async def test_mulaw_carrier_audio_is_decoded_and_upsampled(self):
-        tm = make_tm(io_provider="plivo", in_rate=24000)
+        tm = make_tm(io_provider="twilio", in_rate=24000)
         mulaw = pcm_to_ulaw(_silence_pcm(160))  # 20ms @ 8kHz
         await tm.audio_queue.put({"data": mulaw, "meta_info": {}})
         await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
@@ -147,7 +189,7 @@ class TestAudioIngest:
 
     @pytest.mark.asyncio
     async def test_gemini_gets_16k_not_24k(self):
-        tm = make_tm(io_provider="plivo", in_rate=16000)
+        tm = make_tm(io_provider="twilio", in_rate=16000)
         await tm.audio_queue.put({"data": pcm_to_ulaw(_silence_pcm(160)), "meta_info": {}})
         await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
 
@@ -169,7 +211,7 @@ class TestAudioIngest:
 
     @pytest.mark.asyncio
     async def test_welcome_gate_discards_inbound_audio(self):
-        tm = make_tm(io_provider="plivo")
+        tm = make_tm(io_provider="twilio")
         tm._s2s_welcome_gate_ms = 60_000
         tm._s2s_started_at = time.time()
         await tm.audio_queue.put({"data": pcm_to_ulaw(_silence_pcm(160)), "meta_info": {}})
@@ -200,6 +242,11 @@ class TestAudioOutput:
         tm._s2s_hangup_after_response = True
         assert tm._s2s_meta()["message_category"] == "agent_hangup"
 
+    def test_meta_carries_the_type_the_web_output_handler_indexes(self):
+        # DefaultOutputHandler.handle reads meta_info["type"] first and swallows the KeyError
+        # by closing itself, which silenced the entire browser leg with no error surfaced.
+        assert make_tm(io_provider="default", web=True)._s2s_meta()["type"] == "audio"
+
 
 class TestBargeIn:
     @pytest.mark.asyncio
@@ -212,6 +259,15 @@ class TestBargeIn:
 
         assert tm.buffered_output_queue.empty()
         tm.tools["output"].handle_interruption.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_barge_in_releases_the_audio_playing_flag(self):
+        # handle_interruption clears the pending final-chunk mark, and that mark's echo is
+        # the only thing that would flip this back off. Latched True, the inactivity
+        # watchdog never fires and the call stays open and billing.
+        tm = make_tm()
+        await tm._s2s_drop_queued_audio()
+        tm.tools["input"].update_is_audio_being_played.assert_called_with(False)
 
 
 class TestToolDispatch:
@@ -226,6 +282,24 @@ class TestToolDispatch:
         result = json.loads(tm.tools["s2s"].send_function_result.await_args.args[2])
         assert result["status"] == "success"
         tm.tools["s2s"].commit_function_results.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hangup_is_armed_only_after_the_commit(self):
+        # Arming it before the commit let the tool-call turn's own response.done consume the
+        # flag, cutting the caller off before the goodbye was ever spoken. commit waits on
+        # that response.done, so anything armed after it can only fire on the goodbye.
+        tm = make_tm()
+        armed_at_commit = {}
+
+        async def record_state():
+            armed_at_commit["value"] = tm._s2s_hangup_after_response
+
+        tm.tools["s2s"].commit_function_results = AsyncMock(side_effect=record_state)
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="end_call", call_id="c1", arguments="{}"))
+
+        assert armed_at_commit["value"] is False
+        assert tm._s2s_hangup_after_response is True
 
     @pytest.mark.asyncio
     async def test_hangup_runs_once_the_turn_completes(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -54,6 +54,7 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm._s2s_welcome_gate_ms = 0
     tm._s2s_agent_speaking = False
     tm._s2s_turn_seq = 0
+    tm._s2s_playout_until = 0.0
     tm.interruption_manager = MagicMock()
     tm.last_transmitted_timestamp = 0
     tm.time_since_last_spoken_human_word = 0
@@ -324,10 +325,34 @@ class TestBargeInAccounting:
     async def test_speech_over_agent_audio_counts_as_an_interruption(self):
         tm = make_tm()
         await self._run_events(
-            tm, [s2s_events.AudioDelta(data=_silence_pcm(160)), s2s_events.Interrupted()]
+            tm, [s2s_events.AudioDelta(data=_silence_pcm(4800)), s2s_events.Interrupted()]
         )
 
         tm.interruption_manager.on_interruption_triggered.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_barge_in_over_the_tail_of_a_finished_response_still_counts(self):
+        # The model stops generating seconds before the caller stops hearing the response.
+        # Gating on the generation window missed every barge-in over that tail.
+        tm = make_tm()
+        await self._run_events(
+            tm,
+            [
+                s2s_events.AudioDelta(data=_silence_pcm(48000)),  # 2s of 24k audio still to play
+                s2s_events.ResponseDone(transcript="hi", usage=None),
+                s2s_events.Interrupted(),
+            ],
+        )
+
+        tm.interruption_manager.on_interruption_triggered.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_speech_after_the_response_finished_playing_is_not_an_interruption(self):
+        tm = make_tm()
+        tm._s2s_playout_until = time.time() - 1  # everything sent has already been heard
+        await self._run_events(tm, [s2s_events.Interrupted()])
+
+        tm.interruption_manager.on_interruption_triggered.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_speech_while_agent_is_silent_is_not_an_interruption(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -66,6 +66,7 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
         send_dtmf=AsyncMock(),
         send_function_result=AsyncMock(),
         commit_function_results=AsyncMock(),
+        trigger_response=AsyncMock(),
     )
     output = SimpleNamespace(
         handle=AsyncMock(), handle_interruption=AsyncMock(), get_provider=MagicMock(return_value=io_provider)
@@ -451,6 +452,62 @@ class TestStreamSidPropagation:
         await tm._TaskManager__await_stream_sid(timeout=0.05)
         tm._TaskManager__process_end_of_conversation.assert_awaited_once()
         tm.tools["output"].set_stream_sid.assert_not_awaited()
+
+
+class TestUserOnlinePrompt:
+    """An s2s task has no synthesizer, so the shared path silently failed and recorded a
+    line the caller never heard."""
+
+    def _make_tm(self):
+        tm = make_tm()
+        tm.s2s_config = {"provider": "openai_realtime"}
+        tm.task_config["task_type"] = "conversation"
+        tm.check_if_user_online = True
+        tm.check_user_online_message_config = "Hey, are you still there"
+        tm.language = "en"
+        tm._synthesize = AsyncMock()
+        tm.conversation_history = MagicMock()
+        tm.tools["output"] = MagicMock(handle_interruption=AsyncMock(), get_provider=MagicMock(return_value="plivo"))
+        tm.tools["input"] = MagicMock(
+            is_audio_being_played_to_user=MagicMock(return_value=False),
+            reset_response_heard_by_user=MagicMock(),
+            update_is_audio_being_played=MagicMock(),
+        )
+        # Silence long enough for the online check, short enough to stay under the hangup.
+        tm.start_time = time.time()
+        tm.last_transmitted_timestamp = time.time() - 30
+        tm.time_since_last_spoken_human_word = time.time() - 30
+        tm.compute_last_ai_audio_timestamp = MagicMock(return_value=time.time() - 30)
+        tm._should_stall_hangup = MagicMock(return_value=False)
+        tm.trigger_user_online_message_after = 10
+        tm.hang_conversation_after = 0
+        tm.repeat_after_silence_seconds = 0
+        tm.asked_if_user_is_still_there = False
+        tm.hangup_triggered = False
+        tm.response_in_pipeline = False
+        tm.llm_task = None
+        tm.execute_function_call_task = None
+        return tm
+
+    async def _run_one_pass(self, tm):
+        runner = asyncio.create_task(tm._TaskManager__check_for_completion())
+        for _ in range(60):
+            await asyncio.sleep(0.05)
+            if tm.tools["s2s"].trigger_response.await_count or tm._synthesize.await_count:
+                break
+        runner.cancel()
+        await asyncio.gather(runner, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_the_model_speaks_it_instead_of_the_synthesizer(self):
+        tm = self._make_tm()
+        await self._run_one_pass(tm)
+
+        tm.tools["s2s"].trigger_response.assert_awaited_once()
+        assert "still there" in tm.tools["s2s"].trigger_response.await_args.kwargs["instructions"]
+        # The shared path pushes a packet the caller never hears and then clears carrier audio.
+        tm._synthesize.assert_not_awaited()
+        tm.tools["output"].handle_interruption.assert_not_awaited()
 
 
 class TestToolDispatch:

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -58,6 +58,8 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm.interruption_manager = MagicMock()
     tm.last_transmitted_timestamp = 0
     tm.time_since_last_spoken_human_word = 0
+    tm._language = "en"
+    tm.call_hangup_message_config = None
 
     provider = SimpleNamespace(
         input_sample_rate=in_rate,
@@ -553,6 +555,62 @@ class TestBackgroundTaskLifecycle:
 
         assert "socket gone" in caplog.text
         assert "c9" in caplog.text
+
+
+class TestHangupAndFillerParity:
+    """An s2s task has no synthesizer, so anything the llm path renders itself has to be
+    spoken by the model instead."""
+
+    @pytest.mark.asyncio
+    async def test_configured_hangup_message_becomes_the_models_goodbye(self):
+        tm = make_tm()
+        tm.call_hangup_message_config = "Thanks for calling Acme, goodbye."
+        tm.language = "en"
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="end_call", call_id="c1", arguments="{}"))
+
+        sent = tm.tools["s2s"].send_function_result.await_args.args[2]
+        assert "Thanks for calling Acme, goodbye." in sent
+
+    @pytest.mark.asyncio
+    async def test_default_goodbye_when_none_configured(self):
+        tm = make_tm()
+        tm.call_hangup_message_config = None
+        tm.language = "en"
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="end_call", call_id="c1", arguments="{}"))
+
+        assert "brief goodbye" in tm.tools["s2s"].send_function_result.await_args.args[2]
+
+    @pytest.mark.asyncio
+    async def test_api_tool_speaks_a_filler_before_the_request(self):
+        # The endpoint can take seconds; without this the caller hears dead air.
+        tm = make_tm(tools_params={"book": {"url": "https://api.example/book", "pre_call_message": "One moment."}})
+        tm.language = "en"
+        tm._start_api_call_detail = MagicMock(return_value={})
+        tm._finalize_api_call_detail = MagicMock()
+        with (
+            patch("bolna.agent_manager.task_manager.convert_to_request_log"),
+            patch(
+                "bolna.agent_manager.task_manager.trigger_api",
+                new=AsyncMock(return_value={"body": "{}", "status_code": 200}),
+            ),
+        ):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="book", call_id="c1", arguments="{}"))
+
+        tm.tools["s2s"].trigger_response.assert_awaited_once()
+        assert "One moment." in tm.tools["s2s"].trigger_response.await_args.kwargs["instructions"]
+
+    @pytest.mark.asyncio
+    async def test_end_call_gets_no_filler(self):
+        tm = make_tm()
+        tm.call_hangup_message_config = None
+        tm.language = "en"
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="end_call", call_id="c1", arguments="{}"))
+
+        # The goodbye is the response; a filler would talk over it.
+        tm.tools["s2s"].trigger_response.assert_not_awaited()
 
 
 class TestUserOnlinePrompt:

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -378,6 +378,22 @@ class TestBargeInAccounting:
         tm.interruption_manager.on_agent_speech_ended.assert_called_once()
         assert tm._s2s_turn_seq == 1
 
+    @pytest.mark.asyncio
+    async def test_a_completed_turn_after_a_barge_in_counts_as_recovery(self):
+        tm = make_tm()
+        await self._run_events(
+            tm,
+            [
+                s2s_events.AudioDelta(data=_silence_pcm(4800)),
+                s2s_events.Interrupted(),
+                s2s_events.AudioDelta(data=_silence_pcm(4800)),
+                s2s_events.ResponseDone(transcript="sure", usage=None),
+            ],
+        )
+
+        tm.interruption_manager.on_interruption_triggered.assert_called_once()
+        tm.interruption_manager.on_successful_response_delivered.assert_called_once()
+
 
 class TestToolDispatch:
     @pytest.mark.asyncio

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -454,6 +454,80 @@ class TestStreamSidPropagation:
         tm.tools["output"].set_stream_sid.assert_not_awaited()
 
 
+class TestBackgroundTaskLifecycle:
+    """Tool work runs detached, so a dropped exception or an uncancelled task is invisible."""
+
+    async def _run_events(self, tm, events):
+        async def stream():
+            for e in events:
+                # Let a task spawned by the previous event actually reach its first await.
+                await asyncio.sleep(0.01)
+                yield e
+
+        tm.tools["s2s"].receive_events = stream
+        await tm._s2s_event_loop()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_call_id_cancels_the_running_tool(self):
+        tm = make_tm(tools_params={"book": {"url": "https://api.example/book"}})
+        started = asyncio.Event()
+        spawned = []
+
+        async def slow_tool(event):
+            started.set()
+            spawned.append(asyncio.current_task())
+            await asyncio.sleep(30)
+
+        tm._s2s_execute_tool = slow_tool
+        await self._run_events(
+            tm,
+            [
+                s2s_events.FunctionCall(name="book", call_id="c1", arguments="{}"),
+                s2s_events.FunctionCallCancelled(call_ids=["c1"]),
+            ],
+        )
+        await asyncio.sleep(0.01)
+        # Left running it would POST the booking and then answer an id the model discarded.
+        assert started.is_set()
+        assert spawned[0].cancelled()
+
+    @pytest.mark.asyncio
+    async def test_unrelated_call_id_is_left_alone(self):
+        tm = make_tm(tools_params={"book": {"url": "https://api.example/book"}})
+
+        async def slow_tool(event):
+            await asyncio.sleep(30)
+
+        tm._s2s_execute_tool = slow_tool
+        await self._run_events(
+            tm,
+            [
+                s2s_events.FunctionCall(name="book", call_id="c1", arguments="{}"),
+                s2s_events.FunctionCallCancelled(call_ids=["other"]),
+            ],
+        )
+        await asyncio.sleep(0)
+        running = [t for t in tm._s2s_tool_tasks if not t.done()]
+        assert len(running) == 1
+        for t in running:
+            t.cancel()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_tool_task_is_logged_not_swallowed(self, caplog):
+        tm = make_tm()
+
+        async def boom(event):
+            raise RuntimeError("socket gone")
+
+        tm._s2s_execute_tool = boom
+        with caplog.at_level("ERROR"):
+            await self._run_events(tm, [s2s_events.FunctionCall(name="book", call_id="c9", arguments="{}")])
+            await asyncio.sleep(0.05)
+
+        assert "socket gone" in caplog.text
+        assert "c9" in caplog.text
+
+
 class TestUserOnlinePrompt:
     """An s2s task has no synthesizer, so the shared path silently failed and recorded a
     line the caller never heard."""

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -52,6 +52,9 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm._s2s_hangup_after_response = False
     tm._s2s_started_at = 0  # welcome gate already elapsed
     tm._s2s_welcome_gate_ms = 0
+    tm._s2s_agent_speaking = False
+    tm._s2s_turn_seq = 0
+    tm.interruption_manager = MagicMock()
     tm.last_transmitted_timestamp = 0
     tm.time_since_last_spoken_human_word = 0
 
@@ -303,6 +306,52 @@ class TestBargeIn:
         tm = make_tm()
         await tm._s2s_drop_queued_audio()
         tm.tools["input"].update_is_audio_being_played.assert_called_with(False)
+
+
+class TestBargeInAccounting:
+    """Barge-in counts drive the interruption stats on the call record. The provider
+    reports every speech start, so counting them all would inflate the rate."""
+
+    async def _run_events(self, tm, events):
+        async def stream():
+            for e in events:
+                yield e
+
+        tm.tools["s2s"].receive_events = stream
+        await tm._s2s_event_loop()
+
+    @pytest.mark.asyncio
+    async def test_speech_over_agent_audio_counts_as_an_interruption(self):
+        tm = make_tm()
+        await self._run_events(
+            tm, [s2s_events.AudioDelta(data=_silence_pcm(160)), s2s_events.Interrupted()]
+        )
+
+        tm.interruption_manager.on_interruption_triggered.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_speech_while_agent_is_silent_is_not_an_interruption(self):
+        tm = make_tm()
+        await self._run_events(tm, [s2s_events.Interrupted()])
+
+        tm.interruption_manager.on_interruption_triggered.assert_not_called()
+        tm.interruption_manager.on_user_speech_started.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_agent_speech_window_opens_once_per_turn_and_closes_on_done(self):
+        tm = make_tm()
+        await self._run_events(
+            tm,
+            [
+                s2s_events.AudioDelta(data=_silence_pcm(160)),
+                s2s_events.AudioDelta(data=_silence_pcm(160)),
+                s2s_events.ResponseDone(transcript="hi", usage=None),
+            ],
+        )
+
+        tm.interruption_manager.on_agent_speech_started.assert_called_once_with(0)
+        tm.interruption_manager.on_agent_speech_ended.assert_called_once()
+        assert tm._s2s_turn_seq == 1
 
 
 class TestToolDispatch:

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -613,6 +613,50 @@ class TestHangupAndFillerParity:
         tm.tools["s2s"].trigger_response.assert_not_awaited()
 
 
+class TestInactivityHangupParity:
+    """The llm path speaks call_hangup_message on a silence timeout; s2s has no
+    synthesizer, so the model has to say it or the caller is cut off mid-silence."""
+
+    def _make_tm(self, message):
+        tm = make_tm()
+        tm.s2s_config = {"provider": "openai_realtime"}
+        tm.task_config["task_type"] = "conversation"
+        tm.call_hangup_message_config = message
+        tm.voicemail_handler = MagicMock(detected=False)
+        tm.process_call_hangup = AsyncMock()
+        return tm
+
+    @pytest.mark.asyncio
+    async def test_model_speaks_the_goodbye_then_the_turn_end_hangs_up(self):
+        tm = self._make_tm("Thanks for calling, goodbye.")
+        await tm._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
+
+        assert "Thanks for calling, goodbye." in tm.tools["s2s"].trigger_response.await_args.kwargs["instructions"]
+        # Arming the flag is what ends the call, once, after the goodbye plays.
+        assert tm._s2s_hangup_after_response is True
+        # Calling it here would re-enter and trip the in-progress guard.
+        tm.process_call_hangup.assert_not_awaited()
+        assert tm.hangup_detail == HangupReason.INACTIVITY_TIMEOUT
+
+    @pytest.mark.asyncio
+    async def test_no_configured_message_hangs_up_directly(self):
+        tm = self._make_tm(None)
+        await tm._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
+
+        tm.tools["s2s"].trigger_response.assert_not_awaited()
+        tm.process_call_hangup.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_voicemail_skips_the_goodbye(self):
+        tm = self._make_tm("Thanks for calling, goodbye.")
+        tm.voicemail_handler.detected = True
+        await tm._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
+
+        # Talking to a machine, so no goodbye and no waiting for one.
+        tm.tools["s2s"].trigger_response.assert_not_awaited()
+        tm.process_call_hangup.assert_awaited_once()
+
+
 class TestUserOnlinePrompt:
     """An s2s task has no synthesizer, so the shared path silently failed and recorded a
     line the caller never heard."""

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -454,6 +454,33 @@ class TestStreamSidPropagation:
         tm.tools["output"].set_stream_sid.assert_not_awaited()
 
 
+class TestUsageAttribution:
+    """Billing reads usage_source to know whether it can trust the token counts."""
+
+    async def _finish(self, tm, usage):
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log:
+            await tm._s2s_finish_turn(s2s_events.ResponseDone(transcript="hi", usage=usage))
+        return log.call_args
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_is_not_stamped_as_reported(self):
+        call = await self._finish(make_tm(), None)
+        assert call.kwargs["input_tokens"] is None
+        assert call.kwargs["output_tokens"] is None
+
+    @pytest.mark.asyncio
+    async def test_a_genuine_zero_turn_still_reports_zero(self):
+        call = await self._finish(make_tm(), s2s_events.S2SUsage())
+        assert call.kwargs["input_tokens"] == 0
+        assert call.kwargs["output_tokens"] == 0
+
+    @pytest.mark.asyncio
+    async def test_reported_usage_passes_through(self):
+        call = await self._finish(make_tm(), s2s_events.S2SUsage(input_tokens=11, output_tokens=3))
+        assert call.kwargs["input_tokens"] == 11
+        assert call.kwargs["output_tokens"] == 3
+
+
 class TestBackgroundTaskLifecycle:
     """Tool work runs detached, so a dropped exception or an uncancelled task is invisible."""
 

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -18,6 +18,7 @@ from bolna.agent_manager.task_manager import TaskManager
 from bolna.enums import HangupReason
 from bolna.helpers.utils import pcm_to_ulaw
 from bolna.s2s import events as s2s_events
+from bolna.s2s.events import AudioEncoding, AudioFormat
 
 
 def _silence_pcm(samples=480):
@@ -69,8 +70,8 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm.tools = {"s2s": provider, "output": output, "input": inp}
     # __setup_output_handlers stamps this before the S2S loop starts.
     tm.sampling_rate = 8000 if tm._s2s_is_carrier_leg() else 24000
-    tm._s2s_in_encoding, tm._s2s_in_rate = tm._s2s_input_format()
-    tm._s2s_out_encoding, tm._s2s_out_rate = tm._s2s_output_format()
+    tm._s2s_input = tm._s2s_input_format()
+    tm._s2s_output = tm._s2s_output_format()
     return tm
 
 
@@ -80,20 +81,20 @@ class TestIOFormatSelection:
         # Plivo is the primary carrier and streams mu-law like the rest; treating it as
         # linear PCM would send noise to the model.
         tm = make_tm(io_provider=provider)
-        assert tm._s2s_input_format() == ("mulaw", 8000)
-        assert tm._s2s_output_format() == ("mulaw", 8000)
+        assert tm._s2s_input_format() == AudioFormat(AudioEncoding.MULAW, 8000)
+        assert tm._s2s_output_format() == AudioFormat(AudioEncoding.MULAW, 8000)
 
     def test_web_call_sends_16k_and_plays_back_24k(self):
         # The browser leg is asymmetric: encoding output at the input rate would play
         # the agent back at the wrong speed.
         tm = make_tm(io_provider="default", web=True)
-        assert tm._s2s_input_format() == ("pcm", 16000)
-        assert tm._s2s_output_format() == ("pcm", 24000)
+        assert tm._s2s_input_format() == AudioFormat(AudioEncoding.PCM, 16000)
+        assert tm._s2s_output_format() == AudioFormat(AudioEncoding.PCM, 24000)
 
     def test_dashboard_playground_matches_the_web_leg(self):
         tm = make_tm(io_provider="default", turn_based=True)
-        assert tm._s2s_input_format() == ("pcm", 16000)
-        assert tm._s2s_output_format() == ("pcm", 24000)
+        assert tm._s2s_input_format() == AudioFormat(AudioEncoding.PCM, 16000)
+        assert tm._s2s_output_format() == AudioFormat(AudioEncoding.PCM, 24000)
 
 
 class TestOutputHandlerSetup:
@@ -348,7 +349,7 @@ class TestUsageReporting:
     async def test_turn_usage_reaches_the_billing_hook(self):
         tm = make_tm()
         tm.on_turn_usage = AsyncMock()
-        usage = {"input_tokens": 11, "output_tokens": 22, "cached_tokens": 3}
+        usage = s2s_events.S2SUsage(input_tokens=11, output_tokens=22, cached_tokens=3)
         with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
             await tm._s2s_finish_turn(s2s_events.ResponseDone(transcript="x", usage=usage))
         await asyncio.gather(*tm._s2s_tool_tasks, return_exceptions=True)

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -67,23 +67,67 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     )
     inp = SimpleNamespace(io_provider=io_provider, update_is_audio_being_played=MagicMock(), is_dtmf_active=False)
     tm.tools = {"s2s": provider, "output": output, "input": inp}
-    tm._s2s_encoding, tm._s2s_rate = tm._s2s_io_format()
-    tm.sampling_rate = tm._s2s_rate
+    # __setup_output_handlers stamps this before the S2S loop starts.
+    tm.sampling_rate = 8000 if tm._s2s_is_carrier_leg() else 24000
+    tm._s2s_in_encoding, tm._s2s_in_rate = tm._s2s_input_format()
+    tm._s2s_out_encoding, tm._s2s_out_rate = tm._s2s_output_format()
     return tm
 
 
 class TestIOFormatSelection:
     @pytest.mark.parametrize("provider", ["plivo", "twilio", "exotel", "vobiz", "sip-trunk"])
-    def test_every_carrier_leg_is_8k_mulaw(self, provider):
+    def test_every_carrier_leg_is_8k_mulaw_both_ways(self, provider):
         # Plivo is the primary carrier and streams mu-law like the rest; treating it as
         # linear PCM would send noise to the model.
-        assert make_tm(io_provider=provider)._s2s_io_format() == ("mulaw", 8000)
+        tm = make_tm(io_provider=provider)
+        assert tm._s2s_input_format() == ("mulaw", 8000)
+        assert tm._s2s_output_format() == ("mulaw", 8000)
 
-    def test_web_call_is_16k_pcm(self):
-        assert make_tm(io_provider="default", web=True)._s2s_io_format() == ("pcm", 16000)
+    def test_web_call_sends_16k_and_plays_back_24k(self):
+        # The browser leg is asymmetric: encoding output at the input rate would play
+        # the agent back at the wrong speed.
+        tm = make_tm(io_provider="default", web=True)
+        assert tm._s2s_input_format() == ("pcm", 16000)
+        assert tm._s2s_output_format() == ("pcm", 24000)
 
-    def test_dashboard_playground_is_16k_pcm(self):
-        assert make_tm(io_provider="default", turn_based=True)._s2s_io_format() == ("pcm", 16000)
+    def test_dashboard_playground_matches_the_web_leg(self):
+        tm = make_tm(io_provider="default", turn_based=True)
+        assert tm._s2s_input_format() == ("pcm", 16000)
+        assert tm._s2s_output_format() == ("pcm", 24000)
+
+
+class TestOutputHandlerSetup:
+    """__setup_output_handlers runs before the S2S loop and used to stamp synthesizer config."""
+
+    def _setup(self, output_provider, *, web=False):
+        tm = TaskManager.__new__(TaskManager)
+        tm.task_config = {
+            "task_type": "conversation",
+            "tools_config": {
+                "output": {"provider": output_provider},
+                "input": {"provider": output_provider},
+                "s2s": {"provider": "openai_realtime", "provider_config": {}},
+            },
+        }
+        tm.s2s_config = tm.task_config["tools_config"]["s2s"]
+        tm.websocket = MagicMock()
+        tm.mark_event_meta_data = MagicMock()
+        tm.is_web_based_call = web
+        tm.turn_based_conversation = False
+        tm.context_data = {}
+        tm.tools = {}
+        tm.output_handler_set = False
+        TaskManager._TaskManager__setup_output_handlers(tm, False, asyncio.Queue())
+        return tm
+
+    @pytest.mark.parametrize("provider", ["plivo", "twilio", "sip-trunk"])
+    def test_telephony_setup_without_a_synthesizer(self, provider):
+        # An S2S agent carries no tools_config["synthesizer"]; stamping it would KeyError
+        # before the call ever started.
+        assert self._setup(provider).sampling_rate == 8000
+
+    def test_web_setup_without_a_synthesizer(self):
+        assert self._setup("default", web=True).sampling_rate == 24000
 
 
 class TestAudioIngest:
@@ -143,9 +187,10 @@ class TestAudioOutput:
         assert len(encoded) == 160
         assert audioop.ulaw2lin(encoded, 2) == _silence_pcm(160)
 
-    def test_web_output_stays_pcm(self):
-        tm = make_tm(io_provider="default", web=True, out_rate=16000)
-        pcm = _silence_pcm(320)
+    def test_web_output_stays_pcm_at_the_playback_rate(self):
+        # Model already emits 24k and the browser plays 24k, so nothing is resampled.
+        tm = make_tm(io_provider="default", web=True, out_rate=24000)
+        pcm = _silence_pcm(480)
         assert tm._s2s_encode_output(pcm) == pcm
 
     def test_hangup_audio_is_tagged_so_it_bypasses_interruption_gating(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -172,6 +172,41 @@ class TestLoopTermination:
 
         assert tm.conversation_ended is True
 
+    @pytest.mark.asyncio
+    async def test_hangup_tears_down_while_the_provider_socket_is_still_quiet(self):
+        # conversation_ended alone does not wake a reader parked on a silent socket, so
+        # joining on both loops left the call hung: no teardown, no post-call, execution
+        # stuck in-progress until the provider's own session limit fired.
+        tm = make_tm(io_provider="default", web=True, in_rate=16000)
+        tm.conversation_config = {}
+        tm.s2s = SimpleNamespace(welcome_audio_gate_ms=0)
+        tm.kwargs["agent_welcome_message"] = ""
+        provider = tm.tools["s2s"]
+        provider.connect = AsyncMock()
+        provider.disconnect = AsyncMock()
+
+        async def never_speaks():
+            await asyncio.Event().wait()
+            yield  # pragma: no cover
+
+        provider.receive_events = never_speaks
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        with (
+            patch.object(TaskManager, "_build_s2s_provider", return_value=provider),
+            patch.object(TaskManager, "_s2s_output_loop", AsyncMock()),
+            patch.object(TaskManager, "_TaskManager__check_for_completion", AsyncMock()),
+        ):
+            runner = asyncio.create_task(tm._run_s2s_conversation())
+            # Deliberately not wait_for: the run loop swallows CancelledError, so a timeout
+            # cancellation would surface as a clean return and the hang would go unnoticed.
+            done, _ = await asyncio.wait({runner}, timeout=5)
+            if runner not in done:
+                runner.cancel()
+                pytest.fail("run loop did not tear down after the caller hung up")
+
+        provider.disconnect.assert_awaited_once()
+
 
 class TestAudioIngest:
     @pytest.mark.asyncio

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -35,6 +35,8 @@ def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, 
     tm.conversation_ended = False
     tm.should_record = False
     tm.has_transfer = False
+    tm.hangup_triggered = False
+    tm._end_call_in_progress = False
     tm.hangup_detail = None
     tm.on_turn_usage = None
     tm.on_provider_health = None

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -429,8 +429,10 @@ class TestStreamSidPropagation:
         tm.stream_sid_ts = None
         tm.output_handler_set = True
         tm._report_stream_connect = AsyncMock()
+        ready = asyncio.Event()
+        ready.set()
         tm.tools = {
-            "input": MagicMock(get_stream_sid=MagicMock(return_value="sid-abc")),
+            "input": MagicMock(get_stream_sid=MagicMock(return_value="sid-abc"), stream_sid_ready=ready),
             "output": MagicMock(set_stream_sid=AsyncMock()),
         }
         return tm
@@ -452,7 +454,7 @@ class TestStreamSidPropagation:
     @pytest.mark.asyncio
     async def test_missing_stream_sid_ends_the_call_rather_than_hanging(self):
         tm = self._make_telephony_tm()
-        tm.tools["input"].get_stream_sid.return_value = None
+        tm.tools["input"].stream_sid_ready = asyncio.Event()  # never set: carrier never reports
         tm._TaskManager__process_end_of_conversation = AsyncMock()
         await tm._TaskManager__await_stream_sid(timeout=0.05)
         tm._TaskManager__process_end_of_conversation.assert_awaited_once()

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -415,6 +415,46 @@ class TestWelcomeMessageMarking:
         assert tm._s2s_meta()["message_category"] == "agent_hangup"
 
 
+class TestStreamSidPropagation:
+    """The telephony output handler drops every packet while stream_sid is None, so an
+    s2s call that skips this claims a live carrier leg and plays to nobody."""
+
+    def _make_telephony_tm(self):
+        tm = make_tm()
+        tm.stream_sid = None
+        tm.stream_sid_ts = None
+        tm.output_handler_set = True
+        tm._report_stream_connect = AsyncMock()
+        tm.tools = {
+            "input": MagicMock(get_stream_sid=MagicMock(return_value="sid-abc")),
+            "output": MagicMock(set_stream_sid=AsyncMock()),
+        }
+        return tm
+
+    @pytest.mark.asyncio
+    async def test_s2s_hands_the_stream_sid_to_the_output_handler(self):
+        tm = self._make_telephony_tm()
+        await tm._s2s_await_stream_sid()
+        tm.tools["output"].set_stream_sid.assert_awaited_once_with("sid-abc")
+        assert tm.stream_sid == "sid-abc"
+
+    @pytest.mark.asyncio
+    async def test_s2s_marks_the_welcome_as_played(self):
+        tm = self._make_telephony_tm()
+        await tm._s2s_await_stream_sid()
+        # The model speaks the greeting itself, so no mark event is ever coming for it.
+        assert tm.tools["input"].is_welcome_message_played is True
+
+    @pytest.mark.asyncio
+    async def test_missing_stream_sid_ends_the_call_rather_than_hanging(self):
+        tm = self._make_telephony_tm()
+        tm.tools["input"].get_stream_sid.return_value = None
+        tm._TaskManager__process_end_of_conversation = AsyncMock()
+        await tm._TaskManager__await_stream_sid(timeout=0.05)
+        tm._TaskManager__process_end_of_conversation.assert_awaited_once()
+        tm.tools["output"].set_stream_sid.assert_not_awaited()
+
+
 class TestToolDispatch:
     @pytest.mark.asyncio
     async def test_end_call_defers_hangup_until_the_goodbye_finishes(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -519,6 +519,21 @@ class TestToolDispatch:
         assert tm.has_transfer is True
 
     @pytest.mark.asyncio
+    async def test_transfer_sends_the_configured_param_not_the_model_arguments(self):
+        # call_transfer_number is config, so the webhook cannot resolve a destination from
+        # the model's arguments.
+        tm = make_tm(tools_params={"transfer_call": {"url": None, "param": {"call_transfer_number": "+15550001"}}})
+        tm._execute_transfer_call_webhook = AsyncMock()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(
+                s2s_events.FunctionCall(name="transfer_call", call_id="c1", arguments='{"reason":"wants a human"}')
+            )
+
+        _, _, param, resp, _ = tm._execute_transfer_call_webhook.await_args.args
+        assert param == {"call_transfer_number": "+15550001"}
+        assert resp == {"reason": "wants a human"}
+
+    @pytest.mark.asyncio
     async def test_duplicate_transfer_is_ignored(self):
         tm = make_tm(tools_params={"transfer_call": {"url": "https://hook.example/transfer"}})
         tm.has_transfer = True
@@ -546,6 +561,28 @@ class TestToolDispatch:
         assert api.await_args.kwargs["url"] == "https://api.example/book"
         assert api.await_args.kwargs["day"] == "mon"
         assert tm.tools["s2s"].send_function_result.await_args.args[2] == '{"ok":1}'
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_forwards_the_configured_headers(self):
+        # The field is `headers` everywhere else; reading `header` sends every authenticated
+        # tool call without its Authorization header.
+        tm = make_tm(
+            tools_params={
+                "book": {"url": "https://api.example/book", "headers": {"Authorization": "Bearer tok"}},
+            }
+        )
+        tm._start_api_call_detail = MagicMock(return_value={})
+        tm._finalize_api_call_detail = MagicMock()
+        with (
+            patch("bolna.agent_manager.task_manager.convert_to_request_log"),
+            patch(
+                "bolna.agent_manager.task_manager.trigger_api",
+                new=AsyncMock(return_value={"body": "{}", "status_code": 200}),
+            ) as api,
+        ):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="book", call_id="c1", arguments="{}"))
+
+        assert api.await_args.kwargs["headers_data"] == {"Authorization": "Bearer tok"}
 
     @pytest.mark.asyncio
     async def test_unconfigured_tool_reports_an_error_instead_of_raising(self):

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -277,6 +277,7 @@ class TestAudioOutput:
 
     def test_hangup_audio_is_tagged_so_it_bypasses_interruption_gating(self):
         tm = make_tm()
+        tm._s2s_turn_seq = 1  # past the welcome turn, which carries its own category
         assert "message_category" not in tm._s2s_meta()
         tm._s2s_hangup_after_response = True
         assert tm._s2s_meta()["message_category"] == "agent_hangup"
@@ -393,6 +394,25 @@ class TestBargeInAccounting:
 
         tm.interruption_manager.on_interruption_triggered.assert_called_once()
         tm.interruption_manager.on_successful_response_delivered.assert_called_once()
+
+
+class TestWelcomeMessageMarking:
+    """time_to_first_audio is derived from welcome_message_sent_ts, which the output
+    handlers stamp only when a packet is tagged as the welcome message."""
+
+    def test_first_turn_audio_is_tagged_as_the_welcome_message(self):
+        tm = make_tm()
+        assert tm._s2s_meta()["message_category"] == "agent_welcome_message"
+
+    def test_later_turns_are_not_tagged(self):
+        tm = make_tm()
+        tm._s2s_turn_seq = 1
+        assert "message_category" not in tm._s2s_meta()
+
+    def test_hangup_tagging_wins_over_the_welcome_tag(self):
+        tm = make_tm()
+        tm._s2s_hangup_after_response = True
+        assert tm._s2s_meta()["message_category"] == "agent_hangup"
 
 
 class TestToolDispatch:

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -325,9 +325,7 @@ class TestBargeInAccounting:
     @pytest.mark.asyncio
     async def test_speech_over_agent_audio_counts_as_an_interruption(self):
         tm = make_tm()
-        await self._run_events(
-            tm, [s2s_events.AudioDelta(data=_silence_pcm(4800)), s2s_events.Interrupted()]
-        )
+        await self._run_events(tm, [s2s_events.AudioDelta(data=_silence_pcm(4800)), s2s_events.Interrupted()])
 
         tm.interruption_manager.on_interruption_triggered.assert_called_once()
 

--- a/tests/tests/test_s2s_task_manager.py
+++ b/tests/tests/test_s2s_task_manager.py
@@ -1,0 +1,311 @@
+"""Pipeline-side tests for the speech-to-speech run loop.
+
+Covers the parts that only exist once a provider is wired into TaskManager: audio
+transcoding between the carrier leg and the model, tool dispatch, barge-in draining
+and DTMF forwarding.
+"""
+
+import asyncio
+import audioop
+import json
+import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.enums import HangupReason
+from bolna.helpers.utils import pcm_to_ulaw
+from bolna.s2s import events as s2s_events
+
+
+def _silence_pcm(samples=480):
+    return b"\x00\x00" * samples
+
+
+def make_tm(*, io_provider="plivo", web=False, turn_based=False, in_rate=24000, out_rate=24000, tools_params=None):
+    tm = TaskManager.__new__(TaskManager)
+    tm.task_id = 0
+    tm.run_id = "exec-123"
+    tm.turn_based_conversation = turn_based
+    tm.is_web_based_call = web
+    tm.default_io = io_provider == "default"
+    tm.conversation_ended = False
+    tm.should_record = False
+    tm.has_transfer = False
+    tm.hangup_detail = None
+    tm.on_turn_usage = None
+    tm.on_provider_health = None
+    tm.dtmf_events = []
+    tm.conversation_start_init_ts = 0
+    tm.s2s_provider_name = "openai_realtime"
+    tm.s2s_model = "gpt-realtime-2.1"
+    tm.buffered_output_queue = asyncio.Queue()
+    tm.audio_queue = asyncio.Queue()
+    tm.queues = {"dtmf": asyncio.Queue()}
+    tm.conversation_history = MagicMock()
+    tm.kwargs = {"api_tools": {"tools_params": tools_params or {}}}
+    tm.task_config = {"tools_config": {"input": {"provider": io_provider}}}
+    tm._s2s_tool_tasks = set()
+    tm._s2s_hangup_after_response = False
+    tm._s2s_started_at = 0  # welcome gate already elapsed
+    tm._s2s_welcome_gate_ms = 0
+    tm.last_transmitted_timestamp = 0
+    tm.time_since_last_spoken_human_word = 0
+
+    provider = SimpleNamespace(
+        input_sample_rate=in_rate,
+        output_sample_rate=out_rate,
+        send_audio=AsyncMock(),
+        send_dtmf=AsyncMock(),
+        send_function_result=AsyncMock(),
+        commit_function_results=AsyncMock(),
+    )
+    output = SimpleNamespace(
+        handle=AsyncMock(), handle_interruption=AsyncMock(), get_provider=MagicMock(return_value=io_provider)
+    )
+    inp = SimpleNamespace(io_provider=io_provider, update_is_audio_being_played=MagicMock(), is_dtmf_active=False)
+    tm.tools = {"s2s": provider, "output": output, "input": inp}
+    tm._s2s_encoding, tm._s2s_rate = tm._s2s_io_format()
+    tm.sampling_rate = tm._s2s_rate
+    return tm
+
+
+class TestIOFormatSelection:
+    @pytest.mark.parametrize("provider", ["plivo", "twilio", "exotel", "vobiz", "sip-trunk"])
+    def test_every_carrier_leg_is_8k_mulaw(self, provider):
+        # Plivo is the primary carrier and streams mu-law like the rest; treating it as
+        # linear PCM would send noise to the model.
+        assert make_tm(io_provider=provider)._s2s_io_format() == ("mulaw", 8000)
+
+    def test_web_call_is_16k_pcm(self):
+        assert make_tm(io_provider="default", web=True)._s2s_io_format() == ("pcm", 16000)
+
+    def test_dashboard_playground_is_16k_pcm(self):
+        assert make_tm(io_provider="default", turn_based=True)._s2s_io_format() == ("pcm", 16000)
+
+
+class TestAudioIngest:
+    @pytest.mark.asyncio
+    async def test_mulaw_carrier_audio_is_decoded_and_upsampled(self):
+        tm = make_tm(io_provider="plivo", in_rate=24000)
+        mulaw = pcm_to_ulaw(_silence_pcm(160))  # 20ms @ 8kHz
+        await tm.audio_queue.put({"data": mulaw, "meta_info": {}})
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        sent = tm.tools["s2s"].send_audio.await_args.args[0]
+        # 160 mu-law bytes -> 160 PCM samples @8k -> 480 samples @24k -> 960 bytes
+        assert len(sent) == 960
+
+    @pytest.mark.asyncio
+    async def test_gemini_gets_16k_not_24k(self):
+        tm = make_tm(io_provider="plivo", in_rate=16000)
+        await tm.audio_queue.put({"data": pcm_to_ulaw(_silence_pcm(160)), "meta_info": {}})
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        # 160 samples @8k -> 320 samples @16k -> 640 bytes
+        assert len(tm.tools["s2s"].send_audio.await_args.args[0]) == 640
+
+    @pytest.mark.asyncio
+    async def test_web_pcm_passes_through_at_matching_rate(self):
+        tm = make_tm(io_provider="default", web=True, in_rate=16000)
+        pcm = _silence_pcm(320)
+        await tm.audio_queue.put({"data": pcm, "meta_info": {}})
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        assert tm.tools["s2s"].send_audio.await_args.args[0] == pcm
+
+    @pytest.mark.asyncio
+    async def test_welcome_gate_discards_inbound_audio(self):
+        tm = make_tm(io_provider="plivo")
+        tm._s2s_welcome_gate_ms = 60_000
+        tm._s2s_started_at = time.time()
+        await tm.audio_queue.put({"data": pcm_to_ulaw(_silence_pcm(160)), "meta_info": {}})
+        await tm.audio_queue.put({"data": None, "meta_info": {"eos": True}})
+
+        await tm._s2s_audio_ingest_loop()
+
+        tm.tools["s2s"].send_audio.assert_not_awaited()
+
+
+class TestAudioOutput:
+    def test_model_audio_is_downsampled_and_mulaw_encoded_for_carriers(self):
+        tm = make_tm(io_provider="plivo", out_rate=24000)
+        encoded = tm._s2s_encode_output(_silence_pcm(480))  # 20ms @24k
+        # 480 samples @24k -> 160 samples @8k -> 160 mu-law bytes
+        assert len(encoded) == 160
+        assert audioop.ulaw2lin(encoded, 2) == _silence_pcm(160)
+
+    def test_web_output_stays_pcm(self):
+        tm = make_tm(io_provider="default", web=True, out_rate=16000)
+        pcm = _silence_pcm(320)
+        assert tm._s2s_encode_output(pcm) == pcm
+
+    def test_hangup_audio_is_tagged_so_it_bypasses_interruption_gating(self):
+        tm = make_tm()
+        assert "message_category" not in tm._s2s_meta()
+        tm._s2s_hangup_after_response = True
+        assert tm._s2s_meta()["message_category"] == "agent_hangup"
+
+
+class TestBargeIn:
+    @pytest.mark.asyncio
+    async def test_queued_audio_is_dropped_and_output_interrupted(self):
+        tm = make_tm()
+        for _ in range(3):
+            tm.buffered_output_queue.put_nowait({"data": b"x", "meta_info": {}})
+
+        await tm._s2s_drop_queued_audio()
+
+        assert tm.buffered_output_queue.empty()
+        tm.tools["output"].handle_interruption.assert_awaited_once()
+
+
+class TestToolDispatch:
+    @pytest.mark.asyncio
+    async def test_end_call_defers_hangup_until_the_goodbye_finishes(self):
+        tm = make_tm()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="end_call", call_id="c1", arguments="{}"))
+
+        # The model still has to speak its goodbye, so the hangup waits for response.done.
+        assert tm._s2s_hangup_after_response is True
+        result = json.loads(tm.tools["s2s"].send_function_result.await_args.args[2])
+        assert result["status"] == "success"
+        tm.tools["s2s"].commit_function_results.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_hangup_runs_once_the_turn_completes(self):
+        tm = make_tm()
+        tm._s2s_hangup_after_response = True
+        tm.process_call_hangup = AsyncMock()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_finish_turn(s2s_events.ResponseDone(transcript="bye", usage=None))
+
+        tm.process_call_hangup.assert_awaited_once()
+        assert tm.hangup_detail == HangupReason.END_CALL_TOOL
+        assert tm._s2s_hangup_after_response is False
+
+    @pytest.mark.asyncio
+    async def test_turn_end_emits_the_stream_sentinel(self):
+        tm = make_tm()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_finish_turn(s2s_events.ResponseDone(transcript="hi", usage=None))
+
+        message = tm.buffered_output_queue.get_nowait()
+        assert message["data"] == b"\x00"
+        assert message["meta_info"]["end_of_synthesizer_stream"] is True
+
+    @pytest.mark.asyncio
+    async def test_transfer_call_reuses_the_shared_webhook_path(self):
+        tm = make_tm(tools_params={"transfer_call": {"url": "https://hook.example/transfer"}})
+        tm._execute_transfer_call_webhook = AsyncMock()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(
+                s2s_events.FunctionCall(name="transfer_call", call_id="c1", arguments='{"call_transfer_number":"+1"}')
+            )
+
+        tm._execute_transfer_call_webhook.assert_awaited_once()
+        assert tm.has_transfer is True
+
+    @pytest.mark.asyncio
+    async def test_duplicate_transfer_is_ignored(self):
+        tm = make_tm(tools_params={"transfer_call": {"url": "https://hook.example/transfer"}})
+        tm.has_transfer = True
+        tm._execute_transfer_call_webhook = AsyncMock()
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="transfer_call", call_id="c1", arguments="{}"))
+
+        tm._execute_transfer_call_webhook.assert_not_awaited()
+        assert "already in progress" in tm.tools["s2s"].send_function_result.await_args.args[2]
+
+    @pytest.mark.asyncio
+    async def test_custom_tool_goes_through_trigger_api(self):
+        tm = make_tm(tools_params={"book": {"url": "https://api.example/book", "method": "POST"}})
+        tm._start_api_call_detail = MagicMock(return_value={})
+        tm._finalize_api_call_detail = MagicMock()
+        with (
+            patch("bolna.agent_manager.task_manager.convert_to_request_log"),
+            patch(
+                "bolna.agent_manager.task_manager.trigger_api",
+                new=AsyncMock(return_value={"body": '{"ok":1}', "status_code": 200}),
+            ) as api,
+        ):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="book", call_id="c1", arguments='{"day":"mon"}'))
+
+        assert api.await_args.kwargs["url"] == "https://api.example/book"
+        assert api.await_args.kwargs["day"] == "mon"
+        assert tm.tools["s2s"].send_function_result.await_args.args[2] == '{"ok":1}'
+
+    @pytest.mark.asyncio
+    async def test_unconfigured_tool_reports_an_error_instead_of_raising(self):
+        tm = make_tm(tools_params={})
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="ghost", call_id="c1", arguments="{}"))
+
+        assert json.loads(tm.tools["s2s"].send_function_result.await_args.args[2])["status"] == "error"
+
+    @pytest.mark.asyncio
+    async def test_api_failure_is_reported_back_to_the_model(self):
+        tm = make_tm(tools_params={"book": {"url": "https://api.example/book"}})
+        tm._start_api_call_detail = MagicMock(return_value={})
+        tm._finalize_api_call_detail = MagicMock()
+        with (
+            patch("bolna.agent_manager.task_manager.convert_to_request_log"),
+            patch("bolna.agent_manager.task_manager.trigger_api", new=AsyncMock(side_effect=RuntimeError("down"))),
+        ):
+            await tm._s2s_execute_tool(s2s_events.FunctionCall(name="book", call_id="c1", arguments="{}"))
+
+        payload = json.loads(tm.tools["s2s"].send_function_result.await_args.args[2])
+        assert payload["status"] == "error" and "down" in payload["message"]
+
+
+class TestDtmf:
+    @pytest.mark.asyncio
+    async def test_digits_are_forwarded_and_recorded(self):
+        tm = make_tm()
+        tm.queues["dtmf"].put_nowait("42")
+
+        async def stop_after_first():
+            await asyncio.sleep(0.05)
+            tm.conversation_ended = True
+            tm.queues["dtmf"].put_nowait("")
+
+        await asyncio.gather(tm._s2s_dtmf_loop(), stop_after_first())
+
+        tm.tools["s2s"].send_dtmf.assert_any_await("42")
+        assert [e["digit"] for e in tm.dtmf_events] == ["4", "2"]
+
+    @pytest.mark.asyncio
+    async def test_provider_without_dtmf_does_not_break_the_call(self):
+        tm = make_tm()
+        tm.tools["s2s"].send_dtmf = AsyncMock(side_effect=NotImplementedError)
+        tm.queues["dtmf"].put_nowait("7")
+
+        async def stop_after_first():
+            await asyncio.sleep(0.05)
+            tm.conversation_ended = True
+            tm.queues["dtmf"].put_nowait("")
+
+        await asyncio.gather(tm._s2s_dtmf_loop(), stop_after_first())
+        assert tm.conversation_ended is True
+
+
+class TestUsageReporting:
+    @pytest.mark.asyncio
+    async def test_turn_usage_reaches_the_billing_hook(self):
+        tm = make_tm()
+        tm.on_turn_usage = AsyncMock()
+        usage = {"input_tokens": 11, "output_tokens": 22, "cached_tokens": 3}
+        with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+            await tm._s2s_finish_turn(s2s_events.ResponseDone(transcript="x", usage=usage))
+        await asyncio.gather(*tm._s2s_tool_tasks, return_exceptions=True)
+
+        tm.on_turn_usage.assert_awaited_once_with(11, 22, 3)


### PR DESCRIPTION
Linear: BOLNA-2043

Adds a speech-to-speech agent type where a single provider socket replaces the transcriber, LLM and synthesizer legs. Supports OpenAI Realtime and Gemini Live.

## What is here

A new `bolna/s2s` package with a shared `BaseS2SProvider` and the two provider implementations, plus an s2s run loop in `TaskManager` that owns audio ingest, provider events, output, tool dispatch and DTMF.

Behaviour is kept consistent with the existing pipeline:

1. Barge-in and interruption stats, counted against audio playout rather than generation, since the model finishes a turn seconds before the caller has finished hearing it.
2. Turn latencies recorded in the same shape as LLM turns, so `time_to_first_audio` and the per-turn latency dashboards keep working.
3. Tool calls, including `end_call` and `transfer_call`.
4. Language pinning on both providers.

## Known gaps

Perceived turn latency is not yet right for s2s and is left as a follow-up. `latency_ms` in `user_bot_latencies` is anchored on the provider's final input transcript rather than on end of caller speech, which lands after the model has already started answering, so it reads near zero on Gemini and is missing or measured across the previous turn on OpenAI. `agent_end_ms` is also unset, because s2s packets carry `sequence_id: -1` (bolna's convention for template speech) while the playout marks are matched per turn. Per-turn first-audio and stream duration in `llm_latencies.turn_latencies` are unaffected.

The `end_call` goodbye is armed after the tool result is committed. OpenAI awaits the tool-call turn's `response.done` inside that commit, so the next turn to finish is the goodbye. Gemini returns as soon as it has sent the `toolResponse`, so a `turnComplete` for the tool-call turn arriving in that window would end the call before the goodbye is spoken.

## Notes for reviewers

An s2s task stores `llm_agent`, `transcriber` and `synthesizer` as explicit `None`, so the key is present and a `.get(key, {})` default never fires. Several call sites needed `or {}` instead.

Gemini rejects the entire setup frame over an unsupported JSON Schema key rather than dropping the offending tool, so tool parameter schemas are sanitised through a shared helper that the Gemini LLM path already needed.

Provider connect failures were previously invisible: a typed component error was written only to the request log, and a cancellation during the handshake was swallowed entirely, so a failed call ended clean with no error recorded. Both now log.

Verified end to end on both providers over telephony and web, covering the welcome message, two way conversation, barge-in, tool calls, agent hangup, billing and recording.

