### PR TITLE
fix: wait for stream_sid before building the welcome message packet

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.170"
+__version__ = "0.10.171"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1309,103 +1309,103 @@ class TaskManager(BaseManager):
             if delay_ms > 0:
                 logger.info(f"Welcome message delay set to {delay_ms} ms")
                 await asyncio.sleep(delay_ms / 1000)
+            # Wait for the stream to be usable before building anything. A connection that never
+            # carries a start frame keeps stream_sid None for the whole timeout, so any work inside
+            # this loop is paid ~100 times a second per such connection and thrown away.
             start_time = asyncio.get_running_loop().time()
+            logger.info("Waiting for stream_sid before sending the welcome message")
             while True:
-                elapsed_time = asyncio.get_running_loop().time() - start_time
-                if elapsed_time > timeout:
-                    await self.__process_end_of_conversation()
-                    logger.warning("Timeout reached while waiting for stream_sid")
-                    break
-
-                text = self.kwargs.get("agent_welcome_message", None)
-                meta_info = {
-                    "io": self.tools["output"].get_provider(),
-                    "message_category": "agent_welcome_message",
-                    "request_id": str(uuid.uuid4()),
-                    "cached": True,
-                    "sequence_id": -1,
-                    "format": self.task_config["tools_config"]["output"]["format"],
-                    "text": text,
-                    "end_of_llm_stream": True,
-                }
-                ws_data_packet = create_ws_data_packet(text, meta_info=meta_info)
-
-                meta_info = ws_data_packet["meta_info"]
-                text = ws_data_packet["data"]
-                meta_info["type"] = "audio"
-                meta_info["synthesizer_start_time"] = time.time()
-
-                audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None
-                if meta_info["text"] == "":
-                    audio_chunk = None
-
-                # Convert to ulaw for Asterisk/sip-trunk provider (cached welcome is PCM)
-                if self.tools["output"].get_provider() == TelephonyProvider.SIP_TRUNK.value and audio_chunk:
-                    original_size = len(audio_chunk)
-                    audio_chunk = pcm_to_ulaw(audio_chunk)
-                    logger.info(
-                        f"[SIP-TRUNK] Converted welcome message PCM to ulaw: {original_size} bytes -> {len(audio_chunk)} bytes"
-                    )
-                    meta_info["format"] = "ulaw"
-                else:
-                    meta_info["format"] = "pcm"
-                meta_info["is_first_chunk"] = True
-                meta_info["end_of_synthesizer_stream"] = True
-                meta_info["chunk_id"] = 1
-                meta_info["is_first_chunk_of_entire_response"] = True
-                meta_info["is_final_chunk_of_entire_response"] = True
-                message = create_ws_data_packet(audio_chunk, meta_info)
-
                 stream_sid = self.tools["input"].get_stream_sid()
                 if stream_sid is not None and self.output_handler_set:
-                    self.stream_sid_ts = time.time() * 1000
-                    await self._report_stream_connect()
-                    logger.info(f"Got stream sid and hence sending the first message {stream_sid}")
-                    self.stream_sid = stream_sid
-                    await self.tools["output"].set_stream_sid(stream_sid)
-
-                    if audio_chunk is None:
-                        # No welcome message to play - mark as played immediately
-                        # so the system doesn't wait for a mark event that will never arrive
-                        logger.info("No welcome message audio to send, marking welcome message as played")
-                        self.tools["input"].is_welcome_message_played = True
-                    else:
-                        self.tools["input"].update_is_audio_being_played(True)
-                        self.conversation_history.append_welcome_message(text)
-                        convert_to_request_log(
-                            message=text,
-                            meta_info=meta_info,
-                            component=LogComponent.SYNTHESIZER,
-                            direction=LogDirection.RESPONSE,
-                            model=self.synthesizer_provider,
-                            is_cached=meta_info.get("is_cached", False),
-                            engine=self.tools["synthesizer"].get_engine(),
-                            run_id=self.run_id,
-                        )
-                        await self.tools["output"].handle(message)
-                        try:
-                            data = message.get("data")
-                            if data is not None:
-                                duration = calculate_audio_duration(
-                                    len(data), self.sampling_rate, format=message["meta_info"]["format"]
-                                )
-                                self.welcome_message_duration_ms = round(duration * 1000, 2)
-                                if self.should_record:
-                                    self.conversation_recording["output"].append(
-                                        {"data": data, "start_time": time.time(), "duration": duration}
-                                    )
-                        except Exception as e:
-                            duration = 0.256
-                            self.welcome_message_duration_ms = round(duration * 1000, 2)
-                            logger.error(
-                                "Exception in __forced_first_message for duration calculation: {}".format(str(e))
-                            )
                     break
