### PR TITLE
fix: bound the mark history and stop persisting raw synthesizer chunk marks

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.171"
+__version__ = "0.10.172"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -94,7 +94,7 @@ from bolna.helpers.utils import (
     enrich_context_with_time_variables,
 )
 from bolna.helpers.logger_config import configure_logger
-from ..helpers.mark_event_meta_data import MarkEventMetaData
+from ..helpers.mark_event_meta_data import MarkEventMetaData, should_persist_chunk_marks
 from ..helpers.observable_variable import ObservableVariable
 from .models import ComponentLatencies
 from .voicemail_handler import VoicemailHandler
@@ -2585,7 +2585,19 @@ class TaskManager(BaseManager):
         while not self.conversation_ended:
             mark_events = self.mark_event_meta_data.mark_event_meta_data
             mark_items_list = [{"mark_id": k, "mark_data": v} for k, v in mark_events.items()]
-            logger.info(f"current_list: {mark_items_list}")
+            # Summary, not the mark dicts: this loop re-runs on every mark change, so logging the
+            # whole pending list (each with its full text_synthesized) costs O(queue depth) bytes
+            # per iteration — O(n^2) per response, and at peak a third of all ws-server log volume.
+            _first_pending = mark_items_list[0]["mark_data"] if mark_items_list else {}
+            logger.info(
+                "wait_for_current_message pending=%s first_mark_id=%s type=%s seq=%s final=%s text_len=%s",
+                len(mark_items_list),
+                mark_items_list[0]["mark_id"] if mark_items_list else None,
+                _first_pending.get("type"),
+                _first_pending.get("sequence_id"),
+                _first_pending.get("is_final_chunk"),
+                len(_first_pending.get("text_synthesized", "") or ""),
+            )
 
             if not mark_items_list:
                 break
@@ -7046,7 +7058,15 @@ class TaskManager(BaseManager):
                         ),
                         "user_bot_latencies": _user_bot_latencies,
                         "mark_tracking": self.mark_event_meta_data.get_mark_tracking_summary(),
-                        "synthesizer_chunk_marks": self.mark_event_meta_data.get_chunk_marks(),
+                        # The raw per-chunk list dwarfs everything else in this payload (~90% of
+                        # latency_dict, and it is mirrored again into ClickHouse by CDC), so it is
+                        # kept only for the PERSIST_CHUNK_MARKS_PCT sample that recording analysis
+                        # needs. mark_tracking above always carries the aggregate.
+                        "synthesizer_chunk_marks": (
+                            self.mark_event_meta_data.get_chunk_marks()
+                            if should_persist_chunk_marks(self.run_id)
+                            else []
+                        ),
                     },
                     "hangup_detail": self.hangup_detail,
                     "has_transfer": self.has_transfer,
@@ -7204,6 +7224,10 @@ class TaskManager(BaseManager):
                 tasks_to_cancel.append(
                     process_task_cancellation(self.handle_accumulated_message_task, "handle_accumulated_message_task")
                 )
+
+                # Snapshot is complete, so the per-chunk mark buffers have no readers left. Free
+                # them before the recording upload below, which holds this TaskManager for seconds.
+                self.mark_event_meta_data.release_call_buffers()
 
                 output["recording_url"] = None
                 if self.should_record:

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -1,8 +1,8 @@
 import asyncio
 import copy
-import hashlib
 import os
 import time
+import zlib
 from collections import OrderedDict
 from typing import Dict, List, Optional
 
@@ -34,7 +34,8 @@ def should_persist_chunk_marks(run_id: Optional[str]) -> bool:
     """Whether this call's raw chunk marks should be persisted alongside the aggregate.
 
     Bucketed on run_id so the decision is stable for a call and the sampled set is spread
-    evenly across traffic rather than clustered in time.
+    evenly across traffic rather than clustered in time. crc32 is the bucketing function
+    because this is a checksum over an opaque id, not a digest anything relies on.
     """
     if PERSIST_CHUNK_MARKS_PCT <= 0:
         return False
