### PR TITLE
fixed lid in false interruption

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.201"
+__version__ = "0.10.202"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -158,8 +158,7 @@ def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
 
 
 def is_alphanumeric_readout(text: str) -> bool:
-    """Code/number readout, not language evidence (judge rule 3a): ≥1 digit-bearing token and
-    ≤2 others. Bare letters never count, so "I want English" must not trip this."""
+    """Code readout, not language evidence (rule 3a): ≥1 digit-bearing token, ≤2 others."""
     tokens = re.findall(r"\w+", text or "", flags=re.UNICODE)
     if not tokens:
         return False
@@ -601,8 +600,7 @@ class TaskManager(BaseManager):
         # Records every language switch — manual tool call (legacy) or LLM-driven
         # (triggered_by="lid_llm") — used post-call for precision / latency analysis.
         self.language_switch_events: list[dict] = []
-        # Regeneration debounce for finals that overlap an in-flight response — one
-        # regen per merged utterance instead of a cut/regenerate cycle per fragment.
+        # Debounce for overlapped finals: one regen per merged utterance, not per fragment.
         self.regen_settle_task = None
         self.regen_settle_payload = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
@@ -4521,8 +4519,7 @@ class TaskManager(BaseManager):
             # Re-register the seq_id allocated by __get_updated_meta_info, else the audio blocks.
             self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
 
-        # Unconditional: if the old task completed and the interruption path invalidated
-        # responses, the new seq_id would never be re-added and all audio would stay BLOCKed.
+        # Unconditional: an un-re-added seq_id leaves every chunk of this turn BLOCKed.
         self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
         self.response_in_pipeline = True
         # Background once-per-turn switch decision; gates this turn's AUDIO, not its generation.
@@ -4534,8 +4531,7 @@ class TaskManager(BaseManager):
         return self.regen_settle_task is not None and not self.regen_settle_task.done()
 
     def regen_settle_can_fire(self):
