### PR TITLE
fix(sip-trunk): stop end_call teardown from cancelling its own hangup

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.176"
+__version__ = "0.10.177"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4033,8 +4033,15 @@ class TaskManager(BaseManager):
         # TODO : Write a better check for completion prompt
 
         # Hangup detection - now supported for all agent types including graph_agent.
-        # Skipped when end_call is the primary hangup; those agents hang up via the tool.
-        if self.use_llm_to_determine_hangup and not self.turn_based_conversation and not self.end_call_primary:
+        # Skipped when end_call is the primary hangup; those agents hang up via the tool. Also
+        # skipped once the call is over: a node-scoped end_call tears down inside this task and
+        # returns here, where asking the LLM whether to hang up is a request nobody can act on.
+        if (
+            self.use_llm_to_determine_hangup
+            and not self.turn_based_conversation
+            and not self.end_call_primary
+            and not self.conversation_ended
+        ):
             completion_res, metadata = await self.tools["llm_agent"].check_for_completion(
                 messages, self.check_for_completion_prompt, meta_info=meta_info
             )

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2808,11 +2808,17 @@ class TaskManager(BaseManager):
         self.conversation_ended = True
         self.ended_by_assistant = True
 
-        # Cancel any running LLM / function-call tasks so they don't add
-        # phantom responses to the transcript after the call has ended.
+        # Cancel any running LLM / function-call tasks so they don't add phantom responses to
+        # the transcript after the call has ended. The end_call tool reaches this from inside
+        # llm_task itself, where cancelling would raise CancelledError at the first await below
+        # and lose the hangup. Dropping the reference is enough there: every path left in that
+        # task bails on conversation_ended.
         if self.llm_task is not None and not self.llm_task.done():
-            logger.info("__process_end_of_conversation: Cancelling LLM task")
-            self.llm_task.cancel()
+            if self.llm_task is asyncio.current_task():
+                logger.info("__process_end_of_conversation: teardown runs inside the LLM task, not cancelling it")
+            else:
+                logger.info("__process_end_of_conversation: Cancelling LLM task")
+                self.llm_task.cancel()
             self.llm_task = None
 
         # Turn-based chat clears its spinner only on the <end_of_stream> marker. When the

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -186,10 +186,15 @@ class SipTrunkInputHandler(TelephonyInputHandler):
     async def stop_handler(self):
         """Stop and disconnect; Asterisk closes quickly after HANGUP."""
         logger.info(f"Stopping sip-trunk handler for channel {self.channel_id}")
-        await self._await_playback_drained()
-        self.running = False
-        self._cancel_dtmf_timer()
-        await self.disconnect_stream()
+        try:
+            await self._await_playback_drained()
+        finally:
+            # The drain wait is the only suspension point between entering teardown and the
+            # hangup, so sending HANGUP from finally is what keeps a cancelled teardown from
+            # leaving the caller on a live channel.
+            self.running = False
+            self._cancel_dtmf_timer()
+            await self.disconnect_stream()
         await asyncio.sleep(HANGUP_SETTLE_S)
         try:
             await self.websocket.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.176"