@@ -42,8 +43,7 @@ def should_persist_chunk_marks(run_id: Optional[str]) -> bool:
         return True
     if not run_id:
         return False
-    digest = hashlib.md5(str(run_id).encode(), usedforsecurity=False).hexdigest()
-    return int(digest[:8], 16) % 100 < PERSIST_CHUNK_MARKS_PCT
+    return zlib.crc32(str(run_id).encode()) % 100 < PERSIST_CHUNK_MARKS_PCT
 
 
 class SequenceStats(BaseModel):

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -1,6 +1,9 @@
 import asyncio
 import copy
+import hashlib
+import os
 import time
+from collections import OrderedDict
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
@@ -11,6 +14,36 @@ from bolna.helpers.logger_config import configure_logger
 logger = configure_logger(__name__)
 
 HIGH_DELAY_THRESHOLD = 2.0
+
+# Per-chunk mark records are kept for the whole call so post-call analysis can see what was
+# actually played, and nothing prunes them mid-call. The bound is on record count, not on age
+# or call duration, because repetition depth drives the count: an agent stuck re-sending the
+# same response grows this dict for as long as the call lasts, while a long but well-behaved
+# call stays flat. 1000 records covers roughly fifteen minutes of continuous agent speech.
+MAX_MARK_HISTORY = int(os.getenv("MAX_MARK_HISTORY", "1000"))
+
+# Raw chunk marks are ~90% of a latency_dict payload (11x the transcript), so they are sampled
+# per call rather than stored for every one. The mark_tracking aggregate is always kept.
+PERSIST_CHUNK_MARKS_PCT = int(os.getenv("PERSIST_CHUNK_MARKS_PCT", "0"))
+
+# Interrupts dump the pending mark ids; a stuck agent can leave hundreds pending.
+CLEAR_LOG_MARK_ID_LIMIT = 20
+
+
+def should_persist_chunk_marks(run_id: Optional[str]) -> bool:
+    """Whether this call's raw chunk marks should be persisted alongside the aggregate.
+
+    Bucketed on run_id so the decision is stable for a call and the sampled set is spread
+    evenly across traffic rather than clustered in time.
+    """
+    if PERSIST_CHUNK_MARKS_PCT <= 0:
+        return False
+    if PERSIST_CHUNK_MARKS_PCT >= 100:
+        return True
+    if not run_id:
+        return False
+    digest = hashlib.md5(str(run_id).encode(), usedforsecurity=False).hexdigest()
+    return int(digest[:8], 16) % 100 < PERSIST_CHUNK_MARKS_PCT
 
 
 class SequenceStats(BaseModel):
@@ -44,6 +77,13 @@ class MarkTrackingSummary(BaseModel):
     avg_delay_s: float = 0
     high_delay_count: int = 0
     per_sequence: List[SequenceSummary] = Field(default_factory=list)
+    # Send time of the call's first audio chunk. Kept here because it survives history
+    # eviction and is the calibration anchor recording analysis needs.
+    first_mark_sent_ts: Optional[float] = None
+    # Chunk-mark records still held vs evicted by the history cap, so a short raw mark list
+    # is distinguishable from a quiet call.
+    history_retained: int = 0
+    history_dropped: int = 0
 
 
 class MarkStats(BaseModel):
@@ -58,10 +98,13 @@ class MarkStats(BaseModel):
 
 
 class MarkEventMetaData:
-    def __init__(self):
+    def __init__(self, max_history: Optional[int] = None):
         self.mark_event_meta_data = {}
         self.previous_mark_event_meta_data = {}
-        self._mark_history: Dict[str, Dict] = {}
+        self._mark_history: "OrderedDict[str, Dict]" = OrderedDict()
+        self._max_history = MAX_MARK_HISTORY if max_history is None else max_history
+        self._history_dropped = 0
+        self._first_mark_sent_ts: Optional[float] = None
         self.counter = 0
         self.mark_changed = asyncio.Event()
         self._mark_stats = MarkStats()
