### PR TITLE
fix(sip-trunk): send HANGUP before closing output handler

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.173"
+__version__ = "0.10.174"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2824,6 +2824,19 @@ class TaskManager(BaseManager):
             except Exception as e:
                 logger.warning(f"Failed to flush end_of_stream marker before closing chat output handler: {e}")
 
+        # For sip-trunk, send HANGUP to Asterisk before closing the output handler.
+        # set_hangup_sent() schedules send_hangup() as an async task, but by the time
+        # that task runs _closed is already True (set by close() below), making the
+        # WebSocket send a no-op. Awaiting send_hangup() directly here guarantees the
+        # HANGUP command reaches Asterisk before the handler is closed.
+        if "output" in self.tools and self.tools["output"] is not None:
+            output_handler = self.tools["output"]
+            if hasattr(output_handler, "send_hangup") and not output_handler.hangup_sent():
+                try:
+                    await output_handler.send_hangup()
+                except Exception as e:
+                    logger.warning(f"sip-trunk send_hangup before close failed: {e}")
+
         # Close output handler to prevent sends after websocket close
         if "output" in self.tools and self.tools["output"] is not None:
             self.tools["output"].close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.173"
+version = "0.10.174"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
On sip-trunk (Asterisk), the HANGUP WebSocket command was never reaching Asterisk because set_hangup_sent() schedules send_hangup() as an async task, but __process_end_of_conversation() calls output_handler.close() synchronously before that task gets a chance to run. close() sets _closed=True which gates every send path in the handler, so the HANGUP command becomes a no-op.

This caused calls to sit open after the agent's goodbye on sip-trunk — the agent had internally ended the conversation but Asterisk never received BYE, so the recipient heard silence and hung up themselves (hangup_by=Recipient).

Fix: await send_hangup() directly before close() in __process_end_of_conversation, ensuring the HANGUP reaches Asterisk while the WebSocket is still open. Only fires for sip-trunk (hasattr guard) and only if not already sent.