+version = "0.10.177"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_end_call_teardown_self_cancel.py
+++ b/tests/tests/test_end_call_teardown_self_cancel.py
@@ -1,0 +1,81 @@
+"""Regression: end_call teardown must not cancel the task it is running on.
+
+The end_call tool is handled inside __do_llm_generation, which runs in llm_task. Teardown
+then cancelled llm_task before awaiting stop_handler(), so the CancelledError landed on the
+hangup instead of on a stray generation, and the input handler was never stopped.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+class _RecordingInputHandler:
+    def __init__(self):
+        self.stop_calls = 0
+
+    async def stop_handler(self):
+        await asyncio.sleep(0)  # a suspension point, like the real sip-trunk drain wait
+        self.stop_calls += 1
+
+
+class _FakeOutputHandler:
+    def __init__(self):
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+def _make_task_manager(input_handler):
+    task_manager = TaskManager.__new__(TaskManager)
+    task_manager._end_of_conversation_in_progress = False
+    task_manager.conversation_ended = False
+    task_manager.ended_by_assistant = False
+    task_manager.hangup_triggered = False
+    task_manager.hangup_message_queued = False
+    task_manager.turn_based_conversation = False
+    task_manager.llm_task = None
+    task_manager.tools = {"input": input_handler, "output": _FakeOutputHandler()}
+    task_manager.voicemail_handler = SimpleNamespace(cancel_task=lambda: None)
+
+    async def _already_flushed():
+        return None
+
+    task_manager.wait_for_current_message = _already_flushed
+    return task_manager
+
+
+def _end_of_conversation(task_manager):
+    return task_manager._TaskManager__process_end_of_conversation()
+
+
+@pytest.mark.asyncio
+async def test_teardown_from_inside_the_llm_task_still_stops_the_input_handler():
+    handler = _RecordingInputHandler()
+    task_manager = _make_task_manager(handler)
+
+    turn = asyncio.create_task(_end_of_conversation(task_manager))
+    task_manager.llm_task = turn
+    await asyncio.gather(turn, return_exceptions=True)
+
+    assert not turn.cancelled(), "teardown cancelled the task it was running on"
+    assert handler.stop_calls == 1
+    assert task_manager.conversation_ended
+
+
+@pytest.mark.asyncio
+async def test_a_concurrent_llm_task_is_still_cancelled():
+    handler = _RecordingInputHandler()
+    task_manager = _make_task_manager(handler)
+    stray = asyncio.create_task(asyncio.sleep(30))
+    task_manager.llm_task = stray
+
+    await _end_of_conversation(task_manager)
+    await asyncio.gather(stray, return_exceptions=True)
+
+    assert stray.cancelled()
+    assert handler.stop_calls == 1

--- a/tests/tests/test_sip_trunk_hangup_drain.py
+++ b/tests/tests/test_sip_trunk_hangup_drain.py
@@ -130,6 +130,25 @@ async def test_no_drain_wait_when_receive_loop_already_gone():
 
 
 @pytest.mark.asyncio
+async def test_hangup_still_sent_when_teardown_is_cancelled_during_the_drain():
+    # Teardown is routinely cancelled mid-flight (the end_call tool tears the call down from
+    # inside the LLM task). Losing HANGUP here leaves the caller on a live channel until the
+    # far end gives up, so it has to go out even on the way past a CancelledError.
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    stopping = asyncio.create_task(handler.stop_handler())
+    await asyncio.sleep(0.05)  # let it reach the drain wait
+    stopping.cancel()
+    await asyncio.gather(stopping, return_exceptions=True)
+    listen_task.cancel()
+
+    assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
+    assert handler.running is False
+
+
+@pytest.mark.asyncio
 async def test_hangup_still_sent_when_report_cannot_be_delivered():
     ws = _FakeWebSocket(fail_send=True)
     listen_task = asyncio.create_task(_live_task())


### PR DESCRIPTION
## Problem

`end_call` teardown cancels the task it is running on, and on sip-trunk that loses the HANGUP.

`end_call` is handled in `__execute_function_call`, which is awaited inline from `__do_llm_generation`, which runs inside `llm_task`. `__process_end_of_conversation` then calls `self.llm_task.cancel()` before awaiting `stop_handler()`. Since `llm_task` is the currently running task, `cancel()` only sets the pending-cancel flag, and the `CancelledError` is delivered at the first suspension point inside `stop_handler()`.

On sip-trunk that suspension is the `QUEUE_DRAINED` wait in `_await_playback_drained`, which sits before `self.running = False` and before `disconnect_stream()`. So `REPORT_QUEUE_DRAINED` goes out, HANGUP never does, and the channel stays up after the agent has said goodbye until the far end gives up. `__check_for_completion` still logs `Call hangup completed successfully`, because it only tests `conversation_ended`, which is set before the cancel.

The other providers inherit `TelephonyInputHandler.stop_handler`, which clears `running` and fires `disconnect_stream` as a detached task before its first await, so their hangup survives. They still lose everything after that await: the websocket close, the graceful transcriber `toggle_connection()`, and `voicemail_handler.cancel_task()`.

On telephony traffic the cancel fires on roughly 39% of agent-initiated teardowns, and it aborts teardown every time it fires (0 of 1110 sampled teardowns reached the log line following the await).

## Changes

`__process_end_of_conversation` no longer cancels `llm_task` when that task is the one running the teardown, and drops the reference instead. Nothing is left for it to add to the transcript, since every remaining path in that task already bails on `conversation_ended`. A genuinely concurrent LLM task is still cancelled exactly as before.

`SipTrunkInputHandler.stop_handler` sends HANGUP from a `finally`. The drain wait is the only suspension point between entering teardown and the hangup, so this is what keeps a cancelled or failed drain from leaving the caller on a live channel. The ordering is unchanged otherwise: `running` cannot be cleared before the drain wait, because `_listen` has to stay alive to receive `QUEUE_DRAINED`.

LLM hangup detection is skipped once `conversation_ended`. A node-scoped `end_call` tears down inside this task and now returns into `_process_conversation_task`, where the existing guard only checked after `check_for_completion` had already been issued.

## Tests

`test_end_call_teardown_self_cancel.py` covers teardown running inside `llm_task` completing and stopping the input handler, plus a concurrent `llm_task` still being cancelled. `test_sip_trunk_hangup_drain.py` gains a case asserting HANGUP still goes out when teardown is cancelled during the drain.

Both new assertions fail on master with the production signature, `['REPORT_QUEUE_DRAINED'] == ['REPORT_QUEUE_DRAINED', 'HANGUP']` and `teardown cancelled the task it was running on`. Full suite shows no new failures against the master baseline, and the three cases were also run against the built package on a staging deployment.
