### PR TITLE
fix: flush pipeline on response.incomplete to prevent inactivity timeout

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.174"
+__version__ = "0.10.175"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -58,7 +58,7 @@ from bolna.enums import (
     ChatRole,
     ToolScope,
 )
-from bolna.exceptions import BolnaComponentError, LLMError, SynthesizerError, TranscriberError
+from bolna.exceptions import BolnaComponentError, LLMError, LLMIncompleteError, SynthesizerError, TranscriberError
 from bolna.prompts import *
 from bolna.helpers.language_detector import LanguageDetector
 from bolna.helpers.language_switcher import LanguageSwitcher
@@ -4171,6 +4171,10 @@ class TaskManager(BaseManager):
                 await self._process_conversation_task(message, sequence, meta_info)
             else:
                 logger.error("unsupported task type: {}".format(self.task_config["task_type"]))
+            self.llm_task = None
+        except LLMIncompleteError:
+            # Stream ended early — flush pipeline and let the call continue.
+            await self.__cleanup_downstream_tasks()
             self.llm_task = None
         except BolnaComponentError as e:
             self.response_in_pipeline = False

--- a/bolna/exceptions.py
+++ b/bolna/exceptions.py
@@ -21,3 +21,8 @@ class SynthesizerError(BolnaComponentError):
 class TranscriberError(BolnaComponentError):
     def __init__(self, message, provider=None, model=None):
         super().__init__(message, component="transcriber", provider=provider, model=model)
+
+
+class LLMIncompleteError(Exception):
+    """OpenAI response.incomplete — stream cut short (token limit / content filter). Recoverable."""
+    pass

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -7,6 +7,7 @@ from openai import BadRequestError, APIError
 
 from bolna.constants import GPT5_MODEL_PREFIX
 from bolna.enums import ChatRole, ResponseStreamEvent, ResponseItemType, LogComponent, LogDirection
+from bolna.exceptions import LLMIncompleteError
 from bolna.helpers.utils import (
     convert_to_request_log,
     compute_function_pre_call_message,
@@ -559,7 +560,7 @@ class OpenAICompatibleLLM(BaseLLM):
             if event.type == ResponseStreamEvent.INCOMPLETE:
                 logger.warning("Responses API stream incomplete, partial response returned")
                 self.invalidate_response_chain()
-                break
+                raise LLMIncompleteError("Responses API stream incomplete")  # task_manager flushes pipeline
 
             if not first_token_time and event.type in (
                 ResponseStreamEvent.OUTPUT_TEXT_DELTA,

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -23,6 +23,7 @@ from websockets.protocol import State as WSState
 
 from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX, default_reasoning_effort
 from bolna.enums import ResponseStreamEvent, ResponseItemType, Verbosity
+from bolna.exceptions import LLMIncompleteError
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
@@ -572,7 +573,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 if evt_type == ResponseStreamEvent.INCOMPLETE:
                     logger.warning("WS Responses API stream incomplete")
                     self.invalidate_response_chain()
-                    break
+                    raise LLMIncompleteError("WS Responses API stream incomplete")  # task_manager flushes pipeline
 
                 if not first_token_time and evt_type in (
                     ResponseStreamEvent.OUTPUT_TEXT_DELTA,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.174"
+version = "0.10.175"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
When OpenAI returns a response.incomplete event , the stream exits via break without clearing response_in_pipeline. The inactivity watchdog skips its check while this flag is True, freezing the pipeline until the stall backstop fires and kills the call.

Introduce LLMIncompleteError, raised on the INCOMPLETE path in both openai_llm.py and openai_base.py. task_manager catches it, calls __cleanup_downstream_tasks to flush and reset the pipeline, and lets the call continue normally.