### PR TITLE
added the logs for speculative llm decide

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.178"
+__version__ = "0.10.179"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -573,9 +573,6 @@ class TaskManager(BaseManager):
         # Records every language switch — manual tool call (legacy) or LLM-driven
         # (triggered_by="lid_llm") — used post-call for precision / latency analysis.
         self.language_switch_events: list[dict] = []
-        # Request/usage snapshot of the in-flight speculative follow-up; emitted as
-        # normal LLM logs only when the speculation is committed (spoken).
-        self.lid_spec_capture = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
         # when the LLM-driven switch flow is NOT enabled for this call).
         self.switch_handoff_messages = {}
@@ -5326,10 +5323,13 @@ class TaskManager(BaseManager):
             # Discard any unconsumed speculative generation — covers every exit path
             # (stay decisions, gate rejections, timeouts, exceptions) without littering
             # the run with per-return cancels.
-            if spec is not None and not spec.done():
-                spec.cancel()
-                logger.info("LanguageSwitcher: speculative follow-up discarded")
-            self.lid_spec_capture = None
+            if spec is not None:
+                if not spec.done():
+                    spec.cancel()
+                    logger.info("LanguageSwitcher: speculative follow-up discarded")
+                elif not spec.cancelled() and spec.exception() is None:
+                    discarded_text, discarded_capture = spec.result()
+                    self.__log_discarded_speculation(discarded_text, discarded_capture)
 
     async def __lid_idle_watcher(self):
         """Recover the stuck-language deadlock.
@@ -5824,9 +5824,9 @@ class TaskManager(BaseManager):
         # the speculation answers stale content, so fall through to fresh generation
         # (the caller's finally discards the unconsumed task).
         if spec_task is not None and spec_target == target and transcript_corrected:
-            spec_text = ""
+            spec_text, spec_capture = "", None
             try:
-                spec_text = await asyncio.wait_for(spec_task, timeout=6.0)
+                spec_text, spec_capture = await asyncio.wait_for(spec_task, timeout=6.0)
             except asyncio.CancelledError:
                 # Always re-raise: wait_for cancels spec_task BEFORE raising, so a
                 # cancelled spec_task is the signature of THIS handler being cancelled
@@ -5844,7 +5844,7 @@ class TaskManager(BaseManager):
                 return None
             if spec_text:
                 self.conversation_history.append_assistant(spec_text)
-                self.__log_committed_speculation(spec_text)
+                self.__log_committed_speculation(spec_text, spec_capture)
                 synth_meta = {
                     "io": self.tools["output"].get_provider(),
                     "request_id": str(uuid.uuid4()),
@@ -6078,21 +6078,22 @@ class TaskManager(BaseManager):
             note += f" Reason: {reasoning}"
         return note
 
-    def __log_committed_speculation(self, spec_text: str):
-        """Emit the committed speculative follow-up's LLM request/response logs, latency
-        and token usage exactly like a normal turn. Runs only on the commit path —
-        discarded speculations are never logged."""
-        capture = self.lid_spec_capture
-        self.lid_spec_capture = None
+    def __log_committed_speculation(self, spec_text: str, capture):
+        """Log a committed speculative follow-up exactly like a normal turn:
+        request/response rows, latency entry, usage and PTU tally."""
         if not capture:
             return
         # Telemetry only — never let a logging failure break the audible follow-up.
         try:
-            spec_meta = capture["meta_info"]
+            # Real seq for the log rows ("-1" collides in the usage parser); retired
+            # immediately so it never counts as pending. Synth meta keeps -1.
+            log_meta = dict(capture["meta_info"])
+            log_meta["sequence_id"] = self.interruption_manager.get_next_sequence_id()
+            self.interruption_manager.retire_sequence_id(log_meta["sequence_id"])
             model = self.llm_config.get("model") if self.llm_config else None
             convert_to_request_log(
                 message=capture["request_message"],
-                meta_info=spec_meta,
+                meta_info=log_meta,
                 model=model,
                 component=LogComponent.LLM,
                 direction=LogDirection.REQUEST,
@@ -6100,7 +6101,7 @@ class TaskManager(BaseManager):
             )
             convert_to_request_log(
                 message=spec_text,
-                meta_info=spec_meta,
+                meta_info=log_meta,
                 model=model,
                 component=LogComponent.LLM,
                 direction=LogDirection.RESPONSE,
@@ -6110,32 +6111,74 @@ class TaskManager(BaseManager):
                 reasoning_tokens=capture["reasoning_tokens"],
                 cached_tokens=capture["cached_tokens"],
             )
+            if self.task_id == 0 and self.on_turn_usage and capture["input_tokens"]:
+                usage_task = asyncio.create_task(
+                    self.on_turn_usage(capture["input_tokens"], capture["output_tokens"], capture["cached_tokens"])
+                )
+                self._usage_tasks.add(usage_task)
+                usage_task.add_done_callback(self._usage_tasks.discard)
             if capture["latency"]:
                 latency_dict = capture["latency"].model_dump()
                 self._stamp_llm_latency_dict(
                     latency_dict,
-                    spec_meta,
+                    log_meta,
                     capture["input_tokens"],
                     capture["output_tokens"],
                     capture["reasoning_tokens"],
                     capture["cached_tokens"],
                     response_text=spec_text,
                 )
+                latency_dict["sequence_id"] = log_meta["sequence_id"]
+                latency_dict["origin"] = capture["meta_info"].get("origin")
                 self.llm_latencies.turn_latencies.append(latency_dict)
         except Exception as e:
             logger.error(f"LanguageSwitcher: failed to log committed speculation: {e!r}")
 
+    def __log_discarded_speculation(self, spec_text: str, capture):
+        """Record a discarded-but-completed speculation's spend under
+        LLM_LANGUAGE_SWITCH — visible in the trace, never billed."""
+        if not capture:
+            return
+        try:
+            model = self.llm_config.get("model") if self.llm_config else None
+            convert_to_request_log(
+                message=capture["request_message"],
+                meta_info=capture["meta_info"],
+                model=model,
+                component=LogComponent.LLM_LANGUAGE_SWITCH,
+                direction=LogDirection.REQUEST,
+                run_id=self.run_id,
+            )
+            convert_to_request_log(
+                message=spec_text,
+                meta_info=capture["meta_info"],
+                model=model,
+                component=LogComponent.LLM_LANGUAGE_SWITCH,
+                direction=LogDirection.RESPONSE,
+                run_id=self.run_id,
+                input_tokens=capture["input_tokens"],
+                output_tokens=capture["output_tokens"],
+                reasoning_tokens=capture["reasoning_tokens"],
+                cached_tokens=capture["cached_tokens"],
+            )
+            logger.info("LanguageSwitcher: discarded speculation spend logged under language_switch")
+        except Exception as e:
+            logger.error(f"LanguageSwitcher: failed to log discarded speculation: {e!r}")
+
     async def __speculative_followup_text(
         self, target_label: str, detector_transcript: str, active_transcript: str = "", idle_user_text: str = ""
-    ) -> str:
+    ) -> tuple[str, dict | None]:
         """Generate the post-switch reply text speculatively, BEFORE the decide confirms.
 
         Runs the agent's MAIN conversational LLM over a COPY of history with the target
         language's system prompt and the unbiased transcript as the user turn —
         synthesis off, so nothing is heard unless the decision confirms and the caller
         commits this text. Real history is never touched here. Tool calls can't be
