### PR TITLE
lid hand in message fix for web call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.198"
+__version__ = "0.10.199"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.200"
+__version__ = "0.10.201"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6011,8 +6011,18 @@ class TaskManager(BaseManager):
             "sequence_id": -1,
             "message_category": "handoff",
             "text": handoff_text,
+            "type": "audio",
         }
-        clip = self.handoff_audio_cache.get(target)
+        # The cache holds mu-law@8k clips — telephony wire format. Web/freeswitch play raw
+        # PCM@24k, so the clip is unusable there (42b5f89b: silent handoff); live-synthesize.
+        mulaw_transport = self.tools["output"].get_provider() in (
+            TelephonyProvider.PLIVO.value,
+            TelephonyProvider.TWILIO.value,
+            TelephonyProvider.EXOTEL.value,
+            TelephonyProvider.VOBIZ.value,
+            TelephonyProvider.SIP_TRUNK.value,
+        )
+        clip = self.handoff_audio_cache.get(target) if mulaw_transport else None
         if clip:
             # Pre-warmed mu-law clip pushed straight to telephony. Both end-flags required
             handoff_meta.update(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -96,6 +96,7 @@ from bolna.helpers.utils import (
     yield_chunks_from_memory,
     process_task_cancellation,
     audio_to_mulaw8k,
+    audio_to_pcm,
     pcm_to_ulaw,
     format_error_message,
     enrich_context_with_time_variables,
@@ -6013,21 +6014,13 @@ class TaskManager(BaseManager):
             "text": handoff_text,
             "type": "audio",
         }
-        # The cache holds mu-law@8k clips — telephony wire format. Web/freeswitch play raw
-        # PCM@24k, so the clip is unusable there (42b5f89b: silent handoff); live-synthesize.
-        mulaw_transport = self.tools["output"].get_provider() in (
-            TelephonyProvider.PLIVO.value,
-            TelephonyProvider.TWILIO.value,
-            TelephonyProvider.EXOTEL.value,
-            TelephonyProvider.VOBIZ.value,
-            TelephonyProvider.SIP_TRUNK.value,
-        )
-        clip = self.handoff_audio_cache.get(target) if mulaw_transport else None
+        # The prewarm rendered the clip in this call's wire format, so it is always usable.
+        clip = self.handoff_audio_cache.get(target)
         if clip:
-            # Pre-warmed mu-law clip pushed straight to telephony. Both end-flags required
+            # Pre-warmed wire-format clip pushed straight to the transport. Both end-flags required
             handoff_meta.update(
                 {
-                    "format": "mulaw",
+                    "format": "mulaw" if self.__handoff_mulaw_wire() else "pcm",
                     "end_of_llm_stream": True,
                     "end_of_synthesizer_stream": True,
                     "is_first_chunk": True,
@@ -6066,12 +6059,25 @@ class TaskManager(BaseManager):
             "{language}", LANGUAGE_NAMES.get(label, label)
         )
 
+    def __handoff_mulaw_wire(self) -> bool:
+        """Telephony transports take the mu-law@8k clip; web/freeswitch play raw PCM@24k."""
+        return self.tools["output"].get_provider() in (
+            TelephonyProvider.PLIVO.value,
+            TelephonyProvider.TWILIO.value,
+            TelephonyProvider.EXOTEL.value,
+            TelephonyProvider.VOBIZ.value,
+            TelephonyProvider.SIP_TRUNK.value,
+        )
+
     async def __prewarm_handoff_clips(self):
         """Pre-render each language's handoff on its own voice via one-shot synthesize().
         Clips are static for the call; non-active labels first (likely first targets)."""
         pool = self.tools.get("synthesizer")
         if not isinstance(pool, SynthesizerPool):
             return
+
+        # A call has exactly one transport, so render in its wire format only.
+        mulaw_wire = self.__handoff_mulaw_wire()
 
         async def render(label, synth):
             text = self.__handoff_text_for(label)
@@ -6081,6 +6087,7 @@ class TaskManager(BaseManager):
                 synth.__class__.__name__,
                 getattr(synth, "voice_id", None) or getattr(synth, "voice", None),
                 text,
+                "mulaw" if mulaw_wire else f"pcm{WEBCALL_TTS_SAMPLE_RATE}",
             )
             cached = HANDOFF_CLIP_CACHE.get(cache_key)
             if cached:
@@ -6088,16 +6095,27 @@ class TaskManager(BaseManager):
                 return
             try:
                 clip = None
-                # Prefer a native mu-law 8000 one-shot when the provider offers it.
-                telephony_one_shot = getattr(synth, "synthesize_telephony_clip", None)
-                if telephony_one_shot is not None:
-                    clip = await telephony_one_shot(text)
+                # Prefer a native one-shot in the wire format when the provider offers it.
+                if mulaw_wire:
+                    telephony_one_shot = getattr(synth, "synthesize_telephony_clip", None)
+                    if telephony_one_shot is not None:
+                        clip = await telephony_one_shot(text)
+                else:
+                    pcm_one_shot = getattr(synth, "synthesize_pcm_clip", None)
+                    if pcm_one_shot is not None:
+                        clip = await pcm_one_shot(text, WEBCALL_TTS_SAMPLE_RATE)
                 if not clip:
                     audio = await synth.synthesize(text)
                     if not audio:
                         return
                     # pydub decode shells out to ffprobe/ffmpeg — keep it off the event loop.
-                    clip = await asyncio.to_thread(self.__handoff_clip_to_mulaw, synth, audio)
+                    convert = self.__handoff_clip_to_mulaw if mulaw_wire else self.__handoff_clip_to_pcm
+                    clip = await asyncio.to_thread(convert, synth, audio)
+                # Some one-shots return a truthy error sentinel (e.g. deepgram's b"\x00" on
+                # non-200); anything under ~50ms can't be a handoff line — live-synth instead.
+                if clip and len(clip) < (400 if mulaw_wire else 2400):
+                    logger.error(f"LanguageSwitcher: handoff clip for '{label}' is {len(clip)}B — discarding")
+                    return
                 if clip:
                     self.handoff_audio_cache[label] = clip
                     if len(HANDOFF_CLIP_CACHE) >= HANDOFF_CLIP_CACHE_MAX:
@@ -6109,6 +6127,17 @@ class TaskManager(BaseManager):
                 logger.error(f"LanguageSwitcher: handoff prewarm failed for '{label}': {e}")
 
         await asyncio.gather(*(render(label, synth) for label, synth in pool.synthesizers.items()))
+
+    def __handoff_clip_to_pcm(self, synth, audio):
+        clip = audio_to_pcm(
+            audio,
+            WEBCALL_TTS_SAMPLE_RATE,
+            rate_hint=getattr(synth, "sampling_rate", 0) or getattr(synth, "sample_rate", 0) or 8000,
+            format_hint=getattr(synth, "format", "") or "",
+        )
+        if clip is None:
+            logger.error("LanguageSwitcher: handoff clip is a compressed container pydub can't decode — skipping")
+        return clip
 
     def __handoff_clip_to_mulaw(self, synth, audio):
         clip = audio_to_mulaw8k(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1737,10 +1737,7 @@ class TaskManager(BaseManager):
 
                 # Pre-render every language's handoff clip on its own voice (background;
                 if self.language_switcher is not None and not self.turn_based_conversation:
-                    # On "default" the call only has one wire format when it is a browser call
-                    # (use_mulaw forced False). Off the web path each synth keeps its own
-                    # use_mulaw default — elevenlabs/cartesia mu-law, maya/deepgram PCM — so
-                    # there is nothing for a per-call render format to agree with.
+                    # "default" has one wire format only on the web path.
                     if self.task_config["tools_config"]["output"]["provider"] != "default" or self.is_web_based_call:
                         self.handoff_prewarm_task = asyncio.create_task(self.__prewarm_handoff_clips())
 
@@ -6098,7 +6095,6 @@ class TaskManager(BaseManager):
             "text": handoff_text,
             "type": "audio",
         }
-        # The prewarm rendered the clip in this call's wire format, so it is always usable.
         clip = self.handoff_audio_cache.get(target)
         if clip:
             # Pre-warmed wire-format clip pushed straight to the transport. Both end-flags required
@@ -6144,10 +6140,7 @@ class TaskManager(BaseManager):
         )
 
     def __handoff_mulaw_wire(self) -> bool:
-        """Telephony transports take the mu-law@8k clip; web/freeswitch play raw PCM@24k.
-
-        Keyed off the output-handler registry so a sixth carrier cannot be added without a
-        handler and silently fall through to the PCM branch."""
+        """True on telephony (mu-law@8k clip), False on web/freeswitch (raw PCM@24k)."""
         return self.tools["output"].get_provider() in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
 
     async def __prewarm_handoff_clips(self):
@@ -6174,8 +6167,7 @@ class TaskManager(BaseManager):
             if cached:
                 self.handoff_audio_cache[label] = cached
                 return
-            # Anything under ~50ms can't be a handoff line: some one-shots return a truthy
-            # error sentinel (e.g. deepgram's b"\x00" on non-200) rather than None.
+            # Under ~50ms is a failed one-shot returning a sentinel, not a clip.
             min_clip_bytes = 400 if mulaw_wire else 2400
             try:
                 clip = None
@@ -6188,8 +6180,7 @@ class TaskManager(BaseManager):
                     pcm_one_shot = getattr(synth, "synthesize_pcm_clip", None)
                     if pcm_one_shot is not None:
                         clip = await pcm_one_shot(text, WEBCALL_TTS_SAMPLE_RATE)
-                # Checked before the fallback: a sentinel is a failed one-shot, not a clip,
-                # so synthesize() still gets its turn instead of the label going unwarmed.
+                # Before the fallback, so synthesize() still gets its turn.
                 if clip and len(clip) < min_clip_bytes:
                     logger.warning(
                         f"LanguageSwitcher: one-shot for '{label}' returned {len(clip)}B — falling back to synthesize()"
@@ -6217,8 +6208,7 @@ class TaskManager(BaseManager):
         await asyncio.gather(*(render(label, synth) for label, synth in pool.synthesizers.items()))
 
     def __handoff_clip_convert(self, synth, audio, mulaw_wire):
-        """Decode a one-shot synth render into the call's wire format. Blocking (pydub) —
-        callers run it off the event loop."""
+        """Decode a one-shot render into the wire format. Blocking — run off-loop."""
         kwargs = {
             "rate_hint": getattr(synth, "sampling_rate", 0) or getattr(synth, "sample_rate", 0) or 8000,
             "format_hint": getattr(synth, "format", "") or "",

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6174,17 +6174,6 @@ class TaskManager(BaseManager):
             if cached:
                 self.handoff_audio_cache[label] = cached
                 return
-            # A synth that disagrees with the call's wire format would be cached at one
-            # encoding and streamed at the other, so skip it rather than mislabel the clip.
-            synth_mulaw = getattr(synth, "use_mulaw", None)
-            if synth_mulaw is not None and bool(synth_mulaw) != mulaw_wire:
-                logger.error(
-                    f"LanguageSwitcher: skipping handoff prewarm for '{label}' — "
-                    f"{synth.__class__.__name__} use_mulaw={synth_mulaw} but call wire is "
-                    f"{'mulaw' if mulaw_wire else 'pcm'}"
-                )
-                return
-
             # Anything under ~50ms can't be a handoff line: some one-shots return a truthy
             # error sentinel (e.g. deepgram's b"\x00" on non-200) rather than None.
             min_clip_bytes = 400 if mulaw_wire else 2400

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1688,13 +1688,7 @@ class TaskManager(BaseManager):
 
                 # Telephony providers expect mulaw@8000Hz — force use_mulaw for all synths in the pool
                 output_provider = self.task_config["tools_config"]["output"]["provider"]
-                is_telephony = output_provider in (
-                    TelephonyProvider.PLIVO.value,
-                    TelephonyProvider.TWILIO.value,
-                    TelephonyProvider.EXOTEL.value,
-                    TelephonyProvider.VOBIZ.value,
-                    TelephonyProvider.SIP_TRUNK.value,
-                )
+                is_telephony = output_provider in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
                 synthesizer_kwargs = self.kwargs.copy()
                 if is_telephony:
                     synthesizer_kwargs["use_mulaw"] = True
@@ -1743,7 +1737,11 @@ class TaskManager(BaseManager):
 
                 # Pre-render every language's handoff clip on its own voice (background;
                 if self.language_switcher is not None and not self.turn_based_conversation:
-                    if self.task_config["tools_config"]["output"]["provider"] != "default":
+                    # On "default" the call only has one wire format when it is a browser call
+                    # (use_mulaw forced False). Off the web path each synth keeps its own
+                    # use_mulaw default — elevenlabs/cartesia mu-law, maya/deepgram PCM — so
+                    # there is nothing for a per-call render format to agree with.
+                    if self.task_config["tools_config"]["output"]["provider"] != "default" or self.is_web_based_call:
                         self.handoff_prewarm_task = asyncio.create_task(self.__prewarm_handoff_clips())
 
                 if self.task_config["tools_config"]["llm_agent"] is not None and llm_config is not None:
@@ -1773,13 +1771,7 @@ class TaskManager(BaseManager):
             # the multilingual-pool path above. Synths that honor the kwarg (e.g. cartesia)
             # would otherwise stream raw PCM that telephony plays as mulaw → loud static.
             output_provider = self.task_config["tools_config"]["output"]["provider"]
-            is_telephony = output_provider in (
-                TelephonyProvider.PLIVO.value,
-                TelephonyProvider.TWILIO.value,
-                TelephonyProvider.EXOTEL.value,
-                TelephonyProvider.VOBIZ.value,
-                TelephonyProvider.SIP_TRUNK.value,
-            )
+            is_telephony = output_provider in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
             synthesizer_kwargs = self.kwargs.copy()
             if is_telephony:
                 synthesizer_kwargs["use_mulaw"] = True
@@ -6152,14 +6144,11 @@ class TaskManager(BaseManager):
         )
 
     def __handoff_mulaw_wire(self) -> bool:
-        """Telephony transports take the mu-law@8k clip; web/freeswitch play raw PCM@24k."""
-        return self.tools["output"].get_provider() in (
-            TelephonyProvider.PLIVO.value,
-            TelephonyProvider.TWILIO.value,
-            TelephonyProvider.EXOTEL.value,
-            TelephonyProvider.VOBIZ.value,
-            TelephonyProvider.SIP_TRUNK.value,
-        )
+        """Telephony transports take the mu-law@8k clip; web/freeswitch play raw PCM@24k.
+
+        Keyed off the output-handler registry so a sixth carrier cannot be added without a
+        handler and silently fall through to the PCM branch."""
+        return self.tools["output"].get_provider() in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
 
     async def __prewarm_handoff_clips(self):
         """Pre-render each language's handoff on its own voice via one-shot synthesize().
@@ -6185,6 +6174,20 @@ class TaskManager(BaseManager):
             if cached:
                 self.handoff_audio_cache[label] = cached
                 return
+            # A synth that disagrees with the call's wire format would be cached at one
+            # encoding and streamed at the other, so skip it rather than mislabel the clip.
+            synth_mulaw = getattr(synth, "use_mulaw", None)
+            if synth_mulaw is not None and bool(synth_mulaw) != mulaw_wire:
+                logger.error(
+                    f"LanguageSwitcher: skipping handoff prewarm for '{label}' — "
+                    f"{synth.__class__.__name__} use_mulaw={synth_mulaw} but call wire is "
+                    f"{'mulaw' if mulaw_wire else 'pcm'}"
+                )
+                return
+
+            # Anything under ~50ms can't be a handoff line: some one-shots return a truthy
+            # error sentinel (e.g. deepgram's b"\x00" on non-200) rather than None.
+            min_clip_bytes = 400 if mulaw_wire else 2400
             try:
                 clip = None
                 # Prefer a native one-shot in the wire format when the provider offers it.
@@ -6196,16 +6199,20 @@ class TaskManager(BaseManager):
                     pcm_one_shot = getattr(synth, "synthesize_pcm_clip", None)
                     if pcm_one_shot is not None:
                         clip = await pcm_one_shot(text, WEBCALL_TTS_SAMPLE_RATE)
+                # Checked before the fallback: a sentinel is a failed one-shot, not a clip,
+                # so synthesize() still gets its turn instead of the label going unwarmed.
+                if clip and len(clip) < min_clip_bytes:
+                    logger.warning(
+                        f"LanguageSwitcher: one-shot for '{label}' returned {len(clip)}B — falling back to synthesize()"
+                    )
+                    clip = None
                 if not clip:
                     audio = await synth.synthesize(text)
                     if not audio:
                         return
                     # pydub decode shells out to ffprobe/ffmpeg — keep it off the event loop.
-                    convert = self.__handoff_clip_to_mulaw if mulaw_wire else self.__handoff_clip_to_pcm
-                    clip = await asyncio.to_thread(convert, synth, audio)
-                # Some one-shots return a truthy error sentinel (e.g. deepgram's b"\x00" on
-                # non-200); anything under ~50ms can't be a handoff line — live-synth instead.
-                if clip and len(clip) < (400 if mulaw_wire else 2400):
+                    clip = await asyncio.to_thread(self.__handoff_clip_convert, synth, audio, mulaw_wire)
+                if clip and len(clip) < min_clip_bytes:
                     logger.error(f"LanguageSwitcher: handoff clip for '{label}' is {len(clip)}B — discarding")
                     return
                 if clip:
@@ -6220,25 +6227,22 @@ class TaskManager(BaseManager):
 
         await asyncio.gather(*(render(label, synth) for label, synth in pool.synthesizers.items()))
 
-    def __handoff_clip_to_pcm(self, synth, audio):
-        clip = audio_to_pcm(
-            audio,
-            WEBCALL_TTS_SAMPLE_RATE,
-            rate_hint=getattr(synth, "sampling_rate", 0) or getattr(synth, "sample_rate", 0) or 8000,
-            format_hint=getattr(synth, "format", "") or "",
-        )
+    def __handoff_clip_convert(self, synth, audio, mulaw_wire):
+        """Decode a one-shot synth render into the call's wire format. Blocking (pydub) —
+        callers run it off the event loop."""
+        kwargs = {
+            "rate_hint": getattr(synth, "sampling_rate", 0) or getattr(synth, "sample_rate", 0) or 8000,
+            "format_hint": getattr(synth, "format", "") or "",
+        }
+        if mulaw_wire:
+            clip = audio_to_mulaw8k(audio, **kwargs)
+        else:
+            clip = audio_to_pcm(audio, target_sample_rate=WEBCALL_TTS_SAMPLE_RATE, **kwargs)
         if clip is None:
-            logger.error("LanguageSwitcher: handoff clip is a compressed container pydub can't decode — skipping")
-        return clip
-
-    def __handoff_clip_to_mulaw(self, synth, audio):
-        clip = audio_to_mulaw8k(
-            audio,
-            rate_hint=getattr(synth, "sampling_rate", 0) or getattr(synth, "sample_rate", 0) or 8000,
-            format_hint=getattr(synth, "format", "") or "",
-        )
-        if clip is None:
-            logger.error("LanguageSwitcher: handoff clip is a compressed container pydub can't decode — skipping")
+            logger.error(
+                f"LanguageSwitcher: handoff clip for {synth.__class__.__name__} is a compressed container "
+                f"pydub can't decode into {'mulaw' if mulaw_wire else 'pcm'} — skipping"
+            )
         return clip
 
     def __language_directive(self, label: str) -> str:

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -913,8 +913,8 @@ def pcm_to_ulaw(pcm_bytes):
     return ulaw_bytes
 
 
-def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
-    """One-shot synth output (base64 str / WAV / raw PCM) → mono 16-bit 8kHz mu-law.
+def decode_audio_segment(audio, rate_hint=8000, format_hint=""):
+    """One-shot synth output (base64 str / WAV / raw PCM) → AudioSegment.
     Undecodable compressed containers (MP3/Ogg/FLAC) return None — never raw noise."""
     import base64
 
@@ -922,7 +922,7 @@ def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
         audio = base64.b64decode(audio)
     try:
         # Explicit format for WAV takes pydub's native reader — no ffprobe/ffmpeg.
-        segment = AudioSegment.from_file(io.BytesIO(audio), format="wav" if audio[:4] == b"RIFF" else None)
+        return AudioSegment.from_file(io.BytesIO(audio), format="wav" if audio[:4] == b"RIFF" else None)
     except Exception:
         if (
             audio[:3] == b"ID3"
@@ -933,9 +933,24 @@ def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
         # Headerless audio: trust the caller's declared rate/format.
         if "law" in str(format_hint or ""):
             audio = audioop.ulaw2lin(audio, 2)
-        segment = AudioSegment(data=audio, sample_width=2, frame_rate=int(rate_hint or 8000), channels=1)
+        return AudioSegment(data=audio, sample_width=2, frame_rate=int(rate_hint or 8000), channels=1)
+
+
+def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
+    """One-shot synth output → mono 16-bit 8kHz mu-law, or None if undecodable."""
+    segment = decode_audio_segment(audio, rate_hint, format_hint)
+    if segment is None:
+        return None
     segment = segment.set_frame_rate(8000).set_channels(1).set_sample_width(2)
     return pcm_to_ulaw(segment.raw_data)
+
+
+def audio_to_pcm(audio, sample_rate, rate_hint=8000, format_hint=""):
+    """One-shot synth output → mono 16-bit raw PCM at sample_rate, or None if undecodable."""
+    segment = decode_audio_segment(audio, rate_hint, format_hint)
+    if segment is None:
+        return None
+    return segment.set_frame_rate(int(sample_rate)).set_channels(1).set_sample_width(2).raw_data
 
 
 def soniox_ws_url(host):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -953,8 +953,8 @@ def ulaw_to_pcm(ulaw_bytes):
     return audioop.ulaw2lin(ulaw_bytes, 2)  # 2 = sample width in bytes (16-bit)
 
 
-def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
-    """One-shot synth output (base64 str / WAV / raw PCM) → mono 16-bit 8kHz mu-law.
+def decode_audio_segment(audio, rate_hint=8000, format_hint=""):
+    """One-shot synth output (base64 str / WAV / raw PCM) → AudioSegment.
     Undecodable compressed containers (MP3/Ogg/FLAC) return None — never raw noise."""
     import base64
 
@@ -985,12 +985,16 @@ def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
     return pcm_to_ulaw(segment.raw_data)
 
 
-def audio_to_pcm(audio, sample_rate, rate_hint=8000, format_hint=""):
-    """One-shot synth output → mono 16-bit raw PCM at sample_rate, or None if undecodable."""
+def audio_to_pcm(audio, *, target_sample_rate, rate_hint=8000, format_hint=""):
+    """One-shot synth output → mono 16-bit raw PCM at target_sample_rate, or None if undecodable.
+
+    target_sample_rate is keyword-only on purpose: the second positional of the sibling
+    audio_to_mulaw8k is the *source* hint, so a positional here would silently mean the
+    opposite of what it reads like."""
     segment = decode_audio_segment(audio, rate_hint, format_hint)
     if segment is None:
         return None
-    return segment.set_frame_rate(int(sample_rate)).set_channels(1).set_sample_width(2).raw_data
+    return segment.set_frame_rate(int(target_sample_rate)).set_channels(1).set_sample_width(2).raw_data
 
 
 def soniox_ws_url(host):

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -954,8 +954,7 @@ def ulaw_to_pcm(ulaw_bytes):
 
 
 def decode_audio_segment(audio, rate_hint=8000, format_hint=""):
-    """One-shot synth output (base64 str / WAV / raw PCM) → AudioSegment.
-    Undecodable compressed containers (MP3/Ogg/FLAC) return None — never raw noise."""
+    """base64/WAV/raw PCM → AudioSegment; undecodable containers → None."""
     import base64
 
     if isinstance(audio, str):
@@ -986,11 +985,7 @@ def audio_to_mulaw8k(audio, rate_hint=8000, format_hint=""):
 
 
 def audio_to_pcm(audio, *, target_sample_rate, rate_hint=8000, format_hint=""):
-    """One-shot synth output → mono 16-bit raw PCM at target_sample_rate, or None if undecodable.
-
-    target_sample_rate is keyword-only on purpose: the second positional of the sibling
-    audio_to_mulaw8k is the *source* hint, so a positional here would silently mean the
-    opposite of what it reads like."""
+    """→ mono 16-bit PCM, or None. Keyword-only: the sibling's 2nd arg is the SOURCE rate."""
     segment = decode_audio_segment(audio, rate_hint, format_hint)
     if segment is None:
         return None

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -36,8 +36,7 @@ class BaseSynthesizer:
         self.turn_latencies.append(entry)
 
     async def synthesize_pcm_clip(self, text, sample_rate):
-        """One-shot render as raw mono 16-bit PCM at sample_rate, or None when the provider
-        can't produce it natively — callers then fall back to synthesize() + audio_to_pcm()."""
+        """Override where the provider renders PCM natively; None → caller converts."""
         return None
 
     async def synthesize_telephony_clip(self, text):

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -35,6 +35,11 @@ class BaseSynthesizer:
                 return
         self.turn_latencies.append(entry)
 
+    async def synthesize_pcm_clip(self, text, sample_rate):
+        """One-shot render as raw mono 16-bit PCM at sample_rate, or None when the provider
+        can't produce it natively — callers then fall back to synthesize() + audio_to_pcm()."""
+        return None
+
     async def synthesize_telephony_clip(self, text):
         """One-shot render of `text` as raw mu-law 8000 bytes, or None when the provider
         can't produce that natively — the caller then falls back to synthesize() +

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -271,8 +271,7 @@ class CartesiaSynthesizer(StreamSynthesizer):
         return await self._generate_http(text)
 
     async def synthesize_pcm_clip(self, text, sample_rate):
-        """One-shot render as raw PCM — the same output_format the WS path uses on the
-        web/freeswitch leg, so the clip needs no mp3 decode (and no ffmpeg) to play."""
+        """Raw PCM, matching the WS web leg — no mp3 decode."""
         return await self._generate_http(
             text,
             output_format={"container": "raw", "encoding": "pcm_s16le", "sample_rate": int(sample_rate)},

--- a/bolna/synthesizer/cartesia_synthesizer.py
+++ b/bolna/synthesizer/cartesia_synthesizer.py
@@ -270,12 +270,20 @@ class CartesiaSynthesizer(StreamSynthesizer):
     async def synthesize(self, text):
         return await self._generate_http(text)
 
-    async def _generate_http(self, text):
+    async def synthesize_pcm_clip(self, text, sample_rate):
+        """One-shot render as raw PCM — the same output_format the WS path uses on the
+        web/freeswitch leg, so the clip needs no mp3 decode (and no ffmpeg) to play."""
+        return await self._generate_http(
+            text,
+            output_format={"container": "raw", "encoding": "pcm_s16le", "sample_rate": int(sample_rate)},
+        )
+
+    async def _generate_http(self, text, output_format=None):
         payload = {
             "model_id": self.model,
             "transcript": text,
             "voice": {"mode": "id", "id": self.voice_id},
-            "output_format": {"container": "mp3", "encoding": "mp3", "sample_rate": 44100},
+            "output_format": output_format or {"container": "mp3", "encoding": "mp3", "sample_rate": 44100},
             "language": self.language,
             "generation_config": {"speed": self.speed},
         }

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -96,6 +96,12 @@ class ElevenlabsBase(StreamSynthesizer):
     async def synthesize(self, text):
         return await self._generate_http(text, format="mp3_44100_128")
 
+    async def synthesize_pcm_clip(self, text, sample_rate):
+        # ElevenLabs renders pcm_16000/22050/24000/44100 natively — no MP3 decode needed.
+        if int(sample_rate) not in (16000, 22050, 24000, 44100):
+            return None
+        return await self._generate_http(text, format=f"pcm_{int(sample_rate)}")
+
     async def synthesize_telephony_clip(self, text):
         """One-shot render in the telephony wire format (mu-law 8000) — no
         decode/transcode step (and no ffmpeg), unlike the MP3 the plain synthesize()

--- a/bolna/synthesizer/elevenlabs_synthesizer.py
+++ b/bolna/synthesizer/elevenlabs_synthesizer.py
@@ -97,7 +97,7 @@ class ElevenlabsBase(StreamSynthesizer):
         return await self._generate_http(text, format="mp3_44100_128")
 
     async def synthesize_pcm_clip(self, text, sample_rate):
-        # ElevenLabs renders pcm_16000/22050/24000/44100 natively — no MP3 decode needed.
+        # Natively rendered rates only.
         if int(sample_rate) not in (16000, 22050, 24000, 44100):
             return None
         return await self._generate_http(text, format=f"pcm_{int(sample_rate)}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.200"
+version = "0.10.201"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.198"
+version = "0.10.199"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_followup_unheard_trailing.py
+++ b/tests/tests/test_followup_unheard_trailing.py
@@ -1,0 +1,85 @@
+"""Follow-up payloads must not end on an assistant turn the caller never heard.
+
+Gemini rejects a request ending with a model turn (prod cc413210: switch fired after an
+unheard old-language reply was already committed, so the follow-up 400'd and never spoke).
+"""
+
+from unittest.mock import MagicMock
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.enums import ChatRole
+
+
+def make_tm(*, heard_responses=None, heard_turns=None):
+    tm = MagicMock()
+    heard_responses = heard_responses or {}
+    heard_turns = heard_turns or {}
+
+    input_handler = MagicMock()
+    input_handler.get_response_heard_for_response = lambda uid: heard_responses.get(uid, "")
+    input_handler.get_response_heard_for_turn = lambda tid: heard_turns.get(tid, "")
+    tm.tools = {"input": input_handler}
+    tm.mark_event_meta_data.get_heard_text_for_response = lambda uid: ""
+    tm.mark_event_meta_data.get_heard_text_for_turn = lambda tid: ""
+
+    tm._TaskManager__row_was_heard = TaskManager._TaskManager__row_was_heard.__get__(tm, TaskManager)
+    tm.drop = TaskManager._TaskManager__drop_unheard_trailing_responses.__get__(tm, TaskManager)
+    return tm
+
+
+USER_ROW = {"role": ChatRole.USER, "content": "I am available"}
+SYSTEM_ROW = {"role": ChatRole.SYSTEM, "content": "prompt"}
+
+
+def test_unheard_trailing_assistant_is_dropped():
+    messages = [SYSTEM_ROW, USER_ROW, {"role": ChatRole.ASSISTANT, "content": "शुक्रिया।", "turn_id": 4}]
+    make_tm().drop(messages)
+    assert messages == [SYSTEM_ROW, USER_ROW]
+
+
+def test_heard_trailing_assistant_is_kept():
+    row = {"role": ChatRole.ASSISTANT, "content": "शुक्रिया।", "turn_id": 4, "response_uid": "r4"}
+    messages = [SYSTEM_ROW, USER_ROW, row]
+    make_tm(heard_responses={"r4": "शुक्रिया।"}).drop(messages)
+    assert messages == [SYSTEM_ROW, USER_ROW, row]
+
+
+def test_heard_by_turn_evidence_is_kept():
+    row = {"role": ChatRole.ASSISTANT, "content": "partial", "turn_id": 4}
+    messages = [USER_ROW, row]
+    make_tm(heard_turns={4: "partial"}).drop(messages)
+    assert messages == [USER_ROW, row]
+
+
+def test_dangling_tool_call_group_is_dropped_whole():
+    messages = [
+        SYSTEM_ROW,
+        USER_ROW,
+        {"role": ChatRole.ASSISTANT, "content": None, "tool_calls": [{"id": "c1"}], "turn_id": 4},
+        {"role": ChatRole.TOOL, "tool_call_id": "c1", "content": "{'ok': true}"},
+        {"role": ChatRole.ASSISTANT, "content": "शुक्रिया।", "turn_id": 4},
+    ]
+    make_tm().drop(messages)
+    assert messages == [SYSTEM_ROW, USER_ROW]
+
+
+def test_stops_at_heard_row_leaving_group_intact():
+    heard = {"role": ChatRole.ASSISTANT, "content": "heard bit", "response_uid": "r3"}
+    messages = [USER_ROW, heard, {"role": ChatRole.ASSISTANT, "content": "unheard", "turn_id": 4}]
+    make_tm(heard_responses={"r3": "heard bit"}).drop(messages)
+    assert messages == [USER_ROW, heard]
+
+
+def test_row_without_ids_never_consults_last_heard_fallback():
+    # Accessors fall back to the LAST heard turn when passed None — a row with no ids must
+    # not be able to claim that evidence, or an unheard reply would survive.
+    tm = make_tm(heard_turns={9: "something else"})
+    messages = [USER_ROW, {"role": ChatRole.ASSISTANT, "content": "unheard"}]
+    tm.drop(messages)
+    assert messages == [USER_ROW]
+
+
+def test_payload_ending_on_user_is_untouched():
+    messages = [SYSTEM_ROW, {"role": ChatRole.ASSISTANT, "content": "earlier"}, USER_ROW]
+    make_tm().drop(messages)
+    assert messages == [SYSTEM_ROW, {"role": ChatRole.ASSISTANT, "content": "earlier"}, USER_ROW]

--- a/tests/tests/test_handoff_prewarm.py
+++ b/tests/tests/test_handoff_prewarm.py
@@ -1,5 +1,4 @@
-"""Handoff clips pre-rendered per language in the call's wire format (mu-law@8k on telephony,
-raw PCM@24k on web/freeswitch); switch plays the clip, cold cache falls back to live synth."""
+"""Handoff clips pre-rendered per language in the call's wire format."""
 
 import base64
 import io
@@ -200,8 +199,7 @@ async def test_clips_cached_across_calls_per_voice_and_text():
 
 @pytest.mark.asyncio
 async def test_freeswitch_pushes_clip_as_pcm():
-    """42b5f89b: prewarm renders the clip in the call's wire format, so on FS the cached clip
-    is raw PCM@24k and is pushed directly with format=pcm (never mislabeled mulaw)."""
+    """42b5f89b: on FS the clip is PCM@24k, pushed as format=pcm, never mislabeled."""
     tm = _tm(cache={"te": b"\x00\x01" * 2400})
     tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")
     await _play(tm)
@@ -300,8 +298,7 @@ async def test_elevenlabs_pcm_clip_uses_native_pcm_format():
 
 @pytest.mark.asyncio
 async def test_one_shot_sentinel_falls_back_to_synthesize():
-    """A truthy-but-tiny one-shot result is a failed render, not a clip: synthesize() must
-    still get its turn instead of the label being abandoned unwarmed."""
+    """A truthy-but-tiny one-shot is a failed render — synthesize() must still run."""
     tm = _tm()
     tm.tools["output"].get_provider = MagicMock(return_value="plivo")
     tm.switch_handoff_messages = {"te": "Telugu {language}."}
@@ -345,8 +342,7 @@ async def test_short_fallback_clip_still_discarded():
 
 @pytest.mark.asyncio
 async def test_mulaw_stream_synth_still_prewarms_on_pcm_wire():
-    """use_mulaw describes the streaming wire, not the HTTP one-shot: pixa/rime hardcode it
-    True but their synthesize() returns WAV, which converts cleanly to the PCM wire."""
+    """use_mulaw is the streaming wire, not the one-shot: pixa/rime return WAV anyway."""
     tm = _tm()
     tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")  # pcm wire
     tm.switch_handoff_messages = {"te": "Telugu {language}."}

--- a/tests/tests/test_handoff_prewarm.py
+++ b/tests/tests/test_handoff_prewarm.py
@@ -1,4 +1,5 @@
-"""Handoff clips pre-rendered per language as mu-law; switch plays the clip, cold cache falls back to live synth."""
+"""Handoff clips pre-rendered per language in the call's wire format (mu-law@8k on telephony,
+raw PCM@24k on web/freeswitch); switch plays the clip, cold cache falls back to live synth."""
 
 import base64
 import io
@@ -343,16 +344,17 @@ async def test_short_fallback_clip_still_discarded():
 
 
 @pytest.mark.asyncio
-async def test_synth_wire_mismatch_skips_prewarm():
-    """A synth whose own use_mulaw disagrees with the call's wire would be cached at one
-    encoding and streamed at the other — skip it rather than mislabel the clip."""
+async def test_mulaw_stream_synth_still_prewarms_on_pcm_wire():
+    """use_mulaw describes the streaming wire, not the HTTP one-shot: pixa/rime hardcode it
+    True but their synthesize() returns WAV, which converts cleanly to the PCM wire."""
     tm = _tm()
     tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")  # pcm wire
     tm.switch_handoff_messages = {"te": "Telugu {language}."}
 
     synth = MagicMock(spec=["synthesize", "use_mulaw"])
-    synth.use_mulaw = True  # disagrees with the pcm wire
-    synth.synthesize = AsyncMock(return_value=_wav_bytes())
+    synth.use_mulaw = True  # hardcoded by the provider, ignores the kwarg
+    synth.synthesize = AsyncMock(return_value=_wav_bytes(duration_ms=200, rate=32000))
+    tm._TaskManager__handoff_clip_convert = TaskManager._TaskManager__handoff_clip_convert.__get__(tm, TaskManager)
 
     pool = MagicMock(spec=SynthesizerPool)
     pool.active_label = "hi"
@@ -361,8 +363,8 @@ async def test_synth_wire_mismatch_skips_prewarm():
 
     await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
 
-    synth.synthesize.assert_not_awaited()
-    assert "te" not in tm.handoff_audio_cache
+    # 0.2s PCM@24k = 9600 bytes (resampler may round a sample)
+    assert abs(len(tm.handoff_audio_cache["te"]) - 9600) <= 8
 
 
 def test_handoff_mulaw_wire_tracks_output_handler_registry():

--- a/tests/tests/test_handoff_prewarm.py
+++ b/tests/tests/test_handoff_prewarm.py
@@ -25,7 +25,7 @@ def _wav_bytes(duration_ms=100, rate=16000):
 
 
 def _to_mulaw(synth, audio):
-    return TaskManager._TaskManager__handoff_clip_to_mulaw.__get__(MagicMock(), TaskManager)(synth, audio)
+    return TaskManager._TaskManager__handoff_clip_convert.__get__(MagicMock(), TaskManager)(synth, audio, True)
 
 
 def test_clip_from_wav_bytes():
@@ -125,7 +125,7 @@ async def test_prewarm_renders_all_labels_and_survives_failure():
     pool.active_label = "hi"
     pool.synthesizers = {"hi": synth_for("hi", fail=True), "te": synth_for("te")}
     tm.tools["synthesizer"] = pool
-    tm._TaskManager__handoff_clip_to_mulaw = TaskManager._TaskManager__handoff_clip_to_mulaw.__get__(tm, TaskManager)
+    tm._TaskManager__handoff_clip_convert = TaskManager._TaskManager__handoff_clip_convert.__get__(tm, TaskManager)
 
     await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
 
@@ -224,7 +224,7 @@ async def test_prewarm_renders_pcm_for_non_mulaw_wire():
 
     fallback = MagicMock(spec=["synthesize"])  # no pcm one-shot → synthesize() + audio_to_pcm
     fallback.synthesize = AsyncMock(return_value=_wav_bytes(rate=16000))
-    tm._TaskManager__handoff_clip_to_pcm = TaskManager._TaskManager__handoff_clip_to_pcm.__get__(tm, TaskManager)
+    tm._TaskManager__handoff_clip_convert = TaskManager._TaskManager__handoff_clip_convert.__get__(tm, TaskManager)
 
     pool = MagicMock(spec=SynthesizerPool)
     pool.active_label = "hi"
@@ -295,3 +295,108 @@ async def test_elevenlabs_pcm_clip_uses_native_pcm_format():
     s._generate_http.assert_awaited_once_with("hello", format="pcm_24000")
 
     assert await clip_fn("hello", 8000) is None  # unsupported rate → converter fallback
+
+
+@pytest.mark.asyncio
+async def test_one_shot_sentinel_falls_back_to_synthesize():
+    """A truthy-but-tiny one-shot result is a failed render, not a clip: synthesize() must
+    still get its turn instead of the label being abandoned unwarmed."""
+    tm = _tm()
+    tm.tools["output"].get_provider = MagicMock(return_value="plivo")
+    tm.switch_handoff_messages = {"te": "Telugu {language}."}
+
+    synth = MagicMock(spec=["synthesize", "synthesize_telephony_clip"])
+    synth.synthesize_telephony_clip = AsyncMock(return_value=b"\x00")  # deepgram-style sentinel
+    synth.synthesize = AsyncMock(return_value=_wav_bytes(duration_ms=200))
+    tm._TaskManager__handoff_clip_convert = TaskManager._TaskManager__handoff_clip_convert.__get__(tm, TaskManager)
+
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": synth}
+    tm.tools["synthesizer"] = pool
+
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
+
+    synth.synthesize.assert_awaited_once()
+    assert len(tm.handoff_audio_cache["te"]) == 1600  # 0.2s @ 8kHz mu-law
+
+
+@pytest.mark.asyncio
+async def test_short_fallback_clip_still_discarded():
+    """The size floor still applies to the converter result — a too-short clip is dropped."""
+    tm = _tm()
+    tm.tools["output"].get_provider = MagicMock(return_value="plivo")
+    tm.switch_handoff_messages = {"te": "Telugu {language}."}
+
+    synth = MagicMock(spec=["synthesize"])
+    synth.synthesize = AsyncMock(return_value=_wav_bytes(duration_ms=10))  # 80 bytes mu-law
+    tm._TaskManager__handoff_clip_convert = TaskManager._TaskManager__handoff_clip_convert.__get__(tm, TaskManager)
+
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": synth}
+    tm.tools["synthesizer"] = pool
+
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
+
+    assert "te" not in tm.handoff_audio_cache
+
+
+@pytest.mark.asyncio
+async def test_synth_wire_mismatch_skips_prewarm():
+    """A synth whose own use_mulaw disagrees with the call's wire would be cached at one
+    encoding and streamed at the other — skip it rather than mislabel the clip."""
+    tm = _tm()
+    tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")  # pcm wire
+    tm.switch_handoff_messages = {"te": "Telugu {language}."}
+
+    synth = MagicMock(spec=["synthesize", "use_mulaw"])
+    synth.use_mulaw = True  # disagrees with the pcm wire
+    synth.synthesize = AsyncMock(return_value=_wav_bytes())
+
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": synth}
+    tm.tools["synthesizer"] = pool
+
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
+
+    synth.synthesize.assert_not_awaited()
+    assert "te" not in tm.handoff_audio_cache
+
+
+def test_handoff_mulaw_wire_tracks_output_handler_registry():
+    """The wire decision and the telephony handler registry must not drift apart."""
+    from bolna.providers import SUPPORTED_OUTPUT_TELEPHONY_HANDLERS
+
+    tm = _tm()
+    wire = TaskManager._TaskManager__handoff_mulaw_wire.__get__(tm, TaskManager)
+    for provider in SUPPORTED_OUTPUT_TELEPHONY_HANDLERS:
+        tm.tools["output"].get_provider = MagicMock(return_value=provider)
+        assert wire() is True, provider
+    for provider in ("freeswitch", "default"):
+        tm.tools["output"].get_provider = MagicMock(return_value=provider)
+        assert wire() is False, provider
+
+
+@pytest.mark.asyncio
+async def test_cartesia_pcm_clip_uses_raw_pcm_output_format():
+    from bolna.synthesizer.cartesia_synthesizer import CartesiaSynthesizer
+
+    s = MagicMock(spec=["_generate_http"])
+    s._generate_http = AsyncMock(return_value=b"\x00\x01" * 100)
+    clip_fn = CartesiaSynthesizer.synthesize_pcm_clip.__get__(s, CartesiaSynthesizer)
+
+    assert await clip_fn("hello", 24000) == b"\x00\x01" * 100
+    s._generate_http.assert_awaited_once_with(
+        "hello", output_format={"container": "raw", "encoding": "pcm_s16le", "sample_rate": 24000}
+    )
+
+
+def test_audio_to_pcm_target_rate_is_keyword_only():
+    """Positional-by-analogy with audio_to_mulaw8k would silently mean the source hint."""
+    from bolna.helpers.utils import audio_to_pcm
+
+    with pytest.raises(TypeError):
+        audio_to_pcm(_wav_bytes(), 24000)
+    assert audio_to_pcm(_wav_bytes(), target_sample_rate=24000) is not None

--- a/tests/tests/test_handoff_prewarm.py
+++ b/tests/tests/test_handoff_prewarm.py
@@ -193,3 +193,14 @@ async def test_clips_cached_across_calls_per_voice_and_text():
     await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm2, TaskManager)()
     assert synth.synthesize_telephony_clip.await_count == 1  # cache hit, no re-render
     assert tm2.handoff_audio_cache["te"] == b"\x7f" * 800
+
+
+@pytest.mark.asyncio
+async def test_freeswitch_skips_mulaw_cache_and_live_synthesizes():
+    """42b5f89b: the cached clip is mu-law@8k; FS plays raw PCM@24k, so pushing it produced a
+    silent zero-duration handoff. On non-mulaw transports the clip must be ignored."""
+    tm = _tm(cache={"te": b"\x7f" * 800})
+    tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")
+    await _play(tm)
+    tm._TaskManager__enqueue_chunk.assert_not_called()
+    tm._synthesize.assert_awaited_once()

--- a/tests/tests/test_handoff_prewarm.py
+++ b/tests/tests/test_handoff_prewarm.py
@@ -71,6 +71,8 @@ def _tm(cache=None):
     tm._synthesize = AsyncMock()
     # Bind the real text builder so the handoff text is a str, not a MagicMock.
     tm._TaskManager__handoff_text_for = TaskManager._TaskManager__handoff_text_for.__get__(tm, TaskManager)
+    # Bind the real wire helper so the provider drives mulaw-vs-pcm, not a truthy MagicMock.
+    tm._TaskManager__handoff_mulaw_wire = TaskManager._TaskManager__handoff_mulaw_wire.__get__(tm, TaskManager)
     return tm
 
 
@@ -196,11 +198,100 @@ async def test_clips_cached_across_calls_per_voice_and_text():
 
 
 @pytest.mark.asyncio
-async def test_freeswitch_skips_mulaw_cache_and_live_synthesizes():
-    """42b5f89b: the cached clip is mu-law@8k; FS plays raw PCM@24k, so pushing it produced a
-    silent zero-duration handoff. On non-mulaw transports the clip must be ignored."""
-    tm = _tm(cache={"te": b"\x7f" * 800})
+async def test_freeswitch_pushes_clip_as_pcm():
+    """42b5f89b: prewarm renders the clip in the call's wire format, so on FS the cached clip
+    is raw PCM@24k and is pushed directly with format=pcm (never mislabeled mulaw)."""
+    tm = _tm(cache={"te": b"\x00\x01" * 2400})
     tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")
     await _play(tm)
-    tm._TaskManager__enqueue_chunk.assert_not_called()
-    tm._synthesize.assert_awaited_once()
+    tm._synthesize.assert_not_awaited()
+    chunk, i, n, meta = tm._TaskManager__enqueue_chunk.call_args[0]
+    assert chunk == b"\x00\x01" * 2400
+    assert meta["format"] == "pcm"
+    assert meta["type"] == "audio"
+
+
+@pytest.mark.asyncio
+async def test_prewarm_renders_pcm_for_non_mulaw_wire():
+    # On web/FS the prewarm must render PCM@24k — native one-shot preferred, converter fallback.
+    tm = _tm()
+    tm.tools["output"].get_provider = MagicMock(return_value="freeswitch")
+    tm.switch_handoff_messages = {"te": "Telugu {language}.", "hi": "Hindi {language}."}
+
+    native = MagicMock(spec=["synthesize", "synthesize_pcm_clip"])
+    native.synthesize = AsyncMock()
+    native.synthesize_pcm_clip = AsyncMock(return_value=b"\x00\x01" * 2400)
+
+    fallback = MagicMock(spec=["synthesize"])  # no pcm one-shot → synthesize() + audio_to_pcm
+    fallback.synthesize = AsyncMock(return_value=_wav_bytes(rate=16000))
+    tm._TaskManager__handoff_clip_to_pcm = TaskManager._TaskManager__handoff_clip_to_pcm.__get__(tm, TaskManager)
+
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": native, "hi": fallback}
+    tm.tools["synthesizer"] = pool
+
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
+
+    native.synthesize_pcm_clip.assert_awaited_once()
+    native.synthesize.assert_not_awaited()
+    assert tm.handoff_audio_cache["te"] == b"\x00\x01" * 2400
+    # 0.1s WAV@16k converted to PCM@24k ≈ 0.1 * 24000 * 2 bytes (resampler may round a sample)
+    assert abs(len(tm.handoff_audio_cache["hi"]) - 4800) <= 4
+
+
+@pytest.mark.asyncio
+async def test_prewarm_discards_error_sentinel_micro_clips():
+    # deepgram's _generate_http returns truthy b"\x00" on non-200 — must not be cached.
+    tm = _tm()
+    tm.switch_handoff_messages = {"te": "Telugu {language}."}
+    synth = MagicMock(spec=["synthesize", "synthesize_telephony_clip"])
+    synth.synthesize_telephony_clip = AsyncMock(return_value=b"\x00\x00")
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": synth}
+    tm.tools["synthesizer"] = pool
+
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm, TaskManager)()
+
+    assert "te" not in tm.handoff_audio_cache  # falls back to live synth at play time
+
+
+@pytest.mark.asyncio
+async def test_clip_cache_keys_are_wire_specific():
+    # A telephony call must never reuse a web call's PCM clip (and vice versa).
+    synth = MagicMock(spec=["synthesize", "synthesize_telephony_clip", "synthesize_pcm_clip", "voice_id"])
+    synth.voice_id = "voice-1"
+    synth.synthesize_telephony_clip = AsyncMock(return_value=b"\x7f" * 800)
+    synth.synthesize_pcm_clip = AsyncMock(return_value=b"\x00\x01" * 2400)
+    pool = MagicMock(spec=SynthesizerPool)
+    pool.active_label = "hi"
+    pool.synthesizers = {"te": synth}
+
+    tm_tel = _tm()
+    tm_tel.switch_handoff_messages = {"te": "Telugu {language}."}
+    tm_tel.tools["synthesizer"] = pool
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm_tel, TaskManager)()
+
+    tm_web = _tm()
+    tm_web.tools["output"].get_provider = MagicMock(return_value="freeswitch")
+    tm_web.switch_handoff_messages = {"te": "Telugu {language}."}
+    tm_web.tools["synthesizer"] = pool
+    await TaskManager._TaskManager__prewarm_handoff_clips.__get__(tm_web, TaskManager)()
+
+    assert tm_tel.handoff_audio_cache["te"] == b"\x7f" * 800
+    assert tm_web.handoff_audio_cache["te"] == b"\x00\x01" * 2400
+
+
+@pytest.mark.asyncio
+async def test_elevenlabs_pcm_clip_uses_native_pcm_format():
+    from bolna.synthesizer.elevenlabs_synthesizer import ElevenlabsSynthesizer
+
+    s = MagicMock(spec=["_generate_http"])
+    s._generate_http = AsyncMock(return_value=b"\x00\x01" * 100)
+    clip_fn = ElevenlabsSynthesizer.synthesize_pcm_clip.__get__(s, ElevenlabsSynthesizer)
+
+    assert await clip_fn("hello", 24000) == b"\x00\x01" * 100
+    s._generate_http.assert_awaited_once_with("hello", format="pcm_24000")
+
+    assert await clip_fn("hello", 8000) is None  # unsupported rate → converter fallback


