### PR TITLE
fix: recover from an empty Responses API turn instead of stalling the call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.191"
+__version__ = "0.10.192"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3973,7 +3973,10 @@ class TaskManager(BaseManager):
 
         empty_turn_detail = None
         if not llm_response.strip():
-            reason = next((e.get("error") for e in meta_info.get("_non_fatal_errors", []) if e.get("error")), None)
+            # Newest first: a turn that recovered from a stale response id and then came back empty
+            # records both, and the later error is the one that silenced it.
+            errors = meta_info.get("_non_fatal_errors", [])
+            reason = next((e.get("error") for e in reversed(errors) if e.get("error")), None)
             empty_turn_detail = f"LLM returned no output ({reason})" if reason else "LLM returned no output"
 
         if self.stream and llm_response != filler_message:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4005,6 +4005,13 @@ class TaskManager(BaseManager):
         if llm_response.strip() and self.llm_latencies.turn_latencies:
             self.llm_latencies.turn_latencies[-1]["response_text"] = llm_response.strip()
 
+        # No speakable text means no synthesizer audio, and __listen_synthesizer is the only
+        # place the success path clears this flag. Left set, it gates every silence-recovery
+        # branch in __check_for_completion.
+        if not llm_response.strip():
+            logger.info("LLM turn produced no speakable text; clearing response_in_pipeline")
+            self.response_in_pipeline = False
+
         # Collect RAG latency if present (from KnowledgeBaseAgent)
         if meta_info.get("rag_latency"):
             rag_latency = meta_info["rag_latency"]

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3586,6 +3586,7 @@ class TaskManager(BaseManager):
         reasoning_tokens=None,
         cached_tokens=None,
         reasoning_content=None,
+        log_message=None,
     ):
         self.llm_response_generated = True
         # task 0 only, so aux LLMs (hangup/voicemail) never tally. Report input/output/cached so the
@@ -3595,7 +3596,8 @@ class TaskManager(BaseManager):
             self._usage_tasks.add(_usage_task)
             _usage_task.add_done_callback(self._usage_tasks.discard)
         convert_to_request_log(
-            message=llm_response,
+            # log_message explains a silent turn; the history below keeps the raw response.
+            message=log_message or llm_response,
             meta_info=meta_info,
             component=LogComponent.LLM,
             direction=LogDirection.RESPONSE,
@@ -3968,6 +3970,12 @@ class TaskManager(BaseManager):
         filler_message = compute_function_pre_call_message(
             meta_info.get("detected_language") or self.language, function_tool, function_tool_message
         )
+
+        empty_turn_detail = None
+        if not llm_response.strip():
+            reason = next((e.get("error") for e in meta_info.get("_non_fatal_errors", []) if e.get("error")), None)
+            empty_turn_detail = f"LLM returned no output ({reason})" if reason else "LLM returned no output"
+
         if self.stream and llm_response != filler_message:
             self.__store_into_history(
                 meta_info,
@@ -3979,6 +3987,7 @@ class TaskManager(BaseManager):
                 reasoning_tokens=actual_reasoning_tokens,
                 cached_tokens=actual_cached_tokens,
                 reasoning_content=actual_reasoning_content,
+                log_message=empty_turn_detail,
             )
         elif not self.stream:
             llm_response = llm_response.strip()
@@ -3988,7 +3997,7 @@ class TaskManager(BaseManager):
                 next_step, llm_response, should_bypass_synth, meta_info, is_function_call=should_trigger_function_call
             )
             convert_to_request_log(
-                message=llm_response,
+                message=empty_turn_detail or llm_response,
                 meta_info=meta_info,
                 component=LogComponent.LLM,
                 direction=LogDirection.RESPONSE,
@@ -4005,11 +4014,10 @@ class TaskManager(BaseManager):
         if llm_response.strip() and self.llm_latencies.turn_latencies:
             self.llm_latencies.turn_latencies[-1]["response_text"] = llm_response.strip()
 
-        # No speakable text means no synthesizer audio, and __listen_synthesizer is the only
-        # place the success path clears this flag. Left set, it gates every silence-recovery
-        # branch in __check_for_completion.
-        if not llm_response.strip():
-            logger.info("LLM turn produced no speakable text; clearing response_in_pipeline")
+        # Only __listen_synthesizer clears this on the success path, and a silent turn never
+        # reaches it, leaving every silence-recovery branch in __check_for_completion gated off.
+        if empty_turn_detail:
+            logger.info(f"{empty_turn_detail}; clearing response_in_pipeline")
             self.response_in_pipeline = False
 
         # Collect RAG latency if present (from KnowledgeBaseAgent)

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -643,9 +643,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     response_usage = event.response.usage
                 break
 
-        # An incomplete response that emitted nothing leaves the turn silent. Nothing was
-        # yielded yet, so one clean retry on full history is safe; a reasoning model that
-        # spent its whole max_output_tokens budget on reasoning usually stays under it here.
+        # Nothing was yielded yet, so a retry cannot duplicate speech.
         if incomplete and not answer and not func_call_args and retry_on_empty:
             logger.warning(f"Responses API returned no output (reason={incomplete_reason}), retrying once")
             if isinstance(meta_info, dict):

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -500,7 +500,6 @@ class OpenAICompatibleLLM(BaseLLM):
         meta_info=None,
         tool_choice=None,
         tools=None,
-        *,
         retry_on_empty=True,
     ):
         if not messages:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -493,7 +493,15 @@ class OpenAICompatibleLLM(BaseLLM):
         return create_kwargs, responses_tools
 
     async def _generate_stream_responses(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
+        self,
+        messages,
+        synthesize=True,
+        request_json=False,
+        meta_info=None,
+        tool_choice=None,
+        tools=None,
+        *,
+        retry_on_empty=True,
     ):
         if not messages:
             raise ValueError("No messages provided")