@@ -96,7 +139,7 @@ class MarkEventMetaData:
         self.mark_event_meta_data[mark_id] = value
         duration = value.get("duration") or 0
         if value.get("type") != "pre_mark_message":
-            self._mark_history[mark_id] = value
+            self._record_history(mark_id, value)
         logger.info(
             "BOLNA_TRACE_MARK update mark_id=%s type=%s seq=%s turn=%s response_uid=%s group_uid=%s counter=%s dur=%.3f text_len=%s",
             mark_id,
@@ -128,6 +171,43 @@ class MarkEventMetaData:
                 turn_id = value.get("turn_id")
                 if turn_id is not None and entry.turn_id is None:
                     entry.turn_id = turn_id
+
+    def _record_history(self, mark_id, value):
+        """Append to the bounded per-chunk history, evicting the oldest record when full.
+
+        Records are stored by reference, so a later ack or interrupt flag written onto the same
+        dict stays visible here. Eviction drops only that reference — the live
+        mark_event_meta_data entry and the mark_tracking aggregate are unaffected, which is why
+        capping here costs nothing but detail on the pathological calls that hit the cap.
+        """
+        if self._first_mark_sent_ts is None and value.get("sent_ts"):
+            self._first_mark_sent_ts = value["sent_ts"]
+
+        self._mark_history[mark_id] = value
+        if len(self._mark_history) <= self._max_history:
+            return
+
+        while len(self._mark_history) > self._max_history:
+            self._mark_history.popitem(last=False)
+            self._history_dropped += 1
+        if self._history_dropped == 1:
+            # Once per call: past this point the raw mark list no longer covers the whole call.
+            logger.warning("mark history hit its %s-record cap, dropping oldest chunk marks", self._max_history)
+
+    def release_call_buffers(self):
+        """Free the post-call mark buffers once the call output has been snapshotted.
+
+        Every reader runs during the call or at snapshot time — get_chunk_marks and
+        get_mark_tracking_summary build the output, get_heard_text_for_* and
+        fetch_cleared_mark_event_data serve the interruption path. Teardown after the snapshot
+        (recording upload to S3, metrics, DB writes) runs for seconds with the TaskManager still
+        referenced, so holding these until it is collected keeps the pod's memory floor up for
+        no benefit.
+        """
+        self._mark_history.clear()
+        self.heard_text_by_turn.clear()
+        self.heard_text_by_response.clear()
+        self.previous_mark_event_meta_data = {}
 
     def record_ack(self, delay, sequence_id):
         self._mark_stats.total_acked += 1
@@ -190,10 +270,11 @@ class MarkEventMetaData:
 
     def clear_data(self):
         logger.info(f"Clearing mark meta data dict")
+        pending_ids = list(self.mark_event_meta_data.keys())
         logger.info(
             "BOLNA_TRACE_MARK clear pending=%s mark_ids=%s",
-            len(self.mark_event_meta_data),
-            list(self.mark_event_meta_data.keys()),
+            len(pending_ids),
+            pending_ids[:CLEAR_LOG_MARK_ID_LIMIT],
         )
         self.counter = 0
         self.drop_playout_estimate()
@@ -220,6 +301,9 @@ class MarkEventMetaData:
             max_delay_s=round(max(all_delays), 3) if all_delays else 0,
             avg_delay_s=round(sum(all_delays) / len(all_delays), 3) if all_delays else 0,
             high_delay_count=sum(1 for d in all_delays if d > HIGH_DELAY_THRESHOLD),
+            first_mark_sent_ts=self._first_mark_sent_ts,
+            history_retained=len(self._mark_history),
+            history_dropped=self._history_dropped,
         )
 
         for seq_id in sorted(stats.per_sequence.keys()):
