### PR TITLE
feat: support eleven v3 conversational over the text-to-dialogue websocket

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.189"
+__version__ = "0.10.190"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -50,7 +50,8 @@ from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, 
 def elevenlabs_synthesizer(**kwargs):
     """Eleven v3 is served only from the text-to-dialogue socket; multi-stream-input 403s
     on those model ids. Everything else stays on the original synthesizer."""
-    cls = ElevenlabsV3Synthesizer if kwargs.get("model", "").startswith("eleven_v3") else ElevenlabsSynthesizer
+    # `or ""` rather than a get() default: a stored config can carry an explicit null model.
+    cls = ElevenlabsV3Synthesizer if (kwargs.get("model") or "").startswith("eleven_v3") else ElevenlabsSynthesizer
     return cls(**kwargs)
 
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -1,6 +1,7 @@
 from .synthesizer import (
     PollySynthesizer,
     ElevenlabsSynthesizer,
+    ElevenlabsV3Synthesizer,
     OPENAISynthesizer,
     DeepgramSynthesizer,
     AzureSynthesizer,
@@ -45,9 +46,17 @@ from .output_handlers import (
 from .llms import OpenAiLLM, LiteLLM, AzureLLM, GeminiLLM
 from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider
 
+
+def elevenlabs_synthesizer(**kwargs):
+    """Eleven v3 is served only from the text-to-dialogue socket; multi-stream-input 403s
+    on those model ids. Everything else stays on the original synthesizer."""
+    cls = ElevenlabsV3Synthesizer if kwargs.get("model", "").startswith("eleven_v3") else ElevenlabsSynthesizer
+    return cls(**kwargs)
+
+
 SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.POLLY.value: PollySynthesizer,
-    SynthesizerProvider.ELEVENLABS.value: ElevenlabsSynthesizer,
+    SynthesizerProvider.ELEVENLABS.value: elevenlabs_synthesizer,
     SynthesizerProvider.OPENAI.value: OPENAISynthesizer,
     SynthesizerProvider.DEEPGRAM.value: DeepgramSynthesizer,
     SynthesizerProvider.AZURETTS.value: AzureSynthesizer,

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -1,7 +1,7 @@
 from .base_synthesizer import BaseSynthesizer
 from .stream_synthesizer import StreamSynthesizer
 from .polly_synthesizer import PollySynthesizer
-from .elevenlabs_synthesizer import ElevenlabsSynthesizer
+from .elevenlabs_synthesizer import ElevenlabsSynthesizer, ElevenlabsV3Synthesizer
 from .openai_synthesizer import OPENAISynthesizer
 from .deepgram_synthesizer import DeepgramSynthesizer
 from .azure_synthesizer import AzureSynthesizer

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -442,6 +442,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         self._new_turn_pending = True
         self._connect_lock = asyncio.Lock()
         self._keep_alive_task = None
+        self._reconnect_task = None
         self._last_send_time = time.perf_counter()
 
     def get_sleep_time(self):
@@ -562,7 +563,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             self._new_turn_pending = True
             if self._is_ws_connected():
                 await self.websocket.close()
-            asyncio.create_task(self._ensure_connection())
+            # Held on the instance: a bare create_task can be garbage collected mid-flight,
+            # which would drop the redial and leave the next turn waiting on monitor_connection.
+            self._reconnect_task = asyncio.create_task(self._ensure_connection())
         except Exception as e:
             logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
 
@@ -600,6 +603,14 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                             self._new_turn_pending = False
                         await self.websocket.send(json.dumps({"inputs": [payload]}))
                         self._last_send_time = time.perf_counter()
+                    except websockets.exceptions.ConnectionClosed:
+                        # Expected, not a failure: barge-in closes the socket mid-turn because
+                        # this endpoint has no cancel. Treating it as a connection error would
+                        # surface as SynthesizerError and hang the call up on every interruption.
+                        # The reconnect is already in flight, so just abandon this turn.
+                        logger.info("ElevenLabs v3 socket closed mid-send, abandoning turn")
+                        self._new_turn_pending = True
+                        return
                     except Exception as e:
                         logger.info(f"Error sending chunk: {e}")
                         self.connection_error = str(e)
@@ -613,6 +624,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                     # the whole session, not the turn.
                     await self.websocket.send(json.dumps({"flush": True}))
                     self._last_send_time = time.perf_counter()
+                    self._new_turn_pending = True
+                except websockets.exceptions.ConnectionClosed:
+                    logger.info("ElevenLabs v3 socket closed before flush, abandoning turn")
                     self._new_turn_pending = True
                 except Exception as e:
                     logger.info(f"Error sending end-of-stream signal: {e}")
@@ -708,7 +722,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 await asyncio.sleep(0.1)
 
     async def cleanup(self):
-        if self._keep_alive_task:
-            self._keep_alive_task.cancel()
-            self._keep_alive_task = None
+        for task in (self._keep_alive_task, self._reconnect_task):
+            if task:
+                task.cancel()
+        self._keep_alive_task = None
+        self._reconnect_task = None
         await super().cleanup()

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -422,7 +422,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
         stability = DEFAULT_STABILITY if self.temperature is None else self.temperature
         self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - stability))
         self._new_turn_pending = True
-        # Tells a close we caused apart from one the provider caused.
         self._interrupted = False
         # last_text_sent stays true between turns, so it cannot say whether a turn is still
         # open. This does, and keeps a dropped socket from ending an already-ended turn twice.
@@ -703,8 +702,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
                     logger.info("ElevenLabs v3 WebSocket closed by barge-in, waiting for reconnect")
                 else:
                     # Dropped after the flush but before is_final_audio_for_turn. End the turn
-                    # explicitly, or nothing stamps end_of_synthesizer_stream and playback
-                    # stays marked as in progress for the rest of the call.
+                    # explicitly, or playback stays marked as in progress for the whole call.
                     logger.error("ElevenLabs v3 WebSocket dropped by provider, ending the turn")
                     if self.last_text_sent and not self._turn_eos_emitted:
                         self._turn_eos_emitted = True

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -413,6 +413,12 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
 
 # Out-of-preset floats are accepted silently, so snap before sending.
 STABILITY_PRESETS = (0.0, 0.5, 1.0)
+DEFAULT_STABILITY = 0.5
+
+# Bounds the abandoned socket's closing handshake. The websockets default is 10s, which is
+# far longer than a barge-in redial should ever wait on a half-open connection.
+CLOSE_TIMEOUT = 1
+RECONNECT_POLL_INTERVAL = 0.05
 
 # The 20s idle cap is not adjustable here: inactivity_timeout is ignored on this endpoint.
 KEEP_ALIVE_INTERVAL = 8
@@ -436,12 +442,17 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         # leave welcome messages and handoff clips silent.
         self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?output_format="
         # Snapped once here so the inherited HTTP path renders welcome clips at the same
-        # stability the streamed conversation uses.
-        self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - self.temperature))
+        # stability the streamed conversation uses. temperature is Optional on ElevenLabsConfig
+        # and the stored dict reaches the constructor unvalidated, so a null lands here.
+        stability = DEFAULT_STABILITY if self.temperature is None else self.temperature
+        self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - stability))
         # Nulled so no inherited code path reads a context this endpoint does not have.
         self.context_id = None
         self.current_turn_context_id = None
         self._new_turn_pending = True
+        # Set while a barge-in teardown is in flight, so a socket close we caused is told
+        # apart from one the provider caused. Without it both look identical to the sender.
+        self._interrupted = False
         self._connect_lock = asyncio.Lock()
         self._keep_alive_task = None
         self._reconnect_task = None
@@ -484,6 +495,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             )
             self._last_send_time = time.perf_counter()
             self._new_turn_pending = True
+            # The barge-in teardown is over once its replacement is up, so a close after
+            # this point is the provider's and must be reported rather than swallowed.
+            self._interrupted = False
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(f"Connected to {self.ws_url}")
@@ -554,18 +568,44 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
     async def handle_interruption(self):
         """Drop the socket, since no control message on this endpoint cancels a turn.
 
-        The redial is backgrounded because awaiting it would stall barge-in cleanup for
-        up to the 10s connect timeout.
+        Does no network I/O: task_manager awaits this inside barge-in cleanup, and both
+        close() and connect() can block for their full timeouts. The socket is detached
+        synchronously so the receiver stops reading the interrupted turn's frames at once,
+        then closed and replaced on a background task.
         """
         try:
             self.current_turn_start_time = None
             self._new_turn_pending = True
-            if self._is_ws_connected():
-                await self.websocket.close()
+            self._interrupted = True
+            old_ws, self.websocket = self.websocket, None
+            if self._reconnect_task and not self._reconnect_task.done():
+                self._reconnect_task.cancel()
             # Referenced so the task cannot be garbage collected before it reconnects.
-            self._reconnect_task = asyncio.create_task(self._ensure_connection())
+            self._reconnect_task = asyncio.create_task(self._recycle_socket(old_ws))
         except Exception as e:
             logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
