### PR TITLE
fix: retry once on transient OpenAI server_error before terminating call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.181"
+__version__ = "0.10.182"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -498,7 +498,14 @@ class OpenAiLLM(OpenAICompatibleLLM):
             return {"type": "text"}
 
     async def _generate_stream_ws_responses(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None, _server_error_attempt=0
+        self,
+        messages,
+        synthesize=True,
+        request_json=False,
+        meta_info=None,
+        tool_choice=None,
+        tools=None,
+        _server_error_attempt=0,
     ):
         """Stream via persistent WebSocket — same interface as _generate_stream_responses."""
         if not messages:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -498,7 +498,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
             return {"type": "text"}
 
     async def _generate_stream_ws_responses(
-        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
+        self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None, _server_error_attempt=0
     ):
         """Stream via persistent WebSocket — same interface as _generate_stream_responses."""
         if not messages:
@@ -543,6 +543,14 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         self.previous_response_id = None
                         async for chunk in self._generate_stream_ws_responses(
                             messages, synthesize, request_json, meta_info, tool_choice
+                        ):
+                            yield chunk
+                        return
+                    if error_code == "server_error" and _server_error_attempt == 0:
+                        logger.warning(f"WS transient server_error from OpenAI, retrying once after 500ms")
+                        await asyncio.sleep(0.5)
+                        async for chunk in self._generate_stream_ws_responses(
+                            messages, synthesize, request_json, meta_info, tool_choice, _server_error_attempt=1
                         ):
                             yield chunk
                         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.181"
+version = "0.10.182"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
A single transient 500 server_error from OpenAI was immediately raising APIError → LLMError → call terminated with no retry. 
Add a one-shot retry with 500ms backoff specifically for server_error on the WS Responses API path, matching the existing retry pattern used for previous_response_not_found. The _server_error_attempt guard ensures we only retry once and don't loop on persistent failures.