@@ -516,6 +524,8 @@ class OpenAICompatibleLLM(BaseLLM):
         service_tier = None
         llm_host = getattr(self, "llm_host", None)
         response_usage = None
+        incomplete = False
+        incomplete_reason = None
 
         try:
             stream = await self._responses_client.responses.create(**create_kwargs)
@@ -528,7 +538,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     )
                 self.previous_response_id = None
                 async for chunk in self._generate_stream_responses(
-                    messages, synthesize, request_json, meta_info, tool_choice, tools
+                    messages, synthesize, request_json, meta_info, tool_choice, tools, retry_on_empty=retry_on_empty
                 ):
                     yield chunk
                 return
@@ -557,7 +567,9 @@ class OpenAICompatibleLLM(BaseLLM):
                 raise APIError(message=f"Response failed: {error_info}", request=None, body=None)
 
             if event.type == ResponseStreamEvent.INCOMPLETE:
-                logger.warning("Responses API stream incomplete, partial response returned")
+                incomplete = True
+                incomplete_reason = getattr(getattr(event.response, "incomplete_details", None), "reason", None)
+                logger.warning(f"Responses API stream incomplete, reason={incomplete_reason}")
                 self.invalidate_response_chain()
                 break
 
@@ -630,6 +642,21 @@ class OpenAICompatibleLLM(BaseLLM):
                 if hasattr(event.response, "usage") and event.response.usage:
                     response_usage = event.response.usage
                 break
+
+        # An incomplete response that emitted nothing leaves the turn silent. Nothing was
+        # yielded yet, so one clean retry on full history is safe; a reasoning model that
+        # spent its whole max_output_tokens budget on reasoning usually stays under it here.
+        if incomplete and not answer and not func_call_args and retry_on_empty:
+            logger.warning(f"Responses API returned no output (reason={incomplete_reason}), retrying once")
+            if isinstance(meta_info, dict):
+                meta_info.setdefault("_non_fatal_errors", []).append(
+                    {"error_type": "incomplete_empty_response", "error": incomplete_reason, "model": self.model}
+                )
+            async for chunk in self._generate_stream_responses(
+                messages, synthesize, request_json, meta_info, tool_choice, tools, retry_on_empty=False
+            ):
+                yield chunk
+            return
 
         if latency_data:
             latency_data.total_stream_duration_ms = now_ms() - start_time

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -668,8 +668,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 yield chunk
             return
 
