### PR TITLE
fix: use input_types['text'] in DefaultInputHandler.__process_text (#898)

### DIFF
--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -247,7 +247,7 @@ class DefaultInputHandler:
     def __process_text(self, text):
         logger.info(f"Sequences {self.input_types}")
         ws_data_packet = create_ws_data_packet(
-            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["audio"]}
+            data=text, meta_info={"io": "default", "type": "text", "sequence": self.input_types["text"]}
         )
 
         if self.turn_based_conversation:

--- a/tests/tests/test_default_input_handler_text_sequence.py
+++ b/tests/tests/test_default_input_handler_text_sequence.py
@@ -1,0 +1,50 @@
+import asyncio
+import unittest
+
+
+def make_handler(input_types):
+    from bolna.input_handlers.default import DefaultInputHandler
+    queues = {"llm": asyncio.Queue(), "transcriber": asyncio.Queue()}
+    handler = DefaultInputHandler.__new__(DefaultInputHandler)
+    handler.queues = queues
+    handler.input_types = input_types
+    handler.turn_based_conversation = False
+    return handler
+
+
+class TestProcessTextUsesTextSequence(unittest.TestCase):
+
+    def test_text_only_agent_does_not_raise_key_error(self):
+        input_types = {"text": 1}
+        handler = make_handler(input_types)
+        try:
+            handler._DefaultInputHandler__process_text("hello")
+        except KeyError as e:
+            self.fail(f"KeyError {e} raised for text-only agent")
+        packet = handler.queues["llm"].get_nowait()
+        self.assertEqual(packet["meta_info"]["sequence"], 1)
+
+    def test_text_sequence_used_not_audio_sequence(self):
+        input_types = {"audio": 99, "text": 42}
+        handler = make_handler(input_types)
+        handler._DefaultInputHandler__process_text("world")
+        packet = handler.queues["llm"].get_nowait()
+        self.assertEqual(packet["meta_info"]["sequence"], 42)
+
+    def test_packet_type_is_text(self):
+        input_types = {"text": 5}
+        handler = make_handler(input_types)
+        handler._DefaultInputHandler__process_text("test")
+        packet = handler.queues["llm"].get_nowait()
+        self.assertEqual(packet["meta_info"]["type"], "text")
+
+    def test_packet_data_is_correct(self):
+        input_types = {"text": 0}
+        handler = make_handler(input_types)
+        handler._DefaultInputHandler__process_text("exact text")
+        packet = handler.queues["llm"].get_nowait()
+        self.assertEqual(packet["data"], "exact text")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Hey! Found a small but impactful bug while going through the open issues.

In DefaultInputHandler.__process_text(), the pipeline sequence was being
looked up using self.input_types["audio"] instead of self.input_types["text"].

This means:
- Text-only agents crash with a KeyError because the "audio" key doesn't exist
- Mixed agents silently route text through the wrong pipeline

The fix is a single word change on line 250 of bolna/input_handlers/default.py.

I also added 4 unit tests to cover this:
- Text-only agent no longer crashes
- Mixed agents correctly use the text sequence and not the audio one
- Packet type is set to "text" as expected
- Packet data is passed through correctly

All 4 tests pass.

Fixes #898