### PR TITLE
feat(llm): overflow a saturated PTU turn instead of ending the call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.193"
+__version__ = "0.10.194"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -276,6 +276,8 @@ class TaskManager(BaseManager):
         self.kwargs["task_manager_instance"] = self
         # Optional load-signal callback (set by the caller only for PTU-served calls).
         self.on_turn_usage = kwargs.get("on_turn_usage")
+        # Fired instead of on_turn_usage when another backend served the turn.
+        self.on_overflow = kwargs.get("on_overflow")
         self._usage_tasks = set()  # strong refs so fire-and-forget tallies aren't GC'd before they run
         # Optional per-provider health callback (circuit-breaker shadow); never affects the call.
         self.on_provider_health = kwargs.get("on_provider_health")
@@ -3596,10 +3598,12 @@ class TaskManager(BaseManager):
         self.llm_response_generated = True
         # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn,
         # which ran on another backend. Cached is exempt and output is weighted by the consumer.
-        if self.task_id == 0 and self.on_turn_usage and input_tokens and not overflowed:
-            _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens, output_tokens, cached_tokens))
-            self._usage_tasks.add(_usage_task)
-            _usage_task.add_done_callback(self._usage_tasks.discard)
+        if self.task_id == 0 and input_tokens:
+            cb = self.on_overflow if overflowed else self.on_turn_usage
+            if cb:
+                _usage_task = asyncio.create_task(cb(input_tokens, output_tokens, cached_tokens))
+                self._usage_tasks.add(_usage_task)
+                _usage_task.add_done_callback(self._usage_tasks.discard)
         convert_to_request_log(
             # log_message explains a silent turn; the history below keeps the raw response.
             message=log_message or llm_response,
@@ -6173,9 +6177,10 @@ class TaskManager(BaseManager):
                 reasoning_tokens=capture["reasoning_tokens"],
                 cached_tokens=capture["cached_tokens"],
             )
-            if self.task_id == 0 and self.on_turn_usage and capture["input_tokens"] and not capture["overflowed"]:
+            _spec_cb = self.on_overflow if capture["overflowed"] else self.on_turn_usage
+            if self.task_id == 0 and _spec_cb and capture["input_tokens"]:
                 usage_task = asyncio.create_task(
-                    self.on_turn_usage(capture["input_tokens"], capture["output_tokens"], capture["cached_tokens"])
+                    _spec_cb(capture["input_tokens"], capture["output_tokens"], capture["cached_tokens"])
                 )
                 self._usage_tasks.add(usage_task)
                 usage_task.add_done_callback(self._usage_tasks.discard)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3768,13 +3768,14 @@ class TaskManager(BaseManager):
 
                     # on_turn_usage meters the conversation LLM's backend; routing on azure means the routing
                     # hop shares that backend, so its tokens draw on the same capacity.
+                    _routing_cb = self.on_overflow if routing_usage.get("overflowed") else self.on_turn_usage
                     if (
-                        self.on_turn_usage
+                        _routing_cb
                         and routing_info.get("routing_provider") == "azure"
                         and routing_usage.get("input_tokens")
                     ):
                         _routing_task = asyncio.create_task(
-                            self.on_turn_usage(
+                            _routing_cb(
                                 routing_usage.get("input_tokens"),
                                 routing_usage.get("output_tokens"),
                                 routing_usage.get("cached_tokens"),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1780,6 +1780,8 @@ class TaskManager(BaseManager):
                 injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
+            if "overflow_llm" in self.kwargs:
+                injected_cfg["overflow_llm"] = self.kwargs["overflow_llm"]
             if "routing_reasoning_effort" in self.kwargs:
                 injected_cfg["routing_reasoning_effort"] = self.kwargs["routing_reasoning_effort"]
             if "routing_max_tokens" in self.kwargs:
@@ -1826,6 +1828,8 @@ class TaskManager(BaseManager):
                 injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
+            if "overflow_llm" in self.kwargs:
+                injected_cfg["overflow_llm"] = self.kwargs["overflow_llm"]
             if self.llm_config.get("use_responses_api"):
                 injected_cfg["use_responses_api"] = True
             if self.llm_config.get("compact_threshold"):
@@ -6169,7 +6173,7 @@ class TaskManager(BaseManager):
                 reasoning_tokens=capture["reasoning_tokens"],
                 cached_tokens=capture["cached_tokens"],
             )
-            if self.task_id == 0 and self.on_turn_usage and capture["input_tokens"]:
+            if self.task_id == 0 and self.on_turn_usage and capture["input_tokens"] and not capture["overflowed"]:
                 usage_task = asyncio.create_task(
                     self.on_turn_usage(capture["input_tokens"], capture["output_tokens"], capture["cached_tokens"])
                 )
@@ -6265,6 +6269,7 @@ class TaskManager(BaseManager):
         }
         text = ""
         input_tokens = output_tokens = reasoning_tokens = cached_tokens = None
+        overflowed = False
         latency_info = None
         async for llm_message in self.tools["llm_agent"].generate(messages, synthesize=False, meta_info=spec_meta):
             if isinstance(llm_message, dict):
@@ -6281,6 +6286,8 @@ class TaskManager(BaseManager):
                 reasoning_tokens = llm_message.reasoning_tokens
             if getattr(llm_message, "cached_tokens", None) is not None:
                 cached_tokens = llm_message.cached_tokens
+            if getattr(llm_message, "overflowed", False):
+                overflowed = True
             if getattr(llm_message, "latency", None):
                 latency_info = llm_message.latency
             if llm_message.data:
@@ -6297,6 +6304,7 @@ class TaskManager(BaseManager):
             "output_tokens": output_tokens,
             "reasoning_tokens": reasoning_tokens,
             "cached_tokens": cached_tokens,
+            "overflowed": overflowed,
             "latency": latency_info,
         }
         return text, capture

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3590,9 +3590,8 @@ class TaskManager(BaseManager):
         overflowed=False,
     ):
         self.llm_response_generated = True