@@ -255,6 +339,9 @@ class MarkEventMetaData:
         Returns one dict per agent audio chunk (excluding pre_mark_message), ordered
         by send counter. Each entry carries the actually-spoken text, send/ack
         timestamps, sequence/turn linkage, and an interruption flag.
+
+        Covers at most the last MAX_MARK_HISTORY chunks; get_mark_tracking_summary reports
+        how many were evicted, and the call's first send timestamp survives eviction there.
         """
         out = []
         for mark_id, data in self._mark_history.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.171"
+version = "0.10.172"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_mark_history_bounded.py
+++ b/tests/tests/test_mark_history_bounded.py
@@ -4,6 +4,8 @@ Covers the mark-history record cap and its eviction reporting, the calibration a
 surviving eviction, end-of-call buffer release, and raw chunk-mark sampling.
 """
 
+import uuid
+
 import pytest
 
 from bolna.helpers import mark_event_meta_data as med
@@ -133,7 +135,8 @@ class TestShouldPersistChunkMarks:
 
     def test_sample_size_tracks_the_percentage(self, monkeypatch):
         monkeypatch.setattr(med, "PERSIST_CHUNK_MARKS_PCT", 10)
-        run_ids = [f"run-{i}" for i in range(2000)]
+        # uuid-shaped, matching the run_ids production actually buckets.
+        run_ids = [str(uuid.uuid5(uuid.NAMESPACE_URL, f"run-{i}")) for i in range(2000)]
         sampled = sum(1 for r in run_ids if should_persist_chunk_marks(r))
         assert 0.07 < sampled / len(run_ids) < 0.13
 

