### PR TITLE
fix: let a Deepgram turn made only of non-final interims reach the LLM

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.190"
+__version__ = "0.10.191"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -672,7 +672,6 @@ class DeepgramTranscriber(BaseTranscriber):
                         self._turn_first_speech_epoch_ms = timestamp_ms()
                         self._turn_pending = True  # counter incremented on first real interim
                     self.speech_start_time = timestamp_ms()
-                    self.current_turn_interim_details = []
                     self.is_transcript_sent_for_processing = False
 
                     logger.info(f"Starting new turn with turn_id: {self.current_turn_id}")
@@ -740,6 +739,8 @@ class DeepgramTranscriber(BaseTranscriber):
                         self.current_turn_interim_details.append(interim_detail)
                         # Track time of last interim for timeout monitoring
                         self.last_interim_time = time.time()
+                        # A turn that never reaches is_final must still be finalizable.
+                        self.is_transcript_sent_for_processing = False
 
                         data = {"type": "interim_transcript_received", "content": transcript}
                         yield create_ws_data_packet(data, self.meta_info)
@@ -755,9 +756,6 @@ class DeepgramTranscriber(BaseTranscriber):
                             len(self.final_transcript.strip()),
                             transcript[:80],
                         )
-
-                        if self.is_transcript_sent_for_processing:
-                            self.is_transcript_sent_for_processing = False
 
                     if msg["speech_final"] and self.final_transcript.strip():
                         if not self.is_transcript_sent_for_processing and self.final_transcript.strip():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.190"