-        """False when the active transcriber is on the exclusion list — its endpointing means no
-        follow-up final can land inside the window, so waiting only adds latency."""
+        """False for excluded transcribers: no final can land inside the window, so waiting only costs."""
         transcriber = self.tools.get("transcriber")
         active = (
             transcriber.transcribers.get(transcriber.active_label, transcriber)
@@ -4637,8 +4633,7 @@ class TaskManager(BaseManager):
                 logger.info(f"Merged transcript with unheard response: {transcriber_message}")
             if any(activity.values()):
                 await self.__cleanup_downstream_tasks()
-            # Cleanup invalidates every pending seq id; re-register this turn's or _synthesize
-            # later drops the fresh response as an invalid sequence.
+            # Cleanup invalidated every pending seq id; without this _synthesize drops this turn.
             self.interruption_manager.revalidate_sequence_id(current_sequence_id)
             logger.info(
                 "BOLNA_TRACE_TM revalidated_current_seq_after_cleanup seq=%s turn=%s response_uid=%s",
@@ -4666,8 +4661,7 @@ class TaskManager(BaseManager):
         if next_task == "llm":
             meta_info["origin"] = "transcriber"
             if overlapped and (self.regen_settle_armed() or self.regen_settle_can_fire()):
-                # More finals are likely coming — regenerate once after they settle.
-                # An already-armed window always absorbs the final so no payload strands.
+                # More finals likely coming; an armed window always absorbs one, so none strands.
                 self.arm_regen_settle(transcriber_message, meta_info)
             else:
                 self.kickoff_llm_generation(transcriber_message, meta_info)
@@ -4876,8 +4870,7 @@ class TaskManager(BaseManager):
                         interim_transcript_len += len(message["data"].get("content").strip().split(" "))
                         transcript_content = message["data"].get("content", "")
 
-                        # Late re-delivery of a transcript already being processed (or owed a
-                        # regen by the armed settle window) is not new user speech.
+                        # Re-delivery of a transcript already processed or owed a regen isn't new speech.
                         if (
                             self.response_in_pipeline or self.regen_settle_armed()
                         ) and self.conversation_history.is_duplicate_user(transcript_content):
@@ -5097,16 +5090,14 @@ class TaskManager(BaseManager):
                         )
 
                         if was_eager and self.eager_llm_task is not None and self.regen_settle_armed():
-                            # A regen is owed for the merged turn — drop the eager reply (generated
-                            # without it) and let this final merge into the pending window instead.
+                            # A regen is owed the merged turn, so drop the eager reply built without it.
                             logger.info("EagerEOT reply dropped: settle window armed — merging final into regen")
                             self.eager_llm_task.cancel()
                             self.eager_llm_task = None
                             eager_stub_text = (self.eager_meta_info or {}).get("eager_transcript")
                             self.eager_meta_info = None
                             self.eager_history_snapshot = None
-                            # Pop only the eager stub; a merged turn (stub + later final) reads
-                            # differently and must survive — it's what the pending regen answers.
+                            # Pop only the stub: a merged turn reads differently and the regen answers it.
                             last_row = self.history[-1] if self.history else None
                             if (
                                 last_row
@@ -5771,8 +5762,7 @@ class TaskManager(BaseManager):
             return
         # One selection, used by BOTH the speculative copy and the real history append —
         idle_flush_user_text = trailing_utterance_text(detector_segments) or detector_transcript
-        # Snapshot before the multi-second decide: if a user turn lands meanwhile, the
-        # idle-flush append below would duplicate it (prod 43571cba / 8e98dbc2).
+        # Pre-decide snapshot: a turn landing meanwhile would be duplicated below.
         history_signature_at_decide = self.conversation_history.user_turn_signature()
         active = self.language
 
@@ -5996,8 +5986,7 @@ class TaskManager(BaseManager):
             emit_lid_decision("gated:short_audio")
             return
 
-        # Rule-3a backstop: the judge can still read "This B1" as English (prod b381ba0a);
-        # explicit by-name requests keep rule-1 precedence via the substance gate's bypass.
+        # Rule-3a backstop: the judge still reads "This B1" as English.
         if not explicit_bypass and is_alphanumeric_readout(detector_transcript):
             logger.info(
                 f"LanguageSwitcher: target '{target}' vetoed — rule-3a alphanumeric readout "
@@ -6086,8 +6075,7 @@ class TaskManager(BaseManager):
                     f"LanguageSwitcher: corrected user turn to detector transcript {detector_transcript[:80]!r}"
                 )
         elif self.conversation_history.user_turn_signature() != history_signature_at_decide:
-            # A main turn for this audio landed during the decide — appending would duplicate
-            # it and re-route the graph on phantom input; answer the real turn instead.
+            # A main turn landed during the decide; appending would re-route on phantom input.
             transcript_corrected = False
             logger.info(
                 "LanguageSwitcher: idle-flush skipped — user turn arrived during decide; "

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -158,14 +158,8 @@ def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
 def is_alphanumeric_readout(text: str) -> bool:
     """True when a turn is a code/number readout, not language evidence (judge rule 3a).
 
-    Code enforcement of the prompt rule the judge violated on prod call b381ba0a
-    ("This B1" -> switched hi->en at 0.92): a turn built around digit-bearing tokens
-    ("B1", "V1", "21, 65, 11, 69") is the caller supplying DATA. Shape: at least one
-    digit-bearing token and at most two other tokens — catches a readout wrapped in
-    filler ("ये B1।", "21 65 11 69. Hello.") while leaving any turn with a real
-    grammatical frame to the judge. Bare letters do NOT count as code ("I want
-    English" must never trip this). Vetoing a switch is fail-safe: worst case a
-    legitimate switch waits for the caller's next substantive turn.
+    ≥1 digit-bearing token and ≤2 other tokens = the caller supplying DATA ("ये B1।",
+    "21 65 11 69. Hello."); bare letters never count ("I want English" must not trip this).
     """
     tokens = re.findall(r"\w+", text or "", flags=re.UNICODE)
     if not tokens:
@@ -2511,9 +2505,8 @@ class TaskManager(BaseManager):
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
         self._cancel_in_flight_llm_response()
-        # A pending settle-window regeneration belongs to the turn being torn down —
-        # whoever is cleaning (barge-in, LID switch) supersedes it. The overlapped
-        # final path re-arms AFTER this cleanup, so ordering keeps the newest turn.
+        # A pending regen belongs to the turn being torn down; the overlapped final
+        # path re-arms after this cleanup, so the newest turn always wins.
         if self.regen_settle_task is not None and not self.regen_settle_task.done():
             self.regen_settle_task.cancel()
         self.regen_settle_payload = None
@@ -4618,8 +4611,7 @@ class TaskManager(BaseManager):
 
         current_sequence_id = meta_info.get("sequence_id")
         activity = self._inflight_response_activity(exclude_sequence_id=current_sequence_id)
-        # A live settle timer counts as overlap: the previous fragment's regeneration hasn't
-        # started yet, so this final must merge into it instead of racing it.
+        # A live settle timer counts as overlap — this final merges into the pending regen.
         settle_pending = self.regen_settle_task is not None and not self.regen_settle_task.done()
         overlapped = next_task == "llm" and (any(activity.values()) or settle_pending)
         if overlapped:
@@ -4671,10 +4663,8 @@ class TaskManager(BaseManager):
         if next_task == "llm":
             meta_info["origin"] = "transcriber"
             if overlapped:
-                # The caller's speech overlapped an in-flight response, so more finals are
-                # likely still coming (multi-part utterances: codes, numbers, dictation).
-                # Debounce: regenerate ONCE after finals stop, against the merged turn,
-                # instead of a cut/regenerate cycle per fragment.
+                # Overlapped speech means more finals are likely coming — regenerate once
+                # after they settle instead of a cut/regenerate cycle per fragment.
                 self.arm_regen_settle(transcriber_message, meta_info)
             else:
                 self.kickoff_llm_generation(transcriber_message, meta_info)
@@ -5980,10 +5970,8 @@ class TaskManager(BaseManager):
             emit_lid_decision("gated:short_audio")
             return
 
-        # Rule-3a enforcement: a code/number readout is never language evidence. The prompt
-        # already says this is absolute, but the judge can still read "This B1" as English
-        # (prod b381ba0a, conf 0.92) — a deterministic veto here is the backstop. An explicit
-        # by-name request keeps its rule-1 precedence via the same bypass as the substance gate.
+        # Rule-3a backstop: the judge can still read "This B1" as English (prod b381ba0a);
+        # explicit by-name requests keep rule-1 precedence via the substance gate's bypass.
         if not explicit_bypass and is_alphanumeric_readout(detector_transcript):
             logger.info(
                 f"LanguageSwitcher: target '{target}' vetoed — rule-3a alphanumeric readout "

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -87,6 +87,7 @@ from bolna.helpers.utils import (
     is_valid_md5,
     get_required_input_types,
     format_messages,
+    safe_log_text,
     get_prompt_responses,
     resample,
     save_audio_file_to_s3,
@@ -4539,7 +4540,7 @@ class TaskManager(BaseManager):
             meta_info.get("sequence_id"),
             meta_info.get("turn_id"),
             LLM_REGEN_SETTLE_S,
-            (transcriber_message or "")[:80],
+            safe_log_text(transcriber_message, 80),
         )
 
     async def __regen_after_settle(self):
@@ -4553,7 +4554,7 @@ class TaskManager(BaseManager):
             "BOLNA_TRACE_TM regen_settle fired seq=%s turn=%s text=%r",
             meta_info.get("sequence_id"),
             meta_info.get("turn_id"),
-            (transcriber_message or "")[:80],
+            safe_log_text(transcriber_message, 80),
         )
         self.kickoff_llm_generation(transcriber_message, meta_info)
 
@@ -4567,7 +4568,7 @@ class TaskManager(BaseManager):
             meta_info.get("response_group_uid"),
             meta_info.get("request_id"),
             len((transcriber_message or "").strip()),
-            (transcriber_message or "")[:120],
+            safe_log_text(transcriber_message),
         )
         if not self.tools["input"].welcome_message_played():
             logger.info(f"Welcome message is playing while spoken: {transcriber_message}")
@@ -4642,7 +4643,7 @@ class TaskManager(BaseManager):
             meta_info.get("turn_id"),
             meta_info.get("response_uid"),
             len(self.conversation_history.messages),
-            (transcriber_message or "")[:120],
+            safe_log_text(transcriber_message),
         )
 
         convert_to_request_log(
@@ -5030,7 +5031,7 @@ class TaskManager(BaseManager):
                             word_count,
                             self.tools["input"].is_audio_being_played_to_user(),
                             self.response_in_pipeline,
-                            transcript_content[:120],
+                            safe_log_text(transcript_content),
                         )
 
                         # response_in_pipeline deliberately not counted: with no audio playing yet, a short

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2503,9 +2503,8 @@ class TaskManager(BaseManager):
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
         self._cancel_in_flight_llm_response()
-        # A pending regen belongs to the turn being torn down; the overlapped final
-        # path re-arms after this cleanup, so the newest turn always wins.
-        if self.regen_settle_task is not None and not self.regen_settle_task.done():
+        # The overlapped-final path re-arms after this cleanup, so the newest turn wins.
+        if self.regen_settle_armed():
             self.regen_settle_task.cancel()
         self.regen_settle_payload = None
         await self.tools["output"].handle_interruption()
@@ -4529,9 +4528,13 @@ class TaskManager(BaseManager):
         self._spawn_language_switch_decision(transcriber_message, meta_info)
         self.llm_task = asyncio.create_task(self._run_llm_task(transcriber_package))
 
+    def regen_settle_armed(self) -> bool:
+        """True while the settle-window timer is pending — a generation is owed for this turn."""
+        return self.regen_settle_task is not None and not self.regen_settle_task.done()
+
     def arm_regen_settle(self, transcriber_message, meta_info):
         """(Re)arm the regeneration debounce with the latest merged turn."""
-        if self.regen_settle_task is not None and not self.regen_settle_task.done():
+        if self.regen_settle_armed():
             self.regen_settle_task.cancel()
         self.regen_settle_payload = (transcriber_message, meta_info)
         self.regen_settle_task = asyncio.create_task(self.__regen_after_settle())
@@ -4603,8 +4606,7 @@ class TaskManager(BaseManager):
         current_sequence_id = meta_info.get("sequence_id")
         activity = self._inflight_response_activity(exclude_sequence_id=current_sequence_id)
         # A live settle timer counts as overlap — this final merges into the pending regen.
-        settle_pending = self.regen_settle_task is not None and not self.regen_settle_task.done()
-        overlapped = next_task == "llm" and (any(activity.values()) or settle_pending)
+        overlapped = next_task == "llm" and (any(activity.values()) or self.regen_settle_armed())
         if overlapped:
             logger.info(
                 "BOLNA_TRACE_TM cleanup_before_user_append seq=%s turn=%s response_uid=%s response_in_pipeline=%s audio_playing=%s pending_marks=%s pending_sequences=%s pending_generation=%s",
@@ -4652,8 +4654,7 @@ class TaskManager(BaseManager):
         if next_task == "llm":
             meta_info["origin"] = "transcriber"
             if overlapped:
-                # Overlapped speech means more finals are likely coming — regenerate once
-                # after they settle instead of a cut/regenerate cycle per fragment.
+                # More finals are likely coming — regenerate once after they settle.
                 self.arm_regen_settle(transcriber_message, meta_info)
             else:
                 self.kickoff_llm_generation(transcriber_message, meta_info)
@@ -4862,13 +4863,11 @@ class TaskManager(BaseManager):
                         interim_transcript_len += len(message["data"].get("content").strip().split(" "))
                         transcript_content = message["data"].get("content", "")
 
-                        # Deepgram sometimes delivers the real speech_final for an utterance
-                        # *after* our utterance timeout already force-finalized the same text
-                        # and started the LLM. Don't treat this late delivery as new user speech
-                        # — the LLM is already processing this exact transcript.
-                        if self.response_in_pipeline and self.conversation_history.is_duplicate_user(
-                            transcript_content
-                        ):
+                        # Late re-delivery of a transcript already being processed (or owed a
+                        # regen by the armed settle window) is not new user speech.
+                        if (
+                            self.response_in_pipeline or self.regen_settle_armed()
+                        ) and self.conversation_history.is_duplicate_user(transcript_content):
                             logger.info(
                                 "Skipping interruption: Deepgram late delivery of already-processing transcript: %s",
                                 transcript_content,
@@ -4980,6 +4979,7 @@ class TaskManager(BaseManager):
                             and self.tools["input"].welcome_message_played()
                             and not self.tools["input"].is_audio_being_played_to_user()
                             and not self.response_in_pipeline
+                            and not self.regen_settle_armed()
                         ):
                             logger.info(f"Starting speculative LLM task")
 
@@ -5081,6 +5081,19 @@ class TaskManager(BaseManager):
                             None,
                             "_cb_transcriber_connect_reported",
                         )
+
+                        if was_eager and self.eager_llm_task is not None and self.regen_settle_armed():
+                            # A regen is owed for the merged turn — drop the eager reply (generated
+                            # without it) and let this final merge into the pending window instead.
+                            logger.info("EagerEOT reply dropped: settle window armed — merging final into regen")
+                            self.eager_llm_task.cancel()
+                            self.eager_llm_task = None
+                            self.eager_meta_info = None
+                            snapshot = getattr(self, "eager_history_snapshot", None)
+                            self.eager_history_snapshot = None
+                            if snapshot is not None and len(self.history) > snapshot:
+                                self.history = self.history[:snapshot]
+                            was_eager = False
 
                         if was_eager and self.eager_llm_task is not None:
                             logger.info(f"EndOfTurn follows EagerEndOfTurn - using speculative LLM")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5737,6 +5737,9 @@ class TaskManager(BaseManager):
             return
         # One selection, used by BOTH the speculative copy and the real history append —
         idle_flush_user_text = trailing_utterance_text(detector_segments) or detector_transcript
+        # Snapshot before the multi-second decide: if a user turn lands meanwhile, the
+        # idle-flush append below would duplicate it (prod 43571cba / 8e98dbc2).
+        history_signature_at_decide = self.conversation_history.user_turn_signature()
         active = self.language
 
         # Foreign-segment max, not the buffer-lifetime max: the idle-flush skip leaves the buffer
@@ -6048,6 +6051,14 @@ class TaskManager(BaseManager):
                 logger.info(
                     f"LanguageSwitcher: corrected user turn to detector transcript {detector_transcript[:80]!r}"
                 )
+        elif self.conversation_history.user_turn_signature() != history_signature_at_decide:
+            # A main turn for this audio landed during the decide — appending would duplicate
+            # it and re-route the graph on phantom input; answer the real turn instead.
+            transcript_corrected = False
+            logger.info(
+                "LanguageSwitcher: idle-flush skipped — user turn arrived during decide; "
+                "generating follow-up for the latest turn"
+            )
         else:
             # Reply to the caller's LAST utterance, not the whole buffer — with the
             self.conversation_history.append_user(idle_flush_user_text)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -36,6 +36,7 @@ from bolna.constants import (
     LANGUAGE_SWITCH_SETTLE_MS,
     LLM_DEFAULT_CONFIGS,
     LLM_REGEN_SETTLE_S,
+    REGEN_SETTLE_EXCLUDED_TRANSCRIBERS,
     NON_EVIDENCE_MARK_TYPES,
     SWITCH_LANGUAGE_TOOL_DEFINITION,
     END_CALL_FUNCTION_PREFIX,
@@ -4532,6 +4533,17 @@ class TaskManager(BaseManager):
         """True while the settle-window timer is pending — a generation is owed for this turn."""
         return self.regen_settle_task is not None and not self.regen_settle_task.done()
 
+    def regen_settle_can_fire(self):
+        """False when the active transcriber is on the exclusion list — its endpointing means no
+        follow-up final can land inside the window, so waiting only adds latency."""
+        transcriber = self.tools.get("transcriber")
+        active = (
+            transcriber.transcribers.get(transcriber.active_label, transcriber)
+            if hasattr(transcriber, "transcribers")
+            else transcriber
+        )
+        return not type(active).__name__.lower().startswith(REGEN_SETTLE_EXCLUDED_TRANSCRIBERS)
+
     def arm_regen_settle(self, transcriber_message, meta_info):
         """(Re)arm the regeneration debounce with the latest merged turn."""
         if self.regen_settle_armed():
@@ -4653,8 +4665,9 @@ class TaskManager(BaseManager):
         )
         if next_task == "llm":
             meta_info["origin"] = "transcriber"
-            if overlapped:
+            if overlapped and (self.regen_settle_armed() or self.regen_settle_can_fire()):
                 # More finals are likely coming — regenerate once after they settle.
+                # An already-armed window always absorbs the final so no payload strands.
                 self.arm_regen_settle(transcriber_message, meta_info)
             else:
                 self.kickoff_llm_generation(transcriber_message, meta_info)
@@ -4989,6 +5002,7 @@ class TaskManager(BaseManager):
                             meta_info = self.__get_updated_meta_info(meta_info)
                             meta_info["eager_eot"] = True
                             meta_info["eot_confidence"] = eot_confidence
+                            meta_info["eager_transcript"] = eager_transcript
 
                             self.eager_history_snapshot = len(self.history)
                             self.eager_meta_info = meta_info
@@ -5088,11 +5102,18 @@ class TaskManager(BaseManager):
                             logger.info("EagerEOT reply dropped: settle window armed — merging final into regen")
                             self.eager_llm_task.cancel()
                             self.eager_llm_task = None
+                            eager_stub_text = (self.eager_meta_info or {}).get("eager_transcript")
                             self.eager_meta_info = None
-                            snapshot = getattr(self, "eager_history_snapshot", None)
                             self.eager_history_snapshot = None
-                            if snapshot is not None and len(self.history) > snapshot:
-                                self.history = self.history[:snapshot]
+                            # Pop only the eager stub; a merged turn (stub + later final) reads
+                            # differently and must survive — it's what the pending regen answers.
+                            last_row = self.history[-1] if self.history else None
+                            if (
+                                last_row
+                                and last_row.get("role") == "user"
+                                and last_row.get("content") == eager_stub_text
+                            ):
+                                self.history = self.history[:-1]
                             was_eager = False
 
                         if was_eager and self.eager_llm_task is not None:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -35,6 +35,7 @@ from bolna.constants import (
     LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S,
     LANGUAGE_SWITCH_SETTLE_MS,
     LLM_DEFAULT_CONFIGS,
+    LLM_REGEN_SETTLE_S,
     NON_EVIDENCE_MARK_TYPES,
     SWITCH_LANGUAGE_TOOL_DEFINITION,
     END_CALL_FUNCTION_PREFIX,
@@ -152,6 +153,25 @@ def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
         "nodes": list(nodes or []),
     }
     return api_tools
+
+
+def is_alphanumeric_readout(text: str) -> bool:
+    """True when a turn is a code/number readout, not language evidence (judge rule 3a).
+
+    Code enforcement of the prompt rule the judge violated on prod call b381ba0a
+    ("This B1" -> switched hi->en at 0.92): a turn built around digit-bearing tokens
+    ("B1", "V1", "21, 65, 11, 69") is the caller supplying DATA. Shape: at least one
+    digit-bearing token and at most two other tokens — catches a readout wrapped in
+    filler ("ये B1।", "21 65 11 69. Hello.") while leaving any turn with a real
+    grammatical frame to the judge. Bare letters do NOT count as code ("I want
+    English" must never trip this). Vetoing a switch is fail-safe: worst case a
+    legitimate switch waits for the caller's next substantive turn.
+    """
+    tokens = re.findall(r"\w+", text or "", flags=re.UNICODE)
+    if not tokens:
+        return False
+    code_tokens = [t for t in tokens if any(ch.isdigit() for ch in t)]
+    return len(code_tokens) >= 1 and (len(tokens) - len(code_tokens)) <= 2
 
 
 def build_lid_decision_record(
@@ -588,6 +608,10 @@ class TaskManager(BaseManager):
         # Records every language switch — manual tool call (legacy) or LLM-driven
         # (triggered_by="lid_llm") — used post-call for precision / latency analysis.
         self.language_switch_events: list[dict] = []
+        # Regeneration debounce for finals that overlap an in-flight response — one
+        # regen per merged utterance instead of a cut/regenerate cycle per fragment.
+        self.regen_settle_task = None
+        self.regen_settle_payload = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
         # when the LLM-driven switch flow is NOT enabled for this call).
         self.switch_handoff_messages = {}
@@ -2487,6 +2511,12 @@ class TaskManager(BaseManager):
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
         self._cancel_in_flight_llm_response()
+        # A pending settle-window regeneration belongs to the turn being torn down —
+        # whoever is cleaning (barge-in, LID switch) supersedes it. The overlapped
+        # final path re-arms AFTER this cleanup, so ordering keeps the newest turn.
+        if self.regen_settle_task is not None and not self.regen_settle_task.done():
+            self.regen_settle_task.cancel()
+        self.regen_settle_payload = None
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
@@ -4485,6 +4515,65 @@ class TaskManager(BaseManager):
             reason,
         )
 
+    def kickoff_llm_generation(self, transcriber_message, meta_info):
+        """Start the LLM turn for a final transcript (immediate path and settle-window path)."""
+        logger.info(f"Running llm Tasks")
+        transcriber_package = create_ws_data_packet(transcriber_message, meta_info)
+
+        # Cancel any existing LLM task to prevent orphaned concurrent responses
+        if self.llm_task is not None and not self.llm_task.done():
+            logger.info("Cancelling existing LLM task for new speech_final")
+            self.llm_task.cancel()
+            self.llm_task = None
+            self.interruption_manager.invalidate_pending_responses()
+            self._drop_all_staged_assistant_history("llm_task_cancelled_for_new_speech_final")
+            # Re-register the current sequence_id (already allocated by
+            # __get_updated_meta_info) so the new response's audio is not blocked
+            self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
+
+        # Always revalidate the new sequence_id — if the old task already
+        # completed and invalidate_pending_responses was called from the
+        # interruption path, the new seq_id would otherwise never be added
+        # back to sequence_ids, causing all audio to be BLOCKed permanently.
+        self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
+        self.response_in_pipeline = True
+        # Once-per-turn language-switch decision (no-op unless gated on); background
+        # task so it never delays the main LLM. When the detector already tagged this
+        # Gates this turn's AUDIO (not its generation) when the detector disagrees with the
+        # active language — see _spawn_language_switch_decision, which arms it for both this
+        # path and the eager one.
+        self._spawn_language_switch_decision(transcriber_message, meta_info)
+        self.llm_task = asyncio.create_task(self._run_llm_task(transcriber_package))
+
+    def arm_regen_settle(self, transcriber_message, meta_info):
+        """(Re)arm the regeneration debounce with the latest merged turn."""
+        if self.regen_settle_task is not None and not self.regen_settle_task.done():
+            self.regen_settle_task.cancel()
+        self.regen_settle_payload = (transcriber_message, meta_info)
+        self.regen_settle_task = asyncio.create_task(self.__regen_after_settle())
+        logger.info(
+            "BOLNA_TRACE_TM regen_settle armed seq=%s turn=%s window=%ss text=%r",
+            meta_info.get("sequence_id"),
+            meta_info.get("turn_id"),
+            LLM_REGEN_SETTLE_S,
+            (transcriber_message or "")[:80],
+        )
+
+    async def __regen_after_settle(self):
+        await asyncio.sleep(LLM_REGEN_SETTLE_S)
+        payload = self.regen_settle_payload
+        self.regen_settle_payload = None
+        if payload is None:
+            return
+        transcriber_message, meta_info = payload
+        logger.info(
+            "BOLNA_TRACE_TM regen_settle fired seq=%s turn=%s text=%r",
+            meta_info.get("sequence_id"),
+            meta_info.get("turn_id"),
+            (transcriber_message or "")[:80],
+        )
+        self.kickoff_llm_generation(transcriber_message, meta_info)
+
     async def _handle_transcriber_output(self, next_task, transcriber_message, meta_info):
         logger.info(
             "BOLNA_TRACE_TM handle_transcript next=%s seq=%s turn=%s response_uid=%s group_uid=%s request_id=%s text_len=%s text=%r",
@@ -4529,7 +4618,11 @@ class TaskManager(BaseManager):
 
         current_sequence_id = meta_info.get("sequence_id")
         activity = self._inflight_response_activity(exclude_sequence_id=current_sequence_id)
-        if next_task == "llm" and any(activity.values()):
+        # A live settle timer counts as overlap: the previous fragment's regeneration hasn't
+        # started yet, so this final must merge into it instead of racing it.
+        settle_pending = self.regen_settle_task is not None and not self.regen_settle_task.done()
+        overlapped = next_task == "llm" and (any(activity.values()) or settle_pending)
+        if overlapped:
             logger.info(
                 "BOLNA_TRACE_TM cleanup_before_user_append seq=%s turn=%s response_uid=%s response_in_pipeline=%s audio_playing=%s pending_marks=%s pending_sequences=%s pending_generation=%s",
                 meta_info.get("sequence_id"),
@@ -4545,7 +4638,8 @@ class TaskManager(BaseManager):
             transcriber_message = self.conversation_history.pop_and_merge_user(transcriber_message)
             if transcriber_message != original_message:
                 logger.info(f"Merged transcript with unheard response: {transcriber_message}")
-            await self.__cleanup_downstream_tasks()
+            if any(activity.values()):
+                await self.__cleanup_downstream_tasks()
             # cleanup invalidates all pending sequence ids. The current turn's
             # sequence_id was already allocated by __get_updated_meta_info, so
             # we must re-register it or the fresh LLM response will later be
@@ -4575,34 +4669,15 @@ class TaskManager(BaseManager):
             message=transcriber_message, meta_info=meta_info, model=self.transcriber_provider, run_id=self.run_id
         )
         if next_task == "llm":
-            logger.info(f"Running llm Tasks")
             meta_info["origin"] = "transcriber"
-            transcriber_package = create_ws_data_packet(transcriber_message, meta_info)
-
-            # Cancel any existing LLM task to prevent orphaned concurrent responses
-            if self.llm_task is not None and not self.llm_task.done():
-                logger.info("Cancelling existing LLM task for new speech_final")
-                self.llm_task.cancel()
-                self.llm_task = None
-                self.interruption_manager.invalidate_pending_responses()
-                self._drop_all_staged_assistant_history("llm_task_cancelled_for_new_speech_final")
-                # Re-register the current sequence_id (already allocated by
-                # __get_updated_meta_info) so the new response's audio is not blocked
-                self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
-
-            # Always revalidate the new sequence_id — if the old task already
-            # completed and invalidate_pending_responses was called from the
-            # interruption path, the new seq_id would otherwise never be added
-            # back to sequence_ids, causing all audio to be BLOCKed permanently.
-            self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
-            self.response_in_pipeline = True
-            # Once-per-turn language-switch decision (no-op unless gated on); background
-            # task so it never delays the main LLM. When the detector already tagged this
-            # Gates this turn's AUDIO (not its generation) when the detector disagrees with the
-            # active language — see _spawn_language_switch_decision, which arms it for both this
-            # path and the eager one.
-            self._spawn_language_switch_decision(transcriber_message, meta_info)
-            self.llm_task = asyncio.create_task(self._run_llm_task(transcriber_package))
+            if overlapped:
+                # The caller's speech overlapped an in-flight response, so more finals are
+                # likely still coming (multi-part utterances: codes, numbers, dictation).
+                # Debounce: regenerate ONCE after finals stop, against the merged turn,
+                # instead of a cut/regenerate cycle per fragment.
+                self.arm_regen_settle(transcriber_message, meta_info)
+            else:
+                self.kickoff_llm_generation(transcriber_message, meta_info)
 
         elif next_task == "synthesizer":
             self.synthesizer_tasks.append(
@@ -5903,6 +5978,18 @@ class TaskManager(BaseManager):
                 f"no switch (short audio is unreliable LID evidence; reason={reasoning})"
             )
             emit_lid_decision("gated:short_audio")
+            return
+
+        # Rule-3a enforcement: a code/number readout is never language evidence. The prompt
+        # already says this is absolute, but the judge can still read "This B1" as English
+        # (prod b381ba0a, conf 0.92) — a deterministic veto here is the backstop. An explicit
+        # by-name request keeps its rule-1 precedence via the same bypass as the substance gate.
+        if not explicit_bypass and is_alphanumeric_readout(detector_transcript):
+            logger.info(
+                f"LanguageSwitcher: target '{target}' vetoed — rule-3a alphanumeric readout "
+                f"({detector_transcript[:60]!r}); no switch (reason={reasoning})"
+            )
+            emit_lid_decision("gated:alphanumeric_readout")
             return
 
         # Truncate the in-flight old-language reply (barge-in cleanup) before switching.
@@ -8215,6 +8302,7 @@ class TaskManager(BaseManager):
                 process_task_cancellation(self.execute_function_call_task, "execute_function_call_task")
             )
             tasks_to_cancel.append(process_task_cancellation(self._lid_idle_watcher_task, "lid_idle_watcher_task"))
+            tasks_to_cancel.append(process_task_cancellation(self.regen_settle_task, "regen_settle_task"))
             # Sync cancel BEFORE clearing, so an in-flight render can't repopulate the
             if self.handoff_prewarm_task is not None:
                 self.handoff_prewarm_task.cancel()

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -156,11 +156,8 @@ def _inject_end_call_tool(api_tools, *, scope, nodes, description=None):
 
 
 def is_alphanumeric_readout(text: str) -> bool:
-    """True when a turn is a code/number readout, not language evidence (judge rule 3a).
-
-    ≥1 digit-bearing token and ≤2 other tokens = the caller supplying DATA ("ये B1।",
-    "21 65 11 69. Hello."); bare letters never count ("I want English" must not trip this).
-    """
+    """Code/number readout, not language evidence (judge rule 3a): ≥1 digit-bearing token and
+    ≤2 others. Bare letters never count, so "I want English" must not trip this."""
     tokens = re.findall(r"\w+", text or "", flags=re.UNICODE)
     if not tokens:
         return False
@@ -4520,21 +4517,14 @@ class TaskManager(BaseManager):
             self.llm_task = None
             self.interruption_manager.invalidate_pending_responses()
             self._drop_all_staged_assistant_history("llm_task_cancelled_for_new_speech_final")
-            # Re-register the current sequence_id (already allocated by
-            # __get_updated_meta_info) so the new response's audio is not blocked
+            # Re-register the seq_id allocated by __get_updated_meta_info, else the audio blocks.
             self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
 
-        # Always revalidate the new sequence_id — if the old task already
-        # completed and invalidate_pending_responses was called from the
-        # interruption path, the new seq_id would otherwise never be added
-        # back to sequence_ids, causing all audio to be BLOCKed permanently.
+        # Unconditional: if the old task completed and the interruption path invalidated
+        # responses, the new seq_id would never be re-added and all audio would stay BLOCKed.
         self.interruption_manager.revalidate_sequence_id(meta_info["sequence_id"])
         self.response_in_pipeline = True
-        # Once-per-turn language-switch decision (no-op unless gated on); background
-        # task so it never delays the main LLM. When the detector already tagged this
-        # Gates this turn's AUDIO (not its generation) when the detector disagrees with the
-        # active language — see _spawn_language_switch_decision, which arms it for both this
-        # path and the eager one.
+        # Background once-per-turn switch decision; gates this turn's AUDIO, not its generation.
         self._spawn_language_switch_decision(transcriber_message, meta_info)
         self.llm_task = asyncio.create_task(self._run_llm_task(transcriber_package))
 
@@ -4632,10 +4622,8 @@ class TaskManager(BaseManager):
                 logger.info(f"Merged transcript with unheard response: {transcriber_message}")
             if any(activity.values()):
                 await self.__cleanup_downstream_tasks()
-            # cleanup invalidates all pending sequence ids. The current turn's
-            # sequence_id was already allocated by __get_updated_meta_info, so
-            # we must re-register it or the fresh LLM response will later be
-            # dropped in _synthesize as an invalid sequence.
+            # Cleanup invalidates every pending seq id; re-register this turn's or _synthesize
+            # later drops the fresh response as an invalid sequence.
             self.interruption_manager.revalidate_sequence_id(current_sequence_id)
             logger.info(
                 "BOLNA_TRACE_TM revalidated_current_seq_after_cleanup seq=%s turn=%s response_uid=%s",

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -48,11 +48,8 @@ LANGUAGE_SWITCH_MIN_SEGMENT_AUDIO_S = 0.7
 # treated as stale — the detector hears the same audio and has produced nothing that long.
 LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
-# A final that lands while a response is in flight means the caller is still mid-thought
-# (multi-part utterances: barcode/serial readouts, dictated numbers). Regenerating per final
-# shattered one logical answer across many synth turns; instead the merged turn regenerates
-# once after finals stop arriving for this long. Sized just under Deepgram's 1s utterance_end
-# floor so a continuing speaker always re-arms the window before it fires.
+# Overlapped finals (multi-part utterances) regenerate once after this quiet window instead of
+# per fragment; sized under Deepgram's 1s utterance_end floor so a continuing speaker re-arms it.
 LLM_REGEN_SETTLE_S = 0.7
 
 # Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -50,8 +50,7 @@ LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
 # Debounce for overlapped finals: one regenerate after this quiet window instead of per fragment.
 LLM_REGEN_SETTLE_S = 0.7
-# Transcribers (class-name prefix, lowercase) whose endpointing means a follow-up final can't
-# land inside the window — their overlapped finals skip the debounce and kick off immediately.
+# Class-name prefixes whose endpointing rules out an in-window final: they skip the debounce.
 REGEN_SETTLE_EXCLUDED_TRANSCRIBERS = ("deepgram",)
 
 # Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -48,6 +48,13 @@ LANGUAGE_SWITCH_MIN_SEGMENT_AUDIO_S = 0.7
 # treated as stale — the detector hears the same audio and has produced nothing that long.
 LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
+# A final that lands while a response is in flight means the caller is still mid-thought
+# (multi-part utterances: barcode/serial readouts, dictated numbers). Regenerating per final
+# shattered one logical answer across many synth turns; instead the merged turn regenerates
+# once after finals stop arriving for this long. Sized just under Deepgram's 1s utterance_end
+# floor so a continuing speaker always re-arms the window before it fires.
+LLM_REGEN_SETTLE_S = 0.7
+
 # Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a
 # healthy turn within utterance_end_ms (1s floor), so a real speaker stays well inside this.
 STUCK_AUDIO_GATE_RELEASE_S = 3.0

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -48,8 +48,7 @@ LANGUAGE_SWITCH_MIN_SEGMENT_AUDIO_S = 0.7
 # treated as stale — the detector hears the same audio and has produced nothing that long.
 LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
-# Overlapped finals (multi-part utterances) regenerate once after this quiet window instead of
-# per fragment; sized under Deepgram's 1s utterance_end floor so a continuing speaker re-arms it.
+# Debounce for overlapped finals: one regenerate after this quiet window instead of per fragment.
 LLM_REGEN_SETTLE_S = 0.7
 
 # Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -50,6 +50,9 @@ LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
 # Debounce for overlapped finals: one regenerate after this quiet window instead of per fragment.
 LLM_REGEN_SETTLE_S = 0.7
+# Transcribers (class-name prefix, lowercase) whose endpointing means a follow-up final can't
+# land inside the window — their overlapped finals skip the debounce and kick off immediately.
+REGEN_SETTLE_EXCLUDED_TRANSCRIBERS = ("deepgram",)
 
 # Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a
 # healthy turn within utterance_end_ms (1s floor), so a real speaker stays well inside this.

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -327,8 +327,7 @@ class ConversationHistory:
         msgs[:] = sanitized
 
     def user_turn_signature(self) -> tuple:
-        """(user message count, last user content) — changes iff a user turn arrives:
-        append_user bumps the count, pop_and_merge changes the content; assistant commits change neither."""
+        """(user count, last user content) — changes iff a user turn arrives, never on assistant commits."""
         users = [m for m in self._messages if m.get("role") == ChatRole.USER]
         return (len(users), users[-1].get("content") if users else None)
 

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -326,6 +326,12 @@ class ConversationHistory:
 
         msgs[:] = sanitized
 
+    def user_turn_signature(self) -> tuple:
+        """(user message count, last user content) — changes iff a user turn arrives:
+        append_user bumps the count, pop_and_merge changes the content; assistant commits change neither."""
+        users = [m for m in self._messages if m.get("role") == ChatRole.USER]
+        return (len(users), users[-1].get("content") if users else None)
+
     def is_duplicate_user(self, content: str) -> bool:
         if not self._messages:
             return False

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -65,8 +65,7 @@ def write_json_file(file_path, data):
 
 
 def safe_log_text(text, limit=120):
-    """Strip control chars from caller-supplied text before logging, then truncate.
-    Blocks forged log entries (CodeQL log-injection) independently of the format spec."""
+    """Strip control chars from caller text and truncate — blocks forged log entries."""
     return re.sub(r"[\x00-\x1f\x7f]+", " ", str(text or ""))[:limit]
 
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -64,6 +64,12 @@ def write_json_file(file_path, data):
         json.dump(data, file, indent=4, ensure_ascii=False)
 
 
+def safe_log_text(text, limit=120):
+    """Strip control chars from caller-supplied text before logging, then truncate.
+    Blocks forged log entries (CodeQL log-injection) independently of the format spec."""
+    return re.sub(r"[\x00-\x1f\x7f]+", " ", str(text or ""))[:limit]
+
+
 def create_ws_data_packet(data, meta_info=None, is_md5_hash=False, llm_generated=False):
     metadata = copy.deepcopy(meta_info)
     if meta_info is not None:  # It'll be none in case we connect through dashboard playground

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.201"
+version = "0.10.202"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_idle_flush_duplicate_guard.py
+++ b/tests/tests/test_idle_flush_duplicate_guard.py
@@ -1,0 +1,50 @@
+"""Idle-flush duplicate-turn guard (prod 43571cba / 8e98dbc2): if a user turn lands during
+the decide, the fire branch must skip the append — signature changes iff a user turn arrives."""
+
+from bolna.helpers.conversation_history import ConversationHistory
+
+
+def make_history():
+    h = ConversationHistory(initial_history=[{"role": "system", "content": "base"}])
+    h.append_assistant("welcome")
+    return h
+
+
+def test_untouched_history_keeps_signature_so_append_proceeds():
+    h = make_history()
+    snap = h.user_turn_signature()
+    h.append_assistant("agent said more")  # assistant commit mid-decide (trap 2)
+    assert h.user_turn_signature() == snap  # true idle-flush still appends
+
+
+def test_arrived_turn_changes_signature_so_append_is_skipped():
+    h = make_history()
+    snap = h.user_turn_signature()
+    h.append_user("ನಾನು ಕನ್ನಡಕ್ಕೆ ಟ್ರಾನ್ಸ್ಫರ್ ಮಾಡಿ,")  # the 28ms race (8e98dbc2)
+    assert h.user_turn_signature() != snap
+
+
+def test_merge_into_existing_turn_changes_signature(trap=1):
+    # Previous turn unanswered -> arriving final merges: count unchanged, content changed.
+    h = make_history()
+    h.append_user("ye B1")
+    snap = h.user_turn_signature()
+    merged = h.pop_and_merge_user("21 65")
+    h.append_user(merged)
+    assert h.user_turn_signature() != snap
+
+
+def test_replace_last_user_changes_signature_only_via_content():
+    # replace_last_user can't race the guard (switch decisions serialize on the lock),
+    # but if semantics ever change the signature must still catch it.
+    h = make_history()
+    h.append_user("garbled")
+    snap = h.user_turn_signature()
+    assert h.replace_last_user("garbled", "clean detector text") is True
+    assert h.user_turn_signature() != snap
+
+
+def test_signature_shape_no_user_turns():
+    h = make_history()
+    count, last = h.user_turn_signature()
+    assert count == 0 and last is None

--- a/tests/tests/test_idle_flush_duplicate_guard.py
+++ b/tests/tests/test_idle_flush_duplicate_guard.py
@@ -1,5 +1,4 @@
-"""Idle-flush duplicate-turn guard (prod 43571cba / 8e98dbc2): if a user turn lands during
-the decide, the fire branch must skip the append — signature changes iff a user turn arrives."""
+"""Idle-flush duplicate-turn guard: a turn landing during the decide must skip the append."""
 
 from bolna.helpers.conversation_history import ConversationHistory
 
@@ -20,7 +19,7 @@ def test_untouched_history_keeps_signature_so_append_proceeds():
 def test_arrived_turn_changes_signature_so_append_is_skipped():
     h = make_history()
     snap = h.user_turn_signature()
-    h.append_user("ನಾನು ಕನ್ನಡಕ್ಕೆ ಟ್ರಾನ್ಸ್ಫರ್ ಮಾಡಿ,")  # the 28ms race (8e98dbc2)
+    h.append_user("ನಾನು ಕನ್ನಡಕ್ಕೆ ಟ್ರಾನ್ಸ್ಫರ್ ಮಾಡಿ,")  # the 28ms race
     assert h.user_turn_signature() != snap
 
 
@@ -35,8 +34,7 @@ def test_merge_into_existing_turn_changes_signature(trap=1):
 
 
 def test_replace_last_user_changes_signature_only_via_content():
-    # replace_last_user can't race the guard (switch decisions serialize on the lock),
-    # but if semantics ever change the signature must still catch it.
+    # Serialized today, but the signature must still catch it if that ever changes.
     h = make_history()
     h.append_user("garbled")
     snap = h.user_turn_signature()

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -1,5 +1,4 @@
-"""Rule-3a alphanumeric veto + settle-window regeneration (prod b381ba0a: judge switched
-hi→en on "This B1", and each fragment final shattered one answer across synth turns)."""
+"""Rule-3a alphanumeric veto + settle-window regeneration."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -1,11 +1,5 @@
-"""Rule-3a alphanumeric veto + settle-window regeneration.
-
-From prod b381ba0a (VBL barcode readout): (1) the judge switched hi→en at 0.92 on
-"This B1" — an alphanumeric readout rule 3a forbids switching on; (2) each fragment
-final ("ये B1।", "V1", "21, 65, 11, 69") cancelled the in-flight generation, shattering
-one answer across many synth turns. The veto blocks (1) deterministically; the settle
-window collapses (2) into a single regeneration of the merged utterance.
-"""
+"""Rule-3a alphanumeric veto + settle-window regeneration (prod b381ba0a: judge switched
+hi→en on "This B1", and each fragment final shattered one answer across synth turns)."""
 
 import asyncio
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -140,3 +140,42 @@ def test_safe_log_text_preserves_speech_and_truncates():
     assert safe_log_text(None) == ""
     assert len(safe_log_text("x" * 500)) == 120
     assert len(safe_log_text("x" * 500, 80)) == 80
+
+
+# ── exclusion list: providers whose finals can't land inside the window ──────────
+
+
+class DeepgramStub:
+    pass
+
+
+class SonioxStub:
+    pass
+
+
+class PoolStub:
+    def __init__(self, active_label, transcribers):
+        self.active_label = active_label
+        self.transcribers = transcribers
+
+
+def make_can_fire_tm(transcriber):
+    tm = MagicMock()
+    tm.tools = {"transcriber": transcriber}
+    tm.regen_settle_can_fire = TaskManager.regen_settle_can_fire.__get__(tm, TaskManager)
+    return tm
+
+
+def test_excluded_transcriber_skips_the_window():
+    assert make_can_fire_tm(DeepgramStub()).regen_settle_can_fire() is False
+
+
+def test_non_excluded_transcriber_arms():
+    assert make_can_fire_tm(SonioxStub()).regen_settle_can_fire() is True
+
+
+def test_can_fire_follows_the_active_pool_member():
+    pool = PoolStub("hi", {"hi": DeepgramStub(), "en": SonioxStub()})
+    assert make_can_fire_tm(pool).regen_settle_can_fire() is False
+    pool.active_label = "en"
+    assert make_can_fire_tm(pool).regen_settle_can_fire() is True

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -1,0 +1,116 @@
+"""Rule-3a alphanumeric veto + settle-window regeneration.
+
+From prod b381ba0a (VBL barcode readout): (1) the judge switched hi→en at 0.92 on
+"This B1" — an alphanumeric readout rule 3a forbids switching on; (2) each fragment
+final ("ये B1।", "V1", "21, 65, 11, 69") cancelled the in-flight generation, shattering
+one answer across many synth turns. The veto blocks (1) deterministically; the settle
+window collapses (2) into a single regeneration of the merged utterance.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager, is_alphanumeric_readout
+from bolna.constants import LLM_REGEN_SETTLE_S
+
+
+# ── rule-3a helper ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "This B1.",
+        "ये B1।",
+        "V1",
+        "21, 65, 11, 69. Hello.",
+        "B1 21 65",
+        "9 8 7 6 5",
+    ],
+)
+def test_readouts_are_vetoed(text):
+    assert is_alphanumeric_readout(text) is True
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "I want English",  # bare letters are not code tokens
+        "can we talk in Tamil",
+        "Is she. Yes.",
+        "మీరు తెలుగులో మాట్లాడతారా?",
+        "मेरा number 98765 hai na call karo",  # code embedded in a real frame -> judge's call
+        "",
+        "okay",
+    ],
+)
+def test_speech_is_not_vetoed(text):
+    assert is_alphanumeric_readout(text) is False
+
+
+# ── settle-window regeneration ───────────────────────────────────────────────────
+
+
+def make_tm(*, activity_values=None):
+    tm = MagicMock()
+    tm.regen_settle_task = None
+    tm.regen_settle_payload = None
+    tm.llm_task = None
+    tm.tools = {"input": MagicMock()}
+    tm.kickoff_calls = []
+
+    def kickoff(text, meta):
+        tm.kickoff_calls.append((text, dict(meta)))
+
+    tm.kickoff_llm_generation = kickoff
+    tm.arm_regen_settle = TaskManager.arm_regen_settle.__get__(tm, TaskManager)
+    tm._TaskManager__regen_after_settle = TaskManager._TaskManager__regen_after_settle.__get__(tm, TaskManager)
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_rapid_fragments_regenerate_once_with_last_merge():
+    tm = make_tm()
+    # Three fragments inside the window — like a barcode readout.
+    tm.arm_regen_settle("ये B1", {"sequence_id": 3, "turn_id": 3})
+    await asyncio.sleep(LLM_REGEN_SETTLE_S / 3)
+    tm.arm_regen_settle("ये B1 21, 65", {"sequence_id": 4, "turn_id": 4})
+    await asyncio.sleep(LLM_REGEN_SETTLE_S / 3)
+    tm.arm_regen_settle("ये B1 21, 65 11, 69", {"sequence_id": 5, "turn_id": 5})
+    await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
+
+    assert len(tm.kickoff_calls) == 1
+    text, meta = tm.kickoff_calls[0]
+    assert text == "ये B1 21, 65 11, 69"
+    assert meta["sequence_id"] == 5
+    assert tm.regen_settle_payload is None
+
+
+@pytest.mark.asyncio
+async def test_settle_fires_after_quiet_window():
+    tm = make_tm()
+    tm.arm_regen_settle("hello there", {"sequence_id": 2, "turn_id": 2})
+    assert tm.kickoff_calls == []  # not yet — window open
+    await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
+    assert len(tm.kickoff_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancelled_settle_never_generates():
+    tm = make_tm()
+    tm.arm_regen_settle("stale", {"sequence_id": 2, "turn_id": 2})
+    tm.regen_settle_task.cancel()  # what __cleanup_downstream_tasks does
+    tm.regen_settle_payload = None
+    await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
+    assert tm.kickoff_calls == []
+
+
+@pytest.mark.asyncio
+async def test_fire_with_cleared_payload_is_noop():
+    tm = make_tm()
+    tm.arm_regen_settle("x", {"sequence_id": 2})
+    tm.regen_settle_payload = None  # cleared by a race with cleanup
+    await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
+    assert tm.kickoff_calls == []

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -8,6 +8,7 @@ import pytest
 
 from bolna.agent_manager.task_manager import TaskManager, is_alphanumeric_readout
 from bolna.constants import LLM_REGEN_SETTLE_S
+from bolna.helpers.utils import safe_log_text
 
 
 # ── rule-3a helper ───────────────────────────────────────────────────────────────
@@ -108,3 +109,19 @@ async def test_fire_with_cleared_payload_is_noop():
     tm.regen_settle_payload = None  # cleared by a race with cleanup
     await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
     assert tm.kickoff_calls == []
+
+
+# ── log sanitization (CodeQL log-injection) ──────────────────────────────────────
+
+
+def test_safe_log_text_blocks_forged_entries():
+    evil = "hello\n2026-08-18 05:00:00 INFO {task_manager} FAKE granted\r\x1b[31m"
+    out = safe_log_text(evil)
+    assert "\n" not in out and "\r" not in out and "\x1b" not in out
+
+
+def test_safe_log_text_preserves_speech_and_truncates():
+    assert safe_log_text("ये B1। 21 65") == "ये B1। 21 65"
+    assert safe_log_text(None) == ""
+    assert len(safe_log_text("x" * 500)) == 120
+    assert len(safe_log_text("x" * 500, 80)) == 80

--- a/tests/tests/test_rule3a_gate_and_regen_settle.py
+++ b/tests/tests/test_rule3a_gate_and_regen_settle.py
@@ -60,6 +60,7 @@ def make_tm(*, activity_values=None):
         tm.kickoff_calls.append((text, dict(meta)))
 
     tm.kickoff_llm_generation = kickoff
+    tm.regen_settle_armed = TaskManager.regen_settle_armed.__get__(tm, TaskManager)
     tm.arm_regen_settle = TaskManager.arm_regen_settle.__get__(tm, TaskManager)
     tm._TaskManager__regen_after_settle = TaskManager._TaskManager__regen_after_settle.__get__(tm, TaskManager)
     return tm
@@ -109,6 +110,20 @@ async def test_fire_with_cleared_payload_is_noop():
     tm.regen_settle_payload = None  # cleared by a race with cleanup
     await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
     assert tm.kickoff_calls == []
+
+
+@pytest.mark.asyncio
+async def test_regen_settle_armed_tracks_timer_lifecycle():
+    tm = make_tm()
+    assert tm.regen_settle_armed() is False  # nothing armed
+    tm.arm_regen_settle("hello", {"sequence_id": 2, "turn_id": 2})
+    assert tm.regen_settle_armed() is True  # window open: eager EOT and late duplicates must gate on this
+    await asyncio.sleep(LLM_REGEN_SETTLE_S + 0.15)
+    assert tm.regen_settle_armed() is False  # fired
+    tm.arm_regen_settle("again", {"sequence_id": 3, "turn_id": 3})
+    tm.regen_settle_task.cancel()
+    await asyncio.sleep(0)
+    assert tm.regen_settle_armed() is False  # cancelled
 
 
 # ── log sanitization (CodeQL log-injection) ──────────────────────────────────────

--- a/tests/tests/test_speculation_commit_logging.py
+++ b/tests/tests/test_speculation_commit_logging.py
@@ -55,6 +55,7 @@ def _capture(**overrides):
         "output_tokens": 30,
         "reasoning_tokens": None,
         "cached_tokens": 100,
+        "overflowed": False,
         "latency": None,
     }
     base.update(overrides)


