### PR TITLE
fixed the utterance end issue

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.184"
+__version__ = "0.10.185"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -16,6 +16,9 @@ OPENAI_TRANSCRIBER_UTTERANCE_TIMEOUT_S = 0.5
 # ElevenLabs realtime (scribe_v2_realtime) accepts up to 50 keyterms for biasing.
 ELEVENLABS_REALTIME_MAX_KEYTERMS = 50
 
+# Deepgram rejects utterance_end_ms below 1000.
+DEEPGRAM_UTTERANCE_END_MS_MIN = 1000
+
 # Deepgram Flux defaults — all overridable via agent transcriber config
 DEEPGRAM_FLUX_EOT_THRESHOLD = 0.7  # confidence to declare end-of-turn
 DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD = 0.5  # confidence to trigger speculative LLM early

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -134,6 +134,8 @@ class Transcriber(BaseModel):
     sampling_rate: Optional[int] = 16000
     encoding: Optional[str] = "linear16"
     endpointing: Optional[int] = 500
+    # Deepgram UtteranceEnd fallback (word-gap based). Defaults to max(1000, endpointing).
+    utterance_end_ms: Optional[int] = None
     keywords: Optional[str] = None
     task: Optional[str] = "transcribe"
     provider: Optional[str] = "deepgram"

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -16,6 +16,7 @@ from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import create_ws_data_packet, timestamp_ms
 from bolna.enums import TelephonyProvider
 from bolna.constants import (
+    DEEPGRAM_UTTERANCE_END_MS_MIN,
     DEEPGRAM_FLUX_EOT_THRESHOLD,
     DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD,
     DEEPGRAM_FLUX_EOT_TIMEOUT_MS,
@@ -50,7 +51,13 @@ class DeepgramTranscriber(BaseTranscriber):
         super().__init__(input_queue)
         self.endpointing = endpointing
         self.endpointing_ms = int(endpointing)
-        self.utterance_end_ms = 1000 if self.endpointing_ms < 1000 else self.endpointing_ms
+        # UtteranceEnd fallback, measured on word gaps not silence — configurable per agent
+        # so it can be lengthened without touching endpointing. Unconfigured: max(1000, ep).
+        configured_utterance_end = kwargs.get("utterance_end_ms")
+        self.utterance_end_ms = max(
+            DEEPGRAM_UTTERANCE_END_MS_MIN,
+            int(configured_utterance_end) if configured_utterance_end else self.endpointing_ms,
+        )
         self.language = language
         self.stream = stream
         self.provider = telephony_provider

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.184"
+version = "0.10.185"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_deepgram_utterance_end_config.py
+++ b/tests/tests/test_deepgram_utterance_end_config.py
@@ -1,0 +1,65 @@
+"""utterance_end_ms drives the UtteranceEnd fallback and is measured on WORD gaps, not
+silence — with endpointing=200 it used to be pinned to 1000ms with no way to lengthen it
+except by wrecking the speech_final fast path. Now configurable per agent; unconfigured
+agents must keep the old derivation byte-for-byte."""
+
+from urllib.parse import urlparse, parse_qs
+
+from bolna.transcriber.deepgram_transcriber import DeepgramTranscriber
+from bolna.models import Transcriber
+
+
+def _make_transcriber(**kwargs):
+    return DeepgramTranscriber(
+        telephony_provider="plivo",
+        model="nova-3",
+        language="hi",
+        stream=True,
+        **kwargs,
+    )
+
+
+def _params(url):
+    return parse_qs(urlparse(url).query, keep_blank_values=True)
+
+
+def test_default_unchanged_low_endpointing():
+    # endpointing=200 → floored to 1000, exactly the old `1000 if ep < 1000 else ep`
+    assert _make_transcriber(endpointing="200").utterance_end_ms == 1000
+
+
+def test_default_unchanged_high_endpointing():
+    assert _make_transcriber(endpointing="1500").utterance_end_ms == 1500
+
+
+def test_override_wins_over_endpointing():
+    t = _make_transcriber(endpointing="200", utterance_end_ms=1500)
+    assert t.utterance_end_ms == 1500
+    assert t.endpointing_ms == 200  # fast path untouched
+
+
+def test_override_clamped_to_deepgram_minimum():
+    assert _make_transcriber(endpointing="200", utterance_end_ms=400).utterance_end_ms == 1000
+
+
+def test_none_override_falls_back():
+    # transcriber_config splat passes utterance_end_ms=None for unconfigured agents
+    assert _make_transcriber(endpointing="200", utterance_end_ms=None).utterance_end_ms == 1000
+
+
+def test_string_override_coerced():
+    # agent configs arrive as JSON; values may be strings like endpointing itself
+    assert _make_transcriber(endpointing="200", utterance_end_ms="2000").utterance_end_ms == 2000
+
+
+def test_value_reaches_ws_url():
+    t = _make_transcriber(endpointing="200", utterance_end_ms=1500)
+    params = _params(t._get_nova_ws_url())
+    assert params["utterance_end_ms"] == ["1500"]
+    assert params["endpointing"] == ["200"]
+
+
+def test_transcriber_model_accepts_field():
+    cfg = Transcriber(provider="deepgram", endpointing=200, utterance_end_ms=1500)
+    assert cfg.utterance_end_ms == 1500
+    assert Transcriber(provider="deepgram").utterance_end_ms is None


### PR DESCRIPTION
## Decouple Deepgram `utterance_end_ms` from `endpointing`

### Problem

Deepgram closes a user turn two ways: `speech_final` (silence-based, driven by
`endpointing`, ~90% of turns) and the `UtteranceEnd` fallback (driven by
`utterance_end_ms`, ~10% of turns — measured on prod: 58,241 vs 6,785 events/hour).

`utterance_end_ms` is measured on **word gaps, not silence**. A caller who hesitates
mid-sentence (filler sounds produce no words) trips it while VAD still shows active
speech — the turn is finalised mid-sentence and shipped to the LLM.

Today the two knobs are welded together:

```python
self.utterance_end_ms = 1000 if self.endpointing_ms < 1000 else self.endpointing_ms

At endpointing=200 an agent is pinned to a 1000ms fallback, and the only way to
lengthen it is to raise endpointing — degrading the fast path that handles 90% of turns.

Incident: exec cc37d373 — user speaking at 47s, Deepgram's own endpointer said
speech_final=false and SpeechStarted fired 40ms before, yet UtteranceEnd finalised
the turn mid-sentence (word gap 1.17s vs the pinned 1.0s trigger — missed by 170ms).
Cascaded into a phantom barge-in and a hangup_after_silence firing while the user was
still talking. utterance_end_ms: 1500 would have absorbed it with 330ms margin.

Change

utterance_end_ms is now independently configurable per agent:

- models.py — Transcriber.utterance_end_ms: Optional[int] = None
- deepgram_transcriber.py — max(DEEPGRAM_UTTERANCE_END_MS_MIN, int(configured) if configured else endpointing_ms)
- constants.py — DEEPGRAM_UTTERANCE_END_MS_MIN = 1000 (Deepgram rejects lower)

No plumbing: the value rides the existing **transcriber_config splat in
__setup_transcriber (same route as eot_timeout_ms), including the multilingual
pool path.

Backward compatibility — zero behaviour change unless opted in

- Unconfigured agents (key absent or None) fall back to max(1000, endpointing_ms),
which is algebraically identical to the old expression — verified exhaustively for
every endpointing value 0–20000, 0 mismatches. Same value, same WS URL, byte-for-byte.
- Pydantic field is optional with a None default — existing payloads validate unchanged.
- Nova streaming only: Flux uses eot_threshold/eot_timeout_ms and never reads this;
the non-streaming HTTP path doesn't either.
- Other transcriber classes all accept **kwargs, so the splat key is inert elsewhere.

Scope

This shifts a threshold; it is not a structural fix — a hesitation longer than the
configured value still truncates. The cc37d373 cascade bugs (contiguous continuation
scored as barge-in; hangup clock frozen while VAD fires) are separate task_manager
issues, not addressed here.

Tests

tests/tests/test_deepgram_utterance_end_config.py — 8 tests:
defaults unchanged (200→1000, 1500→1500), override wins (200 + 1500→1500), clamp holds
(400→1000), None falls back, string coerced ("2000"→2000), value reaches the nova WS
URL alongside untouched endpointing, model accepts the field.

Full suite: 789 passed, 10 pre-existing failures (identical list before/after). Ruff clean.