### PR TITLE
fix: release the audio gate when callee_speaking latches with no interim

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.180"
+__version__ = "0.10.181"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -154,7 +154,6 @@ class InterruptionManager:
     def on_interim_transcript_received(self) -> None:
         """Called on each interim transcript to update timing state."""
         self.let_remaining_audio_pass_through = False
-        self.last_interim_ts = time.time()
 
         if self.time_since_first_interim_result == -1:
             self.time_since_first_interim_result = time.time() * 1000
@@ -469,11 +468,15 @@ class InterruptionManager:
         """Returns current turn ID."""
         return self.turn_id
 
+    def note_user_liveness(self) -> None:
+        """Record that an interim arrived, whether or not this turn acts on it."""
+        self.last_interim_ts = time.time()
+
     def user_speech_staleness_s(self) -> float:
-        """Seconds since the last interim, or since VAD speech-start if none, -1 when not speaking."""
+        """Seconds since the last interim, or since speech start if none yet, -1 when not speaking."""
         if not self.callee_speaking:
             return -1
-        anchor = self.last_interim_ts if self.last_interim_ts > 0 else self.callee_speaking_start_time
+        anchor = max(self.last_interim_ts, self.callee_speaking_start_time)
         return time.time() - anchor if anchor > 0 else -1
 
     def get_user_speaking_duration(self) -> float:

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -32,6 +32,7 @@ class InterruptionManager:
         self.required_delay_before_speaking: float = 0
         self.incremental_delay: int = incremental_delay
         self.utterance_end_time: float = -1
+        self.last_interim_ts: float = -1
 
         # Configuration
         self.number_of_words_for_interruption: int = number_of_words_for_interruption
@@ -153,6 +154,7 @@ class InterruptionManager:
     def on_interim_transcript_received(self) -> None:
         """Called on each interim transcript to update timing state."""
         self.let_remaining_audio_pass_through = False
+        self.last_interim_ts = time.time()
 
         if self.time_since_first_interim_result == -1:
             self.time_since_first_interim_result = time.time() * 1000
@@ -175,6 +177,7 @@ class InterruptionManager:
         self.callee_speaking = False
         self.let_remaining_audio_pass_through = True
         self.time_since_first_interim_result = -1
+        self.last_interim_ts = -1
 
         now_s = time.time()
         if update_utterance_time:
@@ -465,6 +468,13 @@ class InterruptionManager:
     def get_turn_id(self) -> int:
         """Returns current turn ID."""
         return self.turn_id
+
+    def user_speech_staleness_s(self) -> float:
+        """Seconds since the last interim, or since VAD speech-start if none, -1 when not speaking."""
+        if not self.callee_speaking:
+            return -1
+        anchor = self.last_interim_ts if self.last_interim_ts > 0 else self.callee_speaking_start_time
+        return time.time() - anchor if anchor > 0 else -1
 
     def get_user_speaking_duration(self) -> float:
         """Returns how long user has been speaking in seconds."""

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4621,6 +4621,9 @@ class TaskManager(BaseManager):
                         and message["data"].get("type", "") == "interim_transcript_received"
                     ):
                         self.time_since_last_spoken_human_word = time.time()
+                        # Before every early exit below: an interim is proof the caller is still
+                        # talking, so it must refresh liveness even when this turn ignores it.
+                        self.interruption_manager.note_user_liveness()
                         if temp_transcriber_message == message["data"].get("content"):
                             logger.info("Received the same transcript as the previous one we have hence continuing")
                             continue

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -41,6 +41,7 @@ from bolna.constants import (
     END_CALL_TOOL_DEFINITION,
     RESPONSES_API_MODEL_PREFIXES,
     STALL_HANGUP_FLOOR_S,
+    STUCK_AUDIO_GATE_RELEASE_S,
     WEB_BASED_CALL_PROVIDER,
     WEBCALL_TTS_SAMPLE_RATE,
 )
@@ -6759,6 +6760,16 @@ class TaskManager(BaseManager):
                         break  # Exit inner loop, skip to next message
 
                     elif status == "WAIT":
