### PR TITLE
fix: default graph routing reasoning_effort per model instead of hardcoded minimal

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.183"
+__version__ = "0.10.184"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -26,7 +26,7 @@ from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
-from bolna.constants import LANGUAGE_NAMES
+from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
 
 from typing import List, Tuple, AsyncGenerator, Optional, Dict, Any
 
@@ -857,10 +857,13 @@ class GraphAgent(BaseAgent):
                 "parallel_tool_calls": False,
             }
 
-            if self.routing_model and self.routing_model.startswith("gpt-5"):
+            routing_model = canonical_model(self.routing_model)
+            if routing_model.startswith(GPT5_MODEL_PREFIX):
                 routing_kwargs["max_completion_tokens"] = self.routing_max_tokens or 150
-                routing_kwargs["reasoning_effort"] = self.routing_reasoning_effort or os.getenv(
-                    "GPT5_ROUTING_REASONING_EFFORT", "minimal"
+                routing_kwargs["reasoning_effort"] = (
+                    self.routing_reasoning_effort
+                    or os.getenv("GPT5_ROUTING_REASONING_EFFORT")
+                    or default_reasoning_effort(routing_model)
                 )
             else:
                 routing_kwargs["max_tokens"] = self.routing_max_tokens or 250

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.183"
+version = "0.10.184"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_routing_reasoning_effort_default.py
+++ b/tests/tests/test_routing_reasoning_effort_default.py
@@ -1,0 +1,104 @@
+"""Routing reasoning_effort must be one the routing model actually accepts.
+
+The default used to be a hardcoded "minimal", which only gpt-5, gpt-5-mini and gpt-5-nano
+accept, so routing was rejected by the provider on gpt-5.1 and later. The gpt-5 family check
+also read the raw model name, missing Azure deployment names entirely.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.constants import MODEL_REASONING_EFFORT_MAP
+
+GPT5_MODELS = sorted(MODEL_REASONING_EFFORT_MAP)
+AZURE_DEPLOYMENT_FORMS = ["azure/gpt-5.4-mini", "ptu-gpt-5.4-mini"]
+
+
+def _make_agent(**config_overrides):
+    config = {
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "temperature": 0.7,
+        "max_tokens": 150,
+        "current_node_id": "start",
+        "nodes": [{"id": "start", "prompt": "hi", "edges": []}],
+    }
+    config.update(config_overrides)
+
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAI", return_value=MagicMock()),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": MagicMock()}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        return GraphAgent(config)
+
+
+async def _captured_routing_kwargs(agent):
+    """Run one routing decision and return the kwargs sent to the routing client."""
+    captured = {}
+
+    def _create(**kwargs):
+        captured.update(kwargs)
+        response = MagicMock()
+        response.usage = None
+        response.choices[0].message.tool_calls = None
+        return response
+
+    agent.routing_client = MagicMock()
+    agent.routing_client.chat.completions.create = _create
+
+    node = {"id": "start", "prompt": "hi"}
+    edges = [{"to_node_id": "next", "condition_type": "intent", "intent": "wants next"}]
+    await agent._decide_next_node_llm(node, edges, [{"role": "user", "content": "hello"}], 0.0)
+    return captured
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("model", GPT5_MODELS)
+async def test_default_effort_is_accepted_by_the_model(model):
+    agent = _make_agent(routing_model=model, routing_provider="openai")
+    effort = (await _captured_routing_kwargs(agent))["reasoning_effort"]
+    assert effort in [e.value for e in MODEL_REASONING_EFFORT_MAP[model]]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("deployment", AZURE_DEPLOYMENT_FORMS)
+async def test_azure_deployment_names_take_the_gpt5_branch(deployment):
+    agent = _make_agent(routing_model=deployment, routing_provider="openai")
+    kwargs = await _captured_routing_kwargs(agent)
+
+    assert kwargs["reasoning_effort"] in [e.value for e in MODEL_REASONING_EFFORT_MAP["gpt-5.4-mini"]]
+    assert "max_completion_tokens" in kwargs
+    assert "temperature" not in kwargs
+    assert kwargs["model"] == deployment
+
+
+@pytest.mark.asyncio
+async def test_explicit_effort_wins_over_the_default():
+    agent = _make_agent(routing_model="gpt-5.4-mini", routing_provider="openai", routing_reasoning_effort="high")
+    assert (await _captured_routing_kwargs(agent))["reasoning_effort"] == "high"
+
+
+@pytest.mark.asyncio
+async def test_env_override_applies_when_unset():
+    agent = _make_agent(routing_model="gpt-5.4-mini", routing_provider="openai")
+    with patch.dict("os.environ", {"GPT5_ROUTING_REASONING_EFFORT": "medium"}):
+        assert (await _captured_routing_kwargs(agent))["reasoning_effort"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_non_gpt5_routing_is_unchanged():
+    agent = _make_agent(routing_model="gpt-4.1-mini", routing_provider="openai")
+    kwargs = await _captured_routing_kwargs(agent)
+
+    assert "reasoning_effort" not in kwargs
+    assert kwargs["max_tokens"] == 250
+    assert kwargs["temperature"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_routing_max_tokens_override_is_respected():
+    agent = _make_agent(routing_model="gpt-5.4-mini", routing_provider="openai", routing_max_tokens=99)
+    assert (await _captured_routing_kwargs(agent))["max_completion_tokens"] == 99


### PR DESCRIPTION
Graph agent routing sent `reasoning_effort: "minimal"` to any gpt-5 routing model when `routing_reasoning_effort` was unset. `minimal` is only accepted by gpt-5, gpt-5-mini and gpt-5-nano, so routing failed at the provider for gpt-5.1, 5.2, 5.4, 5.5 and 5.6.

The gpt-5 check also read the raw routing model, so Azure deployment names (`azure/gpt-5.4-mini`, `ptu-gpt-5.4-mini`) were not recognised as gpt-5 at all and took the non-reasoning branch, sending `max_tokens` and `temperature: 0.0`.

Resolves the routing model through `canonical_model()` and falls back to `default_reasoning_effort()`, matching what the simple agent path already does. `GPT5_ROUTING_REASONING_EFFORT` stays as an explicit override.

Resolved effort is now legal for all 13 gpt-5 models in `MODEL_REASONING_EFFORT_MAP` plus the two Azure deployment forms; 12 of those 14 were broken before.