-        speculated (side effects), so a function-call chunk aborts and returns "" —
+        speculated (side effects), so a function-call chunk aborts and returns ("", None) —
         the caller then falls back to the normal post-switch generation.
+
+        Returns (text, capture) — the request/usage snapshot rides the task's return
+        value so overlapping switch handlers can't clear each other's capture.
         """
         messages = self.conversation_history.get_copy()
         target_prompt = self.multilingual_prompts.get(target_label)
@@ -6171,7 +6214,7 @@ class TaskManager(BaseManager):
                 continue
             if getattr(llm_message, "is_function_call", False):
                 logger.info("LanguageSwitcher: speculative follow-up wants a tool call — aborting speculation")
-                return ""
+                return "", None
             if getattr(llm_message, "input_tokens", None) is not None:
                 input_tokens = llm_message.input_tokens
             if getattr(llm_message, "output_tokens", None) is not None:
@@ -6187,19 +6230,18 @@ class TaskManager(BaseManager):
             if llm_message.end_of_stream:
                 break
         text = text.strip()
-        if text:
-            # Request/usage snapshot for the commit path — logged like a normal turn
-            # ONLY if this speculation is actually spoken; discards stay unlogged.
-            self.lid_spec_capture = {
-                "meta_info": spec_meta,
-                "request_message": format_messages(messages, use_system_prompt=True, include_tools=True),
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "reasoning_tokens": reasoning_tokens,
-                "cached_tokens": cached_tokens,
-                "latency": latency_info,
-            }
-        return text
+        if not text:
+            return "", None
+        capture = {
+            "meta_info": spec_meta,
+            "request_message": format_messages(messages, use_system_prompt=True, include_tools=True),
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "reasoning_tokens": reasoning_tokens,
+            "cached_tokens": cached_tokens,
+            "latency": latency_info,
+        }
+        return text, capture
 
     async def __generate_switch_followup(self, messages, followup_meta_info, next_step):
         """Generate the post-switch follow-up response (runs outside language_switch_lock).

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -573,6 +573,9 @@ class TaskManager(BaseManager):
         # Records every language switch — manual tool call (legacy) or LLM-driven
         # (triggered_by="lid_llm") — used post-call for precision / latency analysis.
         self.language_switch_events: list[dict] = []