### PR DESCRIPTION
Problem

Two production failures on the same class of calls (QA: b381ba0a, 75f79ad0, bcced1f3 — barcode/serial readouts and multi-part utterances):

The judge switches language on code readouts. On b381ba0a the caller was reading a cooler barcode; the judge switched hi→en at 0.92 confidence with reasoning "Caller speaking English ('This B1')". Prompt rule 3a explicitly forbids switching on a predominantly numeric/alphanumeric turn ("this precedence is absolute") — the model ignored its own rule because the fragment parses as English. A Hindi-speaking caller was answered in English mid-readout. VBL came off the LID exclusion list on 10 Aug and its core flow is asset-tag readouts, so this shape is now common.
One logical answer shatters across many synthesizer turns. A final transcript that lands while a response is in flight triggers cleanup_before_user_append: cancel LLM + synth, send telephony clear, regenerate — with no hysteresis. A caller reading a code produces a final every ~1–2s ("बारकोड, ठीक।" → "ये B1।" → "V1" → "21, 65, 11, 69"), so the pipeline loops cut→regen→cut: b381ba0a produced 27 LLM turns (5 cancelled) in 140s, and the caller heard mid-word fragments ("ठीक है, मैं आपका support ticket rais") with no interruption on their side. On 75f79ad0 the instant regeneration re-asked the identical question into the caller's still-ongoing speech.
Change