-        # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn: it
-        # ran on another backend and placed no load on the pool being metered. Report input/output/
-        # cached so the consumer can compute normalized load (cached is exempt, output is weighted).
+        # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn,
+        # which ran on another backend. Cached is exempt and output is weighted by the consumer.
         if self.task_id == 0 and self.on_turn_usage and input_tokens and not overflowed:
             _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens, output_tokens, cached_tokens))
             self._usage_tasks.add(_usage_task)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3587,11 +3587,13 @@ class TaskManager(BaseManager):
         cached_tokens=None,
         reasoning_content=None,
         log_message=None,
+        overflowed=False,
     ):
         self.llm_response_generated = True
-        # task 0 only, so aux LLMs (hangup/voicemail) never tally. Report input/output/cached so the
-        # consumer can compute normalized load (cached is exempt, output is weighted).
-        if self.task_id == 0 and self.on_turn_usage and input_tokens:
+        # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn: it
+        # ran on another backend and placed no load on the pool being metered. Report input/output/
+        # cached so the consumer can compute normalized load (cached is exempt, output is weighted).
+        if self.task_id == 0 and self.on_turn_usage and input_tokens and not overflowed:
             _usage_task = asyncio.create_task(self.on_turn_usage(input_tokens, output_tokens, cached_tokens))
             self._usage_tasks.add(_usage_task)
             _usage_task.add_done_callback(self._usage_tasks.discard)
@@ -3644,6 +3646,7 @@ class TaskManager(BaseManager):
             None,
             None,
         )
+        actual_overflowed = False
         actual_reasoning_content = None
         synthesize = True
         if should_bypass_synth:
@@ -3850,6 +3853,8 @@ class TaskManager(BaseManager):
                     actual_reasoning_tokens = llm_message.reasoning_tokens
                 if llm_message.cached_tokens is not None:
                     actual_cached_tokens = llm_message.cached_tokens
+                if llm_message.overflowed:
+                    actual_overflowed = True
                 if llm_message.reasoning_content is not None:
                     actual_reasoning_content = llm_message.reasoning_content
 
@@ -3890,6 +3895,7 @@ class TaskManager(BaseManager):
                             reasoning_tokens=actual_reasoning_tokens,
                             cached_tokens=actual_cached_tokens,
                             reasoning_content=actual_reasoning_content,
+                            overflowed=actual_overflowed,
                         )
                     try:
                         await self.__execute_function_call(next_step=next_step, **data.model_dump())
@@ -3991,6 +3997,7 @@ class TaskManager(BaseManager):
                 cached_tokens=actual_cached_tokens,
                 reasoning_content=actual_reasoning_content,
                 log_message=empty_turn_detail,
+                overflowed=actual_overflowed,
             )
         elif not self.stream:
             llm_response = llm_response.strip()

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -25,7 +25,6 @@ from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.llms.azure_llm import should_overflow
-from bolna.llms.http_client_pool import get_shared_http_client
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
 from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
@@ -251,13 +250,16 @@ class GraphAgent(BaseAgent):
         try:
             return self.routing_client.chat.completions.create(**routing_kwargs), False
         except (APIStatusError, APIConnectionError) as e:
-            if getattr(self, "_routing_overflow_client", None) is None or not should_overflow(e):
+            cfg = getattr(self, "_routing_overflow_cfg", None)
+            if cfg is None or not should_overflow(e):
                 raise
-            logger.warning(f"Routing hop saturated, overflowing to {self._routing_overflow_model}")
+            if self._routing_overflow_client is None:
+                self._routing_overflow_client = OpenAI(api_key=cfg["api_key"], base_url=cfg["base_url"])
+            logger.warning(f"Routing hop saturated, overflowing to {cfg['model']}")
             overflow_kwargs = {
                 **routing_kwargs,
-                "model": self._routing_overflow_model,
-                "service_tier": self._routing_overflow_tier,
+                "model": cfg["model"],
+                "service_tier": cfg.get("service_tier") or "priority",
             }
             return self._routing_overflow_client.chat.completions.create(**overflow_kwargs), True
 