+
+    def _classify_lost_socket(self, where):
+        """A send found no socket. Ours to abandon quietly, or the provider's to report.
+
+        Reporting matters: a swallowed provider drop leaves the turn with no end-of-stream,
+        so the final mark never reaches the caller and is_audio_being_played stays latched.
+        """
+        self._new_turn_pending = True
+        if self._interrupted:
+            logger.info(f"ElevenLabs v3 socket closed by barge-in {where}, abandoning turn")
+            return
+        logger.error(f"ElevenLabs v3 socket dropped {where}")
+        self.connection_error = f"socket dropped {where}"
+
+    async def _recycle_socket(self, old_ws):
+        """Close the abandoned socket and dial its replacement, off the barge-in path."""
+        if old_ws is not None:
+            try:
+                await asyncio.wait_for(old_ws.close(), timeout=CLOSE_TIMEOUT)
+            except Exception:
+                pass
+        await self._ensure_connection()
 
     # ------------------------------------------------------------------
     # sender / receiver
@@ -580,7 +620,10 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 await self.flush_synthesizer_stream()
                 return
 
-            await self._wait_for_ws()
+            # Tighter than the 1s default: every barge-in redials, so the next turn (the
+            # hangup goodbye especially) would otherwise wait a full poll tick on a socket
+            # that reconnects in about 200ms.
+            await self._wait_for_ws(poll_interval=RECONNECT_POLL_INTERVAL)
 
             if text != "":
                 for text_chunk in self.text_chunker(text):
@@ -598,14 +641,15 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         if self._new_turn_pending:
                             payload["new_turn"] = True
                             self._new_turn_pending = False
-                        await self.websocket.send(json.dumps({"inputs": [payload]}))
+                        ws = self.websocket
+                        if ws is None:
+                            # Detached by handle_interruption between the wait and this send.
+                            self._classify_lost_socket("mid-send")
+                            return
+                        await ws.send(json.dumps({"inputs": [payload]}))
                         self._last_send_time = time.perf_counter()
                     except websockets.exceptions.ConnectionClosed:
-                        # Expected: barge-in closed the socket. Recording a connection error
-                        # here would surface as SynthesizerError and hang up the call on every
-                        # interruption. The reconnect is already in flight.
-                        logger.info("ElevenLabs v3 socket closed mid-send, abandoning turn")
-                        self._new_turn_pending = True
+                        self._classify_lost_socket("mid-send")
                         return
                     except Exception as e:
                         logger.info(f"Error sending chunk: {e}")
@@ -617,12 +661,15 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 try:
                     # Generates everything buffered and closes the turn with
                     # is_final_audio_for_turn. close_socket would end the session, not the turn.
-                    await self.websocket.send(json.dumps({"flush": True}))
+                    ws = self.websocket
+                    if ws is None:
+                        self._classify_lost_socket("before flush")
+                        return
+                    await ws.send(json.dumps({"flush": True}))
                     self._last_send_time = time.perf_counter()
                     self._new_turn_pending = True
                 except websockets.exceptions.ConnectionClosed:
-                    logger.info("ElevenLabs v3 socket closed before flush, abandoning turn")
-                    self._new_turn_pending = True
+                    self._classify_lost_socket("before flush")
                 except Exception as e:
                     logger.info(f"Error sending end-of-stream signal: {e}")
                     self.connection_error = str(e)
@@ -701,7 +748,16 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 # routinely, and returning here would end generate() for the rest of the call.
                 if self.conversation_ended or self.connection_error:
                     return
-                logger.info("ElevenLabs v3 WebSocket closed, waiting for reconnect")
+                if self._interrupted:
+                    logger.info("ElevenLabs v3 WebSocket closed by barge-in, waiting for reconnect")
+                else:
+                    # Dropped with a turn in flight, i.e. after the flush went out but before
+                    # is_final_audio_for_turn came back. Close the turn out, or nothing stamps
+                    # end_of_synthesizer_stream, the final mark never reaches the caller's
+                    # provider and is_audio_being_played stays latched for the rest of the call.
+                    logger.error("ElevenLabs v3 WebSocket dropped by provider, ending the turn")
+                    if self.last_text_sent:
+                        yield b"\x00", ""
                 audio_chunk_count = 0
                 await asyncio.sleep(0.05)
             except Exception as e:

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -19,7 +19,13 @@ from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
 logger = configure_logger(__name__)
 
 
