### PR TITLE
fix: keep a strong reference to SonioxLID's on_language dispatch task

### DIFF
--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -31,6 +31,7 @@ class SonioxLID(LIDBackend):
 
     def __init__(self, on_language, config):
         super().__init__(on_language, config)
+        self._background_tasks = set()
         self._api_key = config.get("soniox_api_key") or os.getenv("SONIOX_API_KEY", "")
         self._host = config.get("soniox_host") or SONIOX_WEBSOCKET_HOST
         self._telephony = config.get("telephony_provider", "")
@@ -92,7 +93,13 @@ class SonioxLID(LIDBackend):
         self.segments_received += 1
         self._accumulate(text, lang, audio_s, prob=prob)
         if self.on_language is not None and lang:
-            asyncio.create_task(self.on_language(lang, None))  # legacy per-segment signal
+            # asyncio.create_task() only holds a weak reference; an unstored task can be
+            # garbage-collected mid-execution (silently dropping this legacy per-segment
+            # signal). Keep a strong reference until it finishes, same as the identical
+            # on_language dispatch already fixed in the sibling SarvamLID backend.
+            task = asyncio.create_task(self.on_language(lang, None))
+            self._background_tasks.add(task)
+            task.add_done_callback(self._background_tasks.discard)
 
     def _handle_message(self, data: dict):
         if data.get("error_code") is not None:

--- a/tests/tests/test_soniox_lid_on_language_task.py
+++ b/tests/tests/test_soniox_lid_on_language_task.py
@@ -1,0 +1,55 @@
+"""Regression: SonioxLID._flush_pending_segment must not lose the on_language callback to GC.
+
+asyncio.create_task() only holds a weak reference to the task it returns. The
+sibling SarvamLID backend had the identical fire-and-forget shape for its
+on_language dispatch, fixed by routing it through a helper that keeps a strong
+reference until the task completes. SonioxLID has the same pattern at its own
+on_language call site (_flush_pending_segment) and was not covered by that fix.
+"""
+
+import asyncio
+import gc
+
+import pytest
+
+from bolna.lid.soniox import SonioxLID
+
+
+def _make_lid(calls):
+    async def on_language(lang, conf):
+        calls.append((lang, conf))
+
+    lid = SonioxLID(on_language=on_language, config={})
+    lid._pending["text"] = "hello"
+    lid._pending["lang_counts"] = {"en": 1}
+    lid._pending["last_lang"] = "en"
+    lid._pending["start_ms"] = 0
+    lid._pending["end_ms"] = 500
+    return lid
+
+
+@pytest.mark.asyncio
+async def test_on_language_dispatch_is_tracked_while_pending():
+    calls = []
+    lid = _make_lid(calls)
+
+    lid._flush_pending_segment()
+
+    assert len(lid._background_tasks) == 1
+    await asyncio.gather(*lid._background_tasks)
+    assert calls == [("en", None)]
+
+
+@pytest.mark.asyncio
+async def test_on_language_dispatch_survives_gc_before_it_runs():
+    """The core regression: a GC pass immediately after scheduling must not drop
+    the callback. A bare, unstored asyncio.create_task() here would let the
+    interpreter reap the task before the event loop ever ran it."""
+    calls = []
+    lid = _make_lid(calls)
+
+    lid._flush_pending_segment()
+    gc.collect()  # would collect an untracked task before it ever runs
+
+    await asyncio.wait_for(asyncio.gather(*lid._background_tasks), timeout=1.0)
+    assert calls == [("en", None)]


### PR DESCRIPTION
## Summary

`asyncio.create_task()` only holds a *weak* reference to the task it returns. `SonioxLID._flush_pending_segment()` fires `self.on_language(lang, None)` via a bare `create_task()` call with the result discarded immediately (not stored on a local variable, an instance attribute, or anywhere else), so the task can be garbage-collected before the event loop ever runs it - silently dropping this per-segment language signal.

## How I found this

While working on an unrelated telephony provider addition, I noticed the codebase already has an established convention for this exact risk (`self.background_tasks` set + `add_done_callback` in `task_manager.py`). Grepping for unstored `asyncio.create_task(` calls turned up this one in `bolna/lid/soniox.py:95`.

The identical shape - `asyncio.create_task(self.on_language(...))` - already exists in the sibling `SarvamLID` backend, and is fixed in the currently open #809, via a `create_tracked_task` helper in a new `bolna/helpers/async_utils.py`. That PR's file list doesn't include `bolna/lid/soniox.py`, so this one call site looks like it was missed rather than intentionally left out.

## Fix

Kept this self-contained rather than depending on #809's not-yet-merged helper: an instance-level `self._background_tasks` set populated in `__init__`, with the task added and removed via `add_done_callback` at the one call site in `_flush_pending_segment`. Same idiom already used for `background_tasks` in `task_manager.py`, just scoped to this class.

If #809 merges first, this becomes a trivial one-line swap to `create_tracked_task(self.on_language(lang, None), name="soniox-lid-on-language")` - happy to make that follow-up if preferred over keeping the local set.

<details>
<summary><strong>Testing</strong></summary>

- Added `tests/tests/test_soniox_lid_on_language_task.py`:
  - `test_on_language_dispatch_is_tracked_while_pending` - the task is tracked and the callback fires
  - `test_on_language_dispatch_survives_gc_before_it_runs` - the actual regression: calls `gc.collect()` immediately after scheduling, before the event loop gets a chance to run the task, and asserts the callback still fires. Same technique #809's own `test_async_utils.py` uses to reproduce this bug class.
- Verified against unpatched `master`: both new tests fail (`AttributeError: 'SonioxLID' object has no attribute '_background_tasks'` on the untracked-task path).
- Verified against this branch: both pass.
- Full suite (`pytest tests/`): 962 passed, 38 failed - the same 38 pre-existing failures reproduce identically on unpatched `master` with none of this branch's changes present.
- `ruff check` / `ruff format --check`: clean on both changed files.

</details>