### PR TITLE
fix: stop standby transcribers in a pool from injecting phantom user turns

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.193"
+__version__ = "0.10.194"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/base_transcriber.py
+++ b/bolna/transcriber/base_transcriber.py
@@ -23,6 +23,14 @@ class BaseTranscriber:
         self.turn_latencies = []
         self.connection_error = None
         self.is_transcript_sent_for_processing = False
+        self.standby = False
+
+    def quiesce(self):
+        """Go on pool standby: this transcriber hears only keepalive silence from here."""
+        self.standby = True
+
+    def resume(self):
+        self.standby = False
 
     def _upsert_turn_latency(self, entry: dict) -> None:
         """Replace existing turn_latencies entry with matching turn_id, or append if new."""

--- a/bolna/transcriber/soniox_transcriber.py
+++ b/bolna/transcriber/soniox_transcriber.py
@@ -237,6 +237,27 @@ class SonioxTranscriber(BaseTranscriber):
         )
         logger.info(f"Soniox: starting new turn with turn_id {self.current_turn_id}")
 
+    def quiesce(self):
+        # The in-flight turn is not lost: switch() hands current_turn_id to the incoming
+        # transcriber, so a stub kept here would just duplicate the id that one reports.
+        super().quiesce()
+        if self.current_turn_id is not None:
+            self.turn_latencies = [
+                t
+                for t in self.turn_latencies
+                if t.get("turn_id") != self.current_turn_id or t.get("asr_finalized_epoch_ms") is not None
+            ]
+        self._reset_turn_state()
+
+    def resume(self):
+        # Keeps current_turn_id, which switch() sets just before this call, so the
+        # inherited utterance finalizes under its original id.
+        super().resume()
+        self.final_transcript = ""
+        self.current_turn_interim_details = []
+        self.last_interim_time = None
+        self.is_transcript_sent_for_processing = False
+
     def _reset_turn_state(self):
         self._turn_first_speech_epoch_ms = None
         self.current_turn_interim_details = []
@@ -314,6 +335,13 @@ class SonioxTranscriber(BaseTranscriber):
                         non_final_text += text
 
                 has_content = bool(new_final_text or non_final_text)
+
+                if self.standby:
+                    # Keepalive silence plus whatever Soniox is still refining from before
+                    # the switch. Drain it to keep the socket warm, but stay silent.
+                    new_final_text = ""
+                    has_content = False
+                    endpoint_hit = False
 
                 if has_content and self.current_turn_id is None:
                     self._start_turn()

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -67,8 +67,9 @@ class TranscriberPool:
                           Each instance already has its own private input_queue set.
             shared_input_queue: the original audio_queue from TaskManager that
                                 receives raw audio packets from the input handler.
-            output_queue: the shared transcriber_output_queue (all transcribers
-                          write to the same one).
+            output_queue: the shared transcriber_output_queue that TaskManager
+                          consumes. Each transcriber is re-pointed at a private
+                          queue and fanned in through _forward_output.
             active_label: which transcriber label should receive audio initially.
             multilingual_config: raw multilingual config dict from task_config
             lid_provider: "sarvam" | None (disables LID tap)
@@ -87,6 +88,17 @@ class TranscriberPool:
         if active_label not in self.transcribers:
             raise ValueError(f"active_label '{active_label}' not in transcribers: {list(self.transcribers.keys())}")
         self.active_label = active_label
+
+        # Transcribers are constructed against the shared output queue, so anything a
+        # standby emits reaches TaskManager as if the caller had spoken.
+        self._transcriber_queues = {}
+        for label, transcriber in self.transcribers.items():
+            private_queue = asyncio.Queue()
+            transcriber.transcriber_output_queue = private_queue
+            self._transcriber_queues[label] = private_queue
+            transcriber.standby = label != active_label
+        self._fanin_tasks: list[asyncio.Task] = []
+
         self._router_task = None
         self._keepalive_task = None
         self._multilingual_config = multilingual_config
@@ -202,6 +214,9 @@ class TranscriberPool:
             logger.info(f"TranscriberPool: starting transcriber '{label}'")
             await transcriber.run()
 
+        for label, queue in self._transcriber_queues.items():
+            self._fanin_tasks.append(asyncio.create_task(self._forward_output(label, queue)))
+
         self._router_task = asyncio.create_task(self._audio_router())
         self._keepalive_task = asyncio.create_task(self._standby_keepalive())
         logger.info(f"TranscriberPool: audio router started, active='{self.active_label}'")
@@ -243,6 +258,27 @@ class TranscriberPool:
                                 logger.warning(f"TranscriberPool: LID feed error: {e}")
         except asyncio.CancelledError:
             logger.info("TranscriberPool: audio router cancelled")
