### PR TITLE
estimate for mark in last agent message for transcript

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.196"
+__version__ = "0.10.197"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2168,8 +2168,10 @@ class TaskManager(BaseManager):
             or (self.execute_function_call_task is not None and not self.execute_function_call_task.done()),
         }
 
-    async def sync_history(self, mark_events_data, interruption_processed_at):
-        """Sync history to reflect only what was actually spoken. Uses confirmed text or falls back to pending marks."""
+    async def sync_history(self, mark_events_data, interruption_processed_at, extend_with_playback_estimate=False):
+        """Sync history to reflect only what was actually spoken. Uses confirmed text or falls back to pending marks.
+        extend_with_playback_estimate: end-of-call only — credit the unACKed tail when the wall
+        clock since the last ACK covers its full duration (marks can lag playback and get lost)."""
         try:
             mark_events_data = list(mark_events_data)
             target_turn_id = self._get_latest_turn_id_from_marks(mark_events_data)
@@ -2210,6 +2212,31 @@ class TaskManager(BaseManager):
             logger.info(f"sync_history: response_heard len={len(response_heard) if response_heard else 0}")
             if response_heard:
                 logger.info(f"response_heard (last 10 chars): {response_heard[-10:]}")
+
+            if extend_with_playback_estimate and response_heard:
+                pending_tail = []
+                for mark_id, mark_data in mark_events_data:
+                    text = mark_data.get("text_synthesized", "")
+                    if mark_data.get("type") in ["pre_mark_message", "backchanneling"] or not text:
+                        continue
+                    if target_turn_id is not None and mark_data.get("turn_id") != target_turn_id:
+                        continue
+                    pending_tail.append({"text": text, "duration": mark_data.get("duration", 0)})
+                last_ack_ts = self.mark_event_meta_data.get_last_ack_ts_for_turn(target_turn_id)
+                if pending_tail and last_ack_ts:
+                    # All-or-nothing: credit only when playback provably finished; mid-chunk
+                    # hangup keeps the strict ACK trim (never stamp a partial guess).
+                    tail_play_time = max(0.0, interruption_processed_at - last_ack_ts)
+                    pending_duration = sum(chunk["duration"] or 0 for chunk in pending_tail)
+                    if tail_play_time >= pending_duration > 0:
+                        tail_text = "".join(chunk["text"] for chunk in pending_tail)
+                        logger.info(
+                            f"sync_history: crediting fully-played unacked tail "
+                            f"({pending_duration:.2f}s audio, {tail_play_time:.2f}s elapsed, {len(tail_text)} chars)"
+                        )
+                        # Restore the stripped chunk-boundary space or the exact-match trim drops the tail.
+                        joiner = "" if (response_heard[-1:].isspace() or tail_text[:1].isspace()) else " "
+                        response_heard += joiner + tail_text
 
             if not response_heard:
                 pending_marks = [{"mark_id": k, "mark_data": v} for k, v in mark_events_data]
@@ -7368,7 +7395,11 @@ class TaskManager(BaseManager):
                 has_pending_marks = len(self.mark_event_meta_data.mark_event_meta_data) > 0
                 has_response_heard = bool(self.tools["input"].response_heard_by_user)
                 if has_pending_marks or has_response_heard:
-                    await self.sync_history(self.mark_event_meta_data.mark_event_meta_data.items(), time.time())
+                    await self.sync_history(
+                        self.mark_event_meta_data.mark_event_meta_data.items(),
+                        time.time(),
+                        extend_with_playback_estimate=True,
+                    )
                 self.tools["input"].reset_response_heard_by_user()
                 logger.info("Conversation completed")
                 self.conversation_ended = True

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2168,10 +2168,33 @@ class TaskManager(BaseManager):
             or (self.execute_function_call_task is not None and not self.execute_function_call_task.done()),
         }
 