+                        # Nothing clears callee_speaking if the turn's transcriber was retired
+                        # mid-turn or never finalized, and the frame would be held for the call.
+                        staleness = self.interruption_manager.user_speech_staleness_s()
+                        if staleness > STUCK_AUDIO_GATE_RELEASE_S:
+                            logger.warning(
+                                f"Releasing stuck audio gate: callee_speaking held {staleness:.1f}s "
+                                f"with no interim (sequence_id={sequence_id})"
+                            )
+                            self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
+                            continue
                         # Grace period active - hold and retry
                         await asyncio.sleep(0.05)
                         # Continue inner loop to re-check status

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -48,6 +48,10 @@ LANGUAGE_SWITCH_MIN_SEGMENT_AUDIO_S = 0.7
 # treated as stale — the detector hears the same audio and has produced nothing that long.
 LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
+# Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a
+# healthy turn within utterance_end_ms (1s floor), so a real speaker stays well inside this.
+STUCK_AUDIO_GATE_RELEASE_S = 3.0
+
 # Soniox real-time STT
 SONIOX_WEBSOCKET_HOST = "stt-rt.soniox.com"
 SONIOX_ENDPOINT_TOKEN = "<end>"  # sentinel token emitted when the speaker stops

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.180"
+version = "0.10.181"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
`InterruptionManager.callee_speaking` is only ever cleared by the transcriber that owns the open turn. Anything that retires that transcriber mid-turn, or stops it from finalizing, strands the flag: `get_audio_send_status()` then returns WAIT for every subsequent frame, and the WAIT branch has no ceiling. The only escape today is the `agent_hangup` exemption.

The caller hears nothing from that point. The agent's replies are still synthesized and still appended to history, so they show up in the transcript while being absent from the recording, and the call dies on `inactivity_timeout`.

Two ways in, both seen in prod:

1. A mid-turn LID switch. `TranscriberPool.switch()` flips `active_label`, so the outgoing connection stops receiving audio and never delivers the final or `UtteranceEnd` it owed.
2. Interims arrive but no SpeechFinal follows, the case the existing comment above the gate already names. `monitor_utterance_timeout` is supposed to force-finalize these, but a bare `SpeechStarted` clears `current_turn_interim_details`, which drops its guard to false, so it does not always fire.

Release the flag from the WAIT branch once the caller has produced no interim for `STUCK_AUDIO_GATE_RELEASE_S`. Interim cadence rather than wall clock is what makes this safe: a caller who is genuinely still talking keeps producing interims, and Deepgram closes a healthy turn within `utterance_end_ms` (1s floor), so 3s leaves roughly 3x headroom. A wall-clock ceiling would have cut off long real utterances.

`callee_speaking` is set only from interim transcripts, never from the VAD `speech_started` event, so the liveness anchor has to be refreshed by every interim. Three paths return early from the interim branch before the old stamp point (repeated content, pre-welcome, and sub-threshold interims that are deliberately ignored). Each is still proof the caller is talking, so `note_user_liveness()` is called up front, before any of them. Without that a caller producing only ignored interims while a response was queued could have been released mid-utterance.

Same release `_enter_hangup_state()` already performs for the goodbye, for the same reason, generalized so it does not depend on which path stranded the flag.

Behaviour left alone: the grace-period WAIT (`callee_speaking` is already False, staleness reports -1), hard BLOCK on an invalidated sequence after a barge-in, which is checked before the speaking gate and so never reaches this branch, the `agent_hangup` exemption, and the LID playback gate. `update_utterance_time=False` keeps the grace window anchored to the last real turn so no extra `incremental_delay` is introduced. A late `speech_ended` arriving afterwards is idempotent. Talk-time accounting gets more accurate, since a stranded flag currently overcounts for the whole stall.

Not addressed here, worth separate changes: `SpeechStarted` wiping the force-finalize watchdog's evidence, and `__run_language_switch` appending the assistant text to history before the audio ships, which is why unheard replies reach the transcript.

Full suite is unchanged at 736 passed with the same 10 pre-existing failures as master.
