### PR TITLE
Added the turn id for pre synthesize message and dropped asr

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.187"
+__version__ = "0.10.188"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -214,6 +214,14 @@ _NON_NODE_RESPONSE_CATEGORIES = frozenset(
 )
 
 
+def asr_id_to_int(value):
+    """Coerce OpenAI's "turn_3" ASR ids to int (Deepgram's are already ints); unparseable -> None."""
+    if isinstance(value, str):
+        digits = "".join(filter(str.isdigit, value))
+        return int(digits) if digits else None
+    return value
+
+
 def trailing_utterance_text(segments, gap_seconds=4.0):
     """Text of the caller's LAST utterance: trailing detector segments in the same
     language, back to a real silence boundary. Breaks on either a gap > gap_seconds
@@ -4405,8 +4413,8 @@ class TaskManager(BaseManager):
                 meta_info.get("response_uid"),
             )
 
-        # asr_turn_id, not meta_info["turn_id"] — that one counts responses, not ASR turns.
-        self.conversation_history.append_user(transcriber_message, asr_turn_id=meta_info.get("asr_turn_id"))
+        # asr_turn_id (int-coerced), not meta_info["turn_id"] — that one counts responses, not ASR turns.
+        self.conversation_history.append_user(transcriber_message, asr_turn_id=asr_id_to_int(meta_info.get("asr_turn_id")))
         logger.info(
             "BOLNA_TRACE_TM append_user seq=%s turn=%s response_uid=%s history_len=%s text=%r",
             meta_info.get("sequence_id"),
@@ -4786,7 +4794,13 @@ class TaskManager(BaseManager):
                             self.eager_llm_task = asyncio.create_task(
                                 self._run_llm_task(create_ws_data_packet(eager_transcript, meta_info))
                             )
-                            self.history.append({"role": "user", "content": eager_transcript})
+                            # Committed user row when EndOfTurn(was_eager) skips _handle_transcriber_output.
+                            # meta_info["asr_turn_id"] is stale until EndOfTurn, so read the live id.
+                            eager_user_row = {"role": "user", "content": eager_transcript}
+                            eager_asr_turn_id = asr_id_to_int(getattr(active_transcriber, "current_turn_id", None))
+                            if eager_asr_turn_id is not None:
+                                eager_user_row["asr_turn_id"] = eager_asr_turn_id
+                            self.history.append(eager_user_row)
                         else:
                             logger.info(f"Skipping speculative LLM (audio playing or welcome not done)")
 
@@ -7521,7 +7535,8 @@ class TaskManager(BaseManager):
                     "mark_tracking": output["latency_dict"]["mark_tracking"],
                     # Only record of when template speech (are-you-still-there, tool fillers,
                     # handoffs, goodbyes) was actually spoken — it has no LLM turn to anchor to.
-                    "synthesizer_chunk_marks": copy.deepcopy(output["latency_dict"]["synthesizer_chunk_marks"]),
+                    # Shared ref like mark_tracking — get_chunk_marks builds fresh dicts, nothing mutates them.
+                    "synthesizer_chunk_marks": output["latency_dict"]["synthesizer_chunk_marks"],
                     "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2)
                     if self.hangup_triggered_at
                     else None,
@@ -7573,9 +7588,10 @@ class TaskManager(BaseManager):
                     if _ub.get("turn_id") is not None
                 }
                 for _tt in output["progression_data"]["transcriber_latencies"].get("turn_latencies", []):
-                    _tid = _tt.get("turn_id")
-                    # Any id will do — OpenAI's are strings ("turn_3"), Deepgram's are ints.
-                    # Requiring int here silently dropped every Whisper turn from this stamp.
+                    # _ub_turns holds ints; "turn_3" in {3} is always False, which duplicated every
+                    # covered Whisper turn. Compare/store as int (progression copy only).
+                    _tid = asr_id_to_int(_tt.get("turn_id"))
+                    _tt["turn_id"] = _tid
                     if _tid is None or _tid in _ub_turns or not _tt.get("final_transcript"):
                         continue
                     _u_start = _tt.get("asr_turn_start_ms")
@@ -7633,7 +7649,8 @@ class TaskManager(BaseManager):
 
                 _tts_turns = (output["latency_dict"]["synthesizer_latencies"] or {}).get("turn_latencies", [])
                 for _t in _tts_turns:
-                    _t.pop("tts_start_ms", None)
+                    for _f in ("tts_start_ms", "message_category"):
+                        _t.pop(_f, None)
 
                 for _e in output["latency_dict"]["user_bot_latencies"]:
                     for _f in ("user_first_start_ms", "agent_end_ms"):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4414,7 +4414,9 @@ class TaskManager(BaseManager):
             )
 
         # asr_turn_id (int-coerced), not meta_info["turn_id"] — that one counts responses, not ASR turns.
-        self.conversation_history.append_user(transcriber_message, asr_turn_id=asr_id_to_int(meta_info.get("asr_turn_id")))
+        self.conversation_history.append_user(
+            transcriber_message, asr_turn_id=asr_id_to_int(meta_info.get("asr_turn_id"))
+        )
         logger.info(
             "BOLNA_TRACE_TM append_user seq=%s turn=%s response_uid=%s history_len=%s text=%r",
             meta_info.get("sequence_id"),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5943,7 +5943,7 @@ class TaskManager(BaseManager):
                     run_id=self.run_id,
                 )
             self.__enqueue_chunk(clip, 0, 1, handoff_meta)
-            self.conversation_history.append_assistant(handoff_text)
+            self.conversation_history.append_assistant(handoff_text, sequence_id=-1, message_category="handoff")
             self.__record_lid_event({"type": "handoff", "source": "prewarmed", "target": target})
             logger.info(f"LanguageSwitcher: playing pre-warmed handoff clip: {handoff_text!r}")
             return
@@ -5951,7 +5951,7 @@ class TaskManager(BaseManager):
         # Cold cache → live synthesis on the target voice (socket already warm).
         handoff_meta.update({"cached": False, "format": "pcm", "end_of_llm_stream": True})
         await self._synthesize(create_ws_data_packet(handoff_text, meta_info=handoff_meta))
-        self.conversation_history.append_assistant(handoff_text)
+        self.conversation_history.append_assistant(handoff_text, sequence_id=-1, message_category="handoff")
         self.__record_lid_event({"type": "handoff", "source": "live", "target": target})
         logger.info(f"LanguageSwitcher: playing handoff to cover reply generation: {handoff_text!r}")
 
@@ -7031,7 +7031,12 @@ class TaskManager(BaseManager):
                             "end_of_llm_stream": True,
                         }
                         await self._synthesize(create_ws_data_packet(user_online_message, meta_info=meta_info))
-                    self.conversation_history.append_assistant(user_online_message, exclude_from_llm=True)
+                    self.conversation_history.append_assistant(
+                        user_online_message,
+                        exclude_from_llm=True,
+                        sequence_id=-1,
+                        message_category="is_user_online_message",
+                    )
 
                     # Explicitly reset the audio flag after synthesizing the prompt.
                     # handle_interruption() below sends clearAudio to Plivo and wipes the
@@ -7500,6 +7505,9 @@ class TaskManager(BaseManager):
                     "interruption_stats": output["latency_dict"]["interruption_stats"],
                     "user_bot_latencies": copy.deepcopy(output["latency_dict"]["user_bot_latencies"]),
                     "mark_tracking": output["latency_dict"]["mark_tracking"],
+                    # Only record of when template speech (are-you-still-there, tool fillers,
+                    # handoffs, goodbyes) was actually spoken — it has no LLM turn to anchor to.
+                    "synthesizer_chunk_marks": copy.deepcopy(output["latency_dict"]["synthesizer_chunk_marks"]),
                     "hangup_triggered_ms": round(self.hangup_triggered_at * 1000 - self.conversation_start_init_ts, 2)
                     if self.hangup_triggered_at
                     else None,

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5859,7 +5859,9 @@ class TaskManager(BaseManager):
                 logger.info("LanguageSwitcher: hangup during speculation — not speaking follow-up")
                 return None
             if spec_text:
-                self.conversation_history.append_assistant(spec_text)
+                # Tagged here, not via _stage_assistant_history — this append bypasses staging,
+                # so without the tag the row cannot anchor to its own playback burst.
+                self.conversation_history.append_assistant(spec_text, message_category="language_switch_followup")
                 self.__log_committed_speculation(spec_text, spec_capture)
                 synth_meta = {
                     "io": self.tools["output"].get_provider(),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4394,7 +4394,7 @@ class TaskManager(BaseManager):
                 meta_info.get("response_uid"),
             )
 
-        self.conversation_history.append_user(transcriber_message)
+        self.conversation_history.append_user(transcriber_message, turn_id=meta_info.get("turn_id"))
         logger.info(
             "BOLNA_TRACE_TM append_user seq=%s turn=%s response_uid=%s history_len=%s text=%r",
             meta_info.get("sequence_id"),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4394,7 +4394,8 @@ class TaskManager(BaseManager):
                 meta_info.get("response_uid"),
             )
 
-        self.conversation_history.append_user(transcriber_message, turn_id=meta_info.get("turn_id"))
+        # asr_turn_id, not meta_info["turn_id"] — that one counts responses, not ASR turns.
+        self.conversation_history.append_user(transcriber_message, asr_turn_id=meta_info.get("asr_turn_id"))
         logger.info(
             "BOLNA_TRACE_TM append_user seq=%s turn=%s response_uid=%s history_len=%s text=%r",
             meta_info.get("sequence_id"),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2835,7 +2835,14 @@ class TaskManager(BaseManager):
                 break
 
         if self.hangup_message_queued and not web_call_timeout:
-            self.history.append({"role": "assistant", "content": self.call_hangup_message})
+            self.history.append(
+                {
+                    "role": "assistant",
+                    "content": self.call_hangup_message,
+                    "sequence_id": -1,
+                    "message_category": "agent_hangup",
+                }
+            )
 
         self.conversation_ended = True
         self.ended_by_assistant = True
@@ -4255,6 +4262,7 @@ class TaskManager(BaseManager):
             "content": content,
             "turn_id": turn_id,
             "response_uid": response_uid,
+            "message_category": meta_info.get("message_category"),
         }
         logger.info(
             "BOLNA_TRACE_TM stage_assistant_history seq=%s turn=%s response_uid=%s text_len=%s",
@@ -4277,7 +4285,10 @@ class TaskManager(BaseManager):
 
         self._committed_assistant_sequences.add(sequence_id)
         self.conversation_history.append_assistant(
-            staged["content"], turn_id=staged["turn_id"], response_uid=staged["response_uid"]
+            staged["content"],
+            turn_id=staged["turn_id"],
+            response_uid=staged["response_uid"],
+            message_category=staged.get("message_category"),
         )
         if staged["turn_id"] is not None:
             self._turn_msg_map[staged["turn_id"]] = self.conversation_history.messages[-1]
@@ -7561,14 +7572,17 @@ class TaskManager(BaseManager):
                 }
                 for _tt in output["progression_data"]["transcriber_latencies"].get("turn_latencies", []):
                     _tid = _tt.get("turn_id")
-                    if not isinstance(_tid, int) or _tid in _ub_turns or not _tt.get("final_transcript"):
+                    # Any id will do — OpenAI's are strings ("turn_3"), Deepgram's are ints.
+                    # Requiring int here silently dropped every Whisper turn from this stamp.
+                    if _tid is None or _tid in _ub_turns or not _tt.get("final_transcript"):
                         continue
                     _u_start = _tt.get("asr_turn_start_ms")
                     if _u_start is None:
                         _u_start = _tt.get("asr_start_ms")
+                    # No fallback to asr_finalized_ms: that is when ASR returned, not when the
+                    # caller stopped. Substituting it made "ASR time" compute to exactly 0 and
+                    # could place the end before the start. None means unknown.
                     _u_end = _tt.get("user_speech_end_ms")
-                    if _u_end is None:
-                        _u_end = _tt.get("asr_finalized_ms")
                     output["progression_data"]["user_bot_latencies"].append(
                         {
                             "turn_id": _tid,

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -27,8 +27,10 @@ class ConversationHistory:
 
         self._interim = copy.deepcopy(self._messages)
 
-    def append_user(self, content: str):
-        self._messages.append({"role": ChatRole.USER, "content": content})
+    def append_user(self, content: str, **kwargs):
+        # kwargs (turn_id) let consumers correlate a user turn to its ASR turn by id
+        # instead of by text. LLM adapters ignore/strip unknown message keys.
+        self._messages.append({"role": ChatRole.USER, "content": content, **kwargs})
 
     def replace_last_user(self, expected_content: str, new_content: str) -> bool:
         """Replace the most recent user message's content, but only if it still matches

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -28,8 +28,23 @@ class ConversationHistory:
         self._interim = copy.deepcopy(self._messages)
 
     def append_user(self, content: str, **kwargs):