-        # Incomplete with nothing emitted leaves the turn silent. Nothing was yielded yet, so
-        # retry once over HTTP SSE on full history.
+        # Nothing was yielded yet, so a retry cannot duplicate speech.
         if incomplete and not answer and not func_call_args:
             logger.warning(f"WS Responses API returned no output (reason={incomplete_reason}), retrying once over HTTP")
             if isinstance(meta_info, dict):

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -663,7 +663,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             logger.error(f"WS streaming error: {e}, falling back to HTTP SSE")
             self.invalidate_response_chain()
             async for chunk in self._generate_stream_responses(
-                messages, synthesize, request_json, meta_info, tool_choice
+                messages, synthesize, request_json, meta_info, tool_choice, tools
             ):
                 yield chunk
             return

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -535,6 +535,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
         ws_service_tier = None
         llm_host = self.llm_host
         response_usage = None
+        incomplete = False
+        incomplete_reason = None
 
         try:
             async for evt in self._ws_transport.stream_response(create_params):
@@ -576,7 +578,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     raise APIError(message=f"Response failed: {error_info}", request=None, body=None)
 
                 if evt_type == ResponseStreamEvent.INCOMPLETE:
-                    logger.warning("WS Responses API stream incomplete")
+                    incomplete = True
+                    incomplete_reason = ((evt.get("response") or {}).get("incomplete_details") or {}).get("reason")
+                    logger.warning(f"WS Responses API stream incomplete, reason={incomplete_reason}")
                     self.invalidate_response_chain()
                     break
 
@@ -660,6 +664,20 @@ class OpenAiLLM(OpenAICompatibleLLM):
             self.invalidate_response_chain()
             async for chunk in self._generate_stream_responses(
                 messages, synthesize, request_json, meta_info, tool_choice
+            ):
+                yield chunk
+            return
+
+        # Incomplete with nothing emitted leaves the turn silent. Nothing was yielded yet, so
+        # retry once over HTTP SSE on full history.
+        if incomplete and not answer and not func_call_args:
+            logger.warning(f"WS Responses API returned no output (reason={incomplete_reason}), retrying once over HTTP")
+            if isinstance(meta_info, dict):
+                meta_info.setdefault("_non_fatal_errors", []).append(
+                    {"error_type": "incomplete_empty_response", "error": incomplete_reason, "model": self.model}
+                )
+            async for chunk in self._generate_stream_responses(
+                messages, synthesize, request_json, meta_info, tool_choice, tools, retry_on_empty=False
             ):
                 yield chunk
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.191"
+version = "0.10.192"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
When the Responses API ends a stream with `response.incomplete` and no output text, the agent speaks nothing and the call sits in dead air until the stall backstop force-hangs up, which then gets recorded as an inactivity timeout. A reasoning model can hit this whenever reasoning consumes the whole `max_output_tokens` budget before any visible token, since that budget covers reasoning as well as spoken text.

Three changes.

1. Log `incomplete_details.reason` on the incomplete event. It was previously dropped, so max_output_tokens could not be told apart from content_filter.

2. Retry once when an incomplete response emitted nothing at all. The guard requires no accumulated text and no function call, so a response that already streamed a partial answer keeps its current behaviour and nothing can be spoken twice. `invalidate_response_chain` has already run at that point, so the retry replays full history. The retry pins the flag off, bounding this at one extra attempt.

3. Clear `response_in_pipeline` when a turn produces no speakable text. It was only cleared when synthesizer audio actually got sent or when an exception propagated, so a silent turn left it set, which gates every recovery branch in `__check_for_completion`: the user-online check, repeat-after-silence, and the normal inactivity hangup. The graph agent's silent router hop hit the same stuck flag.

Both the HTTP SSE and the persistent WebSocket Responses paths are covered. Function calls return before the new check and are unaffected, since their follow-up generation still owes audio. An interrupted turn raises `CancelledError`, which is not caught there, so a barge-in still leaves the flag to the new turn.