+    def estimate_played_text_for_time(self, pending_chunks, actual_play_time):
+        """Credit whole chunks that fit in actual_play_time, then a word-trimmed proportional
+        slice of the chunk the clock lands in."""
+        played_text = []
+        cumulative_duration = 0
+        for chunk in pending_chunks:
+            if cumulative_duration >= actual_play_time:
+                break
+            chunk_duration = chunk["duration"]
+            if cumulative_duration + chunk_duration <= actual_play_time:
+                played_text.append(chunk["text"])
+            else:
+                remaining_time = actual_play_time - cumulative_duration
+                proportion = remaining_time / chunk_duration if chunk_duration > 0 else 0
+                char_count = int(len(chunk["text"]) * proportion)
+                partial_text = chunk["text"][:char_count]
+                if partial_text and char_count < len(chunk["text"]):
+                    partial_text = self._trim_partial_to_complete_words(partial_text)
+                if partial_text:
+                    played_text.append(partial_text)
+            cumulative_duration += chunk_duration
+        return "".join(played_text)
+
     async def sync_history(self, mark_events_data, interruption_processed_at, extend_with_playback_estimate=False):
         """Sync history to reflect only what was actually spoken. Uses confirmed text or falls back to pending marks.
-        extend_with_playback_estimate: end-of-call only — credit the unACKed tail when the wall
-        clock since the last ACK covers its full duration (marks can lag playback and get lost)."""
+        extend_with_playback_estimate: end-of-call only — credit the unACKed tail proportionally
+        to the wall clock elapsed since the last ACK (marks can lag playback and get lost)."""
         try:
             mark_events_data = list(mark_events_data)
             target_turn_id = self._get_latest_turn_id_from_marks(mark_events_data)
@@ -2217,22 +2240,20 @@ class TaskManager(BaseManager):
                 pending_tail = []
                 for mark_id, mark_data in mark_events_data:
                     text = mark_data.get("text_synthesized", "")
-                    if mark_data.get("type") in ["pre_mark_message", "backchanneling"] or not text:
+                    if mark_data.get("type") in NON_EVIDENCE_MARK_TYPES or not text:
                         continue
                     if target_turn_id is not None and mark_data.get("turn_id") != target_turn_id:
                         continue
                     pending_tail.append({"text": text, "duration": mark_data.get("duration", 0)})
                 last_ack_ts = self.mark_event_meta_data.get_last_ack_ts_for_turn(target_turn_id)
                 if pending_tail and last_ack_ts:
-                    # All-or-nothing: credit only when playback provably finished; mid-chunk
-                    # hangup keeps the strict ACK trim (never stamp a partial guess).
+                    # Proportional by the wall clock since the last ACK. The ACK itself lags true
+                    # playout end, so this window under-credits — it can't stamp unheard text.
                     tail_play_time = max(0.0, interruption_processed_at - last_ack_ts)
-                    pending_duration = sum(chunk["duration"] or 0 for chunk in pending_tail)
-                    if tail_play_time >= pending_duration > 0:
-                        tail_text = "".join(chunk["text"] for chunk in pending_tail)
+                    tail_text = self.estimate_played_text_for_time(pending_tail, tail_play_time)
+                    if tail_text:
                         logger.info(
-                            f"sync_history: crediting fully-played unacked tail "
-                            f"({pending_duration:.2f}s audio, {tail_play_time:.2f}s elapsed, {len(tail_text)} chars)"
+                            f"sync_history: crediting unacked tail ({tail_play_time:.2f}s elapsed, {len(tail_text)} chars)"
                         )
                         # Restore the stripped chunk-boundary space or the exact-match trim drops the tail.
                         joiner = "" if (response_heard[-1:].isspace() or tail_text[:1].isspace()) else " "
@@ -2262,27 +2283,9 @@ class TaskManager(BaseManager):
                         elapsed_time = interruption_processed_at - self.tools["input"].get_current_mark_started_time()
                         actual_play_time = max(0, elapsed_time)
 
-                    played_text = []
-                    cumulative_duration = 0
-                    for chunk in pending_chunks:
-                        if cumulative_duration >= actual_play_time:
-                            break
-                        chunk_duration = chunk["duration"]
-                        if cumulative_duration + chunk_duration <= actual_play_time:
-                            played_text.append(chunk["text"])
-                        else:
-                            remaining_time = actual_play_time - cumulative_duration
-                            proportion = remaining_time / chunk_duration if chunk_duration > 0 else 0
-                            char_count = int(len(chunk["text"]) * proportion)
-                            partial_text = chunk["text"][:char_count]
-                            if partial_text and char_count < len(chunk["text"]):
-                                partial_text = self._trim_partial_to_complete_words(partial_text)
-                            if partial_text:
-                                played_text.append(partial_text)
-                        cumulative_duration += chunk_duration
-
-                    if played_text:
-                        response_heard = "".join(played_text)
+                    estimated = self.estimate_played_text_for_time(pending_chunks, actual_play_time)
+                    if estimated:
+                        response_heard = estimated
                         logger.info(
                             f"Estimated played text (last 10 chars): {response_heard[-10:]}, len={len(response_heard)}"
                         )

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -249,6 +249,17 @@ class MarkEventMetaData:
     def fetch_cleared_mark_event_data(self):
         return self.previous_mark_event_meta_data
 
+    def get_last_ack_ts_for_turn(self, turn_id) -> Optional[float]:
+        """Wall-clock of the turn's last ACKed chunk — the playback clock's last confirmed point."""
+        if turn_id is None:
+            return None
+        ack_times = [
+            data.get("ack_ts")
+            for data in self._mark_history.values()
+            if data.get("acked") and data.get("turn_id") == turn_id and data.get("ack_ts")
+        ]
+        return max(ack_times) if ack_times else None
+
     def get_chunk_marks(self) -> List[Dict]:
         """Per-mark wall-clock detail for post-call audio analysis.
 

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -250,7 +250,9 @@ class MarkEventMetaData:
         return self.previous_mark_event_meta_data
 
     def get_last_ack_ts_for_turn(self, turn_id) -> Optional[float]:
-        """Wall-clock of the turn's last ACKed chunk — the playback clock's last confirmed point."""
+        """Wall-clock of the turn's last ACKed chunk — the playback clock's last confirmed point.
+        audio_playing_until can't serve here: it is a send-time estimate, not per-turn, and is
+        zeroed by drop_playout_estimate; crediting needs the turn's last confirmed instant."""
         if turn_id is None:
             return None
         ack_times = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.196"
+version = "0.10.197"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_hangup_goodbye_drain_on_teardown.py
+++ b/tests/tests/test_hangup_goodbye_drain_on_teardown.py
@@ -162,6 +162,6 @@ async def test_wait_is_bounded_when_marks_never_ack():
 def test_run_gates_terminal_sync_on_in_flight_hangup():
     src = inspect.getsource(TaskManager.run)
     gate_idx = src.find("if self.hangup_triggered and not self.conversation_ended:")
-    sync_idx = src.find("await self.sync_history(self.mark_event_meta_data.mark_event_meta_data.items(), time.time())")
+    sync_idx = src.find("await self.sync_history(\n                        self.mark_event_meta_data.mark_event_meta_data.items(),")
     assert gate_idx != -1 and sync_idx != -1
     assert gate_idx < sync_idx

--- a/tests/tests/test_hangup_goodbye_drain_on_teardown.py
+++ b/tests/tests/test_hangup_goodbye_drain_on_teardown.py
@@ -162,6 +162,8 @@ async def test_wait_is_bounded_when_marks_never_ack():
 def test_run_gates_terminal_sync_on_in_flight_hangup():
     src = inspect.getsource(TaskManager.run)
     gate_idx = src.find("if self.hangup_triggered and not self.conversation_ended:")
-    sync_idx = src.find("await self.sync_history(\n                        self.mark_event_meta_data.mark_event_meta_data.items(),")
+    sync_idx = src.find(
+        "await self.sync_history(\n                        self.mark_event_meta_data.mark_event_meta_data.items(),"
+    )
     assert gate_idx != -1 and sync_idx != -1
     assert gate_idx < sync_idx

--- a/tests/tests/test_sync_history_unacked_tail.py
+++ b/tests/tests/test_sync_history_unacked_tail.py
@@ -9,7 +9,9 @@ from bolna.agent_manager.task_manager import TaskManager
 from bolna.helpers.conversation_history import ConversationHistory
 from bolna.helpers.mark_event_meta_data import MarkEventMetaData
 
-FULL_TEXT = "aapka final price rupees two thousand five hundred fifty seven padega abhi ye deal limited time ke liye hai"
+FULL_TEXT = (
+    "aapka final price rupees two thousand five hundred fifty seven padega abhi ye deal limited time ke liye hai"
+)
 PREFIX = "aapka final price "
 TAIL = "rupees two thousand five hundred fifty seven padega abhi ye deal limited time ke liye hai"
 