-                else:
-                    logger.info(
-                        f"Stream id is still None ({stream_sid}) or output handler not set ({self.output_handler_set}), waiting..."
+                if asyncio.get_running_loop().time() - start_time > timeout:
+                    logger.warning(
+                        f"Timeout reached while waiting for stream_sid ({stream_sid})"
+                        f" / output handler ({self.output_handler_set})"
                     )
-                    await asyncio.sleep(0.01)
+                    await self.__process_end_of_conversation()
+                    return
+                await asyncio.sleep(0.01)
+
+            text = self.kwargs.get("agent_welcome_message", None)
+            meta_info = {
+                "io": self.tools["output"].get_provider(),
+                "message_category": "agent_welcome_message",
+                "request_id": str(uuid.uuid4()),
+                "cached": True,
+                "sequence_id": -1,
+                "format": self.task_config["tools_config"]["output"]["format"],
+                "text": text,
+                "end_of_llm_stream": True,
+            }
+            ws_data_packet = create_ws_data_packet(text, meta_info=meta_info)
+
+            meta_info = ws_data_packet["meta_info"]
+            text = ws_data_packet["data"]
+            meta_info["type"] = "audio"
+            meta_info["synthesizer_start_time"] = time.time()
+
+            audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None
+            if meta_info["text"] == "":
+                audio_chunk = None
+
+            # Convert to ulaw for Asterisk/sip-trunk provider (cached welcome is PCM)
+            if self.tools["output"].get_provider() == TelephonyProvider.SIP_TRUNK.value and audio_chunk:
+                original_size = len(audio_chunk)
+                audio_chunk = pcm_to_ulaw(audio_chunk)
+                logger.info(
+                    f"[SIP-TRUNK] Converted welcome message PCM to ulaw: {original_size} bytes -> {len(audio_chunk)} bytes"
+                )
+                meta_info["format"] = "ulaw"
+            else:
+                meta_info["format"] = "pcm"
+            meta_info["is_first_chunk"] = True
+            meta_info["end_of_synthesizer_stream"] = True
+            meta_info["chunk_id"] = 1
+            meta_info["is_first_chunk_of_entire_response"] = True
+            meta_info["is_final_chunk_of_entire_response"] = True
+            message = create_ws_data_packet(audio_chunk, meta_info)
+
+            self.stream_sid_ts = time.time() * 1000
+            await self._report_stream_connect()
+            logger.info(f"Got stream sid and hence sending the first message {stream_sid}")
+            self.stream_sid = stream_sid
+            await self.tools["output"].set_stream_sid(stream_sid)
+
+            if audio_chunk is None:
+                # No welcome message to play - mark as played immediately
+                # so the system doesn't wait for a mark event that will never arrive
+                logger.info("No welcome message audio to send, marking welcome message as played")
+                self.tools["input"].is_welcome_message_played = True
+            else:
+                self.tools["input"].update_is_audio_being_played(True)
+                self.conversation_history.append_welcome_message(text)
+                convert_to_request_log(
+                    message=text,
+                    meta_info=meta_info,
+                    component=LogComponent.SYNTHESIZER,
+                    direction=LogDirection.RESPONSE,
+                    model=self.synthesizer_provider,
+                    is_cached=meta_info.get("is_cached", False),
+                    engine=self.tools["synthesizer"].get_engine(),
+                    run_id=self.run_id,
+                )
+                await self.tools["output"].handle(message)
+                try:
+                    data = message.get("data")
+                    if data is not None:
+                        duration = calculate_audio_duration(
+                            len(data), self.sampling_rate, format=message["meta_info"]["format"]
+                        )
+                        self.welcome_message_duration_ms = round(duration * 1000, 2)
+                        if self.should_record:
+                            self.conversation_recording["output"].append(
+                                {"data": data, "start_time": time.time(), "duration": duration}
+                            )
+                except Exception as e:
+                    duration = 0.256
+                    self.welcome_message_duration_ms = round(duration * 1000, 2)
+                    logger.error("Exception in __forced_first_message for duration calculation: {}".format(str(e)))
         except Exception as e:
             logger.error(f"Exception in __forced_first_message {str(e)}")
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6680,6 +6680,7 @@ class TaskManager(BaseManager):
                 return
 
             start_time = asyncio.get_running_loop().time()
+            logger.info("Waiting for stream_sid before sending the first message")
             while True:
                 elapsed_time = asyncio.get_running_loop().time() - start_time
                 if elapsed_time > timeout:
@@ -6718,8 +6719,7 @@ class TaskManager(BaseManager):
                             await self._synthesize(create_ws_data_packet(text, meta_info=meta_info))
                         break
                     else:
-                        logger.info(f"Stream id is still None, so not passing it")
-                        await asyncio.sleep(0.01)  # Sleep for half a second to see if stream id goes past None
+                        await asyncio.sleep(0.01)
                 elif self.default_io:
                     logger.info(f"Shouldn't record")
                     # meta_info={'io': 'default', 'is_first_message': True, "request_id": str(uuid.uuid4()), "cached": True, "sequence_id": -1, 'format': 'wav'}

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1309,23 +1309,16 @@ class TaskManager(BaseManager):
             if delay_ms > 0:
                 logger.info(f"Welcome message delay set to {delay_ms} ms")
                 await asyncio.sleep(delay_ms / 1000)
-            # Wait for the stream to be usable before building anything. A connection that never
-            # carries a start frame keeps stream_sid None for the whole timeout, so any work inside
-            # this loop is paid ~100 times a second per such connection and thrown away.
-            start_time = asyncio.get_running_loop().time()
+            # output_handler_set is not part of the wait: __setup_output_handlers runs in __init__,
+            # so it is already true by the time this task exists.
             logger.info("Waiting for stream_sid before sending the welcome message")
-            while True:
-                stream_sid = self.tools["input"].get_stream_sid()
-                if stream_sid is not None and self.output_handler_set:
-                    break
-                if asyncio.get_running_loop().time() - start_time > timeout:
-                    logger.warning(
-                        f"Timeout reached while waiting for stream_sid ({stream_sid})"
-                        f" / output handler ({self.output_handler_set})"
-                    )
-                    await self.__process_end_of_conversation()
-                    return
-                await asyncio.sleep(0.01)
+            try:
+                await asyncio.wait_for(self.tools["input"].stream_sid_ready.wait(), timeout)
+            except asyncio.TimeoutError:
+                logger.warning(f"Timeout reached while waiting for stream_sid after {timeout}s")
+                await self.__process_end_of_conversation()
+                return
+            stream_sid = self.tools["input"].get_stream_sid()
 
             text = self.kwargs.get("agent_welcome_message", None)
             meta_info = {

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -32,6 +32,9 @@ class DefaultInputHandler:
         self.input_types = input_types
         self.websocket_listen_task = None
         self.running = True
+        # set here because these handlers mint a stream id on demand; telephony clears it
+        self.stream_sid_ready = asyncio.Event()
+        self.stream_sid_ready.set()
         self.turn_based_conversation = turn_based_conversation
         self.queue = queue
         self.conversation_recording = conversation_recording

--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -32,7 +32,8 @@ class TelephonyInputHandler(DefaultInputHandler):
             is_welcome_message_played=is_welcome_message_played,
             observable_variables=observable_variables,
         )
-        self.stream_sid = None
+        self._stream_sid = None
+        self.stream_sid_ready.clear()
         self.call_sid = None
         self.buffer = []
         self.message_count = 0
@@ -41,8 +42,18 @@ class TelephonyInputHandler(DefaultInputHandler):
         self.io_provider = None
         self.websocket_listen_task = None
 
+    @property
+    def stream_sid(self):
+        return self._stream_sid
+
+    @stream_sid.setter
+    def stream_sid(self, value):
+        self._stream_sid = value
+        if value is not None:
+            self.stream_sid_ready.set()
+
     def get_stream_sid(self):
-        return self.stream_sid
+        return self._stream_sid
 
     def get_call_sid(self):
         return self.call_sid

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.170"
+version = "0.10.171"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

The welcome-message path waited for `stream_sid` by polling the input handler every 10ms, and rebuilt the entire welcome packet on every iteration before checking whether the stream was ready: a fresh `uuid4()`, the full `meta_info` dict, the audio chunk, and for sip-trunk a `pcm_to_ulaw()` conversion of the cached welcome audio. All of it was discarded when the check failed, and it logged one line per iteration.

A connection that never carries a `start` frame keeps `stream_sid` at `None` for the whole `timeout=10.0` window, so each one cost roughly 1,000 wasted packet builds and 1,000 log lines. That became visible during the storm on 3 Aug (BOLNA-2088), when 1,800 to 4,100 agent setups/min were reaching this loop while only 3 to 24/min ever received a `start` event.

The loop was already bounded at 10s and did not hang, contrary to the incident write-up. The cost was the per-iteration work, not an unbounded wait.

## Change

The input handler now signals readiness and the welcome path awaits it, so there is no polling at all.

1. `TelephonyInputHandler.stream_sid` becomes a property whose setter sets `stream_sid_ready`. All five carrier handlers already assign `self.stream_sid` from their start frame, or from the first audio frame for sip-trunk, so they are covered without changes.
2. `DefaultInputHandler` owns the event and starts it set, because the default, web and freeswitch handlers mint a stream id on demand rather than receiving one.
3. `__forced_first_message` awaits the event with `asyncio.wait_for` and builds the packet once afterwards. Wake-up is immediate rather than up to 10ms late, and the timeout is exact rather than drifting past the deadline.
4. `output_handler_set` is dropped from the wait. `__setup_output_handlers` runs in `__init__`, so it is already true by the time this task exists.
5. `__first_message`, the sibling on the web and turn-based paths, keeps its loop. Its handler mints a stream id on demand, so the loop exits on the first iteration and its per-iteration log line was unreachable in practice; removed as dead code along with a comment claiming a half-second sleep that was 10ms.

## Notes

`FreeSwitchInputHandler` extends `DefaultInputHandler`, not `TelephonyInputHandler`, and never assigns `stream_sid`. That is why the event lives on the shared base and starts set; putting it only on the telephony class would leave freeswitch waiting the full timeout on every call.