+version = "0.10.191"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_deepgram_turn_finalization.py
+++ b/tests/tests/test_deepgram_turn_finalization.py
@@ -1,0 +1,190 @@
+"""Nova turns that only ever produce non-final interims must still reach the LLM.
+
+Deepgram can force-close a turn mid-sentence and deliver the continuation as interims that
+never reach is_final. Such a turn must stay force-finalizable, while a cleanly finalized
+turn must never be re-emitted.
+"""
+
+import asyncio
+import json
+
+from bolna.transcriber.deepgram_transcriber import DeepgramTranscriber
+
+
+def _make_nova(output_queue=None, **kwargs):
+    t = DeepgramTranscriber(
+        telephony_provider="plivo",
+        model="nova-3",
+        language="en",
+        stream=True,
+        output_queue=output_queue,
+        **kwargs,
+    )
+    t.meta_info = {"request_id": "test-request"}
+    return t
+
+
+def _results(transcript, is_final=False, speech_final=False, start=0.0, duration=1.0):
+    return json.dumps(
+        {
+            "type": "Results",
+            "channel": {"alternatives": [{"transcript": transcript}]},
+            "is_final": is_final,
+            "speech_final": speech_final,
+            "start": start,
+            "duration": duration,
+            "metadata": {"request_id": "test-request"},
+        }
+    )
+
+
+class _FakeWS:
+    """Feeds a fixed list of Deepgram frames to receiver()."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def __aiter__(self):
+        for message in self._messages:
+            yield message
+
+
+async def _drain(transcriber, messages):
+    return [packet async for packet in transcriber.receiver(_FakeWS(messages))]
+
+
+def _transcripts(packets):
+    return [
+        p["data"]["content"] for p in packets if isinstance(p["data"], dict) and p["data"].get("type") == "transcript"
+    ]
+
+
+def _force_finalize_guard_passes(t):
+    """The condition monitor_utterance_timeout gates force-finalization on."""
+    return bool(
+        t.last_interim_time
+        and not t.is_transcript_sent_for_processing
+        and (t.final_transcript.strip() or t.current_turn_interim_details)
+    )
+
+
+def test_interim_after_emit_rearms_finalization():
+    t = _make_nova()
+    t.is_transcript_sent_for_processing = True
+
+    asyncio.run(_drain(t, [_results("a a a a a battery")]))
+
+    assert t.is_transcript_sent_for_processing is False
+    assert _force_finalize_guard_passes(t)
+
+
+def test_speech_started_preserves_pending_interims():
+    t = _make_nova()
+
+    asyncio.run(
+        _drain(
+            t,
+            [
+                _results("a a a a a battery"),
+                json.dumps({"type": "SpeechStarted"}),
+            ],
+        )
+    )
+
+    assert [d["transcript"] for d in t.current_turn_interim_details] == ["a a a a a battery"]
+    assert _force_finalize_guard_passes(t)
+
+
+def test_interim_only_turn_after_utterance_end_is_rescuable():
+    t = _make_nova()
+
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                _results("i was actually looking for", is_final=True, speech_final=False),
+                json.dumps({"type": "UtteranceEnd", "last_word_end": 4.8}),
+                _results("a a a a a battery", start=2.3, duration=1.0),
+                _results("a a a a a a a not", start=3.3, duration=1.0),
+                json.dumps({"type": "SpeechStarted"}),
+                json.dumps({"type": "SpeechStarted"}),
+            ],
+        )
+    )
+
+    assert _transcripts(packets) == [" i was actually looking for"]
+    assert _force_finalize_guard_passes(t)
+
+
+def test_stranded_turn_force_finalizes_to_the_llm():
+    q = asyncio.Queue()
+    t = _make_nova(output_queue=q)
+
+    async def scenario():
+        await _drain(
+            t,
+            [
+                _results("i was actually looking for", is_final=True, speech_final=False),
+                json.dumps({"type": "UtteranceEnd", "last_word_end": 4.8}),
+                _results("a a a a a battery", start=2.3, duration=1.0),
+                _results("a a a a a a a not", start=3.3, duration=1.0),
+                json.dumps({"type": "SpeechStarted"}),
+            ],
+        )
+        while not q.empty():
+            q.get_nowait()
+        await t._force_finalize_utterance()
+
+    asyncio.run(scenario())
+
+    packet = q.get_nowait()
+    assert packet["data"]["type"] == "transcript"
+    assert packet["data"]["content"] == "a a a a a a a not"
+    assert packet["data"]["force_finalized"] is True
+
+
+def test_speech_final_turn_stays_disarmed_after_emit():
+    t = _make_nova()
+
+    packets = asyncio.run(_drain(t, [_results("sorry who is this", is_final=True, speech_final=True)]))
+
+    assert _transcripts(packets) == [" sorry who is this"]
+    assert t.is_transcript_sent_for_processing is True
+    assert _force_finalize_guard_passes(t) is False
+
+
+def test_utterance_end_does_not_reemit_already_sent_transcript():
+    t = _make_nova()
+
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                _results("sorry who is this", is_final=True, speech_final=True),
+                json.dumps({"type": "UtteranceEnd", "last_word_end": 2.0}),
+            ],
+        )
+    )
+
+    assert _transcripts(packets) == [" sorry who is this"]
+
+
+def test_new_speech_after_speech_final_carries_only_the_new_words():
+    q = asyncio.Queue()
+    t = _make_nova(output_queue=q)
+
+    async def scenario():
+        await _drain(
+            t,
+            [
+                _results("sorry who is this", is_final=True, speech_final=True),
+                _results("actually never mind", start=2.0, duration=1.0),
+            ],
+        )
+        while not q.empty():
+            q.get_nowait()
+        await t._force_finalize_utterance()
+
+    asyncio.run(scenario())
+
+    assert q.get_nowait()["data"]["content"] == "actually never mind"


### PR DESCRIPTION
## Problem

Deepgram closes a Nova turn either on `speech_final` or on the `UtteranceEnd` fallback. When `UtteranceEnd` force-closes a turn mid-sentence, the caller's continuation opens a fresh turn. If that turn only ever produces non-final interims, it can never be emitted.

`is_transcript_sent_for_processing` was cleared only by an `is_final` result, so while interims were buffering, both the `UtteranceEnd` path and `monitor_utterance_timeout` stayed gated shut. `SpeechStarted` also cleared the flag, but it wiped `current_turn_interim_details` at the same time, so once the flag did clear there was no transcript left for the monitor to rescue.

Two reset paths, each satisfying one half of the force-finalize guard and destroying the other. The caller's words never reach the LLM, `callee_speaking` stays latched so the audio gate holds every frame, and the call ends on the inactivity timer with the agent silent.

## Change

Clear `is_transcript_sent_for_processing` on any content-bearing interim, so a turn that never reaches `is_final` stays finalizable.

Stop `SpeechStarted` from clearing `current_turn_interim_details`. Deepgram re-fires `SpeechStarted` mid-turn, so it is not a turn boundary, and every emit path already clears the list.

Drop the now-dead `is_final` reset. Any `is_final` result carrying text passes through the interim block first, so it is unreachable.

## Tests

`tests/tests/test_deepgram_turn_finalization.py`. Four of the seven fail without this change. The remaining three pin behavior that must not move: a cleanly finalized turn stays disarmed, `UtteranceEnd` does not re-emit an already sent transcript, and speech arriving after an emit carries only the new words.

Full suite 839 passed against 832 on master, with an identical set of 11 pre-existing failures.
