### PR TITLE
Bound telephony output websocket sends with a timeout

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.199"
+__version__ = "0.10.200"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/output_handlers/telephony.py
+++ b/bolna/output_handlers/telephony.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import json
 import os
@@ -14,6 +15,12 @@ from bolna.helpers.utils import calculate_audio_duration
 logger = configure_logger(__name__)
 load_dotenv()
 
+# A carrier media socket can go half-dead (TCP stops delivering ACKs, no close
+# frame ever arrives) without raising — a bare `websocket.send_text()` then
+# never returns. Bound every send so a dead socket fails fast instead of
+# freezing the caller (e.g. __cleanup_downstream_tasks) forever.
+OUTPUT_SEND_TIMEOUT_S = float(os.getenv("OUTPUT_SEND_TIMEOUT_S", "5"))
+
 
 class TelephonyOutputHandler(DefaultOutputHandler):
     def __init__(self, io_provider, websocket=None, mark_event_meta_data=None, log_dir_name=None):
@@ -23,6 +30,10 @@ class TelephonyOutputHandler(DefaultOutputHandler):
         self.stream_sid = None
         self.current_request_id = None
         self.rejected_request_ids = set()
+
+    async def _send_text(self, message):
+        """Guarded send_text: raises asyncio.TimeoutError instead of hanging on a dead socket."""
+        await asyncio.wait_for(self.websocket.send_text(message), timeout=OUTPUT_SEND_TIMEOUT_S)
 
     async def handle_interruption(self):
         pass
@@ -82,7 +93,7 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                             meta_info.get("message_category", ""),
                         )
                         mark_message = await self.form_mark_message(mark_id)
-                        await self.websocket.send_text(json.dumps(mark_message))
+                        await self._send_text(json.dumps(mark_message))
 
                         # sending of audio chunk
                         if (
@@ -93,7 +104,7 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                         ):
                             audio_format = "wav"
                         media_message = await self.form_media_message(audio_chunk, audio_format)
-                        await self.websocket.send_text(json.dumps(media_message))
+                        await self._send_text(json.dumps(media_message))
                         if (
                             meta_info.get("message_category", "") == "agent_welcome_message"
                             and not self.welcome_message_sent_ts
@@ -142,7 +153,7 @@ class TelephonyOutputHandler(DefaultOutputHandler):
                         len(mark_event_meta_data.get("text_synthesized", "") or ""),
                     )
                     mark_message = await self.form_mark_message(mark_id)
-                    await self.websocket.send_text(json.dumps(mark_message))
+                    await self._send_text(json.dumps(mark_message))
                 else:
                     logger.info("Not sending")
             except Exception as e:

--- a/bolna/output_handlers/telephony_providers/exotel.py
+++ b/bolna/output_handlers/telephony_providers/exotel.py
@@ -25,7 +25,7 @@ class ExotelOutputHandler(TelephonyOutputHandler):
                 "event": "clear",
                 "stream_sid": self.stream_sid,
             }
-            await self.websocket.send_text(json.dumps(message_clear))
+            await self._send_text(json.dumps(message_clear))
             self.mark_event_meta_data.clear_data()
         except Exception as e:
             logger.info(f"WebSocket closed during interruption: {e}")

--- a/bolna/output_handlers/telephony_providers/plivo.py
+++ b/bolna/output_handlers/telephony_providers/plivo.py
@@ -24,7 +24,7 @@ class PlivoOutputHandler(TelephonyOutputHandler):
                 "event": "clearAudio",
                 "streamId": self.stream_sid,
             }
-            await self.websocket.send_text(json.dumps(message_clear))
+            await self._send_text(json.dumps(message_clear))
             self.mark_event_meta_data.clear_data()
         except Exception as e:
             logger.info(f"WebSocket closed during interruption: {e}")

--- a/bolna/output_handlers/telephony_providers/twilio.py
+++ b/bolna/output_handlers/telephony_providers/twilio.py
@@ -26,7 +26,7 @@ class TwilioOutputHandler(TelephonyOutputHandler):
                 "event": "clear",
                 "streamSid": self.stream_sid,
             }
-            await self.websocket.send_text(json.dumps(message_clear))
+            await self._send_text(json.dumps(message_clear))
             self.mark_event_meta_data.clear_data()
         except Exception as e:
             logger.info(f"WebSocket closed during interruption: {e}")

--- a/bolna/output_handlers/telephony_providers/vobiz.py
+++ b/bolna/output_handlers/telephony_providers/vobiz.py
@@ -24,7 +24,7 @@ class VobizOutputHandler(TelephonyOutputHandler):
                 "event": "clearAudio",
                 "streamId": self.stream_sid,
             }
