### PR TITLE
fix(tests): mock _report_component_health in the transcriber tail tests

### DIFF
--- a/tests/tests/test_split_utterance_tail_not_dropped.py
+++ b/tests/tests/test_split_utterance_tail_not_dropped.py
@@ -45,6 +45,7 @@ def _make_tm(*, audio_playing, response_in_pipeline, function_call_in_flight=Fal
     tm.tools["input"].is_audio_being_played_to_user = MagicMock(return_value=audio_playing)
     tm.interruption_manager = InterruptionManager(number_of_words_for_interruption=2)
     tm._maybe_update_tts_language = AsyncMock()
+    tm._report_component_health = AsyncMock()
     tm._handle_transcriber_output = AsyncMock()
     tm._TaskManager__get_updated_meta_info = MagicMock(side_effect=lambda m: m)
     tm._TaskManager__cleanup_downstream_tasks = AsyncMock()


### PR DESCRIPTION
## What happened

`_make_tm()` in `tests/tests/test_split_utterance_tail_not_dropped.py` fakes the TaskManager with a `MagicMock`, then declares every method the real code awaits as an `AsyncMock`, one by one. It is a hand-maintained list, so it only holds up as long as people remember to update it.

#859 added `await self._report_component_health(...)` to `_listen_transcriber` (`task_manager.py:4814`) and missed that step. The await lands on a plain `MagicMock` and raises `TypeError: object MagicMock can't be used in 'await' expression`, which the handler around it turns into a `TranscriberError`.

Two of the four tests in that file have failed on master ever since.

## Fix

One line, slotted in the order the calls actually run (`_maybe_update_tts_language` at 4803, `_report_component_health` at 4814, `_handle_transcriber_output` at 4856):

```python
tm._report_component_health = AsyncMock()
```

## Why the red is worth fixing

This file exists to stop one specific regression. On call 032a233d, Deepgram force-finalized "hello" partway through an utterance, the real tail arrived about a second later, and the code discarded it as a false interruption. The user's request never reached the LLM.

So I wanted to know whether that guard is still protected today. I patched `is_false_interruption` to always return False, meaning short finals never get dropped, and ran the file both ways:

| | on master | with this fix |
|---|---|---|
| guard intact | 2 failed, 2 passed | 4 passed |
| guard deliberately broken | 3 failed, 1 passed | 1 failed, 3 passed |

With the fix in place, breaking the guard produces exactly one failure, in `test_short_final_still_dropped_while_audio_playing`, which is the test that should catch it. On master you get one more red test in a file that was already red, and nobody is going to act on that.

## Scope

Test-only. Production was never affected, because `_report_component_health` is a real `async def` and awaiting it works fine outside a mock.

I also checked this is the only unmocked await on the path these four tests walk. `_listen_transcriber` awaits 11 distinct targets. Four others are missing from the fixture too (`__process_http_transcription`, `_log_transcriber_connection_error`, `language_detector.collect_transcript`, `tools['transcriber'].reconnect_active`), but they sit on branches these tests never reach.

## Verification

- The file itself: 2 failed, 2 passed becomes 4 passed
- Full suite: 10 failed, 569 passed becomes 8 failed, 571 passed
- Same on Python 3.10 and 3.11
- `ruff check` and `ruff format --check` both clean

Worth flagging that CI will not confirm any of this, since the workflows run ruff and bandit but never pytest.

The 8 remaining failures all sit in `tests/tests/test_event_injection_e2e.py`. I bisected them and they already fail at #609, the commit that introduced them, so they have never passed. I left them alone because I cannot tell from outside whether those tests are wrong or the event injection path is broken. Happy to open a separate issue if that would help.

## One suggestion, take it or leave it

Since the fixture is a manual list of which methods are async, this will happen again on the next await someone adds. `create_autospec` would work that out from the real class instead. That rewrites the fixture though, so I kept this PR to the single line rather than bundle it in.