-        # kwargs (turn_id) let consumers correlate a user turn to its ASR turn by id
-        # instead of by text. LLM adapters ignore/strip unknown message keys.
+        """kwargs (asr_turn_id) let consumers correlate a user turn to its ASR turn by id
+        rather than by text.
+
+        history is passed to the LLM unfiltered (azure_llm.py:132, litellm.py:73/194), so what
+        happens to an extra key depends on the adapter. Measured on litellm 1.84.0 via each
+        provider's real transform_request():
+          - rebuilt from known keys, so the key is dropped: anthropic, bedrock, ollama, Gemini
+            (_prepare_history), and the Responses adapter (ChatMessage is pydantic with the
+            default extra="ignore");
+          - forwarded verbatim in the request body: azure/openai and the OpenAI-compatible
+            litellm providers (cohere, groq, deepseek, openrouter, together_ai, perplexity,
+            fireworks_ai, deepinfra, vllm). These rely on the server ignoring unknown message
+            keys, which OpenAI-compatible APIs do.
+        Forwarding is not new — assistant messages have carried turn_id/response_uid for
+        months (643 such messages across 145/150 sampled prod calls, zero failures, Azure).
+        Prod evidence covers Azure only; the other nine are untested against a live endpoint.
+        """
         self._messages.append({"role": ChatRole.USER, "content": content, **kwargs})
 
     def replace_last_user(self, expected_content: str, new_content: str) -> bool:

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -28,23 +28,8 @@ class ConversationHistory:
         self._interim = copy.deepcopy(self._messages)
 
     def append_user(self, content: str, **kwargs):
