### PR TITLE
fix: restore OpenAI transcriber utterance-timeout safety net to 3s

### DIFF
--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -11,7 +11,14 @@ WEB_BASED_CALL_PROVIDER = "web_based_call"
 WEBCALL_TTS_SAMPLE_RATE = 24000
 
 OPENAI_TRANSCRIBER_HEARTBEAT_INTERVAL_S = 5
-OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 0.5
+# Last-resort safety net for a missing/dropped transcription.completed event, NOT a
+# normal-path timeout. OpenAI's realtime transcription completion can legitimately take a
+# couple of seconds after commit, so this must stay well above typical completion latency.
+# Regressed from 3.0 to 0.5 in #721 with no stated rationale; at 0.5s the monitor fires on
+# ordinary turns and silently discards the user's speech before OpenAI's real transcript
+# ever arrives, which is what issue #711 ("final transcript comes too late, so agent never
+# replies") actually observed. Restored to the pre-regression value.
+OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 3.0
 
 # ElevenLabs realtime (scribe_v2_realtime) accepts up to 50 keyterms for biasing.
 ELEVENLABS_REALTIME_MAX_KEYTERMS = 50

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -243,7 +243,14 @@ class OpenAITranscriber(BaseTranscriber):
             logger.error(f"Error in OpenAI heartbeat: {e}")
 
     async def monitor_utterance_timeout(self):
-        """Force-finalize a committed turn if completed event never arrives."""
+        """Force-finalize a committed turn if completed event never arrives.
+
+        This is a last-resort safety net, not a normal-path timeout — see the comment on
+        OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S. When it does fire, use whatever interim
+        deltas already arrived as a best-effort fallback transcript instead of silently
+        discarding the turn: dropping it with no downstream signal at all means the agent
+        never even knows the caller said anything, and looks like a dead call.
+        """
         try:
             while True:
                 await asyncio.sleep(0.1)
@@ -254,12 +261,27 @@ class OpenAITranscriber(BaseTranscriber):
                 ):
                     elapsed = time.time() - self._commit_time
                     if elapsed > OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S:
+                        turn_id = self.current_turn_id
                         logger.warning(
                             f"Utterance timeout: completed event missing for {elapsed:.1f}s "
-                            f"after commit on turn {self.current_turn_id}. Force-finalizing."
+                            f"after commit on turn {turn_id}. Force-finalizing."
                         )
+                        fallback_transcript = "".join(
+                            d.get("transcript", "") for d in self.current_turn_interim_details
+                        ).strip()
                         self._final_transcript_event.set()
                         self._reset_turn_state()
+                        if fallback_transcript:
+                            logger.warning(
+                                f"Utterance timeout: using {len(fallback_transcript)}-char interim "
+                                f"fallback transcript for turn {turn_id}"
+                            )
+                            await self.push_to_transcriber_queue(
+                                create_ws_data_packet(
+                                    {"type": "transcript", "content": fallback_transcript},
+                                    dict(self.meta_info),
+                                )
+                            )
         except asyncio.CancelledError:
             logger.info("OpenAI utterance timeout task cancelled")
             raise

