### PR TITLE
Mark the conversation history section in graph agent node prompts

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.195"
+__version__ = "0.10.196"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -1251,6 +1251,10 @@ class GraphAgent(BaseAgent):
         else:
             prompt = node_prompt
 
+        # Labels the turns that follow as messages, so they read as the call so far and not
+        # as more instructions.
+        prompt = f"{prompt}\n\n## Conversation History"
+
         # RAG depends on the latest message, so it goes in a trailing message rather
         # than the system prompt, keeping [system + history] a cacheable prefix.
         rag_message = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.195"
+version = "0.10.196"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The node system prompt ended with the language guidelines, so the turns that followed read as a continuation of the instructions. A `## Conversation History` heading now closes the system prompt and labels them. The turns stay real messages, so tool calls and the cacheable prefix are unchanged.