### PR TITLE
fix: run voicemail detection on transcripts dropped during the welcome message

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.186"
+__version__ = "0.10.187"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4335,6 +4335,9 @@ class TaskManager(BaseManager):
         )
         if not self.tools["input"].welcome_message_played():
             logger.info(f"Welcome message is playing while spoken: {transcriber_message}")
+            # A machine greeting plays out under the welcome audio, so a transcript dropped here is
+            # the only voicemail signal the call produces.
+            self._trigger_voicemail_check(transcriber_message, meta_info, is_final=True)
             self._retire_dropped_response(meta_info, "welcome_still_playing")
             return
 
@@ -4629,6 +4632,7 @@ class TaskManager(BaseManager):
                         if not self.tools["input"].welcome_message_played():
                             if self.discard_pre_welcome_utterance:
                                 self._speech_started_before_welcome = True
+                            self._trigger_voicemail_check(message["data"].get("content", ""), meta_info, is_final=False)
                             continue
 
                         # Post-welcome interim → clear stale flag set by pre-welcome SpeechStarted (welcome-audio bleed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.186"
+version = "0.10.187"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Voicemail detection never ran on calls where the machine greeting played entirely under the agent's welcome message.

Both trigger sites sit behind the `welcome_message_played()` guard: interims hit `continue` in `_listen_transcriber` before reaching the check, and `_handle_transcriber_output` returns at the welcome guard several lines ahead of `_trigger_voicemail_check`. A carrier greeting starts at pickup, so with a 10s welcome message every interim and the final transcript are discarded, and a mailbox produces nothing afterwards to re-trigger on. The call then runs to the inactivity nudge and the stall backstop, billing the full duration and finishing as `call-disconnected` rather than `voicemail_detected`.

Both dropped paths now run the check. The transcript is still discarded for conversation purposes, it just gets classified on the way out, so post-welcome behaviour is unchanged. The interim path keeps its existing interval and length gates, so on the call this came from detection lands on the second interim, a little over two seconds in, against a mailbox that previously ran the full 42s.