@@ -42,16 +44,30 @@ def _make_tm():
     # ACKed prefix chunk: sent, then its mark came back.
     marks.update_data(
         "m1",
-        {"type": "", "turn_id": 8, "response_uid": "r8", "sequence_id": 8,
-         "duration": 2.0, "text_synthesized": PREFIX, "sent_ts": time.time() - 30},
+        {
+            "type": "",
+            "turn_id": 8,
+            "response_uid": "r8",
+            "sequence_id": 8,
+            "duration": 2.0,
+            "text_synthesized": PREFIX,
+            "sent_ts": time.time() - 30,
+        },
     )
     acked = marks.fetch_data("m1")
     marks.record_heard_text(acked, PREFIX)
     # Tail chunk (9.6s audio): sent, mark never arrived before teardown.
     marks.update_data(
         "m2",
-        {"type": "", "turn_id": 8, "response_uid": "r8", "sequence_id": 8,
-         "duration": 9.6, "text_synthesized": TAIL, "sent_ts": time.time() - 28},
+        {
+            "type": "",
+            "turn_id": 8,
+            "response_uid": "r8",
+            "sequence_id": 8,
+            "duration": 9.6,
+            "text_synthesized": TAIL,
+            "sent_ts": time.time() - 28,
+        },
     )
     tm.mark_event_meta_data = marks
     return tm, history, marks
@@ -65,20 +81,27 @@ def _assistant_content(history):
 async def test_end_of_call_credits_unacked_tail_played_after_last_ack():
     tm, history, marks = _make_tm()
     teardown_ts = marks.get_last_ack_ts_for_turn(8) + 20  # well past the 9.6s tail
-    await tm.sync_history(
-        marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True
-    )
+    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
     assert _assistant_content(history) == FULL_TEXT
 
 
 @pytest.mark.asyncio
-async def test_end_of_call_mid_chunk_hangup_keeps_strict_ack_trim():
-    # Elapsed < pending duration → playback can't have finished; never stamp a partial guess.
+async def test_end_of_call_mid_chunk_hangup_credits_proportional_word_trimmed():
+    # PR review replay: last ACK 6.97s before teardown vs 9.61s tail → ~72% heard, word-aligned.
     tm, history, marks = _make_tm()
-    teardown_ts = marks.get_last_ack_ts_for_turn(8) + 4.8  # only half the 9.6s tail elapsed
-    await tm.sync_history(
-        marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True
-    )
+    teardown_ts = marks.get_last_ack_ts_for_turn(8) + 6.97
+    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
+    content = _assistant_content(history)
+    assert content.startswith(PREFIX + "rupees")  # tail partially credited
+    assert len(content) < len(FULL_TEXT)
+    assert FULL_TEXT.startswith(content)  # word-aligned prefix of the real text
+
+
+@pytest.mark.asyncio
+async def test_end_of_call_zero_elapsed_keeps_strict_ack_trim():
+    tm, history, marks = _make_tm()
+    teardown_ts = marks.get_last_ack_ts_for_turn(8)  # hangup at the last confirmed instant
+    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
     assert _assistant_content(history) == PREFIX.strip()
 
 