@@ -297,22 +299,19 @@ class GraphAgent(BaseAgent):
             azure_endpoint = self.base_url or os.getenv("AZURE_OPENAI_ENDPOINT")
             api_version = self.config.get("api_version") or os.getenv("AZURE_OPENAI_API_VERSION", "2024-12-01-preview")
             overflow = self.config.get("overflow_llm") or {}
+            # Held as config and built on first use: overflowing is the rare path, so a client per
+            # agent would carry a connection pool that almost never sees traffic.
+            self._routing_overflow_cfg = (
+                overflow if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model") else None
+            )
             self._routing_overflow_client = None
-            if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"):
-                self._routing_overflow_model = overflow["model"]
-                self._routing_overflow_tier = overflow.get("service_tier") or "priority"
-                self._routing_overflow_client = OpenAI(
-                    api_key=overflow["api_key"],
-                    base_url=overflow["base_url"],
-                    http_client=get_shared_http_client(base_url=overflow["base_url"], http2=False),
-                )
             # Same trade as the conversation client: with somewhere to fall to, waiting out the
             # SDK's retries only adds silence on a hop the caller is already waiting through.
             self.routing_client = AzureOpenAI(
                 azure_endpoint=azure_endpoint,
                 api_key=self.llm_key,
                 api_version=api_version,
-                **({"max_retries": 0} if self._routing_overflow_client else {}),
+                **({"max_retries": 0} if self._routing_overflow_cfg else {}),
             )
             if self.routing_model:
                 self.routing_model = self.routing_model.split("/", 1)[-1]

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import os
 import re
 import time
-from openai import OpenAI, AzureOpenAI
+from openai import OpenAI, AzureOpenAI, APIStatusError, APIConnectionError
 from dotenv import load_dotenv
 import json
 
@@ -24,6 +24,7 @@ from bolna.helpers.expression_evaluator import evaluate_edge_expression, describ
 from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
+from bolna.llms.azure_llm import _should_overflow
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
 from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
@@ -244,6 +245,18 @@ class GraphAgent(BaseAgent):
             "used_sources": used_sources or [],
         }
 
+    def _routing_create(self, routing_kwargs):
+        """Run the routing hop, moving it to the overflow backend when the pool cannot serve it."""
+        try:
+            return self.routing_client.chat.completions.create(**routing_kwargs)
+        except (APIStatusError, APIConnectionError) as e:
+            if getattr(self, "_routing_overflow_client", None) is None or not _should_overflow(e):
+                raise
+            logger.warning(f"Routing hop saturated, overflowing to {self._routing_overflow_model}")
+            return self._routing_overflow_client.chat.completions.create(
+                **{**routing_kwargs, "model": self._routing_overflow_model}
+            )
+
     def _init_routing_client(self):
         """Initialize routing client. Uses Groq if available, else OpenAI."""
         groq_available = GROQ_AVAILABLE and os.getenv("GROQ_API_KEY")
@@ -279,8 +292,18 @@ class GraphAgent(BaseAgent):
         elif self.routing_provider == "azure":
             azure_endpoint = self.base_url or os.getenv("AZURE_OPENAI_ENDPOINT")
             api_version = self.config.get("api_version") or os.getenv("AZURE_OPENAI_API_VERSION", "2024-12-01-preview")
+            overflow = self.config.get("overflow_llm") or {}
+            self._routing_overflow_client = None
+            if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"):
+                self._routing_overflow_model = overflow["model"]
+                self._routing_overflow_client = OpenAI(api_key=overflow["api_key"], base_url=overflow["base_url"])
+            # Same trade as the conversation client: with somewhere to fall to, waiting out the
+            # SDK's retries only adds silence on a hop the caller is already waiting through.
             self.routing_client = AzureOpenAI(
-                azure_endpoint=azure_endpoint, api_key=self.llm_key, api_version=api_version
+                azure_endpoint=azure_endpoint,
+                api_key=self.llm_key,
+                api_version=api_version,
+                **({"max_retries": 0} if self._routing_overflow_client else {}),
             )
             if self.routing_model:
                 self.routing_model = self.routing_model.split("/", 1)[-1]
@@ -883,7 +906,7 @@ class GraphAgent(BaseAgent):
 
             self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
 
-            response = await asyncio.to_thread(self.routing_client.chat.completions.create, **routing_kwargs)
+            response = await asyncio.to_thread(self._routing_create, routing_kwargs)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
             # Extract token usage from routing LLM call

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -24,7 +24,8 @@ from bolna.helpers.expression_evaluator import evaluate_edge_expression, describ
 from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
