### PR TITLE
fix: release the superseded Azure recognizer off the event loop on reconnect

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.197"
+__version__ = "0.10.198"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -142,8 +142,48 @@ class AzureTranscriber(BaseTranscriber):
             exc_type, exc_obj, exc_tb = sys.exc_info()
             logger.error(f"Error occurred in send_audio_to_transcriber - {e} at {exc_tb.tb_lineno}")
 
+    def _release_previous_connection(self):
+        """Stop the superseded recognizer and drop it here, off the event loop."""
+        recognizer, self.recognizer = self.recognizer, None
+        push_stream, self.push_stream = self.push_stream, None
+
+        if recognizer is not None:
+            # Detach first: stopping raises session_stopped, whose handler asks for a reconnect,
+            # and a late recognizing event would land a stale transcript in the new turn.
+            for signal in (
+                recognizer.recognizing,
+                recognizer.recognized,
+                recognizer.canceled,
+                recognizer.session_started,
+                recognizer.session_stopped,
+            ):
+                try:
+                    signal.disconnect_all()
+                except Exception as e:
+                    logger.error(f"Error detaching previous recognizer signal: {e}")
+
+        if push_stream is not None:
+            try:
+                push_stream.close()
+            except Exception as e:
+                logger.error(f"Error closing previous push stream: {e}")
+
+        if recognizer is not None:
+            try:
+                recognizer.stop_continuous_recognition_async().get()
+            except Exception as e:
+                logger.error(f"Error stopping previous recognition: {e}")
+
     async def initialize_connection(self):
         try:
+            # The SDK's native teardown blocks for tens of seconds against an unresponsive
+            # endpoint, so a reconnect releases the previous recognizer off the loop.
+            if self.recognizer is not None or self.push_stream is not None:
+                await asyncio.get_event_loop().run_in_executor(None, self._release_previous_connection)
+
+            # run() reads this as "connection dead", so it must describe only this attempt.
+            self.connection_error = None
+
             speech_config = speechsdk.SpeechConfig(subscription=self.subscription_key, region=self.service_region)
             speech_config.speech_recognition_language = self.recognition_language
 

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -137,7 +137,11 @@ class AzureTranscriber(BaseTranscriber):
                     self.audio_frame_timestamps.append((frame_start, frame_end, send_timestamp))
                     self.num_frames += 1
 
-                    self.push_stream.write(ws_data_packet.get("data"))
+                    # None while a reconnect swaps the connection. That audio has nowhere to
+                    # go, but the pump has to survive the gap to serve the new stream.
+                    push_stream = self.push_stream
+                    if push_stream is not None:
+                        push_stream.write(ws_data_packet.get("data"))
         except Exception as e:
             exc_type, exc_obj, exc_tb = sys.exc_info()
             logger.error(f"Error occurred in send_audio_to_transcriber - {e} at {exc_tb.tb_lineno}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.197"
+version = "0.10.198"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Linear: BOLNA-2386

On reconnect, `initialize_connection` reassigns `self.recognizer`, so the previous one is released by refcount on the event loop thread. The Speech SDK exposes no `close()` or `dispose()`, disposal runs through `__del__`, and that native teardown blocks. Against a healthy endpoint it costs about 10s; against an unresponsive one, about 20s. A provider disruption on 13 Aug froze whole ws-server workers, stalling every call on them rather than only the Azure ones.

`_release_previous_connection` now stops and drops the superseded recognizer in an executor, holding the last reference so the teardown runs off the loop.

Signals are detached before stopping. `stop_continuous_recognition_async` raises `session_stopped`, whose handler posts `transcriber_connection_closed`, and that packet is what asks for a reconnect, so leaving them attached would make replacing a connection immediately ask to replace it again until the per-call cap ends the call. Detaching also drops any late `recognizing` or `recognized` event, which would otherwise land a stale transcript in the turn the new connection is serving.

`connection_error` is now scoped to a single attempt. `run()` treats a set value as a dead connection and posts the close packet, and nothing ever reset it, so a reconnect after a cancellation failed even when the new connection had succeeded. Pre-existing and independent of the teardown change, but the same loop.

`send_audio_to_transcriber` now tolerates a null push stream. Moving the teardown off the loop means the pump keeps running while the connection is swapped, and it would otherwise raise on the null stream and exit its loop for good, leaving the call deaf.

## Validation

Driven through `run()` against a **live** Azure endpoint, the path `TranscriberPool.reconnect_active` actually calls:

| reconnect | before | after |
| --- | --- | --- |
| peak event-loop lag | 10,270 ms | **2.4 ms** |
| wall clock | 10.27s | **0.80s** |

The reconnect also gets faster, because an explicit stop with signals detached is cheaper than the implicit destroy. Against an unresponsive endpoint the before figure is 19,839 ms.

Ten checks on a live endpoint cover first connect, that the reconnect establishes a genuinely new session, that it posts no close packet, that the audio pump survives the swap, and that normal teardown still posts the close packet and releases the recognizer. Before: 9 of 10. After: 10 of 10.

Existing suite is unchanged: 838 passed with the same 16 pre-existing failures on both sides.