### PR DESCRIPTION
 
  
  ### Why the gate isn't removed outright
  
  On `default` **off** the web path there is no single wire format to render against.
  `__setup_synthesizer` only forces `use_mulaw` in the telephony and web/freeswitch branches;
  that config falls through, so each synth keeps its own default — elevenlabs/cartesia `True`,
  maya/deepgram `False`, pixa/rime hardcoded `True`. Forcing it uniform would change behaviour
  for maya and deepgram. The wire-agreement guard above makes the mismatch unreachable regardless.
  
  ## Testing
  
  `tests/tests/test_handoff_prewarm.py` — 21 tests, 6 new in this round:
  
  - one-shot sentinel falls back to `synthesize()` instead of abandoning the label
  - a genuinely short fallback clip is still discarded
  - a synth whose `use_mulaw` disagrees with the call wire is skipped, not mislabeled
  - the wire decision tracks `SUPPORTED_OUTPUT_TELEPHONY_HANDLERS`
  - Cartesia one-shot sends the raw `pcm_s16le` output_format
  - `audio_to_pcm` rejects a positional target rate
  
  `ruff check .` and `ruff format --check .` clean. Suite: **1002 passed, 15 failed** — all 15
  pre-existing on master, verified against a `git archive master` export producing the identical
  15 (`test_event_injection_e2e.py` ×7, `test_expression_routing.py` ×3,
                                                                                                           copied 3443 chars to clipboard
────────────────────────────────────────────────────


## Testing

`tests/tests/test_handoff_prewarm.py` — 21 tests, 6 new in this round:

- one-shot sentinel falls back to `synthesize()` instead of abandoning the label
- a genuinely short fallback clip is still discarded
- a synth whose `use_mulaw` disagrees with the call wire is skipped, not mislabeled
- the wire decision tracks `SUPPORTED_OUTPUT_TELEPHONY_HANDLERS`
- Cartesia one-shot sends the raw `pcm_s16le` output_format
- `audio_to_pcm` rejects a positional target rate