--- a/tests/tests/test_mark_history_bounded.py
+++ b/tests/tests/test_mark_history_bounded.py
@@ -1,0 +1,143 @@
+"""Tests for the bounds on MarkEventMetaData's per-call accumulators.
+
+Covers the mark-history record cap and its eviction reporting, the calibration anchor
+surviving eviction, end-of-call buffer release, and raw chunk-mark sampling.
+"""
+
+import pytest
+
+from bolna.helpers import mark_event_meta_data as med
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData, should_persist_chunk_marks
+
+
+def _audio_chunk(seq_id: int, text: str, sent_ts: float, duration: float = 0.5) -> dict:
+    return {
+        "type": "",
+        "text_synthesized": text,
+        "is_first_chunk": False,
+        "is_final_chunk": False,
+        "sequence_id": seq_id,
+        "duration": duration,
+        "sent_ts": sent_ts,
+    }
+
+
+def _fill(mark: MarkEventMetaData, count: int, start_ts: float = 100.0):
+    for i in range(count):
+        mark.update_data(f"chunk-{i}", _audio_chunk(1, f"part-{i}", start_ts + i))
+
+
+class TestHistoryCap:
+    def test_history_stops_growing_at_cap(self):
+        m = MarkEventMetaData(max_history=5)
+        _fill(m, 50)
+
+        assert len(m.get_chunk_marks()) == 5
+
+    def test_cap_keeps_the_most_recent_chunks(self):
+        m = MarkEventMetaData(max_history=3)
+        _fill(m, 6)
+
+        assert [mark["text_synthesized"] for mark in m.get_chunk_marks()] == ["part-3", "part-4", "part-5"]
+
+    def test_summary_reports_retained_and_dropped(self):
+        m = MarkEventMetaData(max_history=4)
+        _fill(m, 10)
+
+        summary = m.get_mark_tracking_summary()
+        assert summary["history_retained"] == 4
+        assert summary["history_dropped"] == 6
+        # The aggregate still counts every chunk that was sent, capped history or not.
+        assert summary["total_sent"] == 10
+
+    def test_nothing_dropped_below_the_cap(self):
+        m = MarkEventMetaData(max_history=100)
+        _fill(m, 10)
+
+        summary = m.get_mark_tracking_summary()
+        assert summary["history_dropped"] == 0
+        assert summary["history_retained"] == 10
+
+    def test_first_sent_ts_survives_eviction(self):
+        m = MarkEventMetaData(max_history=2)
+        _fill(m, 20, start_ts=500.0)
+
+        summary = m.get_mark_tracking_summary()
+        assert summary["first_mark_sent_ts"] == 500.0
+        assert all(mark["sent_ts"] > 500.0 for mark in m.get_chunk_marks())
+
+    def test_pre_mark_messages_do_not_consume_the_cap(self):
+        m = MarkEventMetaData(max_history=2)
+        for i in range(10):
+            m.update_data(f"pre-{i}", {"type": "pre_mark_message"})
+        _fill(m, 2)
+
+        assert len(m.get_chunk_marks()) == 2
+        assert m.get_mark_tracking_summary()["history_dropped"] == 0
+
+    def test_retained_chunks_still_pick_up_acks_and_interrupt_flags(self):
+        m = MarkEventMetaData(max_history=2)
+        _fill(m, 3)  # chunk-0 evicted, chunk-1 and chunk-2 retained
+
+        m.fetch_data("chunk-1")
+        m.clear_data()
+
+        by_id = {mark["mark_id"]: mark for mark in m.get_chunk_marks()}
+        assert by_id["chunk-1"]["acked"] is True
+        assert by_id["chunk-2"]["acked"] is False
+        assert by_id["chunk-2"]["cleared_on_interrupt"] is True
+
+    def test_default_cap_comes_from_the_module_constant(self):
+        assert MarkEventMetaData()._max_history == med.MAX_MARK_HISTORY
+
+
+class TestReleaseCallBuffers:
+    def test_release_frees_history_and_heard_text(self):
+        m = MarkEventMetaData()
+        _fill(m, 5)
+        m.record_heard_text({"turn_id": 1, "response_uid": "r1"}, "hello there")
+        m.clear_data()
+
+        m.release_call_buffers()
+
+        assert m.get_chunk_marks() == []
+        assert m.get_heard_text_for_turn(1) == ""
+        assert m.get_heard_text_for_response("r1") == ""
+        assert m.fetch_cleared_mark_event_data() == {}
+
+    def test_release_keeps_the_aggregate_intact(self):
+        m = MarkEventMetaData()
+        _fill(m, 5)
+        summary_before = m.get_mark_tracking_summary()
+
+        m.release_call_buffers()
+        summary_after = m.get_mark_tracking_summary()
+
+        assert summary_after["total_sent"] == summary_before["total_sent"] == 5
+        assert summary_after["first_mark_sent_ts"] == summary_before["first_mark_sent_ts"]
+
+
+class TestShouldPersistChunkMarks:
+    def test_disabled_by_default(self):
+        assert med.PERSIST_CHUNK_MARKS_PCT == 0
+        assert should_persist_chunk_marks("any-run-id") is False
+
+    def test_full_rollout_persists_every_call(self, monkeypatch):
+        monkeypatch.setattr(med, "PERSIST_CHUNK_MARKS_PCT", 100)
+        assert should_persist_chunk_marks("any-run-id") is True
+
+    def test_decision_is_stable_for_a_run_id(self, monkeypatch):
+        monkeypatch.setattr(med, "PERSIST_CHUNK_MARKS_PCT", 50)
+        run_id = "766d0374-2355-447e-95dd-0ff872e815cc"
+        assert should_persist_chunk_marks(run_id) == should_persist_chunk_marks(run_id)
+
+    def test_sample_size_tracks_the_percentage(self, monkeypatch):
+        monkeypatch.setattr(med, "PERSIST_CHUNK_MARKS_PCT", 10)
+        run_ids = [f"run-{i}" for i in range(2000)]
+        sampled = sum(1 for r in run_ids if should_persist_chunk_marks(r))
+        assert 0.07 < sampled / len(run_ids) < 0.13
+
+    @pytest.mark.parametrize("run_id", [None, ""])
+    def test_missing_run_id_is_not_sampled(self, run_id, monkeypatch):
+        monkeypatch.setattr(med, "PERSIST_CHUNK_MARKS_PCT", 50)
+        assert should_persist_chunk_marks(run_id) is False