-        """kwargs (asr_turn_id) let consumers correlate a user turn to its ASR turn by id
-        rather than by text.
-
-        history is passed to the LLM unfiltered (azure_llm.py:132, litellm.py:73/194), so what
-        happens to an extra key depends on the adapter. Measured on litellm 1.84.0 via each
-        provider's real transform_request():
-          - rebuilt from known keys, so the key is dropped: anthropic, bedrock, ollama, Gemini
-            (_prepare_history), and the Responses adapter (ChatMessage is pydantic with the
-            default extra="ignore");
-          - forwarded verbatim in the request body: azure/openai and the OpenAI-compatible
-            litellm providers (cohere, groq, deepseek, openrouter, together_ai, perplexity,
-            fireworks_ai, deepinfra, vllm). These rely on the server ignoring unknown message
-            keys, which OpenAI-compatible APIs do.
-        Forwarding is not new — assistant messages have carried turn_id/response_uid for
-        months (643 such messages across 145/150 sampled prod calls, zero failures, Azure).
-        Prod evidence covers Azure only; the other nine are untested against a live endpoint.
-        """
+        """kwargs (asr_turn_id) correlate a user turn to its ASR turn by id rather than by text.
+        LLM adapters call strip_internal_keys() before sending, so extras never reach a provider."""
         self._messages.append({"role": ChatRole.USER, "content": content, **kwargs})
 
     def replace_last_user(self, expected_content: str, new_content: str) -> bool:

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -334,7 +334,12 @@ class AzureLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format
+                model=self.model,
+                temperature=0.0,
+                # Same guarantee as the streaming path: bookkeeping keys never reach the wire.
+                messages=strip_internal_keys(messages),
+                stream=False,
+                response_format=response_format,
             )
 
             res = completion.choices[0].message.content

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -22,6 +22,7 @@ from bolna.helpers.utils import convert_to_request_log, compute_function_pre_cal
 from .openai_base import OpenAICompatibleLLM
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import LLMStreamChunk, LatencyData
+from .message_models import strip_internal_keys
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -129,7 +130,7 @@ class AzureLLM(OpenAICompatibleLLM):
         model_args = {
             **self.model_args,
             "response_format": response_format,
-            "messages": messages,
+            "messages": strip_internal_keys(messages),
             "stream": True,
             "stream_options": {"include_usage": True},
         }

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -12,6 +12,7 @@ from bolna.helpers.utils import convert_to_request_log, compute_function_pre_cal
 from .llm import BaseLLM
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import LLMStreamChunk, LatencyData
+from .message_models import strip_internal_keys
 from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