+        # Request/usage snapshot of the in-flight speculative follow-up; emitted as
+        # normal LLM logs only when the speculation is committed (spoken).
+        self.lid_spec_capture = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
         # when the LLM-driven switch flow is NOT enabled for this call).
         self.switch_handoff_messages = {}
@@ -5326,6 +5329,7 @@ class TaskManager(BaseManager):
             if spec is not None and not spec.done():
                 spec.cancel()
                 logger.info("LanguageSwitcher: speculative follow-up discarded")
+            self.lid_spec_capture = None
 
     async def __lid_idle_watcher(self):
         """Recover the stuck-language deadlock.
@@ -5840,6 +5844,7 @@ class TaskManager(BaseManager):
                 return None
             if spec_text:
                 self.conversation_history.append_assistant(spec_text)
+                self.__log_committed_speculation(spec_text)
                 synth_meta = {
                     "io": self.tools["output"].get_provider(),
                     "request_id": str(uuid.uuid4()),
@@ -6073,6 +6078,53 @@ class TaskManager(BaseManager):
             note += f" Reason: {reasoning}"
         return note
 
+    def __log_committed_speculation(self, spec_text: str):
+        """Emit the committed speculative follow-up's LLM request/response logs, latency
+        and token usage exactly like a normal turn. Runs only on the commit path —
+        discarded speculations are never logged."""
+        capture = self.lid_spec_capture
+        self.lid_spec_capture = None
+        if not capture:
+            return
+        # Telemetry only — never let a logging failure break the audible follow-up.
+        try:
+            spec_meta = capture["meta_info"]
+            model = self.llm_config.get("model") if self.llm_config else None
+            convert_to_request_log(
+                message=capture["request_message"],
+                meta_info=spec_meta,
+                model=model,
+                component=LogComponent.LLM,
+                direction=LogDirection.REQUEST,
+                run_id=self.run_id,
+            )
+            convert_to_request_log(
+                message=spec_text,
+                meta_info=spec_meta,
+                model=model,
+                component=LogComponent.LLM,
+                direction=LogDirection.RESPONSE,
+                run_id=self.run_id,
+                input_tokens=capture["input_tokens"],
+                output_tokens=capture["output_tokens"],
+                reasoning_tokens=capture["reasoning_tokens"],
+                cached_tokens=capture["cached_tokens"],
+            )
+            if capture["latency"]:
+                latency_dict = capture["latency"].model_dump()
+                self._stamp_llm_latency_dict(
+                    latency_dict,
+                    spec_meta,
+                    capture["input_tokens"],
+                    capture["output_tokens"],
+                    capture["reasoning_tokens"],
+                    capture["cached_tokens"],
+                    response_text=spec_text,
+                )
+                self.llm_latencies.turn_latencies.append(latency_dict)
+        except Exception as e:
+            logger.error(f"LanguageSwitcher: failed to log committed speculation: {e!r}")
+
     async def __speculative_followup_text(
         self, target_label: str, detector_transcript: str, active_transcript: str = "", idle_user_text: str = ""
     ) -> str:
@@ -6108,8 +6160,11 @@ class TaskManager(BaseManager):
             "sequence_id": -1,
             "turn_id": None,
             "origin": "language_switch_speculation",
+            "llm_start_time": time.time(),
         }
         text = ""
+        input_tokens = output_tokens = reasoning_tokens = cached_tokens = None
+        latency_info = None
         async for llm_message in self.tools["llm_agent"].generate(messages, synthesize=False, meta_info=spec_meta):
             if isinstance(llm_message, dict):
                 # pre-call request logs / routing info — irrelevant to speculation
@@ -6117,11 +6172,34 @@ class TaskManager(BaseManager):
             if getattr(llm_message, "is_function_call", False):
                 logger.info("LanguageSwitcher: speculative follow-up wants a tool call — aborting speculation")
                 return ""
+            if getattr(llm_message, "input_tokens", None) is not None:
+                input_tokens = llm_message.input_tokens
+            if getattr(llm_message, "output_tokens", None) is not None:
+                output_tokens = llm_message.output_tokens
+            if getattr(llm_message, "reasoning_tokens", None) is not None:
+                reasoning_tokens = llm_message.reasoning_tokens
+            if getattr(llm_message, "cached_tokens", None) is not None:
+                cached_tokens = llm_message.cached_tokens
+            if getattr(llm_message, "latency", None):
+                latency_info = llm_message.latency
             if llm_message.data:
                 text += " " + llm_message.data
             if llm_message.end_of_stream:
                 break
-        return text.strip()
+        text = text.strip()
+        if text:
+            # Request/usage snapshot for the commit path — logged like a normal turn
+            # ONLY if this speculation is actually spoken; discards stay unlogged.
+            self.lid_spec_capture = {
+                "meta_info": spec_meta,
+                "request_message": format_messages(messages, use_system_prompt=True, include_tools=True),
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "reasoning_tokens": reasoning_tokens,
+                "cached_tokens": cached_tokens,
+                "latency": latency_info,
+            }
+        return text
 
     async def __generate_switch_followup(self, messages, followup_meta_info, next_step):
         """Generate the post-switch follow-up response (runs outside language_switch_lock).

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -832,7 +832,12 @@ def convert_to_request_log(
                 log["graph_routing_metadata"] = graph_routing_metadata
             else:
                 log["graph_routing_metadata"] = meta_info.get("llm_metadata", {})
-        case LogComponent.LLM_HANGUP | LogComponent.LLM_VOICEMAIL | LogComponent.LLM_LANGUAGE_DETECTION:
+        case (
+            LogComponent.LLM_HANGUP
+            | LogComponent.LLM_VOICEMAIL
+            | LogComponent.LLM_LANGUAGE_DETECTION
+            | LogComponent.LLM_LANGUAGE_SWITCH
+        ):
             log["latency"] = meta_info.get("llm_latency", None) if direction == LogDirection.RESPONSE else None
             if direction == LogDirection.RESPONSE:
                 log["input_tokens"] = input_tokens or 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.178"
+version = "0.10.179"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_speculation_commit_logging.py
+++ b/tests/tests/test_speculation_commit_logging.py
@@ -1,0 +1,153 @@
+"""Tests for committed-speculation LLM logging.
+
+A committed speculative follow-up is a real main-LLM call whose reply the caller hears,
+so it must appear in the execution logs exactly like a normal turn: an LLM request row,
+an LLM response row carrying api-reported token usage, and a turn-latency entry.
+Discarded speculations must log nothing — their capture is dropped.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+
+
+def _msg(data="", end=False, fc=False, **extra):
+    return types.SimpleNamespace(data=data, end_of_stream=end, is_function_call=fc, **extra)
+
+
+def _make_tm(history, generate):
+    tm = MagicMock()
+    tm.conversation_history = history
+    tm.multilingual_prompts = {"en": "You are a helpful agent.", "te": "Telugu prompt"}
+    tm._TaskManager__switch_context_note = TaskManager._TaskManager__switch_context_note.__get__(tm, TaskManager)
+    tm.tools = {"llm_agent": MagicMock()}
+    tm.tools["llm_agent"].generate = generate
+    tm.lid_spec_capture = None
+    return tm
+
+
+def _spec(tm):
+    return TaskManager._TaskManager__speculative_followup_text.__get__(tm, TaskManager)
+
+
+def _log_commit(tm):
+    return TaskManager._TaskManager__log_committed_speculation.__get__(tm, TaskManager)
+
+
+def _usage_generate(input_tokens=120, output_tokens=30, cached_tokens=100, latency=None):
+    async def generate(messages, synthesize=False, meta_info=None):
+        yield _msg(data="telugu reply", end=False)
+        yield _msg(
+            data="",
+            end=True,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            reasoning_tokens=None,
+            cached_tokens=cached_tokens,
+            latency=latency,
+        )
+
+    return generate
+
+
+@pytest.mark.asyncio
+async def test_completed_speculation_captures_request_and_usage():
+    h = ConversationHistory(initial_history=[{"role": "system", "content": "base"}])
+    h.append_user("తెలుగులో మాట్లాడదామా?")
+    tm = _make_tm(h, _usage_generate())
+
+    text = await _spec(tm)("te", "తెలుగులో మాట్లాడదామా?", "", "తెలుగులో మాట్లాడదామా?")
+
+    assert text == "telugu reply"
+    capture = tm.lid_spec_capture
+    assert capture is not None
+    assert capture["input_tokens"] == 120
+    assert capture["output_tokens"] == 30
+    assert capture["cached_tokens"] == 100
+    assert capture["meta_info"]["origin"] == "language_switch_speculation"
+    assert capture["meta_info"]["llm_start_time"] is not None
+    assert "తెలుగులో మాట్లాడదామా?" in capture["request_message"]
+
+
+@pytest.mark.asyncio
+async def test_function_call_abort_leaves_no_capture():
+    async def generate(messages, synthesize=False, meta_info=None):
+        yield _msg(data="", fc=True)
+
+    h = ConversationHistory(initial_history=[{"role": "system", "content": "base"}])
+    tm = _make_tm(h, generate)
+
+    text = await _spec(tm)("te", "detector text")
+
+    assert text == ""
+    assert tm.lid_spec_capture is None
+
+
+def test_commit_emits_request_and_response_rows_with_usage():
+    tm = MagicMock()
+    tm.run_id = "run-1"
+    tm.llm_config = {"model": "gpt-4.1-mini"}
+    tm.lid_spec_capture = {
+        "meta_info": {"request_id": "req-1", "sequence_id": -1, "turn_id": None, "llm_start_time": 123.0},
+        "request_message": "formatted request",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": None,
+        "cached_tokens": 100,
+        "latency": None,
+    }
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
+        _log_commit(tm)("telugu reply")
+
+    assert log_mock.call_count == 2
+    request_call, response_call = log_mock.call_args_list
+    assert request_call.kwargs["direction"].value == "request"
+    assert request_call.kwargs["message"] == "formatted request"
+    assert request_call.kwargs["model"] == "gpt-4.1-mini"
+    assert response_call.kwargs["direction"].value == "response"
+    assert response_call.kwargs["message"] == "telugu reply"
+    assert response_call.kwargs["input_tokens"] == 120
+    assert response_call.kwargs["output_tokens"] == 30
+    assert response_call.kwargs["cached_tokens"] == 100
+    # Capture consumed — a later switch can never re-log it.
+    assert tm.lid_spec_capture is None
+
+
+def test_commit_appends_latency_entry_when_present():
+    latency = MagicMock()
+    latency.model_dump.return_value = {"sequence_id": -1, "first_token_latency_ms": 90.0}
+    tm = MagicMock()
+    tm.run_id = "run-1"
+    tm.llm_config = {"model": "gpt-4.1-mini"}
+    tm.llm_latencies.turn_latencies = []
+    tm.lid_spec_capture = {
+        "meta_info": {"request_id": "req-1", "sequence_id": -1, "turn_id": None, "llm_start_time": 123.0},
+        "request_message": "formatted request",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": None,
+        "cached_tokens": 100,
+        "latency": latency,
+    }
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+        _log_commit(tm)("telugu reply")
+
+    tm._stamp_llm_latency_dict.assert_called_once()
+    assert len(tm.llm_latencies.turn_latencies) == 1
+    assert tm.llm_latencies.turn_latencies[0]["first_token_latency_ms"] == 90.0
+
+
+def test_commit_without_capture_is_noop():
+    tm = MagicMock()
+    tm.lid_spec_capture = None
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
+        _log_commit(tm)("anything")
+
+    log_mock.assert_not_called()

--- a/tests/tests/test_speculation_commit_logging.py
+++ b/tests/tests/test_speculation_commit_logging.py
@@ -1,9 +1,9 @@
-"""Tests for committed-speculation LLM logging.
+"""Tests for committed/discarded speculative follow-up LLM logging.
 
-A committed speculative follow-up is a real main-LLM call whose reply the caller hears,
-so it must appear in the execution logs exactly like a normal turn: an LLM request row,
-an LLM response row carrying api-reported token usage, and a turn-latency entry.
-Discarded speculations must log nothing — their capture is dropped.
+Committed speculation logs like a normal turn (request/response rows with tokens under
+a real sequence id, latency entry with origin, on_turn_usage tally); the capture rides
+the spec task's return value so overlapping handlers can't clear it. Discarded-but-
+completed speculations log their spend under LLM_LANGUAGE_SWITCH (visible, never billed).
 """
 
 import types
@@ -26,7 +26,6 @@ def _make_tm(history, generate):
     tm._TaskManager__switch_context_note = TaskManager._TaskManager__switch_context_note.__get__(tm, TaskManager)
     tm.tools = {"llm_agent": MagicMock()}
     tm.tools["llm_agent"].generate = generate
-    tm.lid_spec_capture = None
     return tm
 
 
@@ -36,6 +35,40 @@ def _spec(tm):
 
 def _log_commit(tm):
     return TaskManager._TaskManager__log_committed_speculation.__get__(tm, TaskManager)
+
+
+def _log_discard(tm):
+    return TaskManager._TaskManager__log_discarded_speculation.__get__(tm, TaskManager)
+
+
+def _capture(**overrides):
+    base = {
+        "meta_info": {
+            "request_id": "req-1",
+            "sequence_id": -1,
+            "turn_id": None,
+            "origin": "language_switch_speculation",
+            "llm_start_time": 123.0,
+        },
+        "request_message": "formatted request",
+        "input_tokens": 120,
+        "output_tokens": 30,
+        "reasoning_tokens": None,
+        "cached_tokens": 100,
+        "latency": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def _commit_tm():
+    tm = MagicMock()
+    tm.run_id = "run-1"
+    tm.task_id = 0
+    tm.llm_config = {"model": "gpt-4.1-mini"}
+    tm.interruption_manager.get_next_sequence_id.return_value = 4
+    tm._usage_tasks = set()
+    return tm
 
 
 def _usage_generate(input_tokens=120, output_tokens=30, cached_tokens=100, latency=None):
@@ -55,15 +88,14 @@ def _usage_generate(input_tokens=120, output_tokens=30, cached_tokens=100, laten
 
 
 @pytest.mark.asyncio
-async def test_completed_speculation_captures_request_and_usage():
+async def test_completed_speculation_returns_text_and_capture():
     h = ConversationHistory(initial_history=[{"role": "system", "content": "base"}])
     h.append_user("తెలుగులో మాట్లాడదామా?")
     tm = _make_tm(h, _usage_generate())
 
-    text = await _spec(tm)("te", "తెలుగులో మాట్లాడదామా?", "", "తెలుగులో మాట్లాడదామా?")
+    text, capture = await _spec(tm)("te", "తెలుగులో మాట్లాడదామా?", "", "తెలుగులో మాట్లాడదామా?")
 
     assert text == "telugu reply"
-    capture = tm.lid_spec_capture
     assert capture is not None
     assert capture["input_tokens"] == 120
     assert capture["output_tokens"] == 30
@@ -74,80 +106,105 @@ async def test_completed_speculation_captures_request_and_usage():
 
 
 @pytest.mark.asyncio
-async def test_function_call_abort_leaves_no_capture():
+async def test_function_call_abort_returns_no_capture():
     async def generate(messages, synthesize=False, meta_info=None):
         yield _msg(data="", fc=True)
 
     h = ConversationHistory(initial_history=[{"role": "system", "content": "base"}])
     tm = _make_tm(h, generate)
 
-    text = await _spec(tm)("te", "detector text")
+    text, capture = await _spec(tm)("te", "detector text")
 
     assert text == ""
-    assert tm.lid_spec_capture is None
+    assert capture is None
 
 
-def test_commit_emits_request_and_response_rows_with_usage():
-    tm = MagicMock()
-    tm.run_id = "run-1"
-    tm.llm_config = {"model": "gpt-4.1-mini"}
-    tm.lid_spec_capture = {
-        "meta_info": {"request_id": "req-1", "sequence_id": -1, "turn_id": None, "llm_start_time": 123.0},
-        "request_message": "formatted request",
-        "input_tokens": 120,
-        "output_tokens": 30,
-        "reasoning_tokens": None,
-        "cached_tokens": 100,
-        "latency": None,
-    }
+def test_commit_emits_rows_with_real_sequence_id_and_usage():
+    tm = _commit_tm()
 
     with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
-        _log_commit(tm)("telugu reply")
+        _log_commit(tm)("telugu reply", _capture())
 
     assert log_mock.call_count == 2
     request_call, response_call = log_mock.call_args_list
     assert request_call.kwargs["direction"].value == "request"
     assert request_call.kwargs["message"] == "formatted request"
     assert request_call.kwargs["model"] == "gpt-4.1-mini"
+    # Log rows carry the minted REAL sequence id, retired immediately so it never
+    # counts as pending; the synth meta elsewhere keeps -1.
+    assert request_call.kwargs["meta_info"]["sequence_id"] == 4
+    tm.interruption_manager.retire_sequence_id.assert_called_once_with(4)
     assert response_call.kwargs["direction"].value == "response"
     assert response_call.kwargs["message"] == "telugu reply"
+    assert response_call.kwargs["meta_info"]["sequence_id"] == 4
     assert response_call.kwargs["input_tokens"] == 120
     assert response_call.kwargs["output_tokens"] == 30
     assert response_call.kwargs["cached_tokens"] == 100
-    # Capture consumed — a later switch can never re-log it.
-    assert tm.lid_spec_capture is None
 
 
-def test_commit_appends_latency_entry_when_present():
-    latency = MagicMock()
-    latency.model_dump.return_value = {"sequence_id": -1, "first_token_latency_ms": 90.0}
-    tm = MagicMock()
-    tm.run_id = "run-1"
-    tm.llm_config = {"model": "gpt-4.1-mini"}
-    tm.llm_latencies.turn_latencies = []
-    tm.lid_spec_capture = {
-        "meta_info": {"request_id": "req-1", "sequence_id": -1, "turn_id": None, "llm_start_time": 123.0},
-        "request_message": "formatted request",
-        "input_tokens": 120,
-        "output_tokens": 30,
-        "reasoning_tokens": None,
-        "cached_tokens": 100,
-        "latency": latency,
-    }
+@pytest.mark.asyncio
+async def test_commit_reports_on_turn_usage():
+    tm = _commit_tm()
+    reported = []
+
+    async def on_turn_usage(input_tokens, output_tokens, cached_tokens):
+        reported.append((input_tokens, output_tokens, cached_tokens))
+
+    tm.on_turn_usage = on_turn_usage
 
     with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
-        _log_commit(tm)("telugu reply")
+        _log_commit(tm)("telugu reply", _capture())
+        for task in list(tm._usage_tasks):
+            await task
+
+    assert reported == [(120, 30, 100)]
+
+
+def test_commit_latency_entry_gets_real_seq_and_origin():
+    latency = MagicMock()
+    latency.model_dump.return_value = {"sequence_id": -1, "first_token_latency_ms": 90.0}
+    tm = _commit_tm()
+    tm.on_turn_usage = None
+    tm.llm_latencies.turn_latencies = []
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+        _log_commit(tm)("telugu reply", _capture(latency=latency))
 
     tm._stamp_llm_latency_dict.assert_called_once()
     assert len(tm.llm_latencies.turn_latencies) == 1
-    assert tm.llm_latencies.turn_latencies[0]["first_token_latency_ms"] == 90.0
+    entry = tm.llm_latencies.turn_latencies[0]
+    assert entry["sequence_id"] == 4
+    assert entry["origin"] == "language_switch_speculation"
 
 
 def test_commit_without_capture_is_noop():
-    tm = MagicMock()
-    tm.lid_spec_capture = None
+    tm = _commit_tm()
 
     with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
-        _log_commit(tm)("anything")
+        _log_commit(tm)("anything", None)
+
+    log_mock.assert_not_called()
+
+
+def test_discard_logs_under_language_switch_component():
+    tm = _commit_tm()
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
+        _log_discard(tm)("unheard reply", _capture())
+
+    assert log_mock.call_count == 2
+    request_call, response_call = log_mock.call_args_list
+    assert request_call.kwargs["component"].value == "llm_language_switch"
+    assert response_call.kwargs["component"].value == "llm_language_switch"
+    assert response_call.kwargs["message"] == "unheard reply"
+    assert response_call.kwargs["input_tokens"] == 120
+    assert response_call.kwargs["output_tokens"] == 30
+
+
+def test_discard_without_capture_is_noop():
+    tm = _commit_tm()
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log") as log_mock:
+        _log_discard(tm)("", None)
 
     log_mock.assert_not_called()

--- a/tests/tests/test_speculative_followup_history.py
+++ b/tests/tests/test_speculative_followup_history.py
@@ -55,11 +55,12 @@ async def test_replaces_garbled_trailing_user_turn():
     h.append_assistant("Hello, how can I help?")
     h.append_user("Kana Rohit Prakaran")  # garbled wrong-language ASR of the Tamil turn
 
-    text = await _spec(_make_tm(h, _capturing_generate(captured)))(
+    text, capture = await _spec(_make_tm(h, _capturing_generate(captured)))(
         "en", "I want to talk in English", "Kana Rohit Prakaran"
     )
 
     assert text == "reply text"
+    assert capture is not None
     msgs = captured["messages"]
     assert captured["synthesize"] is False
     user_turns = [m for m in msgs if m.get("role") == "user"]
@@ -167,5 +168,6 @@ async def test_aborts_and_returns_empty_on_function_call():
     h = ConversationHistory(initial_history=[{"role": "system", "content": "base prompt"}])
     h.append_user("garbled")
 
-    text = await _spec(_make_tm(h, generate))("en", "detector text", "garbled")
+    text, capture = await _spec(_make_tm(h, generate))("en", "detector text", "garbled")
     assert text == ""
+    assert capture is None


### PR DESCRIPTION
PR description
Title: fix(lid): log committed speculative follow-up like a normal LLM turn

Problem
When a language switch commits its speculative follow-up (the reply generated during the judge's decide and spoken directly), that main-LLM call is invisible everywhere: no LLM request/response rows in the execution logs (admin and non-admin dashboards both read the S3 CSV), no turn latency, no token usage, and LLM cost/price shows 0. On a call where the speculation hits and no other turns follow, the execution looks like it never touched the conversation LLM at all.

The fallback path (__generate_switch_followup → __do_llm_generation) logs normally — which is why some switch calls show their post-switch response and others show nothing.

Root cause
__speculative_followup_text() consumes llm_agent.generate() privately: it never calls convert_to_request_log, skips the dict messages carrying request payloads, and drops the token fields from the stream.

Change
Capture-at-generate, emit-at-commit:

__speculative_followup_text() now snapshots the formatted request (format_messages), api-reported token counts (input/output/reasoning/cached), and the latency object into self.lid_spec_capture when generation completes with text. llm_start_time rides the speculation's meta_info so latency stamping works natively.
New __log_committed_speculation(), called only on the commit branch ("speaking speculative follow-up"): emits the LLM REQUEST and RESPONSE rows exactly like a normal turn — the response row carries the tokens, so usage breakdown and pricing follow through the existing channel — and appends a stamped turn-latency entry.
Discarded speculations are intentionally not logged; the capture is cleared in the switch handler's finally and consumed on commit, so it can never leak into a later switch.
The emission is wrapped in try/except: a telemetry failure can never break the audible follow-up.