### PR TITLE
fixed webcall for smallest model

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.205"
+__version__ = "0.10.206"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.204"
+__version__ = "0.10.205"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -76,6 +76,10 @@ class SmallestTranscriber(BaseTranscriber):
         self.sampling_rate = int(sampling_rate)
         self.audio_frame_duration = 0.2  # Default 200ms chunks
 
+        # Dashboard connection flag — must be set BEFORE _configure_audio_params, which reads it
+        # for providers with no explicit branch (a freeswitch webcall crashed on the ordering).
+        self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
+
         # Configure audio params based on telephony provider
         self._configure_audio_params()
 
@@ -118,9 +122,6 @@ class SmallestTranscriber(BaseTranscriber):
         self.last_interim_time = None
         self.interim_timeout = kwargs.get("interim_timeout", 5.0)  # Default 5 seconds
 
-        # Dashboard connection flag
-        self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
-
     def _configure_audio_params(self):
         """Configure audio parameters based on telephony provider."""
         if self.provider in TelephonyProvider.mulaw_values():
@@ -138,6 +139,11 @@ class SmallestTranscriber(BaseTranscriber):
             self.encoding = "linear16"
             self.sampling_rate = 16000
             self.audio_frame_duration = 0.256
+        elif self.provider == TelephonyProvider.FREESWITCH.value:
+            # FreeSWITCH webcall media fork streams linear16 mono @16k (dialplan: `mono 16k`)
+            self.encoding = "linear16"
+            self.sampling_rate = 16000
+            self.audio_frame_duration = 0.2
         elif self.provider == "playground":
             # Playground/dashboard mode
             self.encoding = "linear16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.204"
+version = "0.10.205"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.205"
+version = "0.10.206"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_smallest_transcriber.py
+++ b/tests/test_smallest_transcriber.py
@@ -1,0 +1,73 @@
+"""Unit tests for SmallestTranscriber provider audio-param matrix.
+
+The constructor calls _configure_audio_params(), which reads
+`connected_via_dashboard` for providers without an explicit branch. That
+attribute used to be assigned AFTER the call, so any provider falling through
+the branch chain (freeswitch webcalls) crashed with AttributeError at
+transcriber setup and the whole call died ~3s in. These tests pin the full
+provider matrix so a branch regression is loud, not silent.
+
+Constructor-only: no network happens until run().
+"""
+
+import pytest
+
+from bolna.transcriber.smallest_transcriber import SmallestTranscriber
+
+
+def _transcriber(provider, **kwargs):
+    return SmallestTranscriber(
+        telephony_provider=provider,
+        stream=True,
+        transcriber_key="test-key",
+        **kwargs,
+    )
+
+
+@pytest.mark.parametrize("provider", ["twilio", "sip-trunk"])
+def test_mulaw_telephony_providers(provider):
+    t = _transcriber(provider)
+    assert t.encoding == "mulaw"
+    assert t.sampling_rate == 8000
+    assert t.audio_frame_duration == 0.2
+
+
+@pytest.mark.parametrize("provider", ["exotel", "plivo"])
+def test_linear16_telephony_providers(provider):
+    t = _transcriber(provider)
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 8000
+    assert t.audio_frame_duration == 0.2
+
+
+def test_web_based_call():
+    t = _transcriber("web_based_call")
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 16000
+    assert t.audio_frame_duration == 0.256
+
+
+def test_freeswitch_webcall_does_not_crash_and_uses_16k_linear16():
+    # the regression case: provider="freeswitch" had no branch and fell through to
+    # `elif not self.connected_via_dashboard` before the attribute existed
+    t = _transcriber("freeswitch")
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 16000
+    assert t.audio_frame_duration == 0.2
+
+
+def test_playground_batch_mode():
+    t = _transcriber("playground")
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 8000
+    assert t.audio_frame_duration == 0.0
+
+
+@pytest.mark.parametrize("enforce_streaming", [True, False])
+def test_unknown_provider_never_crashes_on_dashboard_flag(enforce_streaming):
+    # any provider without an explicit branch must resolve via connected_via_dashboard,
+    # which has to exist by the time _configure_audio_params runs
+    t = _transcriber("default", enforce_streaming=enforce_streaming)
+    assert t.connected_via_dashboard is enforce_streaming
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 16000


### PR DESCRIPTION
## What

Every web call on an agent using the Smallest (pulse) transcriber died ~3 seconds after
connecting, with the execution marked `failed` ("Call ended unexpectedly."). Telephony
calls on the same agents were unaffected.


## Root cause

`SmallestTranscriber.__init__` called `_configure_audio_params()` **42 lines before**
assigning `self.connected_via_dashboard`:

- `_configure_audio_params()` resolves audio params through a provider branch chain:
  mulaw providers → exotel/plivo → `web_based_call` → `playground` → and finally
  `elif not self.connected_via_dashboard`.
- Telephony providers all match an early branch, so the dangling attribute was never
  read — which is why phone calls worked and the bug shipped unnoticed.
- `freeswitch` is deliberately **not** a telephony provider (`enums.py`: "linear16 16k
  in / 24k out"), matches no branch, and fell through to the `elif` →
  `AttributeError: 'SmallestTranscriber' object has no attribute 'connected_via_dashboard'`.

The AttributeError aborted `__setup_transcriber`, the pipeline then hit
`TypeError: 'NoneType' object does not support item assignment`, the fork WS closed,
and FreeSWITCH's `stream_hangup_on_disconnect` tore the call down — hence the ~3s cut.

Deepgram, Soniox, and ElevenLabs transcribers assign the flag before configuring,
which is why only Smallest agents broke.

## Fix

`bolna/transcriber/smallest_transcriber.py` (+9 / −3):

1. Move the `connected_via_dashboard` assignment above the `_configure_audio_params()`
   call — the same ordering every other transcriber uses.
2. Add an explicit `FREESWITCH` branch: `linear16 / 16000 / 0.2`, matching what the FS
   media fork actually streams (dialplan forks `mono 16k`). This is byte-identical to
   what the fall-through produces once the flag exists — the branch makes the webcall
   audio shape deliberate instead of an accident of the dashboard flag.

No behavior change for any other provider: they all match earlier branches, and
nothing reads the flag between its old and new position.

## Tests

New `tests/test_smallest_transcriber.py` — 9 tests pinning the full provider audio-param
matrix (twilio, sip-trunk, exotel, plivo, web_based_call, freeswitch, playground, and
the unknown-provider/dashboard-flag path both ways).

The freeswitch test run against the pre-fix code fails with the byte-identical prod
error (`AttributeError ... connected_via_dashboard`, smallest_transcriber.py:146) and
passes with the fix.

- Full suite: **1156 passed, 1 skipped** — no regressions
- `ruff check` + `ruff format --check` clean