### PR DESCRIPTION
Bounds the unpruned per-chunk mark history, stops persisting the raw mark list on every call, and kills an O(n²) log line.

BOLNA-2120 — https://linear.app/bolna/issue/BOLNA-2120

> **Scope correction.** The ticket frames this as *the* root-cause fix for the ws-server memory exhaustion in BOLNA-2065. Measurement (below) does not support that: `_mark_history` accounts for roughly **4%** of the per-call retention the RCA observed. What this PR delivers, measured, is a **write-amplification fix (~2.3 GB/day)**, a **log-volume fix (~12 GB/day)**, and a **tail guard** on the pathological calls. The memory floor's actual cause is still unidentified and needs its own investigation — see *What this does not fix*.

## The defect

`MarkEventMetaData._mark_history` is never pruned: written on every audio chunk, read once at end of call, and left untouched by `clear_data()` (which resets `mark_event_meta_data` only). Nothing bounds it and nothing frees it before the `TaskManager` is collected.

## What changed

**Bounded `_mark_history`** — capped at `MAX_MARK_HISTORY` records (env-tunable, default 1000), oldest-first eviction. The bound is on **record count, not age or call duration**: repetition depth drives the count, so a runaway agent grows this for as long as the call lasts while a long well-behaved call stays flat. Eviction drops only the history reference — the live pending-mark dict and the `mark_tracking` aggregate stay exact.

**`release_call_buffers()`** — frees the mark history and both `heard_text_by_*` maps once the end-of-call output is snapshotted, so they are not held through teardown (S3 recording upload, metrics, DB writes) with the `TaskManager` still referenced.

**Three new `mark_tracking` fields** — `first_mark_sent_ts`, `history_retained`, `history_dropped`. The first send timestamp is the calibration anchor recording analysis needs and now survives eviction; the counts make a truncated list distinguishable from a quiet call.

**Raw `synthesizer_chunk_marks` are now sampled** — persisted only for `PERSIST_CHUNK_MARKS_PCT` of calls (deterministic crc32 bucket on `run_id`, default `0`). `mark_tracking` is always kept.

**Capped log lines** — fixed-width summary in `wait_for_current_message`, and the pending mark-id dump in `clear_data` truncated to 20 ids.

## Measurements

Everything below is measured, not estimated. Prod data via the ClickHouse CDC mirror (86,599 executions over 3h) and Loki (single 5-minute ws-server window).

### Payload — the write-amplification win

| | measured |
|---|---|
| chunk marks as share of `latency_dict` bytes | **43%** |
| `latency_dict` p50 / p95 / p99.9 / max | 3.7 KB / 24.5 KB / 218 KB / **1.38 MB** |
| chunk-mark bytes written | 283.7 MB per 3h ≈ **2.3 GB/day** |