@@ -70,7 +71,7 @@ class LiteLLM(BaseLLM):
         first_token_time = None
 
         model_args = self.model_args.copy()
-        model_args["messages"] = messages
+        model_args["messages"] = strip_internal_keys(messages)
         model_args["stream"] = True
         model_args["stop"] = ["User:"]
 
@@ -191,7 +192,7 @@ class LiteLLM(BaseLLM):
         text = ""
         model_args = self.model_args.copy()
         model_args["model"] = self.model
-        model_args["messages"] = messages
+        model_args["messages"] = strip_internal_keys(messages)
         model_args["stream"] = stream
 
         if request_json:

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -22,6 +22,23 @@ class ChatMessage(BaseModel):
     tool_call_id: Optional[str] = None
 
 
+# Bookkeeping bolna attaches to history messages for correlation and audio gating. Removed
+# before the request is built: OpenAI-compatible providers forward unknown message keys
+# verbatim, and nothing should depend on the server ignoring them. Denylist rather than an
+# allowlist so a legitimate provider key (name, cache_control, multimodal parts) is never
+# silently dropped.
+INTERNAL_MESSAGE_KEYS = frozenset(
+    {"turn_id", "response_uid", "asr_turn_id", "sequence_id", "message_category", "exclude_from_llm"}
+)
+
+
+def strip_internal_keys(messages: list[dict]) -> list[dict]:
+    """Drop bolna's own bookkeeping keys, leaving every other key untouched."""
+    return [
+        {k: v for k, v in m.items() if k not in INTERNAL_MESSAGE_KEYS} if isinstance(m, dict) else m for m in messages
+    ]
+
+
 class ChatToolFunction(BaseModel):
     name: str = ""
     description: str = ""

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -26,6 +26,7 @@ from bolna.enums import ResponseStreamEvent, ResponseItemType, Verbosity
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import compute_function_pre_call_message, now_ms
 from .openai_base import OpenAICompatibleLLM
+from .message_models import strip_internal_keys
 from .tool_call_accumulator import ToolCallAccumulator
 from .types import APIParams, LLMStreamChunk, LatencyData
 from bolna.helpers.logger_config import configure_logger
@@ -238,7 +239,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         model_args = {
             **self.model_args,
             "response_format": response_format,
-            "messages": messages,
+            "messages": strip_internal_keys(messages),
             "stream": True,
             "stream_options": {"include_usage": True},
         }

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -450,7 +450,12 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         try:
             completion = await self.async_client.chat.completions.create(
-                model=self.model, temperature=0.0, messages=messages, stream=False, response_format=response_format
+                model=self.model,
+                temperature=0.0,
+                # Same guarantee as the streaming path: bookkeeping keys never reach the wire.
+                messages=strip_internal_keys(messages),
+                stream=False,
+                response_format=response_format,
             )
             res = completion.choices[0].message.content
             if ret_metadata:

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -23,9 +23,14 @@ class BaseSynthesizer:
         self.model = "default"
 
     def _upsert_turn_latency(self, entry: dict) -> None:
-        """Replace existing turn_latencies entry with matching sequence_id, or append if new."""
+        """Replace existing turn_latencies entry with matching sequence_id, or append if new.
+
+        Canned speech all shares sequence_id -1, so category joins the key — otherwise the
+        goodbye's entry overwrites the follow-up's and every earlier canned synthesis."""
         for i, t in enumerate(self.turn_latencies):
-            if t.get("sequence_id") == entry.get("sequence_id"):
+            if t.get("sequence_id") == entry.get("sequence_id") and t.get("message_category") == entry.get(
+                "message_category"
+            ):
                 self.turn_latencies[i] = entry
                 return
         self.turn_latencies.append(entry)

--- a/bolna/synthesizer/stream_synthesizer.py
+++ b/bolna/synthesizer/stream_synthesizer.py
@@ -59,6 +59,9 @@ class StreamSynthesizer(BaseSynthesizer):
         self.current_turn_start_time = None
         self.current_turn_id = None
         self.current_sequence_id = None