+
+    @staticmethod
+    def _packet_kind(packet):
+        data = packet.get("data") if isinstance(packet, dict) else None
+        return data.get("type") if isinstance(data, dict) else data
+
+    async def _forward_output(self, label, queue):
+        """Forward one transcriber's output to the shared queue, dropping standby speech."""
+        try:
+            while True:
+                packet = await queue.get()
+                kind = self._packet_kind(packet)
+                # Connection-closed passes from any label: TaskManager bills standby sockets
+                # off it and uses it to tell a dead standby from a dead active one.
+                if label == self.active_label or kind == "transcriber_connection_closed":
+                    await self.output_queue.put(packet)
+                    continue
+                if kind != "interim_transcript_received":
+                    logger.info(f"TranscriberPool: dropped '{kind}' from standby '{label}'")
+        except asyncio.CancelledError:
+            logger.info(f"TranscriberPool: output forwarder for '{label}' cancelled")
 
     async def _standby_keepalive(self):
         """Periodically send silence frames to standby transcribers.
@@ -571,10 +607,17 @@ class TranscriberPool:
             # event on the new transcriber will increment the counter normally.
             old_transcriber = self.transcribers[old]
             inherited_turn_counter = getattr(old_transcriber, "turn_counter", 0)
+            inherited_turn_id = getattr(old_transcriber, "current_turn_id", None)
             if hasattr(target, "turn_counter"):
                 target.turn_counter = inherited_turn_counter
-            if hasattr(target, "current_turn_id") and getattr(old_transcriber, "current_turn_id", None) is not None:
-                target.current_turn_id = old_transcriber.current_turn_id
+            if hasattr(target, "current_turn_id") and inherited_turn_id is not None:
+                target.current_turn_id = inherited_turn_id
+
+            # After the inherited state is read above: quiesce() clears it. The outgoing
+            # transcriber keeps a live session for switch-back, so without this its
+            # half-recognized utterance resurfaces later as a phantom user turn.
+            target.resume()
+            old_transcriber.quiesce()
 
             self.active_label = label
             logger.info(f"TranscriberPool: switched {old} -> {label} (inherited turn_counter={inherited_turn_counter})")
@@ -632,7 +675,9 @@ class TranscriberPool:
 
     async def cleanup(self):
         """Clean up all transcribers, cancel pool tasks, and stop LID tap."""
-        for task_name, task in [("router", self._router_task), ("keepalive", self._keepalive_task)]:
+        pool_tasks = [("router", self._router_task), ("keepalive", self._keepalive_task)]
+        pool_tasks += [(f"output forwarder {i}", t) for i, t in enumerate(self._fanin_tasks)]
+        for task_name, task in pool_tasks:
             if task and not task.done():
                 task.cancel()
                 try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.193"
+version = "0.10.194"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_transcriber_pool_lid_heuristic.py
+++ b/tests/tests/test_transcriber_pool_lid_heuristic.py
@@ -10,13 +10,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from bolna.transcriber.base_transcriber import BaseTranscriber
 from bolna.transcriber.transcriber_pool import TranscriberPool
 
 
-class FakeTranscriber:
+class FakeTranscriber(BaseTranscriber):
     def __init__(self):
+        super().__init__(asyncio.Queue())
         self.run = AsyncMock()
-        self.input_queue = asyncio.Queue()
         self.transcription_task = None
 
 

--- a/tests/tests/test_transcriber_pool_reconnect.py
+++ b/tests/tests/test_transcriber_pool_reconnect.py
@@ -8,13 +8,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from bolna.transcriber.base_transcriber import BaseTranscriber
 from bolna.transcriber.transcriber_pool import TranscriberPool
 
 
-class FakeTranscriber:
+class FakeTranscriber(BaseTranscriber):
     def __init__(self):
+        super().__init__(asyncio.Queue())
         self.run = AsyncMock()
-        self.input_queue = asyncio.Queue()
         self.transcription_task = None
 
 

--- a/tests/tests/test_transcriber_pool_standby_isolation.py
+++ b/tests/tests/test_transcriber_pool_standby_isolation.py
@@ -1,0 +1,183 @@
+"""A pool standby must not reach the pipeline.
+
+Every transcriber is constructed against the shared transcriber_output_queue, and switch()
+leaves the outgoing one connected so switch-back is instant. Together that let an abandoned
+transcriber keep refining its un-endpointed hypothesis on keepalive silence and force-finalize
+it as a real user turn every interim_timeout, cancelling the agent's in-flight audio and
+re-running the turn for the rest of the call.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from bolna.transcriber.soniox_transcriber import SonioxTranscriber
+from bolna.transcriber.transcriber_pool import TranscriberPool
+
+
+class _FakeWS:
+    """Feeds a fixed list of Soniox frames to receiver()."""
+
+    def __init__(self, messages):
+        self._messages = messages
+
+    async def __aiter__(self):
+        for message in self._messages:
+            yield json.dumps(message)
+
+
+def _tokens(*texts, final=False, endpoint=False):
+    """A Soniox frame. Non-final tokens are the running hypothesis; only final ones
+    accumulate into final_transcript, which is what the endpoint branch sends."""
+    toks = [{"text": t, "is_final": final, "end_ms": 1000} for t in texts]
+    if endpoint:
+        toks.append({"text": "<end>", "is_final": True})
+    return {"tokens": toks}
+
+
+def _make_soniox():
+    t = SonioxTranscriber("plivo", input_queue=asyncio.Queue(), output_queue=asyncio.Queue())
+    t.meta_info = {}
+    return t
+
+
+def _pool(active="en"):
+    transcribers = {"en": _make_soniox(), "ta": _make_soniox()}
+    shared_output = asyncio.Queue()
+    pool = TranscriberPool(
+        transcribers=transcribers,
+        shared_input_queue=asyncio.Queue(),
+        output_queue=shared_output,
+        active_label=active,
+        multilingual_config={},
+    )
+    # run() would also open real provider sockets; the forwarders are what these tests need.
+    for label, queue in pool._transcriber_queues.items():
+        pool._fanin_tasks.append(asyncio.create_task(pool._forward_output(label, queue)))
+    return pool, transcribers, shared_output
+
+
+async def _drain(transcriber, messages):
+    return [packet async for packet in transcriber.receiver(_FakeWS(messages))]
+
+
+async def _forwarded(pool, shared_output):
+    await asyncio.sleep(0)  # let the forwarder tasks run
+    kinds = []
+    while not shared_output.empty():
+        kinds.append(pool._packet_kind(shared_output.get_nowait()))
+    return kinds
+
+
+async def _stop(pool):
+    for task in pool._fanin_tasks:
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_pool_gives_each_transcriber_a_private_output_queue():
+    pool, transcribers, shared_output = _pool()
+    assert transcribers["en"].transcriber_output_queue is not shared_output
+    assert transcribers["ta"].transcriber_output_queue is not shared_output
+    assert transcribers["en"].standby is False
+    assert transcribers["ta"].standby is True
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_switch_hands_the_turn_over_and_quiesces_the_outgoing_transcriber():
+    pool, transcribers, _ = _pool()
+    en, ta = transcribers["en"], transcribers["ta"]
+    await _drain(en, [_tokens("the quick brown fox")])
+    assert en.current_turn_id == 1
+
+    await pool.switch("ta")
+
+    # The in-flight turn moves to the incoming transcriber rather than being abandoned...
+    assert ta.current_turn_id == 1
+    assert ta.standby is False
+    # ...and the outgoing one keeps nothing that could be force-finalized later.
+    assert en.standby is True
+    assert en.current_turn_id is None
+    assert en.final_transcript == ""
+    # No un-finalized stub either: it would duplicate the turn id 'ta' now reports.
+    assert en.turn_latencies == []
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_standby_does_not_open_a_turn_from_a_stale_hypothesis():
+    pool, transcribers, _ = _pool()
+    en = transcribers["en"]
+    await _drain(en, [_tokens("the quick brown fox")])
+    await pool.switch("ta")
+
+    # Soniox keeps refining the abandoned hypothesis as keepalive silence arrives.
+    await _drain(en, [_tokens("the quick brown fox jumped over the la")])
+
+    assert en.current_turn_id is None
+    assert en.turn_latencies == []
+    assert en.last_interim_time is None
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_force_finalized_standby_transcript_never_reaches_the_pipeline():
+    pool, transcribers, shared_output = _pool()
+    en = transcribers["en"]
+    await _drain(en, [_tokens("the quick brown fox")])
+    await pool.switch("ta")
+
+    # Drive the timeout path directly: even if it fires, the forwarder must swallow it.
+    en.last_interim_time = 0.0
+    en.current_turn_interim_details = [
+        {"transcript": "the quick brown fox jumped over the la", "received_at": 0.0, "is_final": False}
+    ]
+    await en._force_finalize_utterance()
+
+    assert await _forwarded(pool, shared_output) == []
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_active_transcript_is_forwarded():
+    pool, transcribers, shared_output = _pool()
+    ta = transcribers["ta"]
+    await pool.switch("ta")
+    for packet in await _drain(ta, [_tokens("yes that is right", final=True, endpoint=True)]):
+        await ta.push_to_transcriber_queue(packet)
+
+    assert "transcript" in await _forwarded(pool, shared_output)
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_standby_connection_closed_still_reaches_the_pipeline():
+    # TaskManager bills standby sockets off this packet and uses it to tell a dead
+    # standby from a dead active one, so it is the one thing a standby may still send.
+    pool, transcribers, shared_output = _pool()
+    await pool.switch("ta")
+    await transcribers["en"].push_to_transcriber_queue({"data": "transcriber_connection_closed", "meta_info": {}})
+
+    assert await _forwarded(pool, shared_output) == ["transcriber_connection_closed"]
+    await _stop(pool)
+
+
+@pytest.mark.asyncio
+async def test_switch_back_re_arms_the_previously_quiesced_transcriber():
+    # quiesce() sets is_transcript_sent_for_processing, which would otherwise make the
+    # first transcript after a switch-back get dropped in receiver's endpoint branch.
+    pool, transcribers, shared_output = _pool()
+    en = transcribers["en"]
+    await _drain(en, [_tokens("the quick brown fox")])
+    await pool.switch("ta")
+    await pool.switch("en")
+
+    assert en.standby is False
+    assert en.is_transcript_sent_for_processing is False
+    for packet in await _drain(en, [_tokens("ok go ahead", final=True, endpoint=True)]):
+        await en.push_to_transcriber_queue(packet)
+
+    assert "transcript" in await _forwarded(pool, shared_output)
+    await _stop(pool)

