### PR TITLE
fix: break and send EOS on WebSocketDisconnect in telephony _listen

### DIFF
--- a/bolna/input_handlers/telephony.py
+++ b/bolna/input_handlers/telephony.py
@@ -179,6 +179,14 @@ class TelephonyInputHandler(DefaultInputHandler):
                         f"{self.io_provider} websocket disconnected abnormally: code={e.code}, "
                         f"reason={getattr(e, 'reason', None)}, stream_sid={self.stream_sid}, call_sid={self.call_sid}"
                     )
+                # Without break+EOS here, the loop calls receive_text() again on an
+                # already-disconnected socket. Starlette then raises RuntimeError('Cannot
+                # call "receive" once a disconnect message has been received.') on that
+                # second call, which falls into the generic except below -- a spurious
+                # traceback for a normal hangup, and EOS sent one iteration late.
+                ws_data_packet = create_ws_data_packet(data=None, meta_info={"io": "default", "eos": True})
+                self.queues["transcriber"].put_nowait(ws_data_packet)
+                break
 
             except Exception as e:
                 traceback.print_exc()

--- a/tests/tests/test_telephony_input_disconnect.py
+++ b/tests/tests/test_telephony_input_disconnect.py
@@ -1,0 +1,91 @@
+"""Tests for TelephonyInputHandler._listen()'s WebSocketDisconnect handling.
+
+The WebSocketDisconnect branch used to only log the hangup, without breaking the
+loop or emitting an EOS packet -- unlike the sibling `stop`-event and generic
+except-Exception branches, which both do. Since Starlette raises RuntimeError on
+any receive() call after a disconnect has already been received, the loop would
+call receive_text() again, hit that RuntimeError, and fall into the generic
+except branch: a spurious traceback for what was a completely normal hangup, and
+EOS sent one loop iteration late. These drive the real method against a real
+starlette.websockets.WebSocket (fed through a fake ASGI receive channel), so the
+disconnect-state transition being asserted on is Starlette's actual behavior, not
+a guess about it.
+"""
+
+import io
+import sys
+
+import pytest
+from starlette.websockets import WebSocket, WebSocketState
+
+from bolna.input_handlers.telephony import TelephonyInputHandler
+
+
+class _FakeQueue:
+    def __init__(self):
+        self.items = []
+
+    def put_nowait(self, item):
+        self.items.append(item)
+
+
+class _OneShotDisconnectChannel:
+    """Fake ASGI receive() callable returning a single disconnect message."""
+
+    def __init__(self, code):
+        self.code = code
+        self.call_count = 0
+
+    async def __call__(self):
+        self.call_count += 1
+        assert self.call_count == 1, "receive() invoked again -- _listen() did not break"
+        return {"type": "websocket.disconnect", "code": self.code}
+
+
+def _make_handler(code):
+    channel = _OneShotDisconnectChannel(code)
+    ws = WebSocket(scope={"type": "websocket"}, receive=channel, send=None)
+    ws.client_state = WebSocketState.CONNECTED
+    ws.application_state = WebSocketState.CONNECTED
+
+    queues = {"transcriber": _FakeQueue(), "dtmf": _FakeQueue()}
+    handler = TelephonyInputHandler(queues=queues, websocket=ws, input_types={"audio": 0})
+    return handler, channel
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("code", [1000, 1001, 1006])
+async def test_disconnect_breaks_loop_and_sends_eos(code):
+    """Every disconnect code -- clean (1000/1001) or abnormal (1006) -- must break
+    the loop and emit exactly one EOS packet, with no second receive() call.
+
+    NOTE: the buggy (pre-fix) code also ends up with one EOS packet and one
+    channel call -- it just gets there via a SECOND receive_text() call that
+    raises RuntimeError('Cannot call "receive" once a disconnect message has
+    been received.'), caught by the generic except-Exception branch (which
+    also emits EOS+break). The queue/call-count alone can't tell the two apart;
+    the real signal is whether that spurious RuntimeError/traceback fired at
+    all, which is what's actually asserted on below.
+    """
+    handler, channel = _make_handler(code)
+
+    captured_stderr = io.StringIO()
+    real_stderr = sys.stderr
+    sys.stderr = captured_stderr
+    try:
+        await handler._listen()
+    finally:
+        sys.stderr = real_stderr
+
+    printed = captured_stderr.getvalue()
+    assert "RuntimeError" not in printed and "Cannot call" not in printed, (
+        f"disconnect (code={code}) fell through to the generic except-Exception "
+        f"branch via a spurious RuntimeError instead of being handled directly "
+        f"by the WebSocketDisconnect branch:\n{printed}"
+    )
+
+    assert channel.call_count == 1
+    items = handler.queues["transcriber"].items
+    assert len(items) == 1
+    assert items[0]["meta_info"]["eos"] is True
+    assert items[0]["data"] is None


### PR DESCRIPTION
## Summary

The `WebSocketDisconnect` branch in `TelephonyInputHandler._listen()` only logged the hangup. Unlike the sibling `stop`-event branch and the generic `except Exception` branch, it did not break the loop or emit an EOS packet. Starlette raises `RuntimeError` on any `receive()` call made after a disconnect has already been received, so the loop would call `receive_text()` again on the next iteration and hit that RuntimeError instead: a spurious traceback for what was a completely normal hangup, and EOS sent one loop iteration late.

Affects Twilio, Plivo, Exotel, and Vobiz (they inherit `_listen()` from this base class). SIP-trunk and FreeSWITCH override `_listen()` with their own disconnect handling and are unaffected.

Closes #928

## Fix

Emit EOS and break directly in the `WebSocketDisconnect` branch, mirroring the `stop`-event branch a few lines above.

<details>
<summary><strong>Testing</strong> (click to expand, regression tests, before/after verification, full suite results)</summary>

- Added 3 regression tests in `tests/tests/test_telephony_input_disconnect.py`, parametrized over normal (1000, 1001) and abnormal (1006) disconnect codes. Each drives the real `TelephonyInputHandler._listen()` against a real `starlette.websockets.WebSocket` instance (not a mock of Starlette's behavior, fed through a fake ASGI receive channel).
- Note on the test design: the pre-fix code and the fix converge on the same queue state (one EOS packet, one channel call), just reached via different paths, so a queue-only assertion cannot tell them apart. The tests instead capture stderr and assert no `RuntimeError`/`Cannot call "receive"` traceback fired, since that is the actual behavioral difference.
- Verified against unpatched `master`: all 3 fail with the exact traceback described above (`RuntimeError: Cannot call "receive" once a disconnect message has been received.`).
- Verified against this branch: all 3 pass.
- Full suite (`pytest tests/`) on this branch: 570 passed, 12 failed. The same 12 failures reproduce identically on unpatched `master` with none of this branch's changes present, confirmed pre-existing and unrelated to this change:
  - 7 in `test_event_injection_e2e.py` and 2 in `test_split_utterance_tail_not_dropped.py`: timing/mock-sensitive async tests (fixed-timeout waits, `AsyncMock` assertions, one `MagicMock`/await mismatch under this environment's mock library version).
  - 2 in `test_trace_log_encoding.py` + 1 in `test_elevenlabs_close_context_eos.py`: a Windows-only `UnicodeEncodeError`, `write_request_logs`'s `aiofiles.open` doesn't pin `encoding="utf-8"`, so non-ASCII (Hindi) transcript text fails to encode under the `cp1252` locale Windows defaults to. Not present on Linux CI, unrelated to WebSocket handling.
- `ruff check` on both changed files: all checks passed.

</details>