--- a/tests/test_openai_utterance_timeout.py
+++ b/tests/test_openai_utterance_timeout.py
@@ -1,0 +1,131 @@
+"""
+Regression tests for the OpenAI realtime transcriber's utterance-timeout safety net
+(issue #711: "final transcript comes too late, so agent never replies").
+
+Root cause: OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S was silently regressed from 3.0 to 0.5
+in PR #721 with no stated rationale. At 0.5s, monitor_utterance_timeout() fires on
+ordinary turns (OpenAI's realtime completion routinely takes more than 500ms) and used to
+silently discard the turn with zero downstream signal -- the agent never even learns the
+caller said anything, which looks exactly like "the agent never replies".
+
+Fix: restore the timeout to 3.0s (the pre-regression, intentional value), and make the
+timeout handler push a best-effort fallback transcript (built from whatever interim ASR
+deltas already arrived) instead of silently dropping the turn when it does fire.
+
+Run with: python3 test_openai_utterance_timeout.py
+(requires the bolna package + its runtime deps importable; see repo requirements.txt)
+"""
+import asyncio
+import time
+
+from bolna.transcriber.openai_transcriber import OpenAITranscriber
+from bolna.constants import OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S
+
+
+async def make_transcriber():
+    t = OpenAITranscriber(telephony_provider="twilio", input_queue=asyncio.Queue())
+    t.transcriber_output_queue = asyncio.Queue()
+    return t
+
+
+async def test_constant_is_restored():
+    assert OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S == 3.0, (
+        "safety-net timeout should be well above typical OpenAI completion latency, "
+        "not 0.5s (the #721 regression that caused #711)"
+    )
+
+
+async def test_timeout_does_not_fire_within_normal_completion_latency():
+    """Simulates OpenAI taking ~1.5s to send the completed event (normal, not a bug) --
+    the monitor must NOT force-finalize (and must not push anything) before that."""
+    t = await make_transcriber()
+    t.current_turn_id = "turn_1"
+    t._turn_committed = True
+    t._commit_time = time.time()
+    t.is_transcript_sent_for_processing = False
+    t.current_turn_interim_details = [{"transcript": "hello there"}]
+
+    monitor = asyncio.create_task(t.monitor_utterance_timeout())
+    await asyncio.sleep(1.5)  # well under the 3.0s safety net, typical completion latency
+    t.is_transcript_sent_for_processing = True  # simulate completed event arriving normally
+    await asyncio.sleep(0.2)
+    monitor.cancel()
+    try:
+        await monitor
+    except asyncio.CancelledError:
+        pass
+
+    assert t.transcriber_output_queue.empty(), (
+        "monitor must not force-finalize (or push a fallback transcript) while still "
+        "within normal completion latency"
+    )
+
+
+async def test_timeout_pushes_fallback_transcript_when_genuinely_stalled():
+    """Simulates the completed event never arriving at all (genuine failure) -- the
+    monitor should eventually force-finalize AND push whatever interim text it has,
+    instead of silently discarding the user's speech."""
+    t = await make_transcriber()
+    t.current_turn_id = "turn_2"
+    t._turn_committed = True
+    t._commit_time = time.time()
+    t.is_transcript_sent_for_processing = False
+    t.current_turn_interim_details = [
+        {"transcript": "book a "},
+        {"transcript": "table for "},
+        {"transcript": "two"},
+    ]
+
+    monitor = asyncio.create_task(t.monitor_utterance_timeout())
+    await asyncio.sleep(3.3)  # past the 3.0s safety net, event never arrives
+    monitor.cancel()
+    try:
+        await monitor
+    except asyncio.CancelledError:
+        pass
+
+    assert not t.transcriber_output_queue.empty(), (
+        "monitor should push a fallback transcript instead of dropping the turn silently"
+    )
+    packet = t.transcriber_output_queue.get_nowait()
+    assert packet["data"]["type"] == "transcript"
+    assert packet["data"]["content"] == "book a table for two"
+    assert t.current_turn_id is None
+
+
+async def test_timeout_pushes_nothing_when_no_interim_text_available():
+    """If there were no interim deltas at all, there's nothing useful to fall back to --
+    the monitor should still reset turn state but not push an empty/noise transcript."""
+    t = await make_transcriber()
+    t.current_turn_id = "turn_3"
+    t._turn_committed = True
+    t._commit_time = time.time()
+    t.is_transcript_sent_for_processing = False
+    t.current_turn_interim_details = []
+
+    monitor = asyncio.create_task(t.monitor_utterance_timeout())
+    await asyncio.sleep(3.3)
+    monitor.cancel()
+    try:
+        await monitor
+    except asyncio.CancelledError:
+        pass
+
+    assert t.transcriber_output_queue.empty()
+    assert t.current_turn_id is None
+
+
+async def _run_all():
+    await test_constant_is_restored()
+    print("test_constant_is_restored passed")
+    await test_timeout_does_not_fire_within_normal_completion_latency()
+    print("test_timeout_does_not_fire_within_normal_completion_latency passed")
+    await test_timeout_pushes_fallback_transcript_when_genuinely_stalled()
+    print("test_timeout_pushes_fallback_transcript_when_genuinely_stalled passed")
+    await test_timeout_pushes_nothing_when_no_interim_text_available()
+    print("test_timeout_pushes_nothing_when_no_interim_text_available passed")
+    print("All tests passed.")
+
+
+if __name__ == "__main__":
+    asyncio.run(_run_all())


### PR DESCRIPTION
## Summary

`OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S` was silently regressed from `3.0` to `0.5` in
#721 ("fix whisper issue") with no stated rationale. This constant governs
`OpenAITranscriber.monitor_utterance_timeout()`, a safety net that force-finalizes a
committed turn if OpenAI's realtime `transcription.completed` event never arrives.

At 0.5s, this fires on ordinary turns — OpenAI's realtime completion routinely takes
more than 500ms — and force-finalizing used to silently discard the turn with zero
downstream signal. The agent never even learns the caller said anything. From the
caller's side that looks exactly like #711 describes: interim words appear, then
nothing, then "are you still there?" or a hangup.

Closes #711.

## Root cause

Confirmed via git history: the constant was intentionally `3.0` when the OpenAI
transcriber was first added, then dropped to `0.5` in #721 as an incidental part of a
larger, squashed rewrite of the transcriber's turn-detection logic. Nothing in that PR
explains or justifies the drop.

## Changes

- Restore `OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S` to `3.0` in `bolna/constants.py`,
  with a comment explaining why this must stay well above typical completion latency.
- Harden `monitor_utterance_timeout()` so that even a genuine timeout doesn't throw
  the caller's speech away: it now falls back to whatever interim transcript deltas
  already arrived and pushes those downstream, instead of silently dropping the turn.

## Testing

Added `tests/test_openai_utterance_timeout.py`:
- confirms the constant is restored to `3.0`
- confirms the monitor does NOT fire within normal (1.5s) completion latency
- confirms it correctly falls back to the assembled interim transcript when genuinely
  stalled past 3s
- confirms it stays silent (no noise packet) when there's no interim text at all

All 4 tests pass locally. This has not yet been verified against a live OpenAI
realtime connection or a full end-to-end call — happy to follow up with that if
useful.