+        # Canned speech (handoff, goodbye, ...) has no turn_id; the category is the only
+        # way downstream can attribute its latency entry to the message that was spoken.
+        self.current_message_category = None
         self.current_tts_start_ms = None
         self.current_turn_ttfb = None
         self.ws_send_time = None
@@ -194,6 +197,7 @@ class StreamSynthesizer(BaseSynthesizer):
             logger.info(f"Push new_turn text_len={len(meta_info.get('text', '') or '')}")
         self.current_turn_id = meta_info.get("turn_id")
         self.current_sequence_id = meta_info.get("sequence_id")
+        self.current_message_category = meta_info.get("message_category")
         # Eager stub — captured even if turn never produces audio (e.g. TTS WS drop).
         # _record_turn_latency() upserts by sequence_id on completion, replacing this entry.
         self._upsert_turn_latency(
@@ -201,6 +205,7 @@ class StreamSynthesizer(BaseSynthesizer):
                 "turn_id": self.current_turn_id,
                 "sequence_id": self.current_sequence_id,
                 "tts_start_ms": self.current_tts_start_ms,
+                "message_category": self.current_message_category,
             }
         )
 
@@ -297,11 +302,13 @@ class StreamSynthesizer(BaseSynthesizer):
                         "first_result_latency_ms": round((self.current_turn_ttfb or 0) * 1000),
                         "total_stream_duration_ms": round(total_stream_duration * 1000),
                         "characters": self.current_sequence_chars,
+                        "message_category": self.current_message_category,
                     }
                 )
                 self.current_turn_start_time = None
                 self.current_turn_id = None
                 self.current_sequence_id = None
+                self.current_message_category = None
                 self.current_tts_start_ms = None
                 self.ws_send_time = None
                 self.current_turn_ttfb = None
@@ -358,6 +365,7 @@ class StreamSynthesizer(BaseSynthesizer):
                         "sequence_id": self.current_sequence_id,
                         "tts_start_ms": self.current_tts_start_ms,
                         "cancelled_at_ms": _cancelled_at,
+                        "message_category": self.current_message_category,
                     }
                 )
             except Exception as e:

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -26,6 +26,9 @@ class BaseTranscriber:
 
     def _upsert_turn_latency(self, entry: dict) -> None:
         """Replace existing turn_latencies entry with matching turn_id, or append if new."""
+        # task_manager overwrites meta_info["turn_id"] with its own counter, so publish the ASR id separately.
+        if entry.get("turn_id") is not None and isinstance(self.meta_info, dict):
+            self.meta_info["asr_turn_id"] = entry["turn_id"]
         for i, t in enumerate(self.turn_latencies):
             if t.get("turn_id") == entry.get("turn_id"):
                 self.turn_latencies[i] = entry

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -88,7 +88,7 @@ class OpenAITranscriber(BaseTranscriber):
         self._turn_start_epoch_ms = None
         # Saved at commit time so the receiver can still identify the turn after
         # _reset_turn_state() clears current_turn_id (e.g. utterance timeout race).
-        self._last_committed_turn_id: Optional[int] = None
+        self._last_committed_turn_id: Optional[str] = None
         # turn_id of the last entry written to turn_latencies, to keep those keys unique
         self._last_latency_turn_id = None
 
@@ -168,7 +168,7 @@ class OpenAITranscriber(BaseTranscriber):
             # cleared current_turn_id before we got here (shouldn't happen after the
             # _reset_turn_state fix, but guard anyway).
             self.turn_counter += 1
-            self.current_turn_id = self.turn_counter
+            self.current_turn_id = f"turn_{self.turn_counter}"
             logger.warning(f"_commit_turn: assigned fallback turn_id {self.current_turn_id}")
         self._last_committed_turn_id = self.current_turn_id
         try:
@@ -330,7 +330,7 @@ class OpenAITranscriber(BaseTranscriber):
                         self._final_transcript_event.clear()
                         self._audio_appended_since_commit = False
                         self.turn_counter += 1
-                        self.current_turn_id = self.turn_counter
+                        self.current_turn_id = f"turn_{self.turn_counter}"
                         self.current_turn_start_time = time.perf_counter()
                         self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []
@@ -418,7 +418,7 @@ class OpenAITranscriber(BaseTranscriber):
                             # fresh id — they are genuinely distinct transcripts with distinct times.
                             if turn_id is not None and turn_id == self._last_latency_turn_id:
                                 self.turn_counter += 1
-                                turn_id = self.turn_counter
+                                turn_id = f"turn_{self.turn_counter}"
                             self._last_latency_turn_id = turn_id
                             self.meta_info["asr_turn_id"] = turn_id  # appends, so no base-class stamp
                             logger.info(f"Transcript completed for turn {turn_id}: {transcript[:80]}")
@@ -468,7 +468,7 @@ class OpenAITranscriber(BaseTranscriber):
                     elif event_type == "input_audio_buffer.speech_started":
                         self._speech_active = True
                         self.turn_counter += 1
