### PR TITLE
perf: trim the graph routing hop and keep its prompt prefix cacheable

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.219"
+__version__ = "0.10.220"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.200"
+__version__ = "0.10.201"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -47,7 +47,7 @@ logger = configure_logger(__name__)
 _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
 _ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
 # The router's rationale is explanatory only, and its tokens sit on a live turn's critical path.
-_ROUTING_REASONING_ENABLED = os.getenv("GRAPH_ROUTING_REASONING", "").strip().lower() in ("1", "true", "yes")
+_ROUTER_RATIONALE_ENABLED = os.getenv("GRAPH_ROUTER_RATIONALE", "").strip().lower() in ("1", "true", "yes")
 _PROMPT_VAR_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
@@ -405,7 +405,7 @@ class GraphAgent(BaseAgent):
                     }
                     parameters["required"].append(param_name)
 
-            if _ROUTING_REASONING_ENABLED:
+            if _ROUTER_RATIONALE_ENABLED:
                 parameters["properties"]["reasoning"] = {
                     "type": "string",
                     "description": "Brief explanation of why this routing decision was made",
@@ -426,7 +426,7 @@ class GraphAgent(BaseAgent):
 
         if allow_stay:
             stay_properties = {}
-            if _ROUTING_REASONING_ENABLED:
+            if _ROUTER_RATIONALE_ENABLED:
                 stay_properties["reasoning"] = {
                     "type": "string",
                     "description": "Brief explanation of why this routing decision was made",

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -40,8 +40,7 @@ _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
 _ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
 # Root identifier in either syntax, so {{prior.loans}} still validates against recipient_data["prior"].
 _PROMPT_VAR_PATTERN = re.compile(r"\{\{?\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z0-9_]+|\[[^\[\]{}]+\])*\s*\}\}?")
-# The router's rationale is explanatory only, and its tokens sit on a live turn's critical path.
-_ROUTING_REASONING_ENABLED = os.getenv("GRAPH_ROUTING_REASONING", "").strip().lower() in ("1", "true", "yes")
+_ROUTER_RATIONALE_ENABLED = os.getenv("GRAPH_ROUTER_RATIONALE", "").strip().lower() in ("1", "true", "yes")
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
 _TIME_VAR_KEYS = (
@@ -360,7 +359,7 @@ class GraphAgent(BaseAgent):
                     }
                     parameters["required"].append(param_name)
 
-            if _ROUTING_REASONING_ENABLED:
+            if _ROUTER_RATIONALE_ENABLED:
                 parameters["properties"]["reasoning"] = {
                     "type": "string",
                     "description": "Brief explanation of why this routing decision was made",
@@ -381,7 +380,7 @@ class GraphAgent(BaseAgent):
 
         if allow_stay:
             stay_properties = {}
-            if _ROUTING_REASONING_ENABLED:
+            if _ROUTER_RATIONALE_ENABLED:
                 stay_properties["reasoning"] = {
                     "type": "string",
                     "description": "Brief explanation of why this routing decision was made",
@@ -787,8 +786,7 @@ class GraphAgent(BaseAgent):
             option_edges.append(default_edge)
         tools = self._build_transition_tools_for_edges(option_edges, allow_stay=default_edge is None)
 
-        # Internal bookkeeping keys change every turn and would break the cacheable prefix;
-        # expression edges read them straight off context_data.
+        # Skip internal _-prefixed keys so the routing prompt prefix stays cacheable.
         context_section = ""
         if self.context_data:
             context_items = [

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -46,6 +46,8 @@ logger = configure_logger(__name__)
 
 _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
 _ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
+# The router's rationale is explanatory only, and its tokens sit on a live turn's critical path.
+_ROUTING_REASONING_ENABLED = os.getenv("GRAPH_ROUTING_REASONING", "").strip().lower() in ("1", "true", "yes")
 _PROMPT_VAR_PATTERN = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
@@ -403,15 +405,17 @@ class GraphAgent(BaseAgent):
                     }
                     parameters["required"].append(param_name)
 
-            parameters["properties"]["reasoning"] = {
-                "type": "string",
-                "description": "Brief explanation of why this routing decision was made",
-            }
+            if _ROUTING_REASONING_ENABLED:
+                parameters["properties"]["reasoning"] = {
+                    "type": "string",
+                    "description": "Brief explanation of why this routing decision was made",
+                }
+                parameters["required"].append("reasoning")
             parameters["properties"]["confidence"] = {
                 "type": "number",
                 "description": "Confidence score from 0.0 to 1.0 for this routing decision",
             }
-            parameters["required"].extend(["reasoning", "confidence"])
+            parameters["required"].append("confidence")
 
             tools.append(
                 {
@@ -421,6 +425,16 @@ class GraphAgent(BaseAgent):
             )
 
         if allow_stay:
+            stay_properties = {}
+            if _ROUTING_REASONING_ENABLED:
+                stay_properties["reasoning"] = {
+                    "type": "string",
+                    "description": "Brief explanation of why this routing decision was made",
+                }
+            stay_properties["confidence"] = {
+                "type": "number",
+                "description": "Confidence score from 0.0 to 1.0 for this routing decision",
+            }
             tools.append(
                 {
                     "type": "function",
@@ -429,17 +443,8 @@ class GraphAgent(BaseAgent):
                         "description": "No transition matches. Need more info or clarification.",
                         "parameters": {
                             "type": "object",
-                            "properties": {
-                                "reasoning": {
-                                    "type": "string",
-                                    "description": "Brief explanation of why this routing decision was made",
-                                },
-                                "confidence": {
-                                    "type": "number",
-                                    "description": "Confidence score from 0.0 to 1.0 for this routing decision",
-                                },
-                            },
-                            "required": ["reasoning", "confidence"],
+                            "properties": stay_properties,
+                            "required": list(stay_properties),
                         },
                     },
                 }
@@ -820,13 +825,14 @@ class GraphAgent(BaseAgent):
             option_edges.append(default_edge)
         tools = self._build_transition_tools_for_edges(option_edges, allow_stay=default_edge is None)
 
-        # Build compact context for routing
+        # Internal bookkeeping keys change every turn and would break the cacheable prefix;
+        # expression edges read them straight off context_data.
         context_section = ""
         if self.context_data:
             context_items = [
                 f"{k}={v}"
                 for k, v in self.context_data.items()
-                if v is not None and not isinstance(v, dict) and k != "detected_language"
+                if v is not None and not isinstance(v, dict) and k != "detected_language" and not k.startswith("_")
             ]
             if context_items:
                 context_section = f"\nContext: {', '.join(context_items)}"
@@ -842,19 +848,21 @@ class GraphAgent(BaseAgent):
             )
         instructions = self.routing_instructions or default_instructions
 
-        if self.context_data and instructions:
+        # The same frozen context the spoken prompt uses: the router otherwise reads "{Name}" while
+        # the history shows the real value, and live time variables rewrite the prompt every turn.
+        prompt_context = self._prompt_context()
+
+        if prompt_context and instructions:
             try:
-                substitution_data = dict(self.context_data)
-                if "recipient_data" in self.context_data and isinstance(self.context_data["recipient_data"], dict):
-                    substitution_data.update(self.context_data["recipient_data"])
+                substitution_data = dict(prompt_context)
+                recipient_data = prompt_context.get("recipient_data")
+                if isinstance(recipient_data, dict):
+                    substitution_data.update(recipient_data)
                 instructions = instructions.format_map(defaultdict(lambda: "NULL", substitution_data))
             except Exception as e:
                 logger.debug(f"Variable substitution in routing_instructions failed: {e}")
 
-        # Substituted with the same frozen context the spoken prompt uses: the router
-        # otherwise reads "{Name}" while the conversation history shows the real value.
         node_objective = node.get("prompt") or node.get("description") or ""
-        prompt_context = self._prompt_context()
         if prompt_context:
             node_objective = update_prompt_with_context(node_objective, prompt_context)
         system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {node["id"]}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -40,6 +40,8 @@ _DETERMINISTIC_REASONING_PREFIX = "deterministic:"
 _ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
 # Root identifier in either syntax, so {{prior.loans}} still validates against recipient_data["prior"].
 _PROMPT_VAR_PATTERN = re.compile(r"\{\{?\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z0-9_]+|\[[^\[\]{}]+\])*\s*\}\}?")
+# The router's rationale is explanatory only, and its tokens sit on a live turn's critical path.
+_ROUTING_REASONING_ENABLED = os.getenv("GRAPH_ROUTING_REASONING", "").strip().lower() in ("1", "true", "yes")
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
 _TIME_VAR_KEYS = (
@@ -358,15 +360,17 @@ class GraphAgent(BaseAgent):
                     }
                     parameters["required"].append(param_name)
 
-            parameters["properties"]["reasoning"] = {
-                "type": "string",
-                "description": "Brief explanation of why this routing decision was made",
-            }
+            if _ROUTING_REASONING_ENABLED:
+                parameters["properties"]["reasoning"] = {
+                    "type": "string",
+                    "description": "Brief explanation of why this routing decision was made",
+                }
+                parameters["required"].append("reasoning")
             parameters["properties"]["confidence"] = {
                 "type": "number",
                 "description": "Confidence score from 0.0 to 1.0 for this routing decision",
             }
-            parameters["required"].extend(["reasoning", "confidence"])
+            parameters["required"].append("confidence")
 
             tools.append(
                 {
@@ -376,6 +380,16 @@ class GraphAgent(BaseAgent):
             )
 
         if allow_stay:
+            stay_properties = {}
+            if _ROUTING_REASONING_ENABLED:
+                stay_properties["reasoning"] = {
+                    "type": "string",
+                    "description": "Brief explanation of why this routing decision was made",
+                }
+            stay_properties["confidence"] = {
+                "type": "number",
+                "description": "Confidence score from 0.0 to 1.0 for this routing decision",
+            }
             tools.append(
                 {
                     "type": "function",
@@ -384,17 +398,8 @@ class GraphAgent(BaseAgent):
                         "description": "No transition matches. Need more info or clarification.",
                         "parameters": {
                             "type": "object",
-                            "properties": {
-                                "reasoning": {
-                                    "type": "string",
-                                    "description": "Brief explanation of why this routing decision was made",
-                                },
-                                "confidence": {
-                                    "type": "number",
-                                    "description": "Confidence score from 0.0 to 1.0 for this routing decision",
-                                },
-                            },
-                            "required": ["reasoning", "confidence"],
+                            "properties": stay_properties,
+                            "required": list(stay_properties),
                         },
                     },
                 }
@@ -782,13 +787,14 @@ class GraphAgent(BaseAgent):
             option_edges.append(default_edge)
         tools = self._build_transition_tools_for_edges(option_edges, allow_stay=default_edge is None)
 
-        # Build compact context for routing
+        # Internal bookkeeping keys change every turn and would break the cacheable prefix;
+        # expression edges read them straight off context_data.
         context_section = ""
         if self.context_data:
             context_items = [
                 f"{k}={v}"
                 for k, v in self.context_data.items()
-                if v is not None and not isinstance(v, dict) and k != "detected_language"
+                if v is not None and not isinstance(v, dict) and k != "detected_language" and not k.startswith("_")
             ]
             if context_items:
                 context_section = f"\nContext: {', '.join(context_items)}"
@@ -804,19 +810,21 @@ class GraphAgent(BaseAgent):
             )
         instructions = self.routing_instructions or default_instructions
 
-        if self.context_data and instructions:
+        # The same frozen context the spoken prompt uses: the router otherwise reads "{Name}" while
+        # the history shows the real value, and live time variables rewrite the prompt every turn.
+        prompt_context = self._prompt_context()
+
+        if prompt_context and instructions:
             try:
-                substitution_data = dict(self.context_data)
-                if "recipient_data" in self.context_data and isinstance(self.context_data["recipient_data"], dict):
-                    substitution_data.update(self.context_data["recipient_data"])
+                substitution_data = dict(prompt_context)
+                recipient_data = prompt_context.get("recipient_data")
+                if isinstance(recipient_data, dict):
+                    substitution_data.update(recipient_data)
                 instructions = render_prompt(instructions, substitution_data, missing="NULL")
             except Exception as e:
                 logger.debug(f"Variable substitution in routing_instructions failed: {e}")
 
-        # Substituted with the same frozen context the spoken prompt uses: the router
-        # otherwise reads "{Name}" while the conversation history shows the real value.
         node_objective = node.get("prompt") or node.get("description") or ""
-        prompt_context = self._prompt_context()
         if prompt_context:
             node_objective = update_prompt_with_context(node_objective, prompt_context)
         system_prompt = f"""Routing Guidelines: \n {instructions}\n Current Node: {node["id"]}{context_section} \n Node Objective: {node_objective}\n\n Node Conversation History:\n"""

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -41,6 +41,8 @@ _ROUTER_REASONING_PREFIX = f"{_DETERMINISTIC_REASONING_PREFIX}router:"
 # Root identifier in either syntax, so {{prior.loans}} still validates against recipient_data["prior"].
 _PROMPT_VAR_PATTERN = re.compile(r"\{\{?\s*([a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z0-9_]+|\[[^\[\]{}]+\])*\s*\}\}?")
 _ROUTER_RATIONALE_ENABLED = os.getenv("GRAPH_ROUTER_RATIONALE", "").strip().lower() in ("1", "true", "yes")
+_ROUTER_REASONING_DESC = "Brief explanation of why this routing decision was made"
+_ROUTER_CONFIDENCE_DESC = "Confidence score from 0.0 to 1.0 for this routing decision"
 
 # Time variables frozen per call for the conversation prompt; see _prompt_context.
 _TIME_VAR_KEYS = (
@@ -362,12 +364,12 @@ class GraphAgent(BaseAgent):
             if _ROUTER_RATIONALE_ENABLED:
                 parameters["properties"]["reasoning"] = {
                     "type": "string",
-                    "description": "Brief explanation of why this routing decision was made",
+                    "description": _ROUTER_REASONING_DESC,
                 }
                 parameters["required"].append("reasoning")
             parameters["properties"]["confidence"] = {
                 "type": "number",
-                "description": "Confidence score from 0.0 to 1.0 for this routing decision",
+                "description": _ROUTER_CONFIDENCE_DESC,
             }
             parameters["required"].append("confidence")
 
@@ -383,11 +385,11 @@ class GraphAgent(BaseAgent):
             if _ROUTER_RATIONALE_ENABLED:
                 stay_properties["reasoning"] = {
                     "type": "string",
-                    "description": "Brief explanation of why this routing decision was made",
+                    "description": _ROUTER_REASONING_DESC,
                 }
             stay_properties["confidence"] = {
                 "type": "number",
-                "description": "Confidence score from 0.0 to 1.0 for this routing decision",
+                "description": _ROUTER_CONFIDENCE_DESC,
             }
             tools.append(
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.219"
+version = "0.10.220"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.200"
+version = "0.10.201"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
The routing hop runs serially before the answering LLM on every turn of a graph agent, and it is a non-streaming full completion, so it pays for every output token rather than just time-to-first-token. Measured across two days of production graph-agent traffic (26,880 routing calls), it is p50 716ms, p90 1002ms, against a p50 369ms time-to-first-token for the answering call it precedes.

Two things were making it worse than it needs to be.

**The rationale is generated after the decision it explains.** Routing is a tool call with `tool_choice: "required"`, so the decision is the function name. `reasoning` and `confidence` are arguments inside that function, emitted after the name is already committed. The rationale therefore cannot influence the choice, and nothing downstream reads it except the observability payload. It is the median 110 characters of a 43-token response, roughly 64% of the output tokens, at about 6 to 7ms per token. It is now opt-in via `GRAPH_ROUTING_REASONING=true` for debugging a misrouting agent; `confidence` stays, since it is a couple of tokens.

**The routing prompt busts its own prefix cache every turn.** `_enrich_routing_context` refreshes time variables live and writes `_node_turns`, `_total_turns` and `_silence_repeats` into `context_data` each turn, and `_decide_next_node_llm` serialised all of that into the middle of the system prompt while substituting routing instructions against live time. A prompt referencing `{current_time}` diverged 15% of the way in, on every turn. The answering prompt already solved this by rendering through `_prompt_context()`, which freezes time per call; routing now does the same, and the internal bookkeeping keys stay out of the prompt text. Production cache hit rate for routing is 25.2% against 99.3% for the answering call on the same model.

To be clear about what this second part buys: it is a cost and PTU-capacity fix, not a latency one. Cached and uncached routing calls measure 729ms and 712ms, and going from under 1k to 4-6k input tokens only costs 64ms, so prefill was never the bottleneck.

Behaviour worth flagging for review:

`routing_latencies[].reasoning` is null for LLM hops unless the flag is set. Deterministic and router hops still carry their prefixed reason strings, so the `routing_type` classification is unchanged.

Routing instructions now render time variables frozen at call start rather than live, matching the spoken prompt. Expression edges still evaluate against live values, since they read `context_data` directly.

`_total_turns` and friends are no longer dumped into the routing prompt for the model to read. Instructions can still name one explicitly, and expression edges are unaffected.
