### PR TITLE
fix: hold sip-trunk hangup until Asterisk confirms playout drained

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.171"
+__version__ = "0.10.172"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -28,6 +28,13 @@ AUDIO_BATCH_MS = 80
 # time to act on it. Overridable via env.
 HANGUP_SETTLE_S = float(os.environ.get("SIP_HANGUP_SETTLE_S", "0.5"))
 
+# Max wait for Asterisk to confirm (QUEUE_DRAINED) that it has played out everything we
+# sent, before HANGUP cuts the tail off the goodbye. Overridable via env.
+HANGUP_DRAIN_TIMEOUT_S = float(os.environ.get("SIP_HANGUP_DRAIN_TIMEOUT_S", "2.0"))
+
+# Extra wait after QUEUE_DRAINED for the far-end jitter buffer. Overridable via env.
+HANGUP_DRAIN_SETTLE_S = float(os.environ.get("SIP_HANGUP_DRAIN_SETTLE_S", "0.5"))
+
 # Submit accumulated DTMF digits after this much inter-digit silence (reset on each
 # keypress), or immediately when '#' is pressed. Overridable via env.
 DTMF_INTERDIGIT_TIMEOUT_S = float(os.environ.get("SIP_DTMF_INTERDIGIT_TIMEOUT_S", "3"))
@@ -98,6 +105,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         self.ptime = 20
         self._pending_stream_sid = None  # promoted to stream_sid on first audio frame
         self._dtmf_timer_task = None  # inter-digit timeout for DTMF accumulation
+        self._queue_drained = asyncio.Event()  # set by Asterisk's QUEUE_DRAINED event
 
         input_config = self._get_input_config()
         self._expected_format = (input_config.get("audio_format") or input_config.get("format") or "ulaw").lower()
@@ -143,9 +151,38 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         except Exception as e:
             logger.error(f"Error sending HANGUP: {e}")
 
+    async def _await_playback_drained(self):
+        """Hold HANGUP until Asterisk reports its frame queue empty.
+
+        Audio is handed over faster than real time, so at teardown part of the goodbye is
+        usually still buffered in Asterisk and HANGUP would discard it. Bounded, and a
+        no-op once the queue is already empty.
+        """
+        listen_task = self.websocket_listen_task
+        if listen_task is None or listen_task.done():
+            return  # receive loop is gone (caller hung up first) — nothing can answer
+
+        self._queue_drained.clear()
+        try:
+            await self.websocket.send_text("REPORT_QUEUE_DRAINED")
+        except Exception as e:
+            logger.info(f"REPORT_QUEUE_DRAINED not sent for channel {self.channel_id}: {e}")
+            return
+
+        try:
+            await asyncio.wait_for(self._queue_drained.wait(), timeout=HANGUP_DRAIN_TIMEOUT_S)
+        except asyncio.TimeoutError:
+            logger.warning(
+                f"QUEUE_DRAINED not received within {HANGUP_DRAIN_TIMEOUT_S}s for channel "
+                f"{self.channel_id}; hanging up anyway"
+            )
+            return
+        await asyncio.sleep(HANGUP_DRAIN_SETTLE_S)
+
     async def stop_handler(self):
         """Stop and disconnect; Asterisk closes quickly after HANGUP."""
         logger.info(f"Stopping sip-trunk handler for channel {self.channel_id}")
+        await self._await_playback_drained()
         self.running = False
         self._cancel_dtmf_timer()
         await self.disconnect_stream()
@@ -330,9 +367,9 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             logger.debug(f"Asterisk control: {event}")
             return
         if event == "QUEUE_DRAINED" or "QUEUE_DRAINED" in event:
-            # At 1x pacing, playback completion is tracked by the output handler's
-            # send-loop drain detection — QUEUE_DRAINED is informational only.
-            logger.debug(f"QUEUE_DRAINED for channel {self.channel_id} (informational)")
+            # Only requested at teardown, to gate HANGUP on real playout completion.
+            self._queue_drained.set()
+            logger.info(f"QUEUE_DRAINED for channel {self.channel_id}")
             return
         if event or parsed:
             logger.debug(f"Asterisk control: {text} -> event={event}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.171"
+version = "0.10.172"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_sip_trunk_hangup_drain.py
+++ b/tests/tests/test_sip_trunk_hangup_drain.py
@@ -1,0 +1,144 @@
+"""Regression: the sip-trunk hangup must not cut off audio still buffered in Asterisk.
+
+Asterisk gets audio faster than real time (the output handler paces at 1.5x), so when
+teardown runs on the output handler's duration estimate, roughly a third of a long
+goodbye is still sitting in Asterisk's frame queue. HANGUP discards it. The fix asks
+Asterisk for a QUEUE_DRAINED report and holds HANGUP until it lands.
+"""
+
+import asyncio
+
+import pytest
+
+from bolna.input_handlers.telephony_providers import sip_trunk as sip_trunk_input
+from bolna.input_handlers.telephony_providers.sip_trunk import SipTrunkInputHandler
+
+
+class _FakeWebSocket:
+    """Records control frames in order; client_state.value == 1 means connected."""
+
+    class _State:
+        value = 1
+
+    def __init__(self, fail_send=False):
+        self.sent = []
+        self.closed = False
+        self.fail_send = fail_send
+        self.client_state = self._State()
+
+    async def send_text(self, text):
+        if self.fail_send:
+            raise RuntimeError("socket gone")
+        self.sent.append(text)
+
+    async def close(self):
+        self.closed = True
+
+
+def _make_handler(websocket, listen_task):
+    handler = SipTrunkInputHandler.__new__(SipTrunkInputHandler)
+    handler.websocket = websocket
+    handler.websocket_listen_task = listen_task
+    handler.channel_id = "test-channel_1"
+    handler.running = True
+    handler._dtmf_timer_task = None
+    handler._queue_drained = asyncio.Event()
+    return handler
+
+
+async def _live_task():
+    """Stands in for a _listen() loop that is still receiving."""
+    await asyncio.sleep(30)
+
+
+@pytest.fixture(autouse=True)
+def fast_timings(monkeypatch):
+    monkeypatch.setattr(sip_trunk_input, "HANGUP_DRAIN_TIMEOUT_S", 0.30)
+    monkeypatch.setattr(sip_trunk_input, "HANGUP_DRAIN_SETTLE_S", 0.05)
+    monkeypatch.setattr(sip_trunk_input, "HANGUP_SETTLE_S", 0.0)
+
+
+@pytest.mark.asyncio
+async def test_hangup_waits_for_queue_drained_before_disconnecting():
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    async def _drain_soon():
+        await asyncio.sleep(0.10)
+        await handler._handle_control_message("QUEUE_DRAINED")
+
+    drainer = asyncio.create_task(_drain_soon())
+    start = asyncio.get_running_loop().time()
+    await handler.stop_handler()
+    elapsed = asyncio.get_running_loop().time() - start
+    await drainer
+    listen_task.cancel()
+
+    assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
+    # Held for the drain (0.10s) plus the settle (0.05s), not the full grace.
+    assert 0.13 < elapsed < 0.30
+
+
+@pytest.mark.asyncio
+async def test_hangup_is_bounded_when_queue_drained_never_arrives():
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    start = asyncio.get_running_loop().time()
+    await asyncio.wait_for(handler.stop_handler(), timeout=5.0)  # hard-fails if it hangs
+    elapsed = asyncio.get_running_loop().time() - start
+    listen_task.cancel()
+
+    assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
+    assert 0.28 < elapsed < 1.0  # bounded by the grace, and no settle on top of it
+
+
+@pytest.mark.asyncio
+async def test_early_queue_drained_is_not_consumed_from_a_previous_report():
+    # A QUEUE_DRAINED seen before teardown must not satisfy the teardown wait.
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+    await handler._handle_control_message("QUEUE_DRAINED")
+    assert handler._queue_drained.is_set()
+
+    start = asyncio.get_running_loop().time()
+    await handler.stop_handler()
+    elapsed = asyncio.get_running_loop().time() - start
+    listen_task.cancel()
+
+    assert elapsed > 0.28  # waited for a fresh report rather than reusing the stale one
+
+
+@pytest.mark.asyncio
+async def test_no_drain_wait_when_receive_loop_already_gone():
+    # Caller hung up first: nothing is left to deliver QUEUE_DRAINED, so asking would
+    # just burn the full grace on every user-initiated hangup.
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(asyncio.sleep(0))
+    await listen_task
+    handler = _make_handler(ws, listen_task)
+
+    start = asyncio.get_running_loop().time()
+    await handler.stop_handler()
+    elapsed = asyncio.get_running_loop().time() - start
+
+    assert ws.sent == ["HANGUP"]
+    assert elapsed < 0.10
+
+
+@pytest.mark.asyncio
+async def test_hangup_still_sent_when_report_cannot_be_delivered():
+    ws = _FakeWebSocket(fail_send=True)
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    start = asyncio.get_running_loop().time()
+    await handler.stop_handler()
+    elapsed = asyncio.get_running_loop().time() - start
+    listen_task.cancel()
+
+    assert elapsed < 0.10  # gave up immediately instead of waiting on a dead socket
+    assert ws.closed


### PR DESCRIPTION
## Summary

On sip-trunk calls the closing goodbye was cut off before the caller heard the end of it (seen on executions `096f294b-6ff9-4b28-b0bb-c128ad536ef7` and `0831b21c-0491-4a70-ab6d-1549ae3988c7`, both `raw_hangup_reason=end_call_tool`). The transcript held the full text, so the loss was in playback.

Asterisk gives no playback acknowledgement, so the hangup is released by the output handler's estimate `first_send + audio_duration + 0.1s`, which assumes Asterisk began playing the instant the first frame arrived. Because `SIP_MAX_SEND_RATE_FACTOR=1.5` saturates on every turn with ElevenLabs (`audio/elapsed` was exactly 1.50 on all 24 turns across both calls), about a third of a long goodbye is still queued inside Asterisk when the last frame is handed over — 5.06s of 15.17s, and 4.86s of 14.57s. `HANGUP` then lands on the theoretical last millisecond of playout and discards whatever real playout-start lag exists.

`stop_handler()` now sends `REPORT_QUEUE_DRAINED` and waits for Asterisk's `QUEUE_DRAINED` before `HANGUP`, bounded by `SIP_HANGUP_DRAIN_TIMEOUT_S` (2.0s) and followed by `SIP_HANGUP_DRAIN_SETTLE_S` (0.5s) for the far-end jitter buffer. Prod runs Asterisk 22.7.0, whose `chan_websocket` accepts `REPORT_QUEUE_DRAINED` and emits `QUEUE_DRAINED` — verified against the deployed module.

`stop_handler` is the single teardown point for every hangup path (end_call tool, silence, duration limit, voicemail), so no "is this the final utterance" signal is needed. No duration floor is needed either: by teardown the estimate is already spent, so whatever the queue still holds is exactly the lag the estimate cannot see. If the queue is genuinely empty the hangup proceeds at once, i.e. current behaviour — strictly no worse in every case. The wait is skipped when `websocket_listen_task` is already done (caller hung up first), otherwise every user-initiated hangup would pay a pointless 2s.

Confined to the sip-trunk input handler. The output handler could not do this — `__process_end_of_conversation` calls `output.close()` before `input.stop_handler()`, so its `_send_control` is already gated off by `_closed`. The mid-call `_schedule_finish` estimate keeps its 0.1s settle, so barge-in gating on normal turns is unchanged.