-                        self.current_turn_id = self.turn_counter
+                        self.current_turn_id = f"turn_{self.turn_counter}"
                         self.current_turn_start_time = time.perf_counter()
                         self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -412,10 +412,8 @@ class OpenAITranscriber(BaseTranscriber):
                             # most reliable identifier — current_turn_id may already point
                             # to the next turn if the sender started speaking immediately.
                             turn_id = self._last_committed_turn_id or self.current_turn_id or item_id
-                            # OpenAI can emit several transcription items for one committed turn.
-                            # Reusing the id gave turn_latencies duplicate keys, so any consumer
-                            # keying on turn_id silently lost all but the last. Give the extras a
-                            # fresh id — they are genuinely distinct transcripts with distinct times.
+                            # OpenAI emits several items per committed turn; reusing one id made
+                            # turn_latencies upserts clobber each other, so extras get a fresh id.
                             if turn_id is not None and turn_id == self._last_latency_turn_id:
                                 self.turn_counter += 1
                                 turn_id = f"turn_{self.turn_counter}"

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -88,7 +88,9 @@ class OpenAITranscriber(BaseTranscriber):
         self._turn_start_epoch_ms = None
         # Saved at commit time so the receiver can still identify the turn after
         # _reset_turn_state() clears current_turn_id (e.g. utterance timeout race).
-        self._last_committed_turn_id: Optional[str] = None
+        self._last_committed_turn_id: Optional[int] = None
+        # turn_id of the last entry written to turn_latencies, to keep those keys unique
+        self._last_latency_turn_id = None
 
         self._speech_active = False
         self._silence_start_time: Optional[float] = None
@@ -166,7 +168,7 @@ class OpenAITranscriber(BaseTranscriber):
             # cleared current_turn_id before we got here (shouldn't happen after the
             # _reset_turn_state fix, but guard anyway).
             self.turn_counter += 1
-            self.current_turn_id = f"turn_{self.turn_counter}"
+            self.current_turn_id = self.turn_counter
             logger.warning(f"_commit_turn: assigned fallback turn_id {self.current_turn_id}")
         self._last_committed_turn_id = self.current_turn_id
         try:
@@ -328,7 +330,7 @@ class OpenAITranscriber(BaseTranscriber):
                         self._final_transcript_event.clear()
                         self._audio_appended_since_commit = False
                         self.turn_counter += 1
-                        self.current_turn_id = f"turn_{self.turn_counter}"
+                        self.current_turn_id = self.turn_counter
                         self.current_turn_start_time = time.perf_counter()
                         self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []
@@ -410,6 +412,14 @@ class OpenAITranscriber(BaseTranscriber):
                             # most reliable identifier — current_turn_id may already point
                             # to the next turn if the sender started speaking immediately.
                             turn_id = self._last_committed_turn_id or self.current_turn_id or item_id
+                            # OpenAI can emit several transcription items for one committed turn.
+                            # Reusing the id gave turn_latencies duplicate keys, so any consumer
+                            # keying on turn_id silently lost all but the last. Give the extras a
+                            # fresh id — they are genuinely distinct transcripts with distinct times.
+                            if turn_id is not None and turn_id == self._last_latency_turn_id:
+                                self.turn_counter += 1
+                                turn_id = self.turn_counter
+                            self._last_latency_turn_id = turn_id
                             logger.info(f"Transcript completed for turn {turn_id}: {transcript[:80]}")
                             if self.current_turn_start_time:
                                 total_ms = round((time.perf_counter() - self.current_turn_start_time) * 1000)
@@ -457,7 +467,7 @@ class OpenAITranscriber(BaseTranscriber):
                     elif event_type == "input_audio_buffer.speech_started":
                         self._speech_active = True
                         self.turn_counter += 1
-                        self.current_turn_id = f"turn_{self.turn_counter}"
+                        self.current_turn_id = self.turn_counter
                         self.current_turn_start_time = time.perf_counter()
                         self._turn_start_epoch_ms = timestamp_ms()
                         self.current_turn_interim_details = []

--- a/bolna/transcriber/openai_transcriber.py
+++ b/bolna/transcriber/openai_transcriber.py
@@ -420,6 +420,7 @@ class OpenAITranscriber(BaseTranscriber):
                                 self.turn_counter += 1
                                 turn_id = self.turn_counter
                             self._last_latency_turn_id = turn_id
+                            self.meta_info["asr_turn_id"] = turn_id  # appends, so no base-class stamp
                             logger.info(f"Transcript completed for turn {turn_id}: {transcript[:80]}")
                             if self.current_turn_start_time:
                                 total_ms = round((time.perf_counter() - self.current_turn_start_time) * 1000)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.187"
+version = "0.10.188"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_asr_turn_id_normalization.py
+++ b/tests/tests/test_asr_turn_id_normalization.py
@@ -1,0 +1,28 @@
+"""ASR turn ids come in two shapes: Deepgram/Flux ints and OpenAI "turn_N" strings, while
+user_bot_latencies / LLM asr_turn_id use ints (transcriber turn_counter). Comparing across
+the shapes silently fails ("turn_5" in {5} is False), which duplicated every covered Whisper
+turn in user_bot_latencies. asr_id_to_int is the single boundary coercion."""
+
+from bolna.agent_manager.task_manager import asr_id_to_int
+
+
+def test_int_passthrough():
+    assert asr_id_to_int(5) == 5
+    assert asr_id_to_int(0) == 0
+
+
+def test_openai_string_form():
+    assert asr_id_to_int("turn_5") == 5
+    assert asr_id_to_int("turn_12") == 12
+
+
+def test_none_and_unparseable():
+    assert asr_id_to_int(None) is None
+    assert asr_id_to_int("turn_") is None
+    assert asr_id_to_int("") is None
+
+
+def test_string_and_int_forms_join():
+    """The exact failure the reviewer flagged: a covered turn must be seen as covered."""
+    covered = {asr_id_to_int(5)}
+    assert asr_id_to_int("turn_5") in covered

