### PR TITLE
fix(gemini): flush buffered text before dispatching a tool call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.169"
+__version__ = "0.10.170"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -337,6 +337,12 @@ class GeminiLLM(BaseLLM):
                                 f"[GeminiLLM] function_call detected fn={fn_name} call_id={call_id} args={list(fn_args.keys())} native_part_cached=True"
                             )
 
+                            # task_manager dispatches on the function-call chunk and abandons this
+                            # generator, so the post-loop flush never runs.
+                            if synthesize and buffer.strip():
+                                yield LLMStreamChunk(data=buffer, end_of_stream=True, latency=latency_data)
+                                buffer = ""
+
                             if not self.gave_out_prefunction_call_message:
                                 pre_msg_config = self.api_params.get(fn_name, {}).get("pre_call_message")
                                 detected_lang = meta_info.get("detected_language") if meta_info else None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.169"
+version = "0.10.170"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Gemini never flushed buffered text before dispatching a tool call, so when the model emitted a goodbye and called `end_call` in the same turn, the caller heard nothing. `task_manager` dispatches on the function-call chunk and abandons the generator, so the post-loop flush never runs. Any closing line shorter than `buffer_size` (inherited from the synthesizer config, commonly 200) was lost.

It also skipped the recovery path: because `textual_response` was non-empty, `__execute_function_call` treated the goodbye as already spoken and bypassed the follow-up LLM that would otherwise have generated one.

`openai_base.py` already flushes on `OUTPUT_ITEM_ADDED` for a function call. This applies the same flush to Gemini.

Verified on staging against `gemini-2.5-flash`, simulating `task_manager`'s early return on the function-call chunk. Before: `FC -> TEXT(33)`, caller hears nothing. After: `TEXT(33) -> FC`, caller hears the goodbye. 6/6 both ways.

BOLNA-2115