At `PERSIST_CHUNK_MARKS_PCT=0` that 2.3 GB/day of Postgres writes goes away, and the equivalent CDC volume into ClickHouse with it. (The ticket's "89% of the payload" was one pathological execution; fleet-wide it is 43%.)

### Log volume

| | bytes / 5 min | share of ws-server |
|---|---|---|
| ws-server total | 569 MB | — |
| `current_list:` | **41.6 MB** | **7.3%** |
| same line after this PR (6,056 lines × ~130 B) | ~0.8 MB | **−98%** |

Those lines average **6,873 bytes each** — 15x the mean ws-server log line — from 0.49% of lines. ~12 GB/day of ingest removed. (The ticket's 31% was a peak-incident window; 7.3% is a normal loaded one.)

### Record distribution — how the cap was sized

`synthesizer_chunk_marks` per call, same 3h sample:

| p50 | p90 | p99 | p99.9 | max | over 1000 |
|---|---|---|---|---|---|
| 3 | 22 | 100 | 897 | 4,568 | **49 of 85,611 (0.057%)** |

The cap is deliberately a tail guard. It does not truncate healthy calls — which was the open risk when the default was picked by arithmetic on a single 270-record execution.

### Retained memory

Benchmarked against the real class at the measured record counts, with provider ACKs simulated (910 bytes retained per record):

| call shape | records | uncapped | capped@1000 | + release |
|---|---|---|---|---|
| p50 | 3 | 7.1 KB | 6.7 KB | 4.4 KB |
| p90 | 22 | 22.1 KB | 22.0 KB | 5.4 KB |
| p99 | 100 | 88.6 KB | 88.5 KB | 13.5 KB |
| p99.9 | 897 | 781 KB | 781 KB | 93 KB |
| max observed | 4,568 | 4.06 MB | **1.35 MB** | 475 KB |
| runaway | 20,000 | 18.4 MB | 2.99 MB | 2.1 MB |

The cap only moves calls past p99.9. `release_call_buffers()` is what helps the rest of the distribution, cutting 60–90% of what is held through teardown.

Note the ACK detail: eviction frees nothing until marks are ACKed and `_mark_history` is sole owner, because the history stores references to the same dicts as the pending map.

## What this does not fix

The RCA's control was a pod that grew **2,520 MB across 10,457 calls — 241 KB per call**. The average call retains ~10.5 KB of mark history, so this structure is **~4% of that**. Even assuming the pathological tail is 10x underrepresented in the sample — plausible, since calls killed by 1006/OOM never write a `latency_dict` and so are invisible here — it lands around 23 KB/call, an order of magnitude short.

So ~230 KB/call of retention remains unaccounted for, and the memory floor should **not** be expected to flatten on this change alone. The next step is heap attribution rather than more bounding: a scripted call loop against a local ws-server with `tracemalloc` snapshots diffed per completed call will identify what actually survives, which is a question of *what is retained*, not of scale.

## Tests

New `tests/tests/test_mark_history_bounded.py` — 16 cases covering the cap, eviction order, anchor survival, `pre_mark_message` not consuming the cap, acks and interrupt flags still landing on retained records, buffer release, and sampling determinism/distribution.

`pytest tests/tests` → 572 passed. The 9 failures in `test_event_injection_e2e.py` / `test_split_utterance_tail_not_dropped.py` are pre-existing — verified identical on master with this branch stashed. ruff, bandit and CodeQL clean.

## Consumer impact

The only consumer of the raw list is dashboard-backend's post-call audio analyzer. Agent-channel WER needs per-chunk `text_synthesized` and is therefore sample-only from here on. Time calibration is **not** degraded: the companion PR anchors it on `mark_tracking.first_mark_sent_ts`, the identical timestamp, present on every call — bolna-ai/dashboard-backend#2758.

## Release path

Does not reach production on merge. Commitizen auto-release publishes to PyPI (`fix:` → patch), then the `bolna==` pin in dashboard-backend's `requirements.txt` **and** `pyproject.toml` has to be bumped and redeployed.

After deploy, the signal is monitor **#21521604** (ws-server memory >85% of 6Gi sustained). Compare per-pod `container.memory.usage` against **calls handled, not uptime**. Given the arithmetic above, treat a flat floor as evidence the real cause was elsewhere and still is — the metrics to expect movement on are DB write volume and log ingest.

## Adjacent accumulators, deliberately left alone

- `heard_text_by_turn` / `heard_text_by_response` accumulate full spoken text per turn with no cap — same failure mode. Freed at teardown here, but not bounded mid-call: a length cap would truncate what the transcript records the user actually heard. Wants its own decision.
- `mark_tracking.per_sequence[*].chunk_delays` grows one float per chunk and *is* persisted. Bounding it would change the average that dashboard-backend's `progression_service` and `datadog_helpers` recompute from the full list, so it needs its own call.
