### PR TITLE
fix: stop azure tts repeating a turn's text once per audio chunk

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.185"
+__version__ = "0.10.186"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/azure_synthesizer.py
+++ b/bolna/synthesizer/azure_synthesizer.py
@@ -227,12 +227,15 @@ class AzureSynthesizer(BaseSynthesizer):
 
                         self._stamp_first_chunk(meta_info)
 
-                        if done_event.is_set() and chunk_queue.empty():
+                        is_last_chunk_of_text = done_event.is_set() and chunk_queue.empty()
+                        if is_last_chunk_of_text:
                             self._stamp_end_of_stream(meta_info)
 
                         meta_info["text"] = text
                         meta_info["format"] = "wav"
-                        meta_info["text_synthesized"] = f"{text} "
+                        # Only the closing chunk carries the text: the heard-text accumulator
+                        # concatenates text_synthesized per acked mark.
+                        meta_info["text_synthesized"] = f"{text} " if is_last_chunk_of_text else ""
                         self._stamp_mark_id(meta_info)
                         yield create_ws_data_packet(chunk, meta_info)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.185"
+version = "0.10.186"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The Azure streaming loop stamped `text_synthesized` with the full turn text on every audio chunk, and each chunk gets its own mark id. `process_mark_message` concatenates `text_synthesized` per acked mark into the heard-text accumulators, so a turn split into N audio chunks accumulated the sentence N times. When `sync_history` runs for that turn, on barge-in or on the hangup path, it materialises the assistant message from that accumulator, so history and the stored transcript ended up with the same line repeated once per chunk while the LLM had produced it once.

Seen in production on an Azure agent: one `Got a response from LLM` of 115 chars, 19 audio chunks, `sync_history: response_heard len=2184`, and 19 copies in the transcript.

Azure streams raw audio with no text alignment, so there is no truthful per-chunk slice. The closing chunk of each text unit now carries the text and the rest carry none, which matches what ElevenLabs already emits from its receiver. Multi-flush turns still concatenate correctly since each flush has its own closing chunk. A barge-in mid-unit leaves that unit without heard text, so `sync_history` uses its duration-proportion branch, which derives the text from the committed message rather than from marks and is the path every streaming synthesizer already takes.

The cache path and the base HTTP path yield a single chunk per text and were already correct.