-            await self.websocket.send_text(json.dumps(message_clear))
+            await self._send_text(json.dumps(message_clear))
             self.mark_event_meta_data.clear_data()
         except Exception as e:
             logger.info(f"WebSocket closed during interruption: {e}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.199"
+version = "0.10.200"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/tests/test_cleanup_downstream_survives_dead_output_socket.py
+++ b/tests/tests/test_cleanup_downstream_survives_dead_output_socket.py
@@ -1,0 +1,101 @@
+"""End-to-end reproduction of execution 88eeeb50-dadb-4abc-8f79-fd34cb6bac61.
+
+__cleanup_downstream_tasks() awaits self.tools["output"].handle_interruption()
+first, ahead of task cancellation, history sync, and flag resets. With a real
+PlivoOutputHandler wired to a half-dead socket (send_text never resolves,
+never raises), that await used to block forever — freezing _listen_transcriber
+and, transitively, everything gated on cleanup ever returning (the completion
+watchdog kept early-`continue`ing on stale response_in_pipeline/audio flags).
+
+This proves the fix at the level that actually broke in production: cleanup
+must return, cancel the pipeline tasks, and reset state within the send
+timeout — not hang indefinitely.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+from bolna.output_handlers.telephony_providers.plivo import PlivoOutputHandler
+import bolna.output_handlers.telephony as telephony_module
+
+
+class _HangingWebSocket:
+    async def send_text(self, payload):
+        await asyncio.Event().wait()  # never set: hangs forever, never raises
+
+
+def _make_input_tool():
+    inp = MagicMock()
+    inp.welcome_message_played = MagicMock(return_value=True)
+    inp.is_welcome_message_played = True
+    inp.reset_response_heard_by_user = MagicMock()
+    return inp
+
+
+def _make_task_manager(output_tool):
+    from bolna.agent_manager.task_manager import TaskManager
+
+    tm = MagicMock()
+    tm.tools = {
+        "input": _make_input_tool(),
+        "output": output_tool,
+        "synthesizer": AsyncMock(),
+    }
+    tm.mark_event_meta_data = MarkEventMetaData()
+    tm.sync_history = AsyncMock()
+    tm.interruption_manager = MagicMock()
+    tm.interruption_manager.invalidate_pending_responses = MagicMock()
+    tm._drop_all_staged_assistant_history = MagicMock()
+    tm._cancel_in_flight_llm_response = MagicMock()
+    tm.response_in_pipeline = True
+    tm.output_task = MagicMock()
+    tm.llm_task = MagicMock()
+    tm.eager_llm_task = None
+    tm.first_message_task = None
+    tm.voicemail_handler = MagicMock()
+    tm.voicemail_handler.cancel_task = MagicMock()
+    tm.synthesizer_tasks = [MagicMock(), MagicMock()]
+    tm.buffered_output_queue = asyncio.Queue()
+    tm._turn_audio_flushed = MagicMock()
+    tm._turn_audio_flushed.set = MagicMock()
+    tm.started_transmitting_audio = True
+    tm.last_transmitted_timestamp = 0.0
+
+    tm._TaskManager__cleanup_downstream_tasks = TaskManager._TaskManager__cleanup_downstream_tasks.__get__(
+        tm, TaskManager
+    )
+    return tm
+
+
+@pytest.fixture(autouse=True)
+def _fast_send_timeout(monkeypatch):
+    if hasattr(telephony_module, "OUTPUT_SEND_TIMEOUT_S"):
+        monkeypatch.setattr(telephony_module, "OUTPUT_SEND_TIMEOUT_S", 0.05)
+
+
+@pytest.fixture(autouse=True)
+def _patch_create_task(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_task", lambda coro: MagicMock())
+    yield
+
+
+@pytest.mark.asyncio
+async def test_cleanup_finishes_and_cancels_tasks_despite_dead_output_socket():
+    output_tool = PlivoOutputHandler(websocket=_HangingWebSocket(), mark_event_meta_data=MarkEventMetaData())
+    output_tool.stream_sid = "test-stream"
+    tm = _make_task_manager(output_tool)
+    llm_task, output_task = tm.llm_task, tm.output_task
+    synth_tasks = list(tm.synthesizer_tasks)
+
+    await asyncio.wait_for(tm._TaskManager__cleanup_downstream_tasks(), timeout=1.0)
+
+    assert output_tool.is_closed() is True  # the dead socket was actually detected
+    output_task.cancel.assert_called_once()
+    llm_task.cancel.assert_called_once()
+    for t in synth_tasks:
+        t.cancel.assert_called_once()
+    tm._turn_audio_flushed.set.assert_called_once()  # watchdog gate cleared, not left stuck
+    assert tm.response_in_pipeline is False

--- a/tests/tests/test_telephony_output_send_timeout.py
+++ b/tests/tests/test_telephony_output_send_timeout.py
@@ -1,0 +1,112 @@
+"""A telephony provider's media WebSocket can go half-dead: the underlying TCP
+connection stops delivering ACKs without ever sending a close frame, so
+`websocket.send_text()` never raises and never returns.
+
+`__cleanup_downstream_tasks()` awaits `output.handle_interruption()` first,
+ahead of task cancellation and history sync, with nothing above it bounding
+the wait. Production incident: execution 88eeeb50-dadb-4abc-8f79-fd34cb6bac61
+(Plivo, 2026-08-17) froze there for ~10.5 minutes with a lost transcript
+because Plivo's own idle-stream detection was the only thing that ever ended
+the call.
+
+These tests simulate a send that never resolves and assert the call site
+still finishes within bounds instead of hanging indefinitely.
+"""
+
+import asyncio
+
+import pytest
+
+import bolna.output_handlers.telephony as telephony_module
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+from bolna.output_handlers.telephony_providers.exotel import ExotelOutputHandler
+from bolna.output_handlers.telephony_providers.plivo import PlivoOutputHandler
+from bolna.output_handlers.telephony_providers.twilio import TwilioOutputHandler
+from bolna.output_handlers.telephony_providers.vobiz import VobizOutputHandler
+
+
+class _HangingWebSocket:
+    """A socket that never completes a send and never raises — the half-dead case."""
+
+    async def send_text(self, payload):
+        await asyncio.Event().wait()  # never set: hangs forever, never raises
+
+
+class _RecordingWebSocket:
+    def __init__(self):
+        self.sent = []
+
+    async def send_text(self, payload):
+        self.sent.append(payload)
+
+
+@pytest.fixture(autouse=True)
+def _fast_send_timeout(monkeypatch):
+    # Pre-fix, this constant doesn't exist yet and the outer wait_for below is
+    # what catches the hang. Post-fix, shrink the real timeout so the test
+    # runs fast and deterministically instead of riding the outer bound.
+    if hasattr(telephony_module, "OUTPUT_SEND_TIMEOUT_S"):
+        monkeypatch.setattr(telephony_module, "OUTPUT_SEND_TIMEOUT_S", 0.05)
+
+
+@pytest.mark.parametrize(
+    "handler_cls",
+    [PlivoOutputHandler, TwilioOutputHandler, ExotelOutputHandler, VobizOutputHandler],
+)
+@pytest.mark.asyncio
+async def test_handle_interruption_does_not_hang_on_a_dead_socket(handler_cls):
+    handler = handler_cls(websocket=_HangingWebSocket(), mark_event_meta_data=MarkEventMetaData())
+    handler.stream_sid = "test-stream"
+
+    # If handle_interruption's send has no timeout, this outer wait_for is what
+    # actually catches the hang in CI; a real dead call would just never return.
+    await asyncio.wait_for(handler.handle_interruption(), timeout=1.0)
+
+    assert handler.is_closed() is True
+
+
+@pytest.mark.asyncio
+async def test_handle_interruption_still_sends_normally_on_a_healthy_socket():
+    ws = _RecordingWebSocket()
+    handler = PlivoOutputHandler(websocket=ws, mark_event_meta_data=MarkEventMetaData())
+    handler.stream_sid = "test-stream"
+
+    await asyncio.wait_for(handler.handle_interruption(), timeout=1.0)
+
+    assert handler.is_closed() is False
+    assert len(ws.sent) == 1
+
+
+def _audio_packet():
+    return {
+        "data": b"\x01\x02" * 200,
+        "meta_info": {
+            "stream_sid": "test-stream",
+            "sequence_id": 1,
+            "turn_id": "t1",
+            "response_uid": "r1",
+            "response_group_uid": "g1",
+            "cached": False,
+            "format": "wav",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_handle_does_not_hang_sending_audio_on_a_dead_socket():
+    handler = PlivoOutputHandler(websocket=_HangingWebSocket(), mark_event_meta_data=MarkEventMetaData())
+
+    await asyncio.wait_for(handler.handle(_audio_packet()), timeout=1.0)
+
+    assert handler.is_closed() is True
+
+
+@pytest.mark.asyncio
+async def test_handle_still_sends_normally_on_a_healthy_socket():
+    ws = _RecordingWebSocket()
+    handler = PlivoOutputHandler(websocket=ws, mark_event_meta_data=MarkEventMetaData())
+
+    await asyncio.wait_for(handler.handle(_audio_packet()), timeout=1.0)
+
+    assert handler.is_closed() is False
+    assert len(ws.sent) == 3  # pre-mark, media, post-mark


### PR DESCRIPTION
## Summary
- Telephony output handlers (Plivo, Twilio, Exotel, Vobiz) called `websocket.send_text()` with no timeout, so a half-dead carrier socket (TCP stops delivering ACKs, no close frame) hung the send forever instead of raising.
- `TaskManager.__cleanup_downstream_tasks()` awaits `output.handle_interruption()` first, so that hang froze the whole per-call pipeline and disabled the inactivity watchdog — the carrier leg lingered until the provider's own idle-stream detection eventually tore it down, losing whatever transcript had already happened (BOLNA-2423).
- Add a shared timeout-guarded `_send_text()` helper on `TelephonyOutputHandler` (env-overridable via `OUTPUT_SEND_TIMEOUT_S`, default 5s) and route `handle()`'s audio sends plus each provider's `handle_interruption()` through it. Their existing exception handling already recovers correctly once the send actually raises instead of hanging.