--- a/tests/tests/test_transcriber_pool_turn_latencies.py
+++ b/tests/tests/test_transcriber_pool_turn_latencies.py
@@ -9,13 +9,14 @@ mis-paired the user transcript with the wrong agent turn in the latency dict.
 import asyncio
 from unittest.mock import AsyncMock
 
+from bolna.transcriber.base_transcriber import BaseTranscriber
 from bolna.transcriber.transcriber_pool import TranscriberPool
 
 
-class FakeTranscriber:
+class FakeTranscriber(BaseTranscriber):
     def __init__(self, turn_latencies):
+        super().__init__(asyncio.Queue())
         self.run = AsyncMock()
-        self.input_queue = asyncio.Queue()
         self.transcription_task = None
         self.turn_latencies = turn_latencies
 


### PR DESCRIPTION
In a multilingual `TranscriberPool`, every transcriber is constructed against the same `transcriber_output_queue`, and `switch()` only flips `active_label`. The outgoing transcriber keeps its provider session (standby keepalive feeds it silence so switch-back stays instant), keeps its in-flight utterance, and keeps write access to the pipeline.

For Soniox that combination is visible to the caller. The abandoned session never receives an endpoint token, so `monitor_utterance_timeout` force-finalizes its stale partial every `interim_timeout` and pushes it as a real user transcript. Each one arrives at `_handle_transcriber_output` while the agent is still speaking, which triggers `__cleanup_downstream_tasks` and re-runs the turn. The caller hears the agent cut itself off and repeat the same sentence, with no barge-in on their side, for the rest of the call after a language switch. The phantom transcript grows by a syllable each round, so the `is_duplicate_user` guard does not catch it.

