### PR TITLE
fix: pick the lowest thinking level each gemini 3.x model actually supports

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.192"
+__version__ = "0.10.193"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -328,6 +328,29 @@ def default_reasoning_effort(model: str) -> str:
     return supported[0].value
 
 
+GEMINI_THINKING_LEVEL_MAP = {
+    "gemini-3-flash-preview": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.1-flash-lite": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.1-flash-lite-preview": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.1-pro-preview": [RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.5-flash": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.5-flash-lite": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.6-flash": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],
+    "gemini-3.7-flash": [RE.LOW, RE.MEDIUM, RE.HIGH],
+}
+
+
+def default_thinking_level(model: str) -> str:
+    """Lowest-latency thinking level the Gemini 3.x model supports.
+
+    Unknown models fall back to "low", the only level the whole 3.x family accepts.
+    """
+    supported = GEMINI_THINKING_LEVEL_MAP.get(model.rsplit("/", 1)[-1])
+    if not supported:
+        return RE.LOW.value
+    return supported[0].value
+
+
 def canonical_model(name: str) -> str:
     """The known model a deployment serves, e.g. 'ptu-gpt-5.4-mini' -> 'gpt-5.4-mini'.
 

--- a/bolna/llms/gemini_llm.py
+++ b/bolna/llms/gemini_llm.py
@@ -5,6 +5,7 @@ import base64
 from typing import AsyncIterable
 from google import genai
 from google.genai import types
+from bolna.constants import default_thinking_level
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.utils import now_ms, compute_function_pre_call_message, convert_to_request_log
 from .llm import BaseLLM
@@ -192,44 +193,24 @@ class GeminiLLM(BaseLLM):
         return system_instruction, history
 
     def _get_thinking_config(self) -> "types.ThinkingConfig | None":
-        """
-        Return the correct ThinkingConfig per model family based on Google docs:
+        """Thinking knob per family: 3.x takes thinking_level, 2.5 takes thinking_budget.
 
-        Gemini 3.x  → use thinking_level (NOT thinking_budget)
-          - Pro    : level="low"     (minimum; "minimal" not supported for Pro)
-          - Flash/Lite: level="minimal" (near-off; avoids thought_signature overhead)
-
-        Gemini 2.5  → use thinking_budget
-          - Pro    : budget=128      (minimum; cannot disable)
-          - Flash  : budget=0        (fully off; range 0-24576)
-          - Flash-Lite: budget=0     (fully off; range 512-24576 but 0 disables)
-
-        If the user explicitly passed a thinking_budget > 0, honour it (2.5 models).
+        Sending either one to the other family is a 400, so an explicit budget only
+        applies to 2.5.
         """
         m = self.model
 
-        # User explicitly set a budget — honour it for 2.5 models only.
-        # Gemini 3.x uses thinking_level, not thinking_budget; passing budget to 3.x causes 400s.
         if self.thinking_budget and self.thinking_budget > 0 and "2.5" in m:
             return types.ThinkingConfig(thinking_budget=self.thinking_budget, include_thoughts=True)
 
-        # --- Gemini 3.x family: use thinking_level ---
         if m.startswith("gemini-3"):
-            if "pro" in m:
-                # Pro cannot disable thinking; "minimal" is not supported — use "low"
-                return types.ThinkingConfig(thinking_level="low", include_thoughts=True)
-            else:
-                # Flash / Flash-Lite: "minimal" is closest to off, avoids thought_signature cost
-                return types.ThinkingConfig(thinking_level="minimal", include_thoughts=True)
+            return types.ThinkingConfig(thinking_level=default_thinking_level(m), include_thoughts=True)
 
-        # --- Gemini 2.5 family: use thinking_budget ---
         if "2.5" in m:
             if "pro" in m:
-                # Pro cannot disable thinking; minimum budget is 128
+                # Pro cannot disable thinking; 128 is its floor.
                 return types.ThinkingConfig(thinking_budget=128, include_thoughts=True)
-            else:
-                # Flash / Flash-Lite: disable with 0
-                return types.ThinkingConfig(thinking_budget=0)
+            return types.ThinkingConfig(thinking_budget=0)
 
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.192"
+version = "0.10.193"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
`_get_thinking_config` sent `thinking_level=minimal` to every non-Pro gemini-3 model. gemini-3.7-flash rejects MINIMAL with a 400, so selecting it fails every turn.

Replaces the string sniffing with `GEMINI_THINKING_LEVEL_MAP` plus `default_thinking_level()`, mirroring the existing `MODEL_REASONING_EFFORT_MAP` and `default_reasoning_effort` pair. Levels were probed against the API per model rather than inferred. Unknown models fall back to low, the only level the whole 3.x family accepts.

Worth knowing for anyone selecting it: 3.7-flash has no minimal level and spends roughly 140 thought tokens before its first reply token, so an agent left at the default max_tokens of 100 returns a truncated reply. gemini-2.5-pro and gemini-3.1-pro-preview already behave this way for the same reason.