### PR TITLE
fix(sip-trunk): complete playback on Asterisk's mark echo, not a duration guess

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.175"
+__version__ = "0.10.176"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2824,23 +2824,15 @@ class TaskManager(BaseManager):
             except Exception as e:
                 logger.warning(f"Failed to flush end_of_stream marker before closing chat output handler: {e}")
 
-        # For sip-trunk, send HANGUP to Asterisk before closing the output handler.
-        # set_hangup_sent() schedules send_hangup() as an async task, but by the time
-        # that task runs _closed is already True (set by close() below), making the
-        # WebSocket send a no-op. Awaiting send_hangup() directly here guarantees the
-        # HANGUP command reaches Asterisk before the handler is closed.
-        if "output" in self.tools and self.tools["output"] is not None:
-            output_handler = self.tools["output"]
-            if hasattr(output_handler, "send_hangup") and not output_handler.hangup_sent():
-                try:
-                    await output_handler.send_hangup()
-                except Exception as e:
-                    logger.warning(f"sip-trunk send_hangup before close failed: {e}")
-
-        # Close output handler to prevent sends after websocket close
+        # Close output handler to prevent sends after websocket close. This only sets a
+        # flag — the WebSocket stays open, so stop_handler() below can still hang up.
         if "output" in self.tools and self.tools["output"] is not None:
             self.tools["output"].close()
 
+        # stop_handler() is the single hangup path. On sip-trunk it first waits for Asterisk
+        # to finish playing out what it has buffered, then sends HANGUP. Hanging up from here
+        # instead would cut the agent's goodbye short — Asterisk is handed audio faster than
+        # real time, so a chunk of it is still queued when the conversation ends.
         await self.tools["input"].stop_handler()
         logger.info("Stopped input handler")
         if "transcriber" in self.tools and not self.turn_based_conversation:

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -63,6 +63,10 @@ def _parse_asterisk_control_message(text: str) -> dict:
         # "QUEUE_DRAINED" have no space — guarding on `" " in text` dropped them entirely.
         if tokens and ":" not in tokens[0] and "event" not in result:
             result["event"] = tokens[0]
+            # Events carrying a bare correlation id ("MEDIA_MARK_PROCESSED <uuid>") put it
+            # in the second token, with no "key:value" shape to pick it up.
+            if len(tokens) > 1 and ":" not in tokens[1] and "correlation_id" not in result:
+                result["correlation_id"] = tokens[1]
 
     event = (result.get("event") or result.get("command") or "").upper().replace(" ", "_")
     if event:
@@ -363,8 +367,24 @@ class SipTrunkInputHandler(TelephonyInputHandler):
                 task.add_done_callback(_on_drain_done)
             logger.info(f"MEDIA_XON for channel {self.channel_id}")
             return
+        if event == "MEDIA_MARK_PROCESSED":
+            # Asterisk queues the mark in-band behind the audio it follows, so this lands
+            # when that audio has been dequeued for RTP — the same contract as a Twilio or
+            # Plivo mark echo. Routed through the shared path so latency and heard-text
+            # tracking work identically across providers.
+            mark_id = parsed.get("correlation_id")
+            if mark_id:
+                self.process_mark_message({"name": mark_id})
+            else:
+                logger.warning(f"MEDIA_MARK_PROCESSED without a mark id for channel {self.channel_id}: {text}")
+            return
         if event == "STATUS" or "MEDIA_BUFFERING_COMPLETED" in event:
             logger.debug(f"Asterisk control: {event}")
+            return
+        if event == "ERROR":
+            # Asterisk rejects a command (e.g. anything media-related in passthrough mode)
+            # with this. Silently swallowing it once hid a dead REPORT_QUEUE_DRAINED gate.
+            logger.warning(f"Asterisk rejected a command for channel {self.channel_id}: {text}")
             return
         if event == "QUEUE_DRAINED" or "QUEUE_DRAINED" in event:
             # Only requested at teardown, to gate HANGUP on real playout completion.

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -5,12 +5,16 @@ Sends audio to Asterisk in bursts as it arrives from TTS (like Plivo/Twilio).
 Each response is bracketed START_MEDIA_BUFFERING … STOP_MEDIA_BUFFERING: START
 lets Asterisk reframe/retime for smooth RTP, STOP flushes the buffer to RTP so
 even a short isolated response (e.g. the welcome message) plays immediately