1. Rule-3a code enforcement (is_alphanumeric_readout() + veto in __run_language_switch)

A turn with ≥1 digit-bearing token and ≤2 other tokens is a data readout → the switch is vetoed after the substance gate, emitting a new gated:alphanumeric_readout telemetry outcome (countable in lid_shadow_events).
Reuses the substance gate's explicit_bypass, so a rule-1 explicit by-name request keeps precedence.
Bare letters deliberately do not count as code tokens — "I want English" must never trip the veto (regression-tested).
Veto direction is fail-safe: worst case a legitimate switch waits for the caller's next substantive turn.

2. Settle-window regeneration (LLM_REGEN_SETTLE_S = 0.7 + debounce in _handle_transcriber_output)

The llm-branch kickoff is extracted into kickoff_llm_generation() (verbatim old behavior). A final that overlaps an in-flight response now merges (existing pop_and_merge_user), cleans up as before, then arms a 0.7s settle timer instead of regenerating immediately; further finals inside the window re-merge and re-arm; quiet ⇒ one regeneration against the full merged utterance.
A live settle timer itself counts as overlap (a second final merges into the pending regen instead of racing it; when nothing is in flight, it merges without cleanup).
0.7s sits just under Deepgram's 1s utterance-end floor, so a continuing speaker always re-arms before the timer fires.
Supersede semantics: __cleanup_downstream_tasks (barge-in, LID-switch truncation) cancels a pending regen; the overlapped path re-arms after cleanup, so the newest turn always wins; teardown cancels the timer.
Non-overlapped finals keep the existing zero-latency path — the window only exists when the caller's speech provably overlapped a response. Finals during tool calls were already deferred upstream and are untouched.