--- a/tests/tests/test_history_extra_keys_never_reach_llm.py
+++ b/tests/tests/test_history_extra_keys_never_reach_llm.py
@@ -1,0 +1,141 @@
+"""Conversation history carries bookkeeping keys (asr_turn_id, response_uid, turn_id,
+message_category) that must never reach a provider.
+
+Only the anthropic-family transformers and the Responses adapter rebuild the payload from
+known keys; the nine OpenAI-compatible providers forward the message dict verbatim, so the
+LLM adapters strip before sending. These tests pin both halves — what litellm does on its
+own, and what bolna actually puts on the wire.
+"""
+
+import json
+
+import pytest
+
+from bolna.enums import ChatRole
+from bolna.helpers.conversation_history import ConversationHistory
+from bolna.llms.message_models import (
+    INTERNAL_MESSAGE_KEYS,
+    ChatMessage,
+    MessageFormatAdapter,
+    strip_internal_keys,
+)
+
+EXTRA = {"asr_turn_id": 7, "response_uid": "abc"}
+
+
+def _transform(provider: str, model: str, messages: list[dict] | None = None):
+    """Run the provider's real request builder and return the body litellm would send."""
+    pytest.importorskip("litellm")
+    from litellm.types.utils import LlmProviders
+    from litellm.utils import ProviderConfigManager
+
+    config = ProviderConfigManager.get_provider_chat_config(model=model, provider=LlmProviders(provider))
+    if config is None:
+        pytest.skip(f"{provider} has no chat config in this litellm build")
+    return config.transform_request(
+        model=model,
+        messages=messages if messages is not None else [{"role": "user", "content": "hello", **EXTRA}],
+        optional_params={},
+        litellm_params={},
+        headers={},
+    )
+
+
+def test_append_user_carries_extra_keys():
+    history = ConversationHistory()
+    history.append_user("hello", **EXTRA)
+    assert history.messages[-1] == {"role": ChatRole.USER, "content": "hello", **EXTRA}
+
+
+def test_append_user_without_kwargs_stays_bare():
+    """Synthetic turns (idle-flush, injected prompts) have no ASR turn and must not gain a key."""
+    history = ConversationHistory()
+    history.append_user("hello")
+    assert history.messages[-1] == {"role": ChatRole.USER, "content": "hello"}
+
+
+def test_chat_message_model_ignores_unknown_keys():
+    """The Responses adapter parses through ChatMessage; extra="forbid" would raise here."""
+    parsed = ChatMessage(**{"role": "user", "content": "hello", **EXTRA})
+    assert parsed.model_dump(exclude_none=True) == {"role": "user", "content": "hello"}
+
+
+def test_responses_api_input_drops_extra_keys():
+    _, items = MessageFormatAdapter.chat_to_responses_input([{"role": "user", "content": "hello", **EXTRA}])
+    assert len(items) == 1
+    assert set(items[0]) == {"type", "role", "content"}
+    assert "asr_turn_id" not in json.dumps(items, default=str)
+
+
+@pytest.mark.parametrize(
+    "provider,model",
+    [
+        ("anthropic", "claude-3-5-sonnet-20241022"),
+        ("bedrock", "anthropic.claude-3-5-sonnet-20240620-v1:0"),
+    ],
+)
+def test_litellm_rebuilding_providers_drop_extra_keys(provider, model):
+    """These transformers construct the payload from known keys, so nothing extra survives."""
+    assert "asr_turn_id" not in json.dumps(_transform(provider, model), default=str)
+
+
+@pytest.mark.parametrize(
+    "provider,model",
+    [
+        ("cohere", "command-r"),
+        ("groq", "llama-3.1-8b-instant"),
+        ("deepseek", "deepseek-chat"),
+        ("openrouter", "openai/gpt-4o-mini"),
+        ("together_ai", "meta-llama/Llama-3-8b-chat-hf"),
+        ("perplexity", "sonar"),
+        ("fireworks_ai", "accounts/fireworks/models/llama-v3-8b-instruct"),
+        ("deepinfra", "meta-llama/Llama-2-70b-chat-hf"),
+        ("vllm", "facebook/opt-125m"),
+    ],
+)
+def test_openai_compatible_providers_would_forward_extra_keys(provider, model):
+    """These pass the dict through untouched, which is why bolna strips before calling them.
+    Pinned so the day litellm starts sanitising, we notice the guard is redundant."""
+    assert "asr_turn_id" in json.dumps(_transform(provider, model), default=str)
+
+
+@pytest.mark.parametrize(
+    "provider,model",
+    [
+        ("anthropic", "claude-3-5-sonnet-20241022"),
+        ("bedrock", "anthropic.claude-3-5-sonnet-20240620-v1:0"),
+        ("cohere", "command-r"),
+        ("groq", "llama-3.1-8b-instant"),
+        ("deepseek", "deepseek-chat"),
+        ("openrouter", "openai/gpt-4o-mini"),
+        ("together_ai", "meta-llama/Llama-3-8b-chat-hf"),
+        ("perplexity", "sonar"),
+        ("fireworks_ai", "accounts/fireworks/models/llama-v3-8b-instruct"),
+        ("deepinfra", "meta-llama/Llama-2-70b-chat-hf"),
+        ("vllm", "facebook/opt-125m"),
+    ],
+)
+def test_nothing_leaks_once_bolna_strips(provider, model):
+    """The guarantee that matters: what bolna actually sends carries no bookkeeping keys,
+    for every provider, without relying on the server to ignore them."""
+    sent = strip_internal_keys([{"role": "user", "content": "hello", **EXTRA}])
+    body = json.dumps(_transform(provider, model, messages=sent), default=str)
+    assert "asr_turn_id" not in body and "response_uid" not in body
+
+
+def test_strip_preserves_real_chat_keys():
+    """A tool-call turn must keep content=None and tool_calls, or the API rejects the thread."""
+    assert strip_internal_keys([{"role": "assistant", "content": None, "tool_calls": [{"id": "x"}], "turn_id": 3}]) == [
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "x"}]}
+    ]
+
+
+def test_strip_only_removes_our_own_keys():
+    """Denylist, not allowlist — a provider key we don't know about must survive untouched."""
+    message = {"role": "user", "content": "hi", "name": "caller", "cache_control": {"type": "ephemeral"}}
+    assert strip_internal_keys([{**message, **EXTRA, "message_category": "handoff"}]) == [message]
+
+
+def test_strip_removes_every_internal_key():
+    noisy = {k: "x" for k in INTERNAL_MESSAGE_KEYS}
+    assert strip_internal_keys([{"role": "user", "content": "hi", **noisy}]) == [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
fix: give transcript rows the ids and timing the dashboard needs to place them

  ## Problem

  The dashboard can't reliably say *when* a transcript line was spoken, so clicking a line
  seeks to the wrong point in the recording (BLT: "tool call takes to 45s, actually spoken
  at 1:30"). Root cause is on this side: rows leave bolna without the identifiers and
  timing needed to place them, forcing the consumer to correlate by text.

  Measured on 100 long prod calls: **75% of transcript rows carried a fabricated timestamp.**

  ## Changes

  **1. User messages carry `turn_id`** (`conversation_history.py`, `task_manager.py:4397`)
  `append_user` took only content while `append_assistant` had `**kwargs` — an accident of
  `2ca5213`, which added kwargs for an unrelated reason and left the user path behind. The
  value was already in hand and logged on the very next line. Prod: assistant 8/9 messages
  carry `turn_id`, user **0/10**.

  Not changed: the two synthetic call sites (`:5812` idle-flush, `:6832` `_inject_and_run_llm`).
  Neither maps to a real ASR turn, so they stay id-less by design.

  **2. Whisper turn_ids are ints, and unique** (`openai_transcriber.py`)
  - Three sites emitted `f"turn_{n}"` though the counter was already monotonic. The string
    form tripped `task_manager.py:7551`'s `isinstance(_tid, int)` guard, which was silently
    dropping **every** Whisper transcriber turn from the `user_bot_latencies` enrichment.
  - OpenAI emits several transcription items per committed turn, all reusing
    `_last_committed_turn_id` (prod `2e032eca`: `turn_3`×2, `turn_13`×2, `turn_34`×2), so any
    consumer keyed on turn_id lost all but the last. Extras now get a fresh id via
    `_last_latency_turn_id`. Deliberately **not** `_upsert_turn_latency` — that collapses them
    and discards a real transcript.

  **3. Canned agent messages are tagged** (`task_manager.py`)
  `is_user_online_message` and `handoff` now carry `sequence_id=-1` + `message_category`.
  These are template strings with no LLM turn; previously nothing distinguished them from a
  model reply.

  **4. `synthesizer_chunk_marks` added to `progression_data`** (`task_manager.py:7493`)
  It was in `latency_dict` but absent from **930,797 / 930,797** observability blobs. It is the
  only record carrying both the *text* and the *send time* of template speech, so without it
  the ~130 canned agent rows per 100 calls cannot be timed at all — a consumer-side anchor
  written against it measured exactly 0 hits.

  ## LLM payload safety — verified, not assumed

  `self.history` is passed unfiltered (`task_manager.py:2966` → `contextual_conversational_agent.py:73`
  → `azure_llm.py:132` / `litellm.py:73`), so extra message keys already reach providers today:
  **643 messages carrying `turn_id`/`response_uid` across 145/150 prod calls, 0 failures.**

  | adapter | providers | behaviour |
  |---|---|---|
  | Azure/OpenAI chat | azure, openai, custom, ola | ignores unknown keys (proven in prod) |
  | Responses API | `use_responses_api` | `ChatMessage(**msg)` strips them (executed, pydantic 2.13.4) |
  | Gemini | google | `_prepare_history` reads only role/content/tool_calls |
  | LiteLLM | anthropic, groq, deepseek, bedrock, cohere, openrouter, together, perplexity, … | **8/8 models accepted**; `anthropic_messages_pt` rebuilds the payload — `turn_id` does not leak |