-instead of waiting for later audio. Server-side duration tracking knows when
-playback ends without relying on QUEUE_DRAINED. FLUSH_MEDIA on interrupt.
-Generation counter drops stale audio after interruption.
+instead of waiting for later audio. FLUSH_MEDIA on interrupt. Generation counter
+drops stale audio after interruption.
 
-Asterisk has no mark echo, so playback completion is duration-based: a finish
-timer is scheduled on the final chunk (first_send + total_audio_duration + settle).
+Playback completion is mark-driven, same as Twilio/Plivo: each chunk is followed by
+MARK_MEDIA <mark_id>, which Asterisk queues in-band behind that audio and echoes as
+MEDIA_MARK_PROCESSED once it reaches the front of the playout queue (Asterisk 22.6+).
+The duration estimate (first_send + total_audio_duration + settle) is kept only as a
+fallback for when the echo doesn't arrive, and logs a warning when it has to act — it
+runs early, because it assumes playout starts the instant the first frame is sent.
+
 The synthesizer emits the final audio chunk and a trailing null-byte sentinel both
 with is_final=True; both reach _schedule_finish, which is harmless because
 _response_audio_duration is reset only on a new sequence_id or on interruption
@@ -55,11 +59,16 @@ ULAW_BYTES_PER_SECOND = 8000
 # it never re-overflows the queue.  Set SIP_MAX_SEND_RATE_FACTOR=0 to disable.
 MAX_SEND_RATE_FACTOR = float(os.environ.get("SIP_MAX_SEND_RATE_FACTOR", "1.5"))
 
+# Tags for _local_audio_queue entries. Audio and marks share one queue so an XOFF pause
+# can't let a mark overtake the audio it belongs to.
+AUDIO_ENTRY = "audio"
+MARK_ENTRY = "mark"
+
 
 class SipTrunkOutputHandler(TelephonyOutputHandler):
     """
     Sends ulaw audio to Asterisk in bursts — Asterisk buffers and retimes.
-    Server-side duration tracking for playback completion.
+    Playback completion via MARK_MEDIA echo, with duration tracking as fallback.
     FLUSH_MEDIA on interrupt. XOFF/XON for backpressure safety.
     """
 
@@ -168,11 +177,22 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         self._finish_playback(reason="duration-complete")
 
     def _finish_playback(self, reason: str = "duration-complete") -> None:
-        """Process all pending marks and clear playback state."""
+        """Fallback completion: ack whatever Asterisk never echoed and clear playback state.
+
+        Normally a no-op — MEDIA_MARK_PROCESSED completes playback first. It only does real
+        work when the mark echo is missing or late, and says so loudly, because acking on an
+        estimate is what lets HANGUP cut a goodbye short.
+        """
         if not self.input_handler or not self.input_handler.mark_event_meta_data:
             return
         remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
-        logger.info(f"sip-trunk: _finish_playback reason={reason}, {len(remaining)} mark(s)")
+        if not remaining and not self.input_handler.is_audio_being_played_to_user():
+            logger.info(f"sip-trunk: playback completed by mark echo before the {reason} timer")
+            return
+        logger.warning(
+            f"sip-trunk: completing playback from the duration estimate, not Asterisk's mark echo "
+            f"(reason={reason}, {len(remaining)} unacked mark(s))"
+        )
         for mid in remaining:
             self.input_handler.process_mark_message({"name": mid})
         if self.input_handler.is_audio_being_played_to_user():
@@ -221,7 +241,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             if gen != self._flush_generation:
                 return "stale"
             if self.queue_full:
-                self._local_audio_queue.appendleft(chunk[offset:])
+                self._local_audio_queue.appendleft((AUDIO_ENTRY, chunk[offset:]))
                 return "queue_full"
             end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
             if self._response_first_send == 0.0:
