### PR TITLE
feat(graph-agent): expose execution_id as a prompt variable

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.181"
+__version__ = "0.10.182"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1792,6 +1792,7 @@ class TaskManager(BaseManager):
             injected_cfg["buffer_size"] = self.task_config["tools_config"]["synthesizer"].get("buffer_size")
             injected_cfg["language"] = self.language
             injected_cfg["turn_based_conversation"] = self.turn_based_conversation
+            injected_cfg["execution_id"] = self.run_id
 
             llm_agent = GraphAgent(injected_cfg)
             logger.info("Graph agent created with rag-proxy-server support")

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -66,9 +66,6 @@ class GraphAgent(BaseAgent):
         self.agent_information = self.config.get("agent_information")
         self.current_node_id = self.config.get("current_node_id")
         self.context_data = self.config.get("context_data") or {}
-        # Expose execution_id as a prompt/routing variable. It is call-unique, so it is
-        # only ever substituted where a node explicitly references {execution_id}; unused,
-        # the rendered prompt is byte-identical and the prompt cache is untouched.
         execution_id = self.config.get("execution_id")
         if execution_id and isinstance(self.context_data.get("recipient_data"), dict):
             self.context_data["recipient_data"]["execution_id"] = execution_id

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -66,6 +66,12 @@ class GraphAgent(BaseAgent):
         self.agent_information = self.config.get("agent_information")
         self.current_node_id = self.config.get("current_node_id")
         self.context_data = self.config.get("context_data") or {}
+        # Expose execution_id as a prompt/routing variable. It is call-unique, so it is
+        # only ever substituted where a node explicitly references {execution_id}; unused,
+        # the rendered prompt is byte-identical and the prompt cache is untouched.
+        execution_id = self.config.get("execution_id")
+        if execution_id and isinstance(self.context_data.get("recipient_data"), dict):
+            self.context_data["recipient_data"]["execution_id"] = execution_id
         self.variable_types = self.config.get("variable_types") or {}
         self.llm_model = self.config.get("model")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.181"
+version = "0.10.182"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Graph agents never received the execution_id, so node prompts and `agent_information` could not reference it (normal agents get it via the Call information block). This wires `run_id` into the graph agent config and exposes it as `{execution_id}` for prompt substitution and expression routing.

Cache-safe: execution_id is call-unique and only substituted where a node explicitly references `{execution_id}`. When unused, the rendered prompt is byte-identical, so the prompt cache is untouched. Within-call turn caching is unaffected since the value is constant across turns of a call.