-from bolna.llms.azure_llm import _should_overflow
+from bolna.llms.azure_llm import should_overflow
+from bolna.llms.http_client_pool import get_shared_http_client
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
 from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
@@ -246,16 +247,19 @@ class GraphAgent(BaseAgent):
         }
 
     def _routing_create(self, routing_kwargs):
-        """Run the routing hop, moving it to the overflow backend when the pool cannot serve it."""
+        """Run the routing hop, moving it off the pool when it cannot serve. Returns (response, overflowed)."""
         try:
-            return self.routing_client.chat.completions.create(**routing_kwargs)
+            return self.routing_client.chat.completions.create(**routing_kwargs), False
         except (APIStatusError, APIConnectionError) as e:
-            if getattr(self, "_routing_overflow_client", None) is None or not _should_overflow(e):
+            if getattr(self, "_routing_overflow_client", None) is None or not should_overflow(e):
                 raise
             logger.warning(f"Routing hop saturated, overflowing to {self._routing_overflow_model}")
-            return self._routing_overflow_client.chat.completions.create(
-                **{**routing_kwargs, "model": self._routing_overflow_model}
-            )
+            overflow_kwargs = {
+                **routing_kwargs,
+                "model": self._routing_overflow_model,
+                "service_tier": self._routing_overflow_tier,
+            }
+            return self._routing_overflow_client.chat.completions.create(**overflow_kwargs), True
 
     def _init_routing_client(self):
         """Initialize routing client. Uses Groq if available, else OpenAI."""
@@ -296,7 +300,12 @@ class GraphAgent(BaseAgent):
             self._routing_overflow_client = None
             if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"):
                 self._routing_overflow_model = overflow["model"]
-                self._routing_overflow_client = OpenAI(api_key=overflow["api_key"], base_url=overflow["base_url"])
+                self._routing_overflow_tier = overflow.get("service_tier") or "priority"
+                self._routing_overflow_client = OpenAI(
+                    api_key=overflow["api_key"],
+                    base_url=overflow["base_url"],
+                    http_client=get_shared_http_client(base_url=overflow["base_url"], http2=False),
+                )
             # Same trade as the conversation client: with somewhere to fall to, waiting out the
             # SDK's retries only adds silence on a hop the caller is already waiting through.
             self.routing_client = AzureOpenAI(
@@ -906,7 +915,7 @@ class GraphAgent(BaseAgent):
 
             self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
 
-            response = await asyncio.to_thread(self._routing_create, routing_kwargs)
+            response, routing_overflowed = await asyncio.to_thread(self._routing_create, routing_kwargs)
             latency_ms = (time.perf_counter() - start_time) * 1000
 
             # Extract token usage from routing LLM call
@@ -922,6 +931,7 @@ class GraphAgent(BaseAgent):
                     if response.usage.prompt_tokens_details
                     else None,
                     "service_tier": getattr(response, "service_tier", None),
+                    "overflowed": routing_overflowed,
                 }
 
             # Extract the function call

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -25,6 +25,7 @@ from bolna.enums import EdgeConditionType, NodeType, ToolScope
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM
 from bolna.llms.azure_llm import should_overflow
+from bolna.llms.http_client_pool import get_shared_sync_http_client
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
 from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
@@ -254,7 +255,11 @@ class GraphAgent(BaseAgent):
             if cfg is None or not should_overflow(e):
                 raise
             if self._routing_overflow_client is None:
-                self._routing_overflow_client = OpenAI(api_key=cfg["api_key"], base_url=cfg["base_url"])
+                self._routing_overflow_client = OpenAI(
+                    api_key=cfg["api_key"],
+                    base_url=cfg["base_url"],
+                    http_client=get_shared_sync_http_client(base_url=cfg["base_url"], http2=False),
+                )
             logger.warning(f"Routing hop saturated, overflowing to {cfg['model']}")
             overflow_kwargs = {
                 **routing_kwargs,

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -160,6 +160,7 @@ class GraphAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
+                "overflow_llm",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -299,14 +299,12 @@ class GraphAgent(BaseAgent):
             azure_endpoint = self.base_url or os.getenv("AZURE_OPENAI_ENDPOINT")
             api_version = self.config.get("api_version") or os.getenv("AZURE_OPENAI_API_VERSION", "2024-12-01-preview")
             overflow = self.config.get("overflow_llm") or {}
-            # Held as config and built on first use: overflowing is the rare path, so a client per
-            # agent would carry a connection pool that almost never sees traffic.
+            # Built on first use: overflowing is rare, and an unused client still holds a pool.
             self._routing_overflow_cfg = (
                 overflow if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model") else None
             )
             self._routing_overflow_client = None
-            # Same trade as the conversation client: with somewhere to fall to, waiting out the
-            # SDK's retries only adds silence on a hop the caller is already waiting through.
+            # Same trade as the conversation client, on a hop the caller is already waiting through.
             self.routing_client = AzureOpenAI(
                 azure_endpoint=azure_endpoint,
                 api_key=self.llm_key,

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -75,6 +75,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 "service_tier",
                 "use_responses_api",
                 "compact_threshold",
+                "overflow_llm",
             ]:
                 if self.config.get(key, None):
                     llm_kwargs[key] = self.config[key]

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -140,11 +140,13 @@ class AzureLLM(OpenAICompatibleLLM):
         A 429 here means the provisioned deployment is full, not broken. Without an overflow
         target the error propagates and the caller ends the conversation.
         """
+        self._turn_overflowed = False
         try:
             return await self.async_client.chat.completions.create(**model_args)
         except RateLimitError:
             if self._overflow_client is None:
                 raise
+            self._turn_overflowed = True
             overflow_args = {
                 **model_args,
                 "model": self._overflow_model,
@@ -340,6 +342,7 @@ class AzureLLM(OpenAICompatibleLLM):
 
         # Extract actual token counts from stream usage
         usage_kwargs = {}
+        usage_kwargs["overflowed"] = getattr(self, "_turn_overflowed", False)
         if stream_usage:
             usage_kwargs["input_tokens"] = getattr(stream_usage, "prompt_tokens", None)
             usage_kwargs["output_tokens"] = getattr(stream_usage, "completion_tokens", None)

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -134,10 +134,7 @@ class AzureLLM(OpenAICompatibleLLM):
                 yield chunk
 
     async def _create_completion(self, model_args):
-        """Start a completion, moving the turn to the overflow backend on a 429.
-
-        Returns (completion, overflowed).
-        """
+        """Start a completion, overflowing to the fallback backend on a 429. Returns (completion, overflowed)."""
         try:
             return await self.async_client.chat.completions.create(**model_args), False
         except RateLimitError:

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -31,11 +31,7 @@ load_dotenv()
 
 
 def should_overflow(error) -> bool:
-    """Whether another backend is worth trying: saturation, a server fault, or no connection.
-
-    Mirrors what the SDK retries that an overflow-enabled client gives up, so nothing the retry
-    used to absorb is left without a second chance.
-    """
+    """Whether another backend is worth trying: saturation, a server fault, or no connection."""
     if isinstance(error, APIConnectionError):
         return True
     return isinstance(error, APIStatusError) and (error.status_code == 429 or error.status_code >= 500)
@@ -98,8 +94,7 @@ class AzureLLM(OpenAICompatibleLLM):
         overflow = kwargs.get("overflow_llm") or {}
         has_overflow = bool(overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"))
 
-        # Retries stay on unless there is an overflow to fall to, where waiting out two backoffs
-        # would only add dead air before we move the turn anyway.
+        # Retries stay on unless there is an overflow to fall to, which serves the same purpose faster.
         self.async_client = AsyncAzureOpenAI(
             azure_endpoint=azure_endpoint,
             api_key=api_key,
@@ -113,8 +108,7 @@ class AzureLLM(OpenAICompatibleLLM):
 
         # Fallback backend for turns the provisioned deployment cannot serve.
         self._overflow_client = None
-        # The model is required rather than derived: a deployment name need not resemble the model
-        # it serves, so a guess would post something the overflow backend rejects.
+        # Required, not derived: a deployment name need not resemble the model it serves.
         if has_overflow:
             self._overflow_model = overflow["model"]
             self._overflow_service_tier = overflow.get("service_tier") or "priority"

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -90,8 +90,7 @@ class AzureLLM(OpenAICompatibleLLM):
         self.run_id = kwargs.get("run_id", None)
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
-        # Where a turn goes when the provisioned deployment is saturated. Azure answers 429 before
-        # any token streams, so the turn can be re-issued elsewhere with nothing to reconcile.
+        # Fallback backend for turns the provisioned deployment cannot serve.
         self._overflow_client = None
         overflow = kwargs.get("overflow_llm") or {}
         if overflow.get("api_key") and overflow.get("base_url"):
@@ -135,25 +134,22 @@ class AzureLLM(OpenAICompatibleLLM):
                 yield chunk
 
     async def _create_completion(self, model_args):
-        """Start a completion, moving the turn to the overflow backend if the pool is saturated.
+        """Start a completion, moving the turn to the overflow backend on a 429.
 
-        A 429 here means the provisioned deployment is full, not broken. Without an overflow
-        target the error propagates and the caller ends the conversation.
+        Returns (completion, overflowed).
         """
-        self._turn_overflowed = False
         try:
-            return await self.async_client.chat.completions.create(**model_args)
+            return await self.async_client.chat.completions.create(**model_args), False
         except RateLimitError:
             if self._overflow_client is None:
                 raise
-            self._turn_overflowed = True
             overflow_args = {
                 **model_args,
                 "model": self._overflow_model,
                 "service_tier": self._overflow_service_tier,
             }
             logger.warning(f"Azure OpenAI saturated, overflowing turn to {self._overflow_model} run_id={self.run_id}")
-            return await self._overflow_client.chat.completions.create(**overflow_args)
+            return await self._overflow_client.chat.completions.create(**overflow_args), True
 
     async def _generate_stream_chat(
         self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
@@ -197,7 +193,7 @@ class AzureLLM(OpenAICompatibleLLM):
         stream_usage = None
 
         try:
-            completion_stream = await self._create_completion(model_args)
+            completion_stream, turn_overflowed = await self._create_completion(model_args)
         except BadRequestError as e:
             logger.error(f"Azure OpenAI bad request: {e}")
             raise
@@ -342,7 +338,7 @@ class AzureLLM(OpenAICompatibleLLM):
 
         # Extract actual token counts from stream usage
         usage_kwargs = {}
-        usage_kwargs["overflowed"] = getattr(self, "_turn_overflowed", False)
+        usage_kwargs["overflowed"] = turn_overflowed
         if stream_usage:
             usage_kwargs["input_tokens"] = getattr(stream_usage, "prompt_tokens", None)
             usage_kwargs["output_tokens"] = getattr(stream_usage, "completion_tokens", None)
@@ -369,7 +365,7 @@ class AzureLLM(OpenAICompatibleLLM):
         response_format = self.get_response_format(request_json)
 
         try:
-            completion = await self._create_completion(
+            completion, _ = await self._create_completion(
                 {
                     "model": self.model,
                     "temperature": 0.0,

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -90,6 +90,20 @@ class AzureLLM(OpenAICompatibleLLM):
         self.run_id = kwargs.get("run_id", None)
         self.llm_host = urlparse(azure_endpoint).netloc if azure_endpoint else None
 
+        # Where a turn goes when the provisioned deployment is saturated. Azure answers 429 before
+        # any token streams, so the turn can be re-issued elsewhere with nothing to reconcile.
+        self._overflow_client = None
+        overflow = kwargs.get("overflow_llm") or {}
+        if overflow.get("api_key") and overflow.get("base_url"):
+            self._overflow_model = overflow.get("model") or self.model
+            self._overflow_service_tier = overflow.get("service_tier", "priority")
+            self._overflow_client = AsyncOpenAI(
+                api_key=overflow["api_key"],
+                base_url=overflow["base_url"],
+                http_client=get_shared_http_client(base_url=overflow["base_url"], http2=False),
+            )
+            logger.info(f"Azure LLM overflow target ready: {self._overflow_model} @ {overflow['base_url']}")
+
         # Responses API: uses v1 endpoint with regular AsyncOpenAI client
         self._init_responses_api(
             kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold")
@@ -119,6 +133,25 @@ class AzureLLM(OpenAICompatibleLLM):
                 messages, synthesize, request_json, meta_info, tool_choice, tools
             ):
                 yield chunk
+
+    async def _create_completion(self, model_args):
+        """Start a completion, moving the turn to the overflow backend if the pool is saturated.
+
+        A 429 here means the provisioned deployment is full, not broken. Without an overflow
+        target the error propagates and the caller ends the conversation.
+        """
+        try:
+            return await self.async_client.chat.completions.create(**model_args)
+        except RateLimitError:
+            if self._overflow_client is None:
+                raise
+            overflow_args = {
+                **model_args,
+                "model": self._overflow_model,
+                "service_tier": self._overflow_service_tier,
+            }
+            logger.warning(f"Azure OpenAI saturated, overflowing turn to {self._overflow_model} run_id={self.run_id}")
+            return await self._overflow_client.chat.completions.create(**overflow_args)
 
     async def _generate_stream_chat(
         self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
@@ -162,7 +195,7 @@ class AzureLLM(OpenAICompatibleLLM):
         stream_usage = None
 
         try:
-            completion_stream = await self.async_client.chat.completions.create(**model_args)
+            completion_stream = await self._create_completion(model_args)
         except BadRequestError as e:
             logger.error(f"Azure OpenAI bad request: {e}")
             raise
@@ -333,13 +366,15 @@ class AzureLLM(OpenAICompatibleLLM):
         response_format = self.get_response_format(request_json)
 
         try:
-            completion = await self.async_client.chat.completions.create(
-                model=self.model,
-                temperature=0.0,
-                # Same guarantee as the streaming path: bookkeeping keys never reach the wire.
-                messages=strip_internal_keys(messages),
-                stream=False,
-                response_format=response_format,
+            completion = await self._create_completion(
+                {
+                    "model": self.model,
+                    "temperature": 0.0,
+                    # Same guarantee as the streaming path: bookkeeping keys never reach the wire.
+                    "messages": strip_internal_keys(messages),
+                    "stream": False,
+                    "response_format": response_format,
+                }
             )
 
             res = completion.choices[0].message.content

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -30,8 +30,15 @@ logger = configure_logger(__name__)
 load_dotenv()
 
 
-# What Azure's own spillover treats as overflow-worthy.
-OVERFLOW_STATUSES = (429, 500, 503)
+def _should_overflow(error) -> bool:
+    """Whether another backend is worth trying: saturation, a server fault, or no connection.
+
+    Mirrors what the SDK retries that an overflow-enabled client gives up, so nothing the retry
+    used to absorb is left without a second chance.
+    """
+    if isinstance(error, APIConnectionError):
+        return True
+    return isinstance(error, APIStatusError) and (error.status_code == 429 or error.status_code >= 500)
 
 
 class AzureLLM(OpenAICompatibleLLM):
@@ -152,8 +159,8 @@ class AzureLLM(OpenAICompatibleLLM):
         """Start a completion, overflowing when the pool cannot serve it. Returns (completion, overflowed)."""
         try:
             return await self.async_client.chat.completions.create(**model_args), False
-        except APIStatusError as e:
-            if self._overflow_client is None or e.status_code not in OVERFLOW_STATUSES:
+        except (APIStatusError, APIConnectionError) as e:
+            if self._overflow_client is None or not _should_overflow(e):
                 raise
             overflow_args = {
                 **model_args,
@@ -346,7 +353,7 @@ class AzureLLM(OpenAICompatibleLLM):
                     _pd = getattr(stream_usage, "prompt_tokens_details", None)
                     if _pd:
                         fc_chunk.cached_tokens = getattr(_pd, "cached_tokens", None)
-                    fc_chunk.overflowed = turn_overflowed
+                fc_chunk.overflowed = turn_overflowed
                 yield fc_chunk
 
         # Extract actual token counts from stream usage

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -83,8 +83,13 @@ class AzureLLM(OpenAICompatibleLLM):
 
         http_client = get_shared_http_client(base_url=azure_endpoint, http2=False)
 
+        # No SDK retries: a 429 should reach the overflow immediately, not after two backoffs.
         self.async_client = AsyncAzureOpenAI(
-            azure_endpoint=azure_endpoint, api_key=api_key, api_version=api_version, http_client=http_client
+            azure_endpoint=azure_endpoint,
+            api_key=api_key,
+            api_version=api_version,
+            http_client=http_client,
+            max_retries=0,
         )
 
         self.run_id = kwargs.get("run_id", None)
@@ -93,9 +98,11 @@ class AzureLLM(OpenAICompatibleLLM):
         # Fallback backend for turns the provisioned deployment cannot serve.
         self._overflow_client = None
         overflow = kwargs.get("overflow_llm") or {}
-        if overflow.get("api_key") and overflow.get("base_url"):
-            self._overflow_model = overflow.get("model") or self.model
-            self._overflow_service_tier = overflow.get("service_tier", "priority")
+        # The model is required rather than derived: a deployment name need not resemble the model
+        # it serves, so a guess would post something the overflow backend rejects.
+        if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"):
+            self._overflow_model = overflow["model"]
+            self._overflow_service_tier = overflow.get("service_tier") or "priority"
             self._overflow_client = AsyncOpenAI(
                 api_key=overflow["api_key"],
                 base_url=overflow["base_url"],
@@ -331,6 +338,7 @@ class AzureLLM(OpenAICompatibleLLM):
                     _pd = getattr(stream_usage, "prompt_tokens_details", None)
                     if _pd:
                         fc_chunk.cached_tokens = getattr(_pd, "cached_tokens", None)
+                    fc_chunk.overflowed = turn_overflowed
                 yield fc_chunk
 
         # Extract actual token counts from stream usage

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -10,6 +10,7 @@ from openai import (
     AuthenticationError,
     PermissionDeniedError,
     NotFoundError,
+    APIStatusError,
     RateLimitError,
     APIError,
     APIConnectionError,
@@ -27,6 +28,10 @@ from bolna.helpers.logger_config import configure_logger
 
 logger = configure_logger(__name__)
 load_dotenv()
+
+
+# What Azure's own spillover treats as overflow-worthy.
+OVERFLOW_STATUSES = (429, 500, 503)
 
 
 class AzureLLM(OpenAICompatibleLLM):
@@ -83,13 +88,17 @@ class AzureLLM(OpenAICompatibleLLM):
 
         http_client = get_shared_http_client(base_url=azure_endpoint, http2=False)
 
-        # No SDK retries: a 429 should reach the overflow immediately, not after two backoffs.
+        overflow = kwargs.get("overflow_llm") or {}
+        has_overflow = bool(overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"))
+
+        # Retries stay on unless there is an overflow to fall to, where waiting out two backoffs
+        # would only add dead air before we move the turn anyway.
         self.async_client = AsyncAzureOpenAI(
             azure_endpoint=azure_endpoint,
             api_key=api_key,
             api_version=api_version,
             http_client=http_client,
-            max_retries=0,
+            **({"max_retries": 0} if has_overflow else {}),
         )
 
         self.run_id = kwargs.get("run_id", None)
@@ -97,10 +106,9 @@ class AzureLLM(OpenAICompatibleLLM):
 
         # Fallback backend for turns the provisioned deployment cannot serve.
         self._overflow_client = None
-        overflow = kwargs.get("overflow_llm") or {}
         # The model is required rather than derived: a deployment name need not resemble the model
         # it serves, so a guess would post something the overflow backend rejects.
-        if overflow.get("api_key") and overflow.get("base_url") and overflow.get("model"):
+        if has_overflow:
             self._overflow_model = overflow["model"]
             self._overflow_service_tier = overflow.get("service_tier") or "priority"
             self._overflow_client = AsyncOpenAI(
@@ -141,11 +149,11 @@ class AzureLLM(OpenAICompatibleLLM):
                 yield chunk
 
     async def _create_completion(self, model_args):
-        """Start a completion, overflowing to the fallback backend on a 429. Returns (completion, overflowed)."""
+        """Start a completion, overflowing when the pool cannot serve it. Returns (completion, overflowed)."""
         try:
             return await self.async_client.chat.completions.create(**model_args), False
-        except RateLimitError:
-            if self._overflow_client is None:
+        except APIStatusError as e:
+            if self._overflow_client is None or e.status_code not in OVERFLOW_STATUSES:
                 raise
             overflow_args = {
                 **model_args,

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -30,7 +30,7 @@ logger = configure_logger(__name__)
 load_dotenv()
 
 
-def _should_overflow(error) -> bool:
+def should_overflow(error) -> bool:
     """Whether another backend is worth trying: saturation, a server fault, or no connection.
 
     Mirrors what the SDK retries that an overflow-enabled client gives up, so nothing the retry
@@ -160,7 +160,7 @@ class AzureLLM(OpenAICompatibleLLM):
         try:
             return await self.async_client.chat.completions.create(**model_args), False
         except (APIStatusError, APIConnectionError) as e:
-            if self._overflow_client is None or not _should_overflow(e):
+            if self._overflow_client is None or not should_overflow(e):
                 raise
             overflow_args = {
                 **model_args,

--- a/bolna/llms/http_client_pool.py
+++ b/bolna/llms/http_client_pool.py
@@ -16,3 +16,20 @@ def get_shared_http_client(base_url: str | None = None, http2: bool = True) -> h
                 client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
                 _pool[key] = client
     return client
+
+
+_sync_pool: dict[tuple, httpx.Client] = {}
+
+
+def get_shared_sync_http_client(base_url: str | None = None, http2: bool = True) -> httpx.Client:
+    """Sync twin of get_shared_http_client, for SDK clients that reject an AsyncClient."""
+    key = (base_url, http2)
+    client = _sync_pool.get(key)
+    if client is None:
+        with _lock:
+            client = _sync_pool.get(key)
+            if client is None:
+                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=30)
+                client = httpx.Client(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
+                _sync_pool[key] = client
+    return client

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -60,4 +60,6 @@ class LLMStreamChunk(BaseModel):
     output_tokens: Optional[int] = None
     reasoning_tokens: Optional[int] = None
     cached_tokens: Optional[int] = None
+    # Served by the overflow backend rather than the primary, so this turn placed no load on it.
+    overflowed: bool = False
     reasoning_content: Optional[str] = None

--- a/bolna/llms/types.py
+++ b/bolna/llms/types.py
@@ -60,6 +60,5 @@ class LLMStreamChunk(BaseModel):
     output_tokens: Optional[int] = None
     reasoning_tokens: Optional[int] = None
     cached_tokens: Optional[int] = None
-    # Served by the overflow backend rather than the primary, so this turn placed no load on it.
     overflowed: bool = False
     reasoning_content: Optional[str] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.193"
+version = "0.10.194"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Linear: BOLNA-2203

A 429 from the provisioned deployment currently ends the conversation. `azure_llm` catches `RateLimitError`, logs it and re-raises, the exception reaches `task_manager.run`, and the transcriber, synthesizer and websocket are all torn down. On 17 Aug that killed 82 calls between 08:00 and 10:45 IST, one of them 15 seconds in after the caller had already spoken three times.

A 429 on a provisioned deployment is not an error, it is backpressure. Microsoft documents it as "a traffic-management signal" and permits brief bursts above 100%. Admission control in dashboard-backend works on a trailing 60s average and cannot see sub-minute bursts, so some turns will always meet one.

Azure returns the 429 at `chat.completions.create`, before any token streams, so the turn can be re-issued with no partial output to reconcile. When an overflow target is configured the turn is re-issued there; when it is not, the error propagates exactly as before, so this is inert for every caller that does not opt in.

The overflow target is passed as `overflow_llm` with an api_key, base_url, model and service_tier. dashboard-backend supplies the EU OpenAI priority endpoint, which measures 597ms p90 first-token against PTU's 605ms, so a spilled turn costs one failed round trip rather than the call.