@@ -231,9 +251,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             offset = end
         return "sent"
 
-    def _register_mark(self, meta_info: dict, is_final: bool, audio_duration: float) -> None:
-        """Record per-mark metadata (same contract as Plivo/Twilio) so latency / heard-text
-        tracking works against Asterisk's duration-based playback completion."""
+    def _register_mark(self, meta_info: dict, is_final: bool, audio_duration: float) -> str:
+        """Record per-mark metadata (same contract as Plivo/Twilio) and return the mark id
+        so the caller can hand it to Asterisk via MARK_MEDIA."""
         message_category = meta_info.get("message_category", "agent_response")
         mark_id = meta_info.get("mark_id") or str(uuid.uuid4())
         self.mark_event_meta_data.update_data(
@@ -248,6 +268,18 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 "sent_ts": time.time(),
             },
         )
+        return mark_id
+
+    async def _emit_mark(self, mark_id: str) -> None:
+        """Ask Asterisk to echo this mark once the audio ahead of it has been played out.
+
+        Queued behind parked audio during XOFF: MARK_MEDIA is a TEXT frame and would
+        otherwise overtake the binary audio it marks, echoing back early.
+        """
+        if self.queue_full or self._local_audio_queue:
+            self._local_audio_queue.append((MARK_ENTRY, mark_id))
+        else:
+            await self._send_control("MARK_MEDIA", {"id": mark_id})
 
     # ------------------------------------------------------------------
     # Interruption
@@ -305,13 +337,18 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                     self._local_audio_queue.clear()
                     self._pending_finish = False
                     return
-                chunk = self._local_audio_queue.popleft()
-                if not chunk:
+                kind, payload = self._local_audio_queue.popleft()
+                if not payload:
                     continue
                 if self._closed:
                     return
+                if kind == MARK_ENTRY:
+                    # In-band with the audio around it, so Asterisk echoes it at the right
+                    # playout position rather than the moment XOFF lifted.
+                    await self._send_control("MARK_MEDIA", {"id": payload})
+                    continue
                 try:
-                    status = await self._send_frames(chunk, gen)
+                    status = await self._send_frames(payload, gen)
                 except Exception as e:
                     logger.debug(f"sip-trunk drain send_bytes stopped: {e}")
                     return
@@ -355,7 +392,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             await self._send_control("STOP_MEDIA_BUFFERING")
             self._start_buffering_sent = False
 
-    # sip-trunk sends audio as raw binary frames and acks marks via duration tracking,
+    # sip-trunk sends audio as raw binary frames and marks as MARK_MEDIA TEXT frames,
     # so the JSON media/mark framing used by Twilio/Plivo is intentionally unused here.
     async def form_media_message(self, audio_data, audio_format="wav"):
         return None
@@ -431,7 +468,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 # If XOFF is active or a drain is in flight, queue locally to preserve
                 # ordering; otherwise send now (re-queues the remainder on a mid-send XOFF).
                 if self.queue_full or self._local_audio_queue:
-                    self._local_audio_queue.append(audio_chunk)
+                    self._local_audio_queue.append((AUDIO_ENTRY, audio_chunk))
                 else:
                     if self._closed:
                         return
@@ -442,9 +479,12 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                         logger.debug(f"sip-trunk send_bytes stopped: {e}")
                         return
 
-            # Register mark metadata (same contract as Plivo/Twilio)
+            # Register mark metadata (same contract as Plivo/Twilio) and ask Asterisk to
+            # echo it back once this chunk reaches the front of its playout queue.
             if self.mark_event_meta_data:
-                self._register_mark(meta_info, is_final, audio_duration)
+                mark_id = self._register_mark(meta_info, is_final, audio_duration)
+                if gen == self._flush_generation:
+                    await self._emit_mark(mark_id)
 
                 if is_final:
                     if self._local_audio_queue:

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -37,9 +37,9 @@ from dotenv import load_dotenv
 logger = configure_logger(__name__)
 load_dotenv()
 
