### PR TITLE
fix: substitute context variables in graph routing prompts

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.184"
+__version__ = "0.10.185"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -350,11 +350,14 @@ class GraphAgent(BaseAgent):
     def _build_transition_tools_for_edges(self, edges: list, allow_stay: bool = True) -> list:
         """allow_stay=False omits stay_on_current_node so the model must pick a real edge."""
         tools = []
+        prompt_context = self._prompt_context()
         for edge in edges:
             func_name = self._edge_function_name(edge)
             func_description = (
                 edge.get("function_description") or f"Call this function when: {edge.get('condition', '')}"
             )
+            if prompt_context:
+                func_description = update_prompt_with_context(func_description, prompt_context)
 
             parameters = {"type": "object", "properties": {}, "required": []}
             if edge.get("parameters"):
@@ -813,7 +816,12 @@ class GraphAgent(BaseAgent):
             except Exception as e:
                 logger.debug(f"Variable substitution in routing_instructions failed: {e}")
 
+        # Substituted with the same frozen context the spoken prompt uses: the router
+        # otherwise reads "{Name}" while the conversation history shows the real value.
         node_objective = node.get("prompt") or node.get("description") or ""
+        prompt_context = self._prompt_context()
+        if prompt_context:
+            node_objective = update_prompt_with_context(node_objective, prompt_context)
         system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {node["id"]}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""
 
         logger.debug(f"Routing system prompt:\n{system_prompt}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.184"
+version = "0.10.185"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The routing LLM received node prompts and edge conditions with their `{variables}` unsubstituted, while the conversation prompt for the same call rendered them. A router would read `Node Objective: नमस्ते {Name} जी, मैं {assistantName} बोल रही हूँ` immediately above a conversation history showing the real name, so any routing decision that depends on personalized node text or an edge condition was made against placeholders.

`_decide_next_node_llm` substituted `routing_instructions` only. The node objective and the edge conditions that become transition tool descriptions went in raw.

Both now run through `update_prompt_with_context` with `_prompt_context()`, the same helper and same call-start-frozen context the spoken prompt uses, so the two prompts agree and the routing prefix stays stable across turns.

Pre-existing behavior on a missing variable is unchanged: `update_prompt_with_context` renders it empty and returns the text untouched if the string holds braces that are not variables.