The fix has two parts.

`TranscriberPool` now owns the invariant that only the active transcriber reaches the pipeline. Each transcriber gets a private output queue, and one `_forward_output` task per label fans them into the shared queue, forwarding only when that label is active. `transcriber_connection_closed` always passes, since TaskManager bills standby sockets off it and uses it to tell a dead standby from a dead active one.

This gate is not Soniox-specific insurance. Deepgram pools leak too, and by volume more often. A test call on an `en`/`hi` Deepgram pool had the abandoned standby emit a full transcript 1.5 seconds after the switch, which the gate dropped. Deepgram lacks the force-finalize timer so it does not re-emit every `interim_timeout`, which is why the Soniox symptom is the one users report, but the underlying leak is the same and is not provider-specific.

`switch()` now quiesces the outgoing transcriber and resumes the incoming one, mirroring what `SynthesizerPool.switch()` already does with its generate task. `quiesce`/`resume` land on `BaseTranscriber` as no-ops. `SonioxTranscriber` overrides them to drop the in-flight utterance and stay silent while on standby, so the abandoned session drains its socket without opening turns, arming the force-finalize timer, or polluting `turn_latencies` with duplicate turn ids. The in-flight turn is not lost: `switch()` already hands `current_turn_id` to the incoming transcriber, which finalizes it.

Verified on a test environment. Driving identical audio through the telephony websocket on a Soniox pool agent, before: two transcribers running in lockstep, two utterance timeouts, six force-finalize events, four user turns for two utterances, and six LLM responses. After: one transcriber, no timeouts, no force-finalizes, two user turns, and three LLM responses (the third being the usual chunked-stream double log).

Also confirmed on a real inbound phone call over a Soniox pool: the switch fired, the call ran 48 more seconds past it, turn ids stayed strictly increasing with no duplicates, and there were no force-finalizes and no downstream cancellations. A single-language agent never constructs a pool, so that path is untouched, checked with its own call.

Three existing pool tests had hand-rolled `FakeTranscriber` stubs that did not model the base class; they now subclass `BaseTranscriber`.
