### PR TITLE
perf: cache the resample FIR filter instead of redesigning it per audio chunk

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.202"
+__version__ = "0.10.203"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -459,7 +459,7 @@ def mp3_bytes_to_pcm(mp3_bytes, target_sample_rate=8000):
     return audio.raw_data
 
 
-@lru_cache(maxsize=None)
+@lru_cache(maxsize=32)
 def _resample_fir(up, down):
     """resample_poly's default kaiser design, cached per ratio; it applies its own up scaling."""
     max_rate = max(up, down)

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from functools import lru_cache
 from typing import Union, Optional
 import json
 import asyncio
@@ -458,6 +459,13 @@ def mp3_bytes_to_pcm(mp3_bytes, target_sample_rate=8000):
     return audio.raw_data
 
 
+@lru_cache(maxsize=None)
+def _resample_fir(up, down):
+    """resample_poly's default kaiser design, cached per ratio; it applies its own up scaling."""
+    max_rate = max(up, down)
+    return scipy.signal.firwin(20 * max_rate + 1, 1.0 / max_rate, window=("kaiser", 5.0)).astype(np.float32)
+
+
 def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, original_sample_rate=None):
     """
     Resample audio bytes
@@ -479,7 +487,8 @@ def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, orig
         if pcm_channels > 1:
             audio_array = audio_array.reshape(-1, pcm_channels)
         g = math.gcd(original_sample_rate, target_sample_rate)
-        resampled = scipy.signal.resample_poly(audio_array, target_sample_rate // g, original_sample_rate // g, axis=0)
+        up, down = target_sample_rate // g, original_sample_rate // g
+        resampled = scipy.signal.resample_poly(audio_array, up, down, axis=0, window=_resample_fir(up, down))
         return np.clip(resampled, -32768, 32767).astype(np.int16).tobytes()
 
     # Handle other formats (wav, mp3, etc.) via pydub

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.202"
+version = "0.10.203"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
`resample_poly` designs its anti-aliasing FIR from scratch on every call, and `resample` calls it once per audio chunk on the event loop. The coefficients depend only on the up/down ratio, so they are built once and passed in as `window`.

Profiling a single Sarvam call showed 180ms of main-thread time inside `resample`, 140ms of which was `firwin` and `kaiser`, meaning filter design rather than filtering.

Passing the cached filter keeps resample_poly's own padding, trimming and up scaling, so the output does not change. Verified byte-identical across 198 combinations of rate pair, chunk size and channel count, including empty, single-sample, silence, full-scale and same-rate passthrough input.

24kHz to 8kHz, per call: 305us to 95us at a 20ms chunk, 372us to 152us at 100ms, 482us to 259us at 250ms.