-# Asterisk's max WebSocket frame size is 65,500 bytes. Chunks larger than this
-# cause "Cannot fit huge websocket frame" and kill the connection.
-MAX_WS_FRAME_BYTES = 60000  # leave headroom below 65,500
+# One frame must arrive within the 10 short reads ws_safe_read() allows or Asterisk drops
+# the call; a proxy relaying in ~4 KB chunks costs one read each.
+MAX_WS_FRAME_BYTES = int(os.environ.get("SIP_MAX_WS_FRAME_BYTES", "8000"))  # 1 s of ulaw
 
 # Extra buffer after estimated playback end before clearing is_audio_being_played.
 # Accounts for Asterisk's internal retiming and RTP jitter buffer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.175"
+version = "0.10.176"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_sip_trunk_mark_events.py
+++ b/tests/tests/test_sip_trunk_mark_events.py
@@ -1,0 +1,224 @@
+"""sip-trunk playback completion is driven by Asterisk's mark echo, not a duration guess.
+
+Asterisk 22.6+ queues MARK_MEDIA in-band behind the audio it follows and echoes
+MEDIA_MARK_PROCESSED once that audio reaches the front of the playout queue. Before this,
+completion was estimated as first_send + audio_duration + 0.1s, which runs early — Asterisk
+is handed audio at 1.5x real time, so the tail was still queued when HANGUP discarded it.
+
+The duration timer is kept as a fallback for when the echo never arrives, so these tests
+pin both paths and the ordering rule that keeps a mark from overtaking its own audio.
+"""
+
+import asyncio
+from collections import deque
+
+import pytest
+
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+from bolna.input_handlers.telephony_providers.sip_trunk import (
+    SipTrunkInputHandler,
+    _parse_asterisk_control_message,
+)
+from bolna.output_handlers.telephony_providers.sip_trunk import (
+    AUDIO_ENTRY,
+    MARK_ENTRY,
+    SipTrunkOutputHandler,
+)
+
+
+class _FakeWebSocket:
+    """Records TEXT and BINARY frames in one list so ordering between them is assertable."""
+
+    def __init__(self):
+        self.frames = []
+
+    async def send_text(self, text):
+        self.frames.append(("text", text))
+
+    async def send_bytes(self, data):
+        self.frames.append(("bytes", data))
+
+    def texts(self):
+        return [payload for kind, payload in self.frames if kind == "text"]
+
+
+class _FakeInputHandler:
+    """Minimal stand-in for the playback-state side of the input handler."""
+
+    def __init__(self, mark_event_meta_data):
+        self.mark_event_meta_data = mark_event_meta_data
+        self.acked = []
+        self.audio_playing = True
+
+    def process_mark_message(self, packet):
+        mark_id = packet.get("name")
+        self.acked.append(mark_id)
+        self.mark_event_meta_data.mark_event_meta_data.pop(mark_id, None)
+
+    def is_audio_being_played_to_user(self):
+        return self.audio_playing
+
+    def update_is_audio_being_played(self, value):
+        self.audio_playing = value
+
+
+def _make_output_handler(websocket, input_handler):
+    handler = SipTrunkOutputHandler.__new__(SipTrunkOutputHandler)
+    handler.websocket = websocket
+    handler.input_handler = input_handler
+    handler.mark_event_meta_data = input_handler.mark_event_meta_data
+    handler.stream_sid = "stream-1"
+    handler.welcome_message_sent_ts = None
+    handler._closed = False
+    handler.queue_full = False
+    handler._response_first_send = 0.0
+    handler._response_audio_duration = 0.0
+    handler._bytes_sent = 0
+    handler._settle_task = None
+    handler._pending_finish = False
+    handler._current_sequence_id = None
+    handler._flush_generation = 0
+    handler._start_buffering_sent = False
+    handler._local_audio_queue = deque()
+    handler._drain_lock = asyncio.Lock()
+    handler._output_format = "ulaw"
+    return handler
+
+
+def _make_input_handler():
+    handler = SipTrunkInputHandler.__new__(SipTrunkInputHandler)
+    handler.channel_id = "test-channel_1"
+    handler.acked = []
+    handler.process_mark_message = handler.acked.append
+    return handler
+
+
+def _audio_packet(payload, sequence_id=1, is_final=False):
+    return {
+        "data": payload,
+        "meta_info": {
+            "format": "ulaw",
+            "sequence_id": sequence_id,
+            "text_synthesized": "hello",
+            "end_of_llm_stream": is_final,
+            "end_of_synthesizer_stream": is_final,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Outbound: MARK_MEDIA is emitted, and never ahead of its own audio
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_media_is_sent_after_the_audio_it_marks():
+    ws = _FakeWebSocket()
+    out = _make_output_handler(ws, _FakeInputHandler(MarkEventMetaData()))
+
+    await out.handle(_audio_packet(b"\xff" * 800))
+
+    kinds = [kind for kind, _ in ws.frames]
+    assert kinds == ["text", "bytes", "text"]  # START_MEDIA_BUFFERING, audio, MARK_MEDIA
+    assert ws.frames[2][1].startswith("MARK_MEDIA ")
+
+    mark_id = ws.frames[2][1].split(" ", 1)[1]
+    assert mark_id in out.mark_event_meta_data.mark_event_meta_data
+
+
+@pytest.mark.asyncio
+async def test_mark_is_queued_behind_parked_audio_during_xoff():
+    # MARK_MEDIA is a TEXT frame; sending it while audio sits in the local queue would put
+    # it ahead of that audio in Asterisk's queue and echo back early.
+    ws = _FakeWebSocket()
+    out = _make_output_handler(ws, _FakeInputHandler(MarkEventMetaData()))
+    out.queue_full = True
+
+    await out.handle(_audio_packet(b"\xff" * 800))
+
+    assert "MARK_MEDIA" not in " ".join(ws.texts())
+    assert [kind for kind, _ in out._local_audio_queue] == [AUDIO_ENTRY, MARK_ENTRY]
+
+
+@pytest.mark.asyncio
+async def test_drain_replays_audio_and_marks_in_order():
+    ws = _FakeWebSocket()
+    out = _make_output_handler(ws, _FakeInputHandler(MarkEventMetaData()))
+    out.queue_full = True
+
+    await out.handle(_audio_packet(b"\xff" * 800))
+    await out.handle(_audio_packet(b"\xee" * 800))
+
+    out.queue_full = False
+    await out.drain_local_queue()
+
+    # START_MEDIA_BUFFERING, then audio, its mark, audio, its mark — never a mark before
+    # the chunk it belongs to.
+    assert [kind for kind, _ in ws.frames] == ["text", "bytes", "text", "bytes", "text"]
+    assert all(t.startswith("MARK_MEDIA ") for t in ws.texts()[1:])
+
+
+# ---------------------------------------------------------------------------
+# Inbound: MEDIA_MARK_PROCESSED routes into the shared mark path
+# ---------------------------------------------------------------------------
+
+
+def test_parser_keeps_the_bare_correlation_id():
+    parsed = _parse_asterisk_control_message("MEDIA_MARK_PROCESSED 1ab08c3e-b30a-45a0-8b23-7f43e39fcadf")
+    assert parsed["event"] == "MEDIA_MARK_PROCESSED"
+    assert parsed["correlation_id"] == "1ab08c3e-b30a-45a0-8b23-7f43e39fcadf"
+
+
+def test_parser_still_reads_key_value_events():
+    parsed = _parse_asterisk_control_message("DTMF_END digit:5")
+    assert parsed["event"] == "DTMF_END"
+    assert parsed["digit"] == "5"
+    assert "correlation_id" not in parsed
+
+
+@pytest.mark.asyncio
+async def test_mark_echo_is_acked_through_the_shared_path():
+    handler = _make_input_handler()
+    await handler._handle_control_message("MEDIA_MARK_PROCESSED mark-abc")
+    assert handler.acked == [{"name": "mark-abc"}]
+
+
+@pytest.mark.asyncio
+async def test_mark_echo_without_an_id_is_ignored():
+    handler = _make_input_handler()
+    await handler._handle_control_message("MEDIA_MARK_PROCESSED")
+    assert handler.acked == []
+
+
+# ---------------------------------------------------------------------------
+# Fallback: the duration timer only acts when the echo doesn't arrive
+# ---------------------------------------------------------------------------
+
+
+def test_duration_timer_is_a_noop_once_marks_completed_playback():
+    meta = MarkEventMetaData()
+    inp = _FakeInputHandler(meta)
+    out = _make_output_handler(_FakeWebSocket(), inp)
+
+    meta.update_data("m1", {"type": "agent_response", "duration": 1.0, "is_final_chunk": True})
+    inp.process_mark_message({"name": "m1"})  # Asterisk echoed it
+    inp.audio_playing = False
+    inp.acked.clear()
+
+    out._finish_playback()
+
+    assert inp.acked == []  # nothing force-acked on top of the echo
+
+
+def test_duration_timer_completes_playback_when_no_echo_arrives():
+    meta = MarkEventMetaData()
+    inp = _FakeInputHandler(meta)
+    out = _make_output_handler(_FakeWebSocket(), inp)
+
+    meta.update_data("m1", {"type": "agent_response", "duration": 1.0, "is_final_chunk": False})
+    meta.update_data("m2", {"type": "agent_response", "duration": 1.0, "is_final_chunk": True})
+
+    out._finish_playback()
+
+    assert inp.acked == ["m1", "m2"]
+    assert inp.audio_playing is False


### PR DESCRIPTION
This pull request updates the SIP trunk telephony integration to improve playback completion tracking by leveraging Asterisk's new mark echo feature, aligning its behavior with other providers like Twilio and Plivo. It introduces in-band mark handling for accurate playback completion, updates queue management for audio and marks, and refines fallback logic for cases where mark echoes are missing. These changes ensure more reliable and consistent detection of when audio has finished playing, reducing the risk of prematurely cutting off agent messages.

**SIP Trunk Playback Completion Improvements:**

- Playback completion is now driven by Asterisk's `MEDIA_MARK_PROCESSED` echo, matching the contract used by Twilio and Plivo, instead of relying solely on duration estimates. This change ensures that the system accurately detects when audio has actually finished playing, reducing the risk of cutting off agent goodbyes or other audio prematurely. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L8-L13) [[2]](diffhunk://#diff-f8fa47ef7a770403dcbe07c30dab5111e4634586022a94d66668ac7eddd0254cR370-R388)
- Fallback logic for playback completion now clearly logs a warning if it must rely on duration estimates due to missing mark echoes, making it easier to identify and debug such cases.

**Audio and Mark Queue Management:**

- Audio and mark messages are now queued together using tagged entries (`AUDIO_ENTRY`, `MARK_ENTRY`) to ensure that marks never overtake their associated audio, preserving correct playback order even during XOFF pauses or backpressure situations. [[1]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7R62-R71) [[2]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L224-R244) [[3]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L308-R351) [[4]](diffhunk://#diff-2315800a3d6bbc17cdff0a07b66946d0bf04259d44a35917735a9bbd691d41a7L434-R471)
- The maximum WebSocket frame size for SIP audio can now be configured via the `SIP_MAX_WS_FRAME_BYTES` environment variable, with a new default of 8000 bytes, improving compatibility with proxies and network conditions.

**Asterisk Control Message Parsing and Handling:**

- The parser for Asterisk control messages now extracts bare correlation IDs for events like `MEDIA_MARK_PROCESSED`, enabling correct association of mark echoes with their corresponding audio.
- The handler for Asterisk events now routes `MEDIA_MARK_PROCESSED` events through the shared mark processing path, ensuring consistent latency and heard-text tracking across all providers. It also logs and handles `ERROR` events more transparently.

**Task Manager and Versioning:**

- The end-of-conversation flow in the task manager is updated to rely on `stop_handler()` as the single hangup path, preventing premature hangups and ensuring that all buffered audio is played out before the call ends.
- Version numbers are incremented in both `__init__.py` and `pyproject.toml`. [[1]](diffhunk://#diff-cc5880108bc021472b963a6612d57c6538403841abecb650c481a59608159abaL1-R1) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L9-R9)