-class ElevenlabsSynthesizer(StreamSynthesizer):
+class ElevenlabsBase(StreamSynthesizer):
+    """Shared ElevenLabs plumbing: credentials, wire format, and the one-shot HTTP path.
+
+    The two subclasses speak different socket protocols and share nothing below this
+    line, so each owns its own ws_url, api_url and turn lifecycle.
+    """
+
     def __init__(
         self,
         voice,
@@ -59,6 +65,8 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             self.cache = InmemoryScalarCache()
 
         self.elevenlabs_host = os.getenv("ELEVENLABS_API_HOST", "api.elevenlabs.io")
+        # Set from the x-trace-id response header on connect; both sockets log against it.
+        self.ws_trace_id = None
         if self.use_mulaw:
             self.wire_format = "ulaw_8000"
             self.wire_pcm_rate = None
@@ -70,29 +78,6 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             rate = int(self.sampling_rate)
             self.wire_pcm_rate = rate if rate in (16000, 22050, 24000, 44100) else 24000
             self.wire_format = f"pcm_{self.wire_pcm_rate}"
-        self.ws_url = (
-            f"wss://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/multi-stream-input"
-            f"?model_id={self.model}&output_format={self.wire_format}"
-            f"&inactivity_timeout=170&sync_alignment=true&optimize_streaming_latency=4"
-        )
-        self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
-
-        # One context per turn: closed at end_of_llm_stream and on interruption, so each
-        # turn gets a fresh context_id. Closing frees the slot, staying well under
-        # ElevenLabs' 5-concurrent-context cap.
-        self.context_id = None
-        self.context_ids_to_ignore = set()
-        self._eos_context_id = None  # context the last end-of-stream was emitted for
-        self.current_turn_context_id = None  # survives close_context, unlike context_id
-        self.ws_send_time = None
-        self.ws_trace_id = None
-        self.current_turn_ttfb = None
-        self.eos_accum_context_id = None  # context whose spoken chars are being accumulated
-        self.eos_accum_text = ""  # spoken-so-far for that context (end-of-stream match)
-
-    # ------------------------------------------------------------------
-    # StreamSynthesizer hooks
-    # ------------------------------------------------------------------
 
     def _get_audio_format(self):
         return "mulaw" if self.wire_format == "ulaw_8000" else "wav"
@@ -109,23 +94,74 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
         audio, text_synthesized = item
         return audio, {"text_synthesized": text_synthesized}
 
+    def _get_output_format(self):
+        return self.wire_format
+
+    async def synthesize(self, text):
+        return await self._generate_http(text, format="mp3_44100_128")
+
+    async def synthesize_telephony_clip(self, text):
+        """One-shot render in the telephony wire format (mu-law 8000) — no
+        decode/transcode step (and no ffmpeg), unlike the MP3 the plain synthesize()
+        returns. None on non-mulaw configs so callers fall back to synthesize()."""
+        if not self.use_mulaw:
+            return None
+        return await self._generate_http(text)
+
+    async def _generate_http(self, text, format=None):
+        payload = {
+            "text": text,
+            "model_id": self.model,
+            "voice_settings": {
+                "stability": self.temperature,
+                "similarity_boost": self.similarity_boost,
+                "optimize_streaming_latency": 3,
+                "speed": self.speed,
+                "style": self.style,
+            },
+        }
+        headers = {"xi-api-key": self.api_key}
+        fmt = format or self._get_output_format()
+        url = f"{self.api_url}{fmt}"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                if response.status == 200:
+                    return await response.read()
+                else:
+                    logger.error(f"Error: {response.status} - {await response.text()}")
+                    return None
+
+
+class ElevenlabsSynthesizer(ElevenlabsBase):
+    """Eleven v1/v2 models over the multi-stream-input socket, one context per turn."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ws_url = (
+            f"wss://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/multi-stream-input"
+            f"?model_id={self.model}&output_format={self.wire_format}"
+            f"&inactivity_timeout=170&sync_alignment=true&optimize_streaming_latency=4"
+        )
+        self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?optimize_streaming_latency=2&output_format="
+
+        # One context per turn: closed at end_of_llm_stream and on interruption, so each
+        # turn gets a fresh context_id. Closing frees the slot, staying well under
+        # ElevenLabs' 5-concurrent-context cap.
+        self.context_id = None
+        self.context_ids_to_ignore = set()
+        self._eos_context_id = None  # context the last end-of-stream was emitted for
+        self.current_turn_context_id = None  # survives close_context, unlike context_id
+        self.ws_send_time = None
+        self.current_turn_ttfb = None
+        self.eos_accum_context_id = None  # context whose spoken chars are being accumulated
+        self.eos_accum_text = ""  # spoken-so-far for that context (end-of-stream match)
+
     def _on_push(self, meta_info, text):
         # Mint only for pushes that will actually synthesize — a superseded push must not
         # advance current_turn_context_id, or the prior turn's real isFinal gets suppressed.
         if not self.context_id and self.should_synthesize_response(meta_info.get("sequence_id")):
             self.context_id = str(uuid.uuid4())
             self.current_turn_context_id = self.context_id
-
-    # ------------------------------------------------------------------
-    # Format helper
-    # ------------------------------------------------------------------
-
-    def _get_output_format(self):
-        return self.wire_format
-
-    # ------------------------------------------------------------------
-    # Interruption
-    # ------------------------------------------------------------------
 
     async def handle_interruption(self):
         try:
@@ -143,10 +179,6 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 self.context_id = None
         except Exception:
             pass
-
-    # ------------------------------------------------------------------
-    # sender / receiver
-    # ------------------------------------------------------------------
 
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
@@ -326,10 +358,6 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 # Back off so a persistent error can't peg the event loop.
                 await asyncio.sleep(0.1)
 
-    # ------------------------------------------------------------------
-    # Connection
-    # ------------------------------------------------------------------
-
     async def establish_connection(self):
         try:
             start_time = time.perf_counter()
@@ -372,44 +400,6 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
             logger.error(f"Failed to connect to ElevenLabs: {e}")
             return None
 
-    # ------------------------------------------------------------------
-    # HTTP fallback
-    # ------------------------------------------------------------------
-
-    async def synthesize(self, text):
-        return await self._generate_http(text, format="mp3_44100_128")
-
-    async def synthesize_telephony_clip(self, text):
-        """One-shot render in the telephony wire format (mu-law 8000) — no
-        decode/transcode step (and no ffmpeg), unlike the MP3 the plain synthesize()
-        returns. None on non-mulaw configs so callers fall back to synthesize()."""
-        if not self.use_mulaw:
-            return None
-        return await self._generate_http(text)
-
-    async def _generate_http(self, text, format=None):
-        payload = {
-            "text": text,
-            "model_id": self.model,
-            "voice_settings": {
-                "stability": self.temperature,
-                "similarity_boost": self.similarity_boost,
-                "optimize_streaming_latency": 3,
-                "speed": self.speed,
-                "style": self.style,
-            },
-        }
-        headers = {"xi-api-key": self.api_key}
-        fmt = format or self._get_output_format()
-        url = f"{self.api_url}{fmt}"
-        async with aiohttp.ClientSession() as session:
-            async with session.post(url, headers=headers, json=payload) as response:
-                if response.status == 200:
-                    return await response.read()
-                else:
-                    logger.error(f"Error: {response.status} - {await response.text()}")
-                    return None
-
 
 # v3 takes three discrete stability values; anything else is accepted and silently snapped.
 STABILITY_PRESETS = (0.0, 0.5, 1.0)
@@ -421,7 +411,7 @@ RECONNECT_POLL_INTERVAL = 0.05
 KEEP_ALIVE_INTERVAL = 8
 
 
-class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
+class ElevenlabsV3Synthesizer(ElevenlabsBase):
     """Eleven v3, served only from the text-to-dialogue endpoint.
 
     Voices register in a first message rather than the URL, text goes as ``inputs`` arrays,
@@ -457,10 +447,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
 
     def get_sleep_time(self):
         return 0.01
-
-    def _on_push(self, meta_info, text):
-        """No context to mint; turn boundaries are marked with new_turn on the wire."""
-        return
 
     # ------------------------------------------------------------------
     # Connection

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -20,11 +20,7 @@ logger = configure_logger(__name__)
 
 
 class ElevenlabsBase(StreamSynthesizer):
-    """Shared ElevenLabs plumbing: credentials, wire format, and the one-shot HTTP path.
-
-    The two subclasses speak different socket protocols and share nothing below this
-    line, so each owns its own ws_url, api_url and turn lifecycle.
-    """
+    """Credentials, wire format and HTTP synthesis shared by the ElevenLabs synthesizers."""
 
     def __init__(
         self,
@@ -412,12 +408,7 @@ KEEP_ALIVE_INTERVAL = 8
 
 
 class ElevenlabsV3Synthesizer(ElevenlabsBase):
-    """Eleven v3, served only from the text-to-dialogue endpoint.
-
-    Voices register in a first message rather than the URL, text goes as ``inputs`` arrays,
-    turns end on ``is_final_audio_for_turn``, and there are no contexts. The endpoint has no
-    way to cancel a turn, so an interruption closes the socket and dials a replacement.
-    """
+    """Eleven v3 over the text-to-dialogue socket: one flush per turn, no contexts."""
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -548,12 +539,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
-        """Drop the socket, since no control message on this endpoint cancels a turn.
-
-        Does no network I/O, because the caller awaits this on the interruption path. The
-        socket is detached synchronously so the receiver stops reading the abandoned turn,
-        then closed and replaced on a background task.
-        """
+        """Drop the socket and dial a replacement, since nothing here cancels a turn."""
+        # No network I/O: the caller awaits this on the interruption path. Detaching the
+        # socket synchronously also stops the receiver reading the abandoned turn.
         try:
             self.current_turn_start_time = None
             self._new_turn_pending = True
@@ -567,11 +555,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
             logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
 
     def _classify_lost_socket(self, where):
-        """Classify a lost socket: ours to abandon quietly, the provider's to report.
-
-        A swallowed provider drop would leave the turn with no end-of-stream, so the final
-        mark never reaches the output handler and playback stays marked as in progress.
-        """
+        """Classify a lost socket: ours to abandon quietly, the provider's to report."""
+        # A swallowed provider drop leaves the turn with no end-of-stream, so the final mark
+        # never reaches the output handler and playback stays marked as in progress.
         self._new_turn_pending = True
         if self._interrupted:
             logger.info(f"ElevenLabs v3 socket closed by barge-in {where}, abandoning turn")

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -411,25 +411,22 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                     return None
 
 
-# Out-of-preset floats are accepted silently, so snap before sending.
+# v3 takes three discrete stability values; anything else is accepted and silently snapped.
 STABILITY_PRESETS = (0.0, 0.5, 1.0)
 DEFAULT_STABILITY = 0.5
 
-# Bounds the abandoned socket's closing handshake. The websockets default is 10s, which is
-# far longer than a barge-in redial should ever wait on a half-open connection.
 CLOSE_TIMEOUT = 1
 RECONNECT_POLL_INTERVAL = 0.05
-
-# The 20s idle cap is not adjustable here: inactivity_timeout is ignored on this endpoint.
+# The endpoint ignores inactivity_timeout and drops idle sockets at 20s.
 KEEP_ALIVE_INTERVAL = 8
 
 
 class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
-    """Eleven v3, which 403s on multi-stream-input and is served only from text-to-dialogue.
+    """Eleven v3, served only from the text-to-dialogue endpoint.
 
     Voices register in a first message rather than the URL, text goes as ``inputs`` arrays,
-    turns end on ``is_final_audio_for_turn``, and there are no contexts. Everything outside
-    the wire protocol is inherited.
+    turns end on ``is_final_audio_for_turn``, and there are no contexts. The endpoint has no
+    way to cancel a turn, so an interruption closes the socket and dials a replacement.
     """
 
     def __init__(self, *args, **kwargs):
@@ -438,20 +435,17 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             f"wss://{self.elevenlabs_host}/v1/text-to-dialogue/stream-input"
             f"?model_id={self.model}&output_format={self.wire_format}&sync_alignment=true"
         )
-        # No optimize_streaming_latency: v3 rejects the query param with a 400, which would
-        # leave welcome messages and handoff clips silent.
+        # v3 rejects optimize_streaming_latency with a 400.
         self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?output_format="
-        # Snapped once here so the inherited HTTP path renders welcome clips at the same
-        # stability the streamed conversation uses. temperature is Optional on ElevenLabsConfig
-        # and the stored dict reaches the constructor unvalidated, so a null lands here.
+        # Snapped once so the inherited HTTP path matches the streamed voice. temperature is
+        # optional in the config and reaches the constructor unvalidated, so it may be None.
         stability = DEFAULT_STABILITY if self.temperature is None else self.temperature
         self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - stability))
-        # Nulled so no inherited code path reads a context this endpoint does not have.
+        # This endpoint has no contexts; nulled so no inherited path reads one.
         self.context_id = None
         self.current_turn_context_id = None
         self._new_turn_pending = True
-        # Set while a barge-in teardown is in flight, so a socket close we caused is told
-        # apart from one the provider caused. Without it both look identical to the sender.
+        # Tells a close we caused apart from one the provider caused.
         self._interrupted = False
         self._connect_lock = asyncio.Lock()
         self._keep_alive_task = None
@@ -483,8 +477,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")
                 logger.info(f"Elevenlabs v3 WebSocket connected trace_id={self.ws_trace_id}")
-            # First message only. stability is the sole setting v3 honours; similarity_boost,
-            # speed and style measurably do nothing.
+            # First message only. stability is the sole setting v3 honours.
             await websocket.send(
                 json.dumps(
                     {
@@ -495,8 +488,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             )
             self._last_send_time = time.perf_counter()
             self._new_turn_pending = True
-            # The barge-in teardown is over once its replacement is up, so a close after
-            # this point is the provider's and must be reported rather than swallowed.
+            # Teardown is over once a replacement is up.
             self._interrupted = False
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
@@ -518,8 +510,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             return None
 
     async def _ensure_connection(self):
-        """Reconnect if down, serialised so the barge-in redial and the monitor loop
-        cannot both dial and leak a socket."""
+        """Reconnect if down, serialised so two callers cannot both dial and leak a socket."""
         async with self._connect_lock:
             if self._is_ws_connected():
                 return True
@@ -568,9 +559,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
     async def handle_interruption(self):
         """Drop the socket, since no control message on this endpoint cancels a turn.
 
-        Does no network I/O: task_manager awaits this inside barge-in cleanup, and both
-        close() and connect() can block for their full timeouts. The socket is detached
-        synchronously so the receiver stops reading the interrupted turn's frames at once,
+        Does no network I/O, because the caller awaits this on the interruption path. The
+        socket is detached synchronously so the receiver stops reading the abandoned turn,
         then closed and replaced on a background task.
         """
         try:
@@ -580,16 +570,16 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             old_ws, self.websocket = self.websocket, None
             if self._reconnect_task and not self._reconnect_task.done():
                 self._reconnect_task.cancel()
-            # Referenced so the task cannot be garbage collected before it reconnects.
+            # Referenced so the task is not garbage collected before it reconnects.
             self._reconnect_task = asyncio.create_task(self._recycle_socket(old_ws))
         except Exception as e:
             logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
 
     def _classify_lost_socket(self, where):
-        """A send found no socket. Ours to abandon quietly, or the provider's to report.
+        """Classify a lost socket: ours to abandon quietly, the provider's to report.
 
-        Reporting matters: a swallowed provider drop leaves the turn with no end-of-stream,
-        so the final mark never reaches the caller and is_audio_being_played stays latched.
+        A swallowed provider drop would leave the turn with no end-of-stream, so the final
+        mark never reaches the output handler and playback stays marked as in progress.
         """
         self._new_turn_pending = True
         if self._interrupted:
@@ -620,9 +610,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 await self.flush_synthesizer_stream()
                 return
 
-            # Tighter than the 1s default: every barge-in redials, so the next turn (the
-            # hangup goodbye especially) would otherwise wait a full poll tick on a socket
-            # that reconnects in about 200ms.
+            # Tighter than the 1s default: every barge-in redials, and the next turn should
+            # not wait a full poll tick on a socket that reconnects in about 200ms.
             await self._wait_for_ws(poll_interval=RECONNECT_POLL_INTERVAL)
 
             if text != "":
@@ -635,15 +624,14 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         if self.ws_send_time is None:
                             self.ws_send_time = time.perf_counter()
                             logger.info(f"WS send trace_id={self.ws_trace_id} first_text_sent")
-                        # Only the turn's first fragment closes the previous prosody segment;
-                        # per-fragment new_turn would break intonation inside one utterance.
+                        # Only the first fragment of a turn; per-fragment new_turn would
+                        # break intonation inside one utterance.
                         payload = {"text": text_chunk, "voice_id": self.voice}
                         if self._new_turn_pending:
                             payload["new_turn"] = True
                             self._new_turn_pending = False
                         ws = self.websocket
                         if ws is None:
-                            # Detached by handle_interruption between the wait and this send.
                             self._classify_lost_socket("mid-send")
                             return
                         await ws.send(json.dumps({"inputs": [payload]}))
@@ -659,8 +647,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             if end_of_llm_stream:
                 self.last_text_sent = True
                 try:
-                    # Generates everything buffered and closes the turn with
-                    # is_final_audio_for_turn. close_socket would end the session, not the turn.
+                    # Closes the turn with is_final_audio_for_turn. close_socket would end
+                    # the session rather than the turn.
                     ws = self.websocket
                     if ws is None:
                         self._classify_lost_socket("before flush")
@@ -736,8 +724,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         text_spoken = ""
                     yield chunk, text_spoken
 
-                # Standalone message, no audio, once per flush. The only per-turn end marker:
-                # is_final arrives only when the session closes.
+                # Standalone message, no audio, once per flush. The only per-turn end
+                # marker; is_final arrives only when the session closes.
                 if data.get("is_final_audio_for_turn"):
                     logger.info(f"WS recv is_final_audio_for_turn trace_id={self.ws_trace_id}")
                     audio_chunk_count = 0
@@ -751,10 +739,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 if self._interrupted:
                     logger.info("ElevenLabs v3 WebSocket closed by barge-in, waiting for reconnect")
                 else:
-                    # Dropped with a turn in flight, i.e. after the flush went out but before
-                    # is_final_audio_for_turn came back. Close the turn out, or nothing stamps
-                    # end_of_synthesizer_stream, the final mark never reaches the caller's
-                    # provider and is_audio_being_played stays latched for the rest of the call.
+                    # Dropped after the flush but before is_final_audio_for_turn. End the turn
+                    # explicitly, or nothing stamps end_of_synthesizer_stream and playback
+                    # stays marked as in progress for the rest of the call.
                     logger.error("ElevenLabs v3 WebSocket dropped by provider, ending the turn")
                     if self.last_text_sent:
                         yield b"\x00", ""

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -447,6 +447,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         self._new_turn_pending = True
         # Tells a close we caused apart from one the provider caused.
         self._interrupted = False
+        # last_text_sent stays true between turns, so it cannot say whether a turn is still
+        # open. This does, and keeps a dropped socket from ending an already-ended turn twice.
+        self._turn_eos_emitted = True
         self._connect_lock = asyncio.Lock()
         self._keep_alive_task = None
         self._reconnect_task = None
@@ -512,6 +515,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
     async def _ensure_connection(self):
         """Reconnect if down, serialised so two callers cannot both dial and leak a socket."""
         async with self._connect_lock:
+            if self.conversation_ended:
+                return False
             if self._is_ws_connected():
                 return True
             websocket = await self.establish_connection()
@@ -522,7 +527,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
 
     async def monitor_connection(self):
         consecutive_failures = 0
-        while consecutive_failures < 3:
+        while consecutive_failures < 3 and not self.conversation_ended:
             if not self._is_ws_connected():
                 logger.info("Re-establishing ElevenLabs v3 connection...")
                 if await self._ensure_connection():
@@ -623,6 +628,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                     try:
                         if self.ws_send_time is None:
                             self.ws_send_time = time.perf_counter()
+                            self._turn_eos_emitted = False
                             logger.info(f"WS send trace_id={self.ws_trace_id} first_text_sent")
                         # Only the first fragment of a turn; per-fragment new_turn would
                         # break intonation inside one utterance.
@@ -729,6 +735,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 if data.get("is_final_audio_for_turn"):
                     logger.info(f"WS recv is_final_audio_for_turn trace_id={self.ws_trace_id}")
                     audio_chunk_count = 0
+                    self._turn_eos_emitted = True
                     yield b"\x00", ""
 
             except websockets.exceptions.ConnectionClosed:
@@ -743,7 +750,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                     # explicitly, or nothing stamps end_of_synthesizer_stream and playback
                     # stays marked as in progress for the rest of the call.
                     logger.error("ElevenLabs v3 WebSocket dropped by provider, ending the turn")
-                    if self.last_text_sent:
+                    if self.last_text_sent and not self._turn_eos_emitted:
+                        self._turn_eos_emitted = True
                         yield b"\x00", ""
                 audio_chunk_count = 0
                 await asyncio.sleep(0.05)

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -411,23 +411,19 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                     return None
 
 
-# v3 stability is a three-way preset (creative/natural/robust), not a continuous dial.
-# The API accepts out-of-preset floats silently, so snap before sending.
+# Out-of-preset floats are accepted silently, so snap before sending.
 STABILITY_PRESETS = (0.0, 0.5, 1.0)
 
-# The socket is dropped after 20s of client silence and, unlike multi-stream-input,
-# the inactivity_timeout query param is ignored. Heartbeat well inside that window.
+# The 20s idle cap is not adjustable here: inactivity_timeout is ignored on this endpoint.
 KEEP_ALIVE_INTERVAL = 8
 
 
 class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
-    """Eleven v3 over the text-to-dialogue socket.
+    """Eleven v3, which 403s on multi-stream-input and is served only from text-to-dialogue.
 
-    v3 is rejected (403) on the multi-stream-input endpoint the v1 synthesizer uses, so it
-    gets its own WebSocket protocol: voice registration in a first message instead of the
-    URL path, ``inputs`` arrays instead of bare ``text``, ``is_final_audio_for_turn``
-    instead of ``isFinal``, and no contexts at all. Everything that isn't the wire
-    protocol — wire format selection, audio post-processing, HTTP fallbacks — is inherited.
+    Voices register in a first message rather than the URL, text goes as ``inputs`` arrays,
+    turns end on ``is_final_audio_for_turn``, and there are no contexts. Everything outside
+    the wire protocol is inherited.
     """
 
     def __init__(self, *args, **kwargs):
@@ -436,7 +432,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             f"wss://{self.elevenlabs_host}/v1/text-to-dialogue/stream-input"
             f"?model_id={self.model}&output_format={self.wire_format}&sync_alignment=true"
         )
-        # No contexts on this endpoint; null the parent's context state so nothing reads it.
+        # Nulled so no inherited code path reads a context this endpoint does not have.
         self.context_id = None
         self.current_turn_context_id = None
         self._new_turn_pending = True
@@ -449,7 +445,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         return 0.01
 
     def _on_push(self, meta_info, text):
-        """No context to mint — turn boundaries are marked with new_turn on the wire."""
+        """No context to mint; turn boundaries are marked with new_turn on the wire."""
         return
 
     # ------------------------------------------------------------------
@@ -470,8 +466,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
                 self.ws_trace_id = websocket.response.headers.get("x-trace-id")
                 logger.info(f"Elevenlabs v3 WebSocket connected trace_id={self.ws_trace_id}")
-            # voices and voice_settings are read from the first message only. Only stability
-            # is honoured by v3 — similarity_boost, speed and style measurably do nothing.
+            # First message only. stability is the sole setting v3 honours; similarity_boost,
+            # speed and style measurably do nothing.
             await websocket.send(
                 json.dumps(
                     {
@@ -481,7 +477,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 )
             )
             self._last_send_time = time.perf_counter()
-            # A fresh socket has no half-sent turn, so the next input opens a new one.
             self._new_turn_pending = True
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
@@ -506,8 +501,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         return min(STABILITY_PRESETS, key=lambda preset: abs(preset - self.temperature))
 
     async def _ensure_connection(self):
-        """Reconnect if the socket is down. Serialised so the barge-in redial and the
-        monitor loop can't both dial and leak one of the two sockets."""
+        """Reconnect if down, serialised so the barge-in redial and the monitor loop
+        cannot both dial and leak a socket."""
         async with self._connect_lock:
             if self._is_ws_connected():
                 return True
@@ -554,17 +549,17 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
-        """There is no way to cancel a turn on this endpoint — no close_context
-        equivalent, and no control message stops generation — so the socket goes and a
-        replacement is dialled in the background. Awaiting the redial here would stall
-        barge-in cleanup for up to the 10s connect timeout."""
+        """Drop the socket, since no control message on this endpoint cancels a turn.
+
+        The redial is backgrounded because awaiting it would stall barge-in cleanup for
+        up to the 10s connect timeout.
+        """
         try:
             self.current_turn_start_time = None
             self._new_turn_pending = True
             if self._is_ws_connected():
                 await self.websocket.close()
-            # Held on the instance: a bare create_task can be garbage collected mid-flight,
-            # which would drop the redial and leave the next turn waiting on monitor_connection.
+            # Referenced so the task cannot be garbage collected before it reconnects.
             self._reconnect_task = asyncio.create_task(self._ensure_connection())
         except Exception as e:
             logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
@@ -594,9 +589,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         if self.ws_send_time is None:
                             self.ws_send_time = time.perf_counter()
                             logger.info(f"WS send trace_id={self.ws_trace_id} first_text_sent")
-                        # new_turn closes the previous prosody segment. Only the first
-                        # fragment of a turn carries it — setting it per fragment would
-                        # break intonation within a single utterance.
+                        # Only the turn's first fragment closes the previous prosody segment;
+                        # per-fragment new_turn would break intonation inside one utterance.
                         payload = {"text": text_chunk, "voice_id": self.voice}
                         if self._new_turn_pending:
                             payload["new_turn"] = True
@@ -604,10 +598,9 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         await self.websocket.send(json.dumps({"inputs": [payload]}))
                         self._last_send_time = time.perf_counter()
                     except websockets.exceptions.ConnectionClosed:
-                        # Expected, not a failure: barge-in closes the socket mid-turn because
-                        # this endpoint has no cancel. Treating it as a connection error would
-                        # surface as SynthesizerError and hang the call up on every interruption.
-                        # The reconnect is already in flight, so just abandon this turn.
+                        # Expected: barge-in closed the socket. Recording a connection error
+                        # here would surface as SynthesizerError and hang up the call on every
+                        # interruption. The reconnect is already in flight.
                         logger.info("ElevenLabs v3 socket closed mid-send, abandoning turn")
                         self._new_turn_pending = True
                         return
@@ -619,9 +612,8 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             if end_of_llm_stream:
                 self.last_text_sent = True
                 try:
-                    # flush forces generation of everything buffered and makes the server
-                    # close the turn with is_final_audio_for_turn. close_socket would end
-                    # the whole session, not the turn.
+                    # Generates everything buffered and closes the turn with
+                    # is_final_audio_for_turn. close_socket would end the session, not the turn.
                     await self.websocket.send(json.dumps({"flush": True}))
                     self._last_send_time = time.perf_counter()
                     self._new_turn_pending = True
@@ -694,17 +686,16 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                         text_spoken = ""
                     yield chunk, text_spoken
 
-                # Sent once per flush as a standalone message with no audio. This is the
-                # only per-turn end marker; is_final arrives only when the session closes.
+                # Standalone message, no audio, once per flush. The only per-turn end marker:
+                # is_final arrives only when the session closes.
                 if data.get("is_final_audio_for_turn"):
                     logger.info(f"WS recv is_final_audio_for_turn trace_id={self.ws_trace_id}")
                     audio_chunk_count = 0
                     yield b"\x00", ""
 
             except websockets.exceptions.ConnectionClosed:
-                # Expected on barge-in, which closes the socket because the endpoint has no
-                # cancel. Keep looping so the reconnect is picked up instead of ending the
-                # generate() stream for the rest of the call.
+                # Keep looping rather than breaking as v1 does: barge-in closes the socket
+                # routinely, and returning here would end generate() for the rest of the call.
                 if self.conversation_ended or self.connection_error:
                     return
                 logger.info("ElevenLabs v3 WebSocket closed, waiting for reconnect")

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -409,3 +409,306 @@ class ElevenlabsSynthesizer(StreamSynthesizer):
                 else:
                     logger.error(f"Error: {response.status} - {await response.text()}")
                     return None
+
+
+# v3 stability is a three-way preset (creative/natural/robust), not a continuous dial.
+# The API accepts out-of-preset floats silently, so snap before sending.
+STABILITY_PRESETS = (0.0, 0.5, 1.0)
+
+# The socket is dropped after 20s of client silence and, unlike multi-stream-input,
+# the inactivity_timeout query param is ignored. Heartbeat well inside that window.
+KEEP_ALIVE_INTERVAL = 8
+
+
+class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
+    """Eleven v3 over the text-to-dialogue socket.
+
+    v3 is rejected (403) on the multi-stream-input endpoint the v1 synthesizer uses, so it
+    gets its own WebSocket protocol: voice registration in a first message instead of the
+    URL path, ``inputs`` arrays instead of bare ``text``, ``is_final_audio_for_turn``
+    instead of ``isFinal``, and no contexts at all. Everything that isn't the wire
+    protocol — wire format selection, audio post-processing, HTTP fallbacks — is inherited.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.ws_url = (
+            f"wss://{self.elevenlabs_host}/v1/text-to-dialogue/stream-input"
+            f"?model_id={self.model}&output_format={self.wire_format}&sync_alignment=true"
+        )
+        # No contexts on this endpoint; null the parent's context state so nothing reads it.
+        self.context_id = None
+        self.current_turn_context_id = None
+        self._new_turn_pending = True
+        self._connect_lock = asyncio.Lock()
+        self._keep_alive_task = None
+        self._last_send_time = time.perf_counter()
+
+    def get_sleep_time(self):
+        return 0.01
+
+    def _on_push(self, meta_info, text):
+        """No context to mint — turn boundaries are marked with new_turn on the wire."""
+        return
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    async def establish_connection(self):
+        try:
+            start_time = time.perf_counter()
+            websocket = await asyncio.wait_for(
+                websockets.connect(
+                    self.ws_url,
+                    ssl=get_ssl_context(self.ws_url),
+                    additional_headers={"xi-api-key": self.api_key},
+                ),
+                timeout=10.0,
+            )
+            if hasattr(websocket, "response") and hasattr(websocket.response, "headers"):
+                self.ws_trace_id = websocket.response.headers.get("x-trace-id")
+                logger.info(f"Elevenlabs v3 WebSocket connected trace_id={self.ws_trace_id}")
+            # voices and voice_settings are read from the first message only. Only stability
+            # is honoured by v3 — similarity_boost, speed and style measurably do nothing.
+            await websocket.send(
+                json.dumps(
+                    {
+                        "voices": [self.voice],
+                        "voice_settings": {"stability": self._snapped_stability()},
+                    }
+                )
+            )
+            self._last_send_time = time.perf_counter()
+            # A fresh socket has no half-sent turn, so the next input opens a new one.
+            self._new_turn_pending = True
+            if not self.connection_time:
+                self.connection_time = round((time.perf_counter() - start_time) * 1000)
+            logger.info(f"Connected to {self.ws_url}")
+            return websocket
+        except asyncio.TimeoutError:
+            logger.error("Timeout while connecting to ElevenLabs v3 websocket")
+            return None
+        except InvalidHandshake as e:
+            error_msg = str(e)
+            if "401" in error_msg or "403" in error_msg:
+                logger.error(f"ElevenLabs v3 authentication failed: invalid or expired API key - {e}")
+            else:
+                logger.error(f"ElevenLabs v3 handshake failed: {e}")
+            self.connection_error = str(e)
+            return None
+        except Exception as e:
+            logger.error(f"Failed to connect to ElevenLabs v3: {e}")
+            return None
+
+    def _snapped_stability(self):
+        return min(STABILITY_PRESETS, key=lambda preset: abs(preset - self.temperature))
+
+    async def _ensure_connection(self):
+        """Reconnect if the socket is down. Serialised so the barge-in redial and the
+        monitor loop can't both dial and leak one of the two sockets."""
+        async with self._connect_lock:
+            if self._is_ws_connected():
+                return True
+            websocket = await self.establish_connection()
+            if websocket is None:
+                return False
+            self.websocket = websocket
+            return True
+
+    async def monitor_connection(self):
+        consecutive_failures = 0
+        while consecutive_failures < 3:
+            if not self._is_ws_connected():
+                logger.info("Re-establishing ElevenLabs v3 connection...")
+                if await self._ensure_connection():
+                    consecutive_failures = 0
+                else:
+                    consecutive_failures += 1
+                    logger.warning(f"ElevenLabs v3 connection failed (attempt {consecutive_failures}/3)")
+                    if consecutive_failures >= 3:
+                        logger.error("Max connection failures reached for ElevenLabs v3")
+                        self.connection_error = self.connection_error or "Max connection failures reached"
+                        break
+            if self._keep_alive_task is None or self._keep_alive_task.done():
+                self._keep_alive_task = asyncio.create_task(self._keep_alive_loop())
+            await asyncio.sleep(1)
+
+    async def _keep_alive_loop(self):
+        """Hold the socket open through long stretches of caller speech."""
+        while not self.conversation_ended and not self.connection_error:
+            await asyncio.sleep(1)
+            if not self._is_ws_connected():
+                continue
+            if time.perf_counter() - self._last_send_time < KEEP_ALIVE_INTERVAL:
+                continue
+            try:
+                await self.websocket.send(json.dumps({"keep_alive": True}))
+                self._last_send_time = time.perf_counter()
+            except Exception as e:
+                logger.info(f"ElevenLabs v3 keep_alive failed: {e}")
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
+    async def handle_interruption(self):
+        """There is no way to cancel a turn on this endpoint — no close_context
+        equivalent, and no control message stops generation — so the socket goes and a
+        replacement is dialled in the background. Awaiting the redial here would stall
+        barge-in cleanup for up to the 10s connect timeout."""
+        try:
+            self.current_turn_start_time = None
+            self._new_turn_pending = True
+            if self._is_ws_connected():
+                await self.websocket.close()
+            asyncio.create_task(self._ensure_connection())
+        except Exception as e:
+            logger.info(f"Error handling ElevenLabs v3 interruption: {e}")
+
+    # ------------------------------------------------------------------
+    # sender / receiver
+    # ------------------------------------------------------------------
+
+    async def sender(self, text, sequence_id, end_of_llm_stream=False):
+        try:
+            if self.conversation_ended:
+                return
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
+                await self.flush_synthesizer_stream()
+                return
+
+            await self._wait_for_ws()
+
+            if text != "":
+                for text_chunk in self.text_chunker(text):
+                    if not self.should_synthesize_response(sequence_id):
+                        logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                        await self.flush_synthesizer_stream()
+                        return
+                    try:
+                        if self.ws_send_time is None:
+                            self.ws_send_time = time.perf_counter()
+                            logger.info(f"WS send trace_id={self.ws_trace_id} first_text_sent")
+                        # new_turn closes the previous prosody segment. Only the first
+                        # fragment of a turn carries it — setting it per fragment would
+                        # break intonation within a single utterance.
+                        payload = {"text": text_chunk, "voice_id": self.voice}
+                        if self._new_turn_pending:
+                            payload["new_turn"] = True
+                            self._new_turn_pending = False
+                        await self.websocket.send(json.dumps({"inputs": [payload]}))
+                        self._last_send_time = time.perf_counter()
+                    except Exception as e:
+                        logger.info(f"Error sending chunk: {e}")
+                        self.connection_error = str(e)
+                        return
+
+            if end_of_llm_stream:
+                self.last_text_sent = True
+                try:
+                    # flush forces generation of everything buffered and makes the server
+                    # close the turn with is_final_audio_for_turn. close_socket would end
+                    # the whole session, not the turn.
+                    await self.websocket.send(json.dumps({"flush": True}))
+                    self._last_send_time = time.perf_counter()
+                    self._new_turn_pending = True
+                except Exception as e:
+                    logger.info(f"Error sending end-of-stream signal: {e}")
+                    self.connection_error = str(e)
+
+        except asyncio.CancelledError:
+            logger.info("Sender task was cancelled.")
+        except Exception as e:
+            logger.error(f"Unexpected error in sender: {e}")
+
+    async def receiver(self):
+        """Yields (audio_chunk, text_spoken) tuples, or (b'\\x00', '') for end-of-stream."""
+        audio_chunk_count = 0
+        not_connected_since = None
+        consecutive_errors = 0
+        max_consecutive_errors = 10
+        while True:
+            try:
+                if self.conversation_ended:
+                    return
+                if not self._is_ws_connected():
+                    if self.connection_error:
+                        return
+                    now = time.perf_counter()
+                    if not_connected_since is None:
+                        not_connected_since = now
+                    elif now - not_connected_since > 30:
+                        logger.error("ElevenLabs v3 receiver: WebSocket never connected after 30s, giving up.")
+                        self.connection_error = self.connection_error or "WebSocket never connected"
+                        return
+                    await asyncio.sleep(0.10)
+                    continue
+                else:
+                    not_connected_since = None
+
+                recv_start = time.perf_counter()
+                response = await self.websocket.recv()
+                recv_duration = (time.perf_counter() - recv_start) * 1000
+                data = json.loads(response)
+                consecutive_errors = 0
+
+                if data.get("error"):
+                    logger.error(f"ElevenLabs v3 error: {data.get('error')} - {data.get('message')}")
+                    self.connection_error = data.get("message") or data.get("error")
+                    return
+
+                if data.get("audio"):
+                    if self.ws_send_time is not None:
+                        audio_chunk_count += 1
+                        if audio_chunk_count == 1:
+                            time_since_send = (time.perf_counter() - self.ws_send_time) * 1000
+                            logger.info(
+                                f"WS recv FIRST trace_id={self.ws_trace_id} recv_wait={recv_duration:.0f}ms "
+                                f"time_since_send={time_since_send:.0f}ms"
+                            )
+                        elif recv_duration > 200:
+                            logger.info(
+                                f"WS recv SLOW chunk={audio_chunk_count} trace_id={self.ws_trace_id} "
+                                f"recv_wait={recv_duration:.0f}ms"
+                            )
+                    chunk = base64.b64decode(data["audio"])
+                    try:
+                        text_spoken = "".join(data.get("alignment", {}).get("chars", []))
+                    except Exception:
+                        text_spoken = ""
+                    yield chunk, text_spoken
+
+                # Sent once per flush as a standalone message with no audio. This is the
+                # only per-turn end marker; is_final arrives only when the session closes.
+                if data.get("is_final_audio_for_turn"):
+                    logger.info(f"WS recv is_final_audio_for_turn trace_id={self.ws_trace_id}")
+                    audio_chunk_count = 0
+                    yield b"\x00", ""
+
+            except websockets.exceptions.ConnectionClosed:
+                # Expected on barge-in, which closes the socket because the endpoint has no
+                # cancel. Keep looping so the reconnect is picked up instead of ending the
+                # generate() stream for the rest of the call.
+                if self.conversation_ended or self.connection_error:
+                    return
+                logger.info("ElevenLabs v3 WebSocket closed, waiting for reconnect")
+                audio_chunk_count = 0
+                await asyncio.sleep(0.05)
+            except Exception as e:
+                consecutive_errors += 1
+                logger.error(f"Error occurred in receiver - {e}")
+                if consecutive_errors >= max_consecutive_errors:
+                    logger.error(
+                        f"ElevenLabs v3 receiver: {consecutive_errors} consecutive errors, giving up to avoid busy-spin."
+                    )
+                    self.connection_error = self.connection_error or str(e)
+                    return
+                await asyncio.sleep(0.1)
+
+    async def cleanup(self):
+        if self._keep_alive_task:
+            self._keep_alive_task.cancel()
+            self._keep_alive_task = None
+        await super().cleanup()

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -432,6 +432,12 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
             f"wss://{self.elevenlabs_host}/v1/text-to-dialogue/stream-input"
             f"?model_id={self.model}&output_format={self.wire_format}&sync_alignment=true"
         )
+        # No optimize_streaming_latency: v3 rejects the query param with a 400, which would
+        # leave welcome messages and handoff clips silent.
+        self.api_url = f"https://{self.elevenlabs_host}/v1/text-to-speech/{self.voice}/stream?output_format="
+        # Snapped once here so the inherited HTTP path renders welcome clips at the same
+        # stability the streamed conversation uses.
+        self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - self.temperature))
         # Nulled so no inherited code path reads a context this endpoint does not have.
         self.context_id = None
         self.current_turn_context_id = None