--- a/tests/tests/test_sync_history_unacked_tail.py
+++ b/tests/tests/test_sync_history_unacked_tail.py
@@ -1,0 +1,89 @@
+"""The final chunk's mark never arrived before hangup, so end-of-call sync trimmed the last
+agent message even though the tail audio played."""
+
+import time
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+
+FULL_TEXT = "aapka final price rupees two thousand five hundred fifty seven padega abhi ye deal limited time ke liye hai"
+PREFIX = "aapka final price "
+TAIL = "rupees two thousand five hundred fifty seven padega abhi ye deal limited time ke liye hai"
+
+
+class _InputStub:
+    last_heard_turn_id = 8
+    last_heard_response_uid = "r8"
+    response_heard_by_user = ""
+
+    def get_response_heard_for_response(self, uid):
+        return ""
+
+    def get_response_heard_for_turn(self, turn_id):
+        return ""
+
+    def get_current_mark_started_time(self):
+        return 0.0
+
+
+def _make_tm():
+    tm = TaskManager.__new__(TaskManager)
+    history = ConversationHistory()
+    history.append_user("haan main purchase karne mein interested hoon")
+    history.append_assistant(FULL_TEXT, turn_id=8, response_uid="r8")
+    tm.conversation_history = history
+    tm.tools = {"input": _InputStub()}
+    tm._turn_msg_map = {}
+
+    marks = MarkEventMetaData()
+    # ACKed prefix chunk: sent, then its mark came back.
+    marks.update_data(
+        "m1",
+        {"type": "", "turn_id": 8, "response_uid": "r8", "sequence_id": 8,
+         "duration": 2.0, "text_synthesized": PREFIX, "sent_ts": time.time() - 30},
+    )
+    acked = marks.fetch_data("m1")
+    marks.record_heard_text(acked, PREFIX)
+    # Tail chunk (9.6s audio): sent, mark never arrived before teardown.
+    marks.update_data(
+        "m2",
+        {"type": "", "turn_id": 8, "response_uid": "r8", "sequence_id": 8,
+         "duration": 9.6, "text_synthesized": TAIL, "sent_ts": time.time() - 28},
+    )
+    tm.mark_event_meta_data = marks
+    return tm, history, marks
+
+
+def _assistant_content(history):
+    return next(m["content"] for m in reversed(history.messages) if m["role"] == "assistant")
+
+
+@pytest.mark.asyncio
+async def test_end_of_call_credits_unacked_tail_played_after_last_ack():
+    tm, history, marks = _make_tm()
+    teardown_ts = marks.get_last_ack_ts_for_turn(8) + 20  # well past the 9.6s tail
+    await tm.sync_history(
+        marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True
+    )
+    assert _assistant_content(history) == FULL_TEXT
+
+
+@pytest.mark.asyncio
+async def test_end_of_call_mid_chunk_hangup_keeps_strict_ack_trim():
+    # Elapsed < pending duration → playback can't have finished; never stamp a partial guess.
+    tm, history, marks = _make_tm()
+    teardown_ts = marks.get_last_ack_ts_for_turn(8) + 4.8  # only half the 9.6s tail elapsed
+    await tm.sync_history(
+        marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True
+    )
+    assert _assistant_content(history) == PREFIX.strip()
+
+
+@pytest.mark.asyncio
+async def test_interruption_path_still_trims_to_acked_text():
+    tm, history, marks = _make_tm()
+    await tm.sync_history(marks.mark_event_meta_data.items(), time.time())
+    assert _assistant_content(history) == PREFIX.strip()


### PR DESCRIPTION
Fix: last agent message truncated in transcript when playback marks are lost at call end

Problem

When a caller hangs up while (or just after) the agent's final message plays, the stored transcript can cut off mid-sentence even though the recording contains the full line. Prod example: last reply synthesized as 12 chunks — chunks 1–10 ACKed, chunk 11 (9.6s of audio) played fully but its mark never returned (marks lagged playback by 5.4s avg / 13.5s max across the call; 15 of 46 were never delivered). End-of-call sync_history trimmed the message to ACK-confirmed text, dropping the sentence the caller actually heard. This also degrades everything downstream of the transcript: conversation view, webhooks, and post-call extractions.

Root cause

The end-of-call trim treats "no ACK" as "not played". Telephony marks are delivery confirmations that arrive only after playout and are routinely late or lost when the call ends — so the trim systematically under-reports the final message on any call that ends before the tail marks arrive.

Fix

sync_history gains an opt-in extend_with_playback_estimate flag, passed only from the end-of-call sync. When ACKed text exists and unACKed chunks remain for the same turn, the tail is credited all-or-nothing: only if the wall-clock elapsed since the turn's last ACK covers the tail's entire audio duration — proof playback had time to finish. A mid-chunk hangup keeps today's strict ACK trim; we never stamp a partial guess of text that may not have been heard.

- MarkEventMetaData.get_last_ack_ts_for_turn(turn_id) — read-only helper returning the turn's last confirmed playback point.
- A chunk-boundary space is restored when joining (heard-text accumulators strip trailing spaces; without it the downstream exact-match trim silently drops the tail again).

Not changed

- All interruption/barge-in paths call sync_history with the flag default (False) — byte-identical behavior.
- Nothing during the live call changes; the extension runs only at teardown, after the conversation is over.
