### PR TITLE
fix(sip-trunk): stop HANGUP from clipping a goodbye still being written to Asterisk

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.179"
+__version__ = "0.10.180"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -205,8 +205,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             await asyncio.wait_for(self._queue_drained.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             logger.warning(
-                f"QUEUE_DRAINED not received within {timeout:.1f}s for channel "
-                f"{self.channel_id}; hanging up anyway"
+                f"QUEUE_DRAINED not received within {timeout:.1f}s for channel {self.channel_id}; hanging up anyway"
             )
             return
         await asyncio.sleep(HANGUP_DRAIN_SETTLE_S)

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -7,6 +7,7 @@ Ref: https://docs.asterisk.org/Configuration/Channel-Drivers/WebSocket/
 import asyncio
 import json
 import os
+import time
 import traceback
 from bolna.input_handlers.telephony import TelephonyInputHandler
 from bolna.helpers.utils import create_ws_data_packet
@@ -28,9 +29,15 @@ AUDIO_BATCH_MS = 80
 # time to act on it. Overridable via env.
 HANGUP_SETTLE_S = float(os.environ.get("SIP_HANGUP_SETTLE_S", "0.5"))
 
-# Max wait for Asterisk to confirm (QUEUE_DRAINED) that it has played out everything we
-# sent, before HANGUP cuts the tail off the goodbye. Overridable via env.
+# Grace on top of the unplayed-audio estimate when waiting for Asterisk to confirm
+# (QUEUE_DRAINED) that it has played out everything we sent, before HANGUP cuts the
+# tail off the goodbye. Overridable via env.
 HANGUP_DRAIN_TIMEOUT_S = float(os.environ.get("SIP_HANGUP_DRAIN_TIMEOUT_S", "2.0"))
+
+# Hard ceiling on the whole teardown drain (finish writing + play out). Asterisk's own
+# frame queue caps at ~24s of audio, so anything beyond this is a stuck signal, not a
+# long goodbye. Overridable via env.
+HANGUP_DRAIN_MAX_WAIT_S = float(os.environ.get("SIP_HANGUP_DRAIN_MAX_WAIT_S", "30.0"))
 
 # Extra wait after QUEUE_DRAINED for the far-end jitter buffer. Overridable via env.
 HANGUP_DRAIN_SETTLE_S = float(os.environ.get("SIP_HANGUP_DRAIN_SETTLE_S", "0.5"))
@@ -155,16 +162,33 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         except Exception as e:
             logger.error(f"Error sending HANGUP: {e}")
 
+    def _unplayed_audio_estimate(self) -> float:
+        """Seconds of audio registered but not yet confirmed played, from pending marks."""
+        meta = getattr(self, "mark_event_meta_data", None)
+        if not meta:
+            return 0.0
+        events = meta.mark_event_meta_data
+        return sum(v.get("duration") or 0.0 for v in events.values() if v.get("type") != "pre_mark_message")
+
     async def _await_playback_drained(self):
         """Hold HANGUP until Asterisk reports its frame queue empty.
 
         Audio is handed over faster than real time, so at teardown part of the goodbye is
-        usually still buffered in Asterisk and HANGUP would discard it. Bounded, and a
-        no-op once the queue is already empty.
+        usually still buffered in Asterisk — and, because sends are rate-limited, part of
+        it may not even have been written yet. Wait for the output handler to finish
+        writing, then wait for QUEUE_DRAINED for as long as the pending-mark durations
+        say is left to play. Bounded, and a no-op once the queue is already empty.
         """
         listen_task = self.websocket_listen_task
         if listen_task is None or listen_task.done():
             return  # receive loop is gone (caller hung up first) — nothing can answer
+
+        deadline = time.monotonic() + HANGUP_DRAIN_MAX_WAIT_S
+
+        output = getattr(self, "output_handler_ref", None)
+        if output is not None and hasattr(output, "has_unsent_audio"):
+            while output.has_unsent_audio() and time.monotonic() < deadline:
+                await asyncio.sleep(0.1)
 
         self._queue_drained.clear()
         try:
@@ -173,11 +197,15 @@ class SipTrunkInputHandler(TelephonyInputHandler):
             logger.info(f"REPORT_QUEUE_DRAINED not sent for channel {self.channel_id}: {e}")
             return
 
+        timeout = max(
+            HANGUP_DRAIN_TIMEOUT_S,
+            min(self._unplayed_audio_estimate() + HANGUP_DRAIN_TIMEOUT_S, deadline - time.monotonic()),
+        )
         try:
-            await asyncio.wait_for(self._queue_drained.wait(), timeout=HANGUP_DRAIN_TIMEOUT_S)
+            await asyncio.wait_for(self._queue_drained.wait(), timeout=timeout)
         except asyncio.TimeoutError:
             logger.warning(
-                f"QUEUE_DRAINED not received within {HANGUP_DRAIN_TIMEOUT_S}s for channel "
+                f"QUEUE_DRAINED not received within {timeout:.1f}s for channel "
                 f"{self.channel_id}; hanging up anyway"
             )
             return

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -260,8 +260,13 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
             self._send_in_flight = False
 
     def has_unsent_audio(self) -> bool:
-        """Audio accepted but not yet written to Asterisk (mid-send or XOFF-parked)."""
-        return self._send_in_flight or bool(self._local_audio_queue)
+        """Audio accepted but not yet written to Asterisk (mid-send or XOFF-parked).
+
+        XOFF-parked audio is only counted while the handler is open: close() runs before
+        stop_handler() and drain_local_queue() bails once _closed, so after close that
+        audio can never be sent — waiting on it would stall teardown for the full cap.
+        """
+        return self._send_in_flight or (not self._closed and bool(self._local_audio_queue))
 
     def _register_mark(self, meta_info: dict, is_final: bool, audio_duration: float) -> str:
         """Record per-mark metadata (same contract as Plivo/Twilio) and return the mark id

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -104,6 +104,10 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         # Asterisk buffering state
         self._start_buffering_sent: bool = False
 
+        # True while _send_frames is writing a chunk — sends are rate-limited, so a
+        # large chunk stays in flight for seconds and teardown must not hang up over it.
+        self._send_in_flight: bool = False
+
         # XOFF/XON: local queue when Asterisk signals backpressure
         self._local_audio_queue: deque = deque()
         # Serialize drains so a second MEDIA_XON can't run a drain concurrently with an
@@ -236,20 +240,28 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                          at the front of _local_audio_queue (preserves ordering)
           "stale"      — a FLUSH_MEDIA/interruption bumped the generation; nothing more sent
         """
-        offset = 0
-        while offset < len(chunk):
-            if gen != self._flush_generation:
-                return "stale"
-            if self.queue_full:
-                self._local_audio_queue.appendleft((AUDIO_ENTRY, chunk[offset:]))
-                return "queue_full"
-            end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
-            if self._response_first_send == 0.0:
-                self._response_first_send = time.monotonic()
-            await self.websocket.send_bytes(chunk[offset:end])
-            await self._rate_limit(end - offset)
-            offset = end
-        return "sent"
+        self._send_in_flight = True
+        try:
+            offset = 0
+            while offset < len(chunk):
+                if gen != self._flush_generation:
+                    return "stale"
+                if self.queue_full:
+                    self._local_audio_queue.appendleft((AUDIO_ENTRY, chunk[offset:]))
+                    return "queue_full"
+                end = min(offset + MAX_WS_FRAME_BYTES, len(chunk))
+                if self._response_first_send == 0.0:
+                    self._response_first_send = time.monotonic()
+                await self.websocket.send_bytes(chunk[offset:end])
+                await self._rate_limit(end - offset)
+                offset = end
+            return "sent"
+        finally:
+            self._send_in_flight = False
+
+    def has_unsent_audio(self) -> bool:
+        """Audio accepted but not yet written to Asterisk (mid-send or XOFF-parked)."""
+        return self._send_in_flight or bool(self._local_audio_queue)
 
     def _register_mark(self, meta_info: dict, is_final: bool, audio_duration: float) -> str:
         """Record per-mark metadata (same contract as Plivo/Twilio) and return the mark id
@@ -409,8 +421,8 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
 
     async def handle(self, ws_data_packet):
         """Send audio to Asterisk in bursts; track playback completion by accumulated
-        duration. Pipeline: convert → reset-on-new-sequence → buffer-gate → send (or
-        XOFF-queue) → register mark → schedule finish on the final chunk.
+        duration. Pipeline: convert → reset-on-new-sequence → buffer-gate → register
+        mark → send (or XOFF-queue) → emit mark → schedule finish on the final chunk.
         """
         if self._closed:
             return
@@ -465,6 +477,13 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                 if gen != self._flush_generation:
                     return
 
+            # Register the mark BEFORE sending: the send is rate-limited, so a large
+            # chunk stays in flight for seconds, and the hangup gate reads "no pending
+            # marks" as "everything heard" — registering after the send lets HANGUP
+            # cut off a chunk that is still being written.
+            mark_id = self._register_mark(meta_info, is_final, audio_duration) if self.mark_event_meta_data else None
+
+            if has_audio:
                 # If XOFF is active or a drain is in flight, queue locally to preserve
                 # ordering; otherwise send now (re-queues the remainder on a mid-send XOFF).
                 if self.queue_full or self._local_audio_queue:
@@ -479,10 +498,9 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
                         logger.debug(f"sip-trunk send_bytes stopped: {e}")
                         return
 
-            # Register mark metadata (same contract as Plivo/Twilio) and ask Asterisk to
-            # echo it back once this chunk reaches the front of its playout queue.
-            if self.mark_event_meta_data:
-                mark_id = self._register_mark(meta_info, is_final, audio_duration)
+            # Ask Asterisk to echo the mark back once this chunk reaches the front of
+            # its playout queue (same contract as Plivo/Twilio).
+            if mark_id is not None:
                 if gen == self._flush_generation:
                     await self._emit_mark(mark_id)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.179"
+version = "0.10.180"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_sip_trunk_hangup_drain.py
+++ b/tests/tests/test_sip_trunk_hangup_drain.py
@@ -56,6 +56,7 @@ def fast_timings(monkeypatch):
     monkeypatch.setattr(sip_trunk_input, "HANGUP_DRAIN_TIMEOUT_S", 0.30)
     monkeypatch.setattr(sip_trunk_input, "HANGUP_DRAIN_SETTLE_S", 0.05)
     monkeypatch.setattr(sip_trunk_input, "HANGUP_SETTLE_S", 0.0)
+    monkeypatch.setattr(sip_trunk_input, "HANGUP_DRAIN_MAX_WAIT_S", 3.0)
 
 
 @pytest.mark.asyncio
@@ -146,6 +147,68 @@ async def test_hangup_still_sent_when_teardown_is_cancelled_during_the_drain():
 
     assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
     assert handler.running is False
+
+
+@pytest.mark.asyncio
+async def test_drain_waits_for_output_handler_to_finish_writing():
+    # The output handler paces sends at 1.5x real time, so a long goodbye is often still
+    # being WRITTEN at teardown. Asking Asterisk for QUEUE_DRAINED before the tail is even
+    # sent would hang up over it.
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    class _FakeOutput:
+        unsent = True
+
+        def has_unsent_audio(self):
+            return self.unsent
+
+    output = _FakeOutput()
+    handler.output_handler_ref = output
+
+    async def _finish_sending_then_drain():
+        await asyncio.sleep(0.15)
+        assert ws.sent == []  # REPORT_QUEUE_DRAINED must not go out while still writing
+        output.unsent = False
+        await asyncio.sleep(0.15)
+        await handler._handle_control_message("QUEUE_DRAINED")
+
+    sender = asyncio.create_task(_finish_sending_then_drain())
+    start = asyncio.get_running_loop().time()
+    await handler.stop_handler()
+    elapsed = asyncio.get_running_loop().time() - start
+    await sender
+    listen_task.cancel()
+
+    assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
+    assert elapsed > 0.30  # held through the write (0.15s) and the playout (0.15s)
+
+
+@pytest.mark.asyncio
+async def test_drain_timeout_scales_with_pending_mark_durations():
+    # A flat grace clips any goodbye whose unplayed tail is longer than it; the wait must
+    # cover what the pending marks say is still queued in Asterisk.
+    ws = _FakeWebSocket()
+    listen_task = asyncio.create_task(_live_task())
+    handler = _make_handler(ws, listen_task)
+
+    class _Meta:
+        mark_event_meta_data = {
+            "m1": {"type": "agent_response", "duration": 0.5},
+            "m2": {"type": "agent_response", "duration": 0.3},
+        }
+
+    handler.mark_event_meta_data = _Meta()
+
+    start = asyncio.get_running_loop().time()
+    await asyncio.wait_for(handler.stop_handler(), timeout=5.0)
+    elapsed = asyncio.get_running_loop().time() - start
+    listen_task.cancel()
+
+    assert ws.sent == ["REPORT_QUEUE_DRAINED", "HANGUP"]
+    # 0.8s of unplayed audio + 0.3s grace, not the bare 0.3s grace.
+    assert 1.0 < elapsed < 2.0
 
 
 @pytest.mark.asyncio

--- a/tests/tests/test_sip_trunk_mark_events.py
+++ b/tests/tests/test_sip_trunk_mark_events.py
@@ -151,6 +151,22 @@ async def test_mark_is_registered_before_the_first_frame_is_written():
 
 
 @pytest.mark.asyncio
+async def test_xoff_parked_audio_does_not_count_as_unsent_after_close():
+    # close() runs before stop_handler() and drain_local_queue() bails once closed, so
+    # XOFF-parked audio can never be sent afterwards — teardown must not wait on it.
+    ws = _FakeWebSocket()
+    out = _make_output_handler(ws, _FakeInputHandler(MarkEventMetaData()))
+    out._send_in_flight = False
+    out.queue_full = True
+
+    await out.handle(_audio_packet(b"\xff" * 800))
+    assert out.has_unsent_audio()
+
+    out._closed = True
+    assert not out.has_unsent_audio()
+
+
+@pytest.mark.asyncio
 async def test_mark_is_queued_behind_parked_audio_during_xoff():
     # MARK_MEDIA is a TEXT frame; sending it while audio sits in the local queue would put
     # it ahead of that audio in Asterisk's queue and echo back early.

--- a/tests/tests/test_sip_trunk_mark_events.py
+++ b/tests/tests/test_sip_trunk_mark_events.py
@@ -127,6 +127,30 @@ async def test_mark_media_is_sent_after_the_audio_it_marks():
 
 
 @pytest.mark.asyncio
+async def test_mark_is_registered_before_the_first_frame_is_written():
+    # Sends are rate-limited, so a large chunk stays in flight for seconds. The hangup
+    # gate reads "no pending marks" as "everything heard" — if the mark only appears
+    # after the send, teardown can hang up over a chunk that is still being written.
+    meta = MarkEventMetaData()
+    inp = _FakeInputHandler(meta)
+
+    class _SnoopWS(_FakeWebSocket):
+        marks_at_first_frame = None
+
+        async def send_bytes(self, data):
+            if self.marks_at_first_frame is None:
+                self.marks_at_first_frame = dict(meta.mark_event_meta_data)
+            await super().send_bytes(data)
+
+    ws = _SnoopWS()
+    out = _make_output_handler(ws, inp)
+
+    await out.handle(_audio_packet(b"\xff" * 800))
+
+    assert ws.marks_at_first_frame, "mark must be pending before the first frame is written"
+
+
+@pytest.mark.asyncio
 async def test_mark_is_queued_behind_parked_audio_during_xoff():
     # MARK_MEDIA is a TEXT frame; sending it while audio sits in the local queue would put
     # it ahead of that audio in Asterisk's queue and echo back early.


### PR DESCRIPTION
## Summary

Prod sip-trunk calls (e.g. runs 00bba9c5-a811-47f0-bd52-0cf98ed0015f, 4ea5975b-e484-47ea-919c-e1ba11761cad) hung up mid-goodbye, clipping ~5-6s of audio. Two compounding defects:

- The output handler registered a chunk's mark only after the chunk was fully written, but writes are rate-limited to 1.5x real time. ElevenLabs flushes its remaining buffer at end-of-stream as one large chunk (in the sampled calls, 114 of 210 goodbye chars, ~7.7s of audio), which stays in flight for seconds with no mark anywhere — teardown then ran mid-write and HANGUP/close discarded the tail before its mark was ever created.
- The teardown QUEUE_DRAINED wait was a flat 2s, far shorter than the real Asterisk playout backlog at 1.5x pacing, so the fallback fired ("QUEUE_DRAINED not received within 2.0s; hanging up anyway") and HANGUP discarded whatever was queued.

Changes:

- `handle()` registers the mark before `_send_frames`, so the in-flight chunk exists in the mark ledger. Note this does not delay the hangup gate itself — `wait_for_current_message` still exits on its final-chunk break at the same instant — it makes the unwritten/unplayed tail *measurable* by the teardown drain below.
- `_await_playback_drained()` first waits for the output handler to finish writing (`has_unsent_audio()`: mid-send via `_send_in_flight`, or XOFF-parked audio while the handler is still open — parked audio is ignored after `close()`, since `drain_local_queue()` can never send it then), and only then asks Asterisk for QUEUE_DRAINED, with the wait scaled to the pending marks' durations plus the existing 2s grace, bounded by `SIP_HANGUP_DRAIN_MAX_WAIT_S` (default 30s — Asterisk's own frame queue caps at ~24s of audio).

Replaying the sampled call against the fix: teardown at 25.25s holds through the remaining ~2.3s of writing, QUEUE_DRAINED lands ~5.4s into a 9.7s window, HANGUP goes out at ~33.5s — 0s clipped (previously HANGUP at 27.26s, ~5.7s clipped).

Known limit (follow-up, pre-existing): the `__check_for_completion` watchdog force-sends HANGUP at `hangup_triggered_at + hangup_mark_event_timeout` (10s) if end-of-conversation hasn't been entered yet; both sampled calls cleared it with under 1.3s of margin, so goodbyes with ~2s more leading audio can still be clipped by that path.

Tests: 4 new regression tests (mark pending before the first frame is written; drain holds REPORT_QUEUE_DRAINED until writing finishes; drain timeout scales with pending mark durations; XOFF-parked audio not counted after close). All 25 sip-trunk/goodbye-gate tests pass; the 9 failures elsewhere in tests/tests are pre-existing on master.