@@ -472,7 +478,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
                 json.dumps(
                     {
                         "voices": [self.voice],
-                        "voice_settings": {"stability": self._snapped_stability()},
+                        "voice_settings": {"stability": self.temperature},
                     }
                 )
             )
@@ -496,9 +502,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsSynthesizer):
         except Exception as e:
             logger.error(f"Failed to connect to ElevenLabs v3: {e}")
             return None
-
-    def _snapped_stability(self):
-        return min(STABILITY_PRESETS, key=lambda preset: abs(preset - self.temperature))
 
     async def _ensure_connection(self):
         """Reconnect if down, serialised so the barge-in redial and the monitor loop

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -397,14 +397,13 @@ class ElevenlabsSynthesizer(ElevenlabsBase):
             return None
 
 
-# v3 takes three discrete stability values; anything else is accepted and silently snapped.
+# v3 accepts any stability value but only these three change anything.
 STABILITY_PRESETS = (0.0, 0.5, 1.0)
 DEFAULT_STABILITY = 0.5
-
-CLOSE_TIMEOUT = 1
-RECONNECT_POLL_INTERVAL = 0.05
+CLOSE_TIMEOUT_S = 1
+RECONNECT_POLL_INTERVAL_S = 0.05
 # The endpoint ignores inactivity_timeout and drops idle sockets at 20s.
-KEEP_ALIVE_INTERVAL = 8
+KEEP_ALIVE_INTERVAL_S = 8
 
 
 class ElevenlabsV3Synthesizer(ElevenlabsBase):
@@ -422,9 +421,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
         # optional in the config and reaches the constructor unvalidated, so it may be None.
         stability = DEFAULT_STABILITY if self.temperature is None else self.temperature
         self.temperature = min(STABILITY_PRESETS, key=lambda preset: abs(preset - stability))
-        # This endpoint has no contexts; nulled so no inherited path reads one.
-        self.context_id = None
-        self.current_turn_context_id = None
         self._new_turn_pending = True
         # Tells a close we caused apart from one the provider caused.
         self._interrupted = False
@@ -438,10 +434,6 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
 
     def get_sleep_time(self):
         return 0.01
-
-    # ------------------------------------------------------------------
-    # Connection
-    # ------------------------------------------------------------------
 
     async def establish_connection(self):
         try:
@@ -526,17 +518,13 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
             await asyncio.sleep(1)
             if not self._is_ws_connected():
                 continue
-            if time.perf_counter() - self._last_send_time < KEEP_ALIVE_INTERVAL:
+            if time.perf_counter() - self._last_send_time < KEEP_ALIVE_INTERVAL_S:
                 continue
             try:
                 await self.websocket.send(json.dumps({"keep_alive": True}))
                 self._last_send_time = time.perf_counter()
             except Exception as e:
                 logger.info(f"ElevenLabs v3 keep_alive failed: {e}")
-
-    # ------------------------------------------------------------------
-    # Interruption
-    # ------------------------------------------------------------------
 
     async def handle_interruption(self):
         """Drop the socket and dial a replacement, since nothing here cancels a turn."""
@@ -569,14 +557,10 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
         """Close the abandoned socket and dial its replacement, off the barge-in path."""
         if old_ws is not None:
             try:
-                await asyncio.wait_for(old_ws.close(), timeout=CLOSE_TIMEOUT)
+                await asyncio.wait_for(old_ws.close(), timeout=CLOSE_TIMEOUT_S)
             except Exception:
                 pass
         await self._ensure_connection()
-
-    # ------------------------------------------------------------------
-    # sender / receiver
-    # ------------------------------------------------------------------
 
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
@@ -589,7 +573,7 @@ class ElevenlabsV3Synthesizer(ElevenlabsBase):
 
             # Tighter than the 1s default: every barge-in redials, and the next turn should
             # not wait a full poll tick on a socket that reconnects in about 200ms.
-            await self._wait_for_ws(poll_interval=RECONNECT_POLL_INTERVAL)
+            await self._wait_for_ws(poll_interval=RECONNECT_POLL_INTERVAL_S)
 
             if text != "":
                 for text_chunk in self.text_chunker(text):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.189"
+version = "0.10.190"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_elevenlabs_v3_synthesizer.py
+++ b/tests/test_elevenlabs_v3_synthesizer.py
@@ -1,0 +1,278 @@
+"""Eleven v3 on the text-to-dialogue socket, and the split that keeps it off v1's back.
+
+v1 and v3 are siblings under ElevenlabsBase rather than one extending the other, so most of
+these lock in that neither can drift into the other: v1 keeps its endpoint, its contexts and
+its settings, and v3 keeps its own turn lifecycle.
+"""
+
+import asyncio
+import base64
+import json
+
+from websockets.exceptions import ConnectionClosed
+from websockets.protocol import State
+
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
+from bolna.synthesizer.elevenlabs_synthesizer import (
+    DEFAULT_STABILITY,
+    STABILITY_PRESETS,
+    ElevenlabsBase,
+    ElevenlabsSynthesizer,
+    ElevenlabsV3Synthesizer,
+)
+
+VOICE_ID = "JBFqnCBsd6RMkjVDRZzb"
+
+
+class StubTaskManager:
+    def is_sequence_id_in_current_ids(self, sequence_id):
+        return True
+
+
+class FakeWS:
+    """Replays server frames, then behaves like a socket the far end has closed."""
+
+    def __init__(self, messages=()):
+        self._messages = list(messages)
+        self.sent = []
+        self.state = State.OPEN
+        self.closed = False
+
+    async def recv(self):
+        if not self._messages:
+            self.state = State.CLOSED
+            raise ConnectionClosed(None, None)
+        return self._messages.pop(0)
+
+    async def send(self, data):
+        if self.closed:
+            raise ConnectionClosed(None, None)
+        self.sent.append(json.loads(data))
+
+    async def close(self):
+        self.closed = True
+        self.state = State.CLOSED
+
+
+def _audio_msg(text=""):
+    return json.dumps({"audio": base64.b64encode(b"\x01\x02\x03\x04").decode(), "alignment": {"chars": list(text)}})
+
+
+def _turn_end_msg():
+    return json.dumps({"is_final_audio_for_turn": True})
+
+
+async def _drain(synth, limit=8, timeout=2.0):
+    """receiver() waits for a reconnect rather than returning, so stop at the sentinel."""
+    got = []
+
+    async def pump():
+        async for item in synth.receiver():
+            got.append(item)
+            if item[0] == b"\x00" or len(got) >= limit:
+                return
+
+    try:
+        await asyncio.wait_for(pump(), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass
+    return got
+
+
+def _make(model="eleven_v3_conversational", **kwargs):
+    opts = dict(voice="George", voice_id=VOICE_ID, sampling_rate="8000", use_mulaw=True, caching=False)
+    opts.update(kwargs)
+    return SUPPORTED_SYNTHESIZER_MODELS["elevenlabs"](model=model, task_manager_instance=StubTaskManager(), **opts)
+
+
+# ---------------------------------------------------------------------------
+# class layout
+# ---------------------------------------------------------------------------
+
+
+def test_v1_and_v3_are_siblings_not_a_chain():
+    assert issubclass(ElevenlabsSynthesizer, ElevenlabsBase)
+    assert issubclass(ElevenlabsV3Synthesizer, ElevenlabsBase)
+    assert not issubclass(ElevenlabsV3Synthesizer, ElevenlabsSynthesizer)
+    assert not issubclass(ElevenlabsSynthesizer, ElevenlabsV3Synthesizer)
+
+
+def test_shared_plumbing_lives_on_the_base():
+    for name in ("_get_audio_format", "_process_audio_chunk", "_get_output_format", "_generate_http"):
+        assert name in vars(ElevenlabsBase), f"{name} should be shared"
+        assert name not in vars(ElevenlabsSynthesizer), f"{name} should not be duplicated on v1"
+
+
+def test_v3_does_not_carry_v1_context_state():
+    v3 = _make()
+    for attr in ("context_ids_to_ignore", "_eos_context_id", "eos_accum_text", "eos_accum_context_id"):
+        assert not hasattr(v3, attr), f"v3 should not inherit {attr}"
+    assert hasattr(_make("eleven_turbo_v2_5"), "context_ids_to_ignore")
+
+
+# ---------------------------------------------------------------------------
+# dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_only_v3_models_reach_the_dialogue_class():
+    for model in ("eleven_turbo_v2_5", "eleven_flash_v2_5", "eleven_multilingual_v2"):
+        assert type(_make(model)) is ElevenlabsSynthesizer, model
+    for model in ("eleven_v3", "eleven_v3_conversational"):
+        assert type(_make(model)) is ElevenlabsV3Synthesizer, model
+
+
+def test_dispatch_survives_a_null_model():
+    """A stored provider_config can carry an explicit null, which must not raise."""
+    assert type(_make(model=None)) is ElevenlabsSynthesizer
+
+
+# ---------------------------------------------------------------------------
+# endpoints, which must not bleed between the two
+# ---------------------------------------------------------------------------
+
+
+def test_v3_uses_the_dialogue_endpoint_without_the_rejected_param():
+    v3 = _make()
+    assert "/v1/text-to-dialogue/stream-input" in v3.ws_url
+    assert VOICE_ID not in v3.ws_url, "v3 registers its voice in the first message, not the URL"
+    assert "optimize_streaming_latency" not in v3.ws_url
+    assert "optimize_streaming_latency" not in v3.api_url, "v3 rejects it with a 400"
+
+
+def test_v1_endpoints_are_unchanged():
+    v1 = _make("eleven_turbo_v2_5")
+    assert f"/v1/text-to-speech/{VOICE_ID}/multi-stream-input" in v1.ws_url
+    assert "optimize_streaming_latency=4" in v1.ws_url
+    assert "inactivity_timeout=170" in v1.ws_url
+    assert "optimize_streaming_latency=2" in v1.api_url
+
+
+def test_wire_format_selection_is_shared():
+    for model in ("eleven_turbo_v2_5", "eleven_v3_conversational"):
+        assert _make(model).wire_format == "ulaw_8000"
+        assert _make(model)._get_audio_format() == "mulaw"
+        web = _make(model, sampling_rate="24000", use_mulaw=False)
+        assert web.wire_format == "pcm_24000"
+        assert web._get_audio_format() == "wav"
+
+
+def test_trace_id_is_available_to_both_before_connecting():
+    """Both receivers log against it, so it cannot live on only one subclass."""
+    assert _make().ws_trace_id is None
+    assert _make("eleven_turbo_v2_5").ws_trace_id is None
+
+
+# ---------------------------------------------------------------------------
+# stability, which v3 narrows and v1 leaves alone
+# ---------------------------------------------------------------------------
+
+
+def test_v3_snaps_stability_to_a_preset():
+    for given, expected in [(0.0, 0.0), (0.2, 0.0), (0.3, 0.5), (0.5, 0.5), (0.75, 0.5), (1.0, 1.0)]:
+        assert _make(temperature=given).temperature == expected
+    assert _make(temperature=None).temperature == DEFAULT_STABILITY
+    assert DEFAULT_STABILITY in STABILITY_PRESETS
+
+
+def test_v1_leaves_temperature_untouched():
+    assert _make("eleven_turbo_v2_5", temperature=0.3).temperature == 0.3
+    assert _make("eleven_turbo_v2_5", temperature=None).temperature is None
+
+
+# ---------------------------------------------------------------------------
+# turn lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_sender_opens_a_turn_then_flushes_it():
+    v3 = _make()
+    v3.websocket = FakeWS()
+    asyncio.run(v3.sender("hello there", sequence_id=1, end_of_llm_stream=True))
+
+    inputs = [m for m in v3.websocket.sent if "inputs" in m]
+    assert inputs, "text should go as inputs entries"
+    assert all(i["inputs"][0]["voice_id"] == VOICE_ID for i in inputs), "voice_id repeats per input"
+    assert inputs[0]["inputs"][0].get("new_turn") is True, "first fragment opens the turn"
+    assert not any(i["inputs"][0].get("new_turn") for i in inputs[1:]), "new_turn only on the first"
+    assert v3.websocket.sent[-1] == {"flush": True}
+    assert not any("close_socket" in m for m in v3.websocket.sent), "close_socket would end the session"
+
+
+def test_turn_end_marker_yields_the_sentinel():
+    v3 = _make()
+    v3.websocket = FakeWS([_audio_msg("hi"), _turn_end_msg()])
+    v3.ws_send_time = 1.0
+    got = asyncio.run(_drain(v3))
+    assert got[0][1] == "hi", "alignment chars carry the spoken text"
+    assert (b"\x00", "") in got, "is_final_audio_for_turn ends the turn"
+
+
+# ---------------------------------------------------------------------------
+# telling our own close apart from the provider's
+# ---------------------------------------------------------------------------
+
+
+def test_barge_in_close_is_not_a_connection_error():
+    v3 = _make()
+    v3._interrupted = True
+    v3._classify_lost_socket("mid-send")
+    assert v3.connection_error is None, "a barge-in must not end the call"
+    assert v3._new_turn_pending is True
+
+
+def test_provider_drop_is_reported():
+    v3 = _make()
+    v3._interrupted = False
+    v3._classify_lost_socket("mid-send")
+    assert v3.connection_error, "a provider drop must surface, not be swallowed"
+
+
+def test_interruption_detaches_without_awaiting_the_close():
+    """handle_interruption runs on the barge-in path, so it must not block on the network."""
+    v3 = _make()
+    v3.websocket = FakeWS()
+    dialled = []
+
+    async def fake_ensure():
+        dialled.append(True)
+        return True
+
+    v3._ensure_connection = fake_ensure
+
+    async def go():
+        await v3.handle_interruption()
+        detached = v3.websocket is None
+        await asyncio.sleep(0.05)  # let the background recycle run
+        return detached
+
+    assert asyncio.run(go()) is True
+    assert dialled, "the replacement socket is dialled off the barge-in path"
+    assert v3._interrupted is True
+    assert v3._new_turn_pending is True
+
+
+def test_a_turn_ends_only_once():
+    """last_text_sent stays true between turns, so a later drop must not re-end a done turn."""
+    v3 = _make()
+    v3.last_text_sent = True
+    v3._turn_eos_emitted = True  # the turn already ended normally
+    v3.websocket = FakeWS()
+    assert (b"\x00", "") not in asyncio.run(_drain(v3, timeout=1.0))
+
+
+def test_a_drop_mid_turn_still_ends_it():
+    v3 = _make()
+    v3.last_text_sent = True
+    v3._turn_eos_emitted = False  # flushed, but the end marker never arrived
+    v3.websocket = FakeWS()
+    assert (b"\x00", "") in asyncio.run(_drain(v3, timeout=1.0)), "otherwise playback stays marked in progress"
+
+
+def test_monitor_stops_once_the_call_is_over():
+    """Otherwise it redials between cleanup() and its own cancellation, leaking a socket."""
+    v3 = _make()
+    v3.conversation_ended = True
+    asyncio.run(asyncio.wait_for(v3.monitor_connection(), timeout=2))
+    assert v3.websocket is None
+    assert asyncio.run(v3._ensure_connection()) is False

--- a/tests/test_elevenlabs_v3_synthesizer.py
+++ b/tests/test_elevenlabs_v3_synthesizer.py
@@ -1,9 +1,4 @@
-"""Eleven v3 on the text-to-dialogue socket, and the split that keeps it off v1's back.
-
-v1 and v3 are siblings under ElevenlabsBase rather than one extending the other, so most of
-these lock in that neither can drift into the other: v1 keeps its endpoint, its contexts and
-its settings, and v3 keeps its own turn lifecycle.
-"""
+"""Eleven v3 on the text-to-dialogue socket, and the boundary that keeps it clear of v1."""
 
 import asyncio
 import base64


### PR DESCRIPTION
Eleven v3 is rejected with a 403 on the `multi-stream-input` endpoint the existing synthesizer uses. It is served only from `/v1/text-to-dialogue/stream-input`, which is a different protocol: voices register in a first message rather than the URL path, text goes as `inputs` arrays, and turns end on `is_final_audio_for_turn` rather than `isFinal`. So this cannot be a config-only change.

`ElevenlabsBase` now holds what the two protocols genuinely share (credentials, host, wire-format selection, audio post-processing and the one-shot HTTP path), with `ElevenlabsSynthesizer` and `ElevenlabsV3Synthesizer` as siblings under it. They are not a specialisation of one another: v3 previously extended v1 and had to null out inherited context state it never uses. `providers.py` dispatches on the model prefix, so every non-v3 model resolves exactly as before.

Three properties of the endpoint shape the implementation. There are no contexts and no control message cancels a turn, so an interruption closes the socket and dials a replacement on a background task; a close we caused is told apart from one the provider caused, because swallowing the latter would leave the turn with no end-of-stream and playback stuck marked as in progress. The 20s idle cap is not adjustable here (`inactivity_timeout` is ignored), so a keep-alive heartbeat is required. And `optimize_streaming_latency` is rejected by v3, so the HTTP path used for welcome clips omits it.

Only `eleven_v3_conversational` is wired up. v3 stability is a three-way preset, so it is snapped to the nearest of 0.0/0.5/1.0, and `similarity_boost`, `speed` and `style` are measurably inert on v3 so none are sent.

Companion catalog and pricing changes are in bolna-ai/dashboard-backend#2807.