### PR TITLE
Bound the hangup drain when the media socket stops acking

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.210"
+__version__ = "0.10.211"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2954,19 +2954,33 @@ class TaskManager(BaseManager):
 
         await self.wait_for_current_message()
 
-        # Check completion of agent_hangup_message sent from output
-        # Only wait for hangup chunk if a hangup message was actually queued
-        while self.hangup_triggered and self.hangup_message_queued:
-            try:
-                if self.tools["output"].hangup_sent():
-                    logger.info("final hangup chunk is now sent. Breaking now")
-                    break
-                else:
-                    logger.info("final hangup chunk has not been sent yet")
+        # Wait for the queued goodbye to finish playing, but no longer than the audio still
+        # queued plus the mark grace. A dead media socket never acks, so an unbounded wait here
+        # holds the whole TaskManager until the pod dies and the final save never runs. The
+        # deadline is stamped once, up front, so it cannot recede with each iteration.
+        if self.hangup_triggered and self.hangup_message_queued:
+            pending_playout = sum(
+                mark.get("duration", 0)
+                for mark in self.mark_event_meta_data.mark_event_meta_data.values()
+                if mark.get("type") != "pre_mark_message" and mark.get("sent_ts")
+            )
+            drain_budget = pending_playout + self.hangup_mark_event_timeout
+            drain_deadline = time.time() + drain_budget
+            while True:
+                try:
+                    if self.tools["output"].hangup_sent():
+                        logger.info("final hangup chunk is now sent. Breaking now")
+                        break
+                    if self.tools["output"].is_closed():
+                        logger.warning("output socket closed before the hangup chunk was acked, tearing down")
+                        break
+                    if time.time() >= drain_deadline:
+                        logger.warning(f"hangup drain timed out after {drain_budget:.1f}s, tearing down")
+                        break
                     await asyncio.sleep(0.5)
-            except Exception as e:
-                logger.error(f"Error while checking queue: {e}", exc_info=True)
-                break
+                except Exception as e:
+                    logger.error(f"Error while checking queue: {e}", exc_info=True)
+                    break
 
         if self.hangup_message_queued and not web_call_timeout:
             self.history.append(
@@ -7203,7 +7217,9 @@ class TaskManager(BaseManager):
                 self.hangup_detail = HangupReason.WEB_CALL_MAX_DURATION_REACHED
                 break
 
-            if self.last_transmitted_timestamp == 0:
+            # A hangup still needs its timeout enforced even on a call where no mark was
+            # ever acked, so this idle guard must not swallow the branch below.
+            if self.last_transmitted_timestamp == 0 and not self.hangup_triggered:
                 logger.info(f"Last transmitted timestamp is simply 0 and hence continuing")
                 continue
 
@@ -7212,8 +7228,11 @@ class TaskManager(BaseManager):
                     logger.info(f"Call hangup completed successfully")
                     break
 
-                if self.hangup_triggered_at:
-                    time_since_hangup = time.time() - self.hangup_triggered_at
+                # hangup_triggered_at is only stamped once the goodbye is queued; fall back to
+                # the decision timestamp so a hangup that stalls before that still times out.
+                hangup_started_at = self.hangup_triggered_at or self.hangup_decision_at
+                if hangup_started_at:
+                    time_since_hangup = time.time() - hangup_started_at
                     if time_since_hangup > self.hangup_mark_event_timeout:
                         logger.warning(
                             f"Hangup mark event not received within {self.hangup_mark_event_timeout}s (waited {time_since_hangup:.1f}s), forcing conversation end"

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2745,6 +2745,14 @@ class TaskManager(BaseManager):
             self.tools["output"].set_hangup_sent()
             await self.__process_end_of_conversation()
 
+    def _queued_playout_seconds(self) -> float:
+        """Seconds of already-sent audio the provider has not acked playing yet."""
+        return sum(
+            mark.get("duration", 0)
+            for mark in self.mark_event_meta_data.mark_event_meta_data.values()
+            if mark.get("type") != "pre_mark_message" and mark.get("sent_ts")
+        )
+
     async def wait_for_current_message(self):
         try:
             await asyncio.wait_for(self._turn_audio_flushed.wait(), timeout=3.0)
@@ -2781,12 +2789,7 @@ class TaskManager(BaseManager):
             # future rather than one that recedes with each iteration. Without this,
             # `remaining = sum(durations) + hangup_mark_event_timeout` never reaches 0
             # when Plivo stops ACKing marks, causing an indefinite spin.
-            remaining_durations = [
-                v.get("duration", 0)
-                for v in mark_events.values()
-                if v.get("type") != "pre_mark_message" and v.get("sent_ts")
-            ]
-            expected_play_end = (entry_time + sum(remaining_durations)) if remaining_durations else entry_time
+            expected_play_end = entry_time + self._queued_playout_seconds()
             deadline = expected_play_end + self.hangup_mark_event_timeout
 
             remaining = deadline - time.time()
@@ -2954,33 +2957,15 @@ class TaskManager(BaseManager):
 
         await self.wait_for_current_message()
 
-        # Wait for the queued goodbye to finish playing, but no longer than the audio still
-        # queued plus the mark grace. A dead media socket never acks, so an unbounded wait here
-        # holds the whole TaskManager until the pod dies and the final save never runs. The
-        # deadline is stamped once, up front, so it cannot recede with each iteration.
+        # A dead media socket never acks the goodbye, so bound the wait by the audio still
+        # queued plus the mark grace. Unbounded, teardown never reached the final save.
         if self.hangup_triggered and self.hangup_message_queued:
-            pending_playout = sum(
-                mark.get("duration", 0)
-                for mark in self.mark_event_meta_data.mark_event_meta_data.values()
-                if mark.get("type") != "pre_mark_message" and mark.get("sent_ts")
-            )
-            drain_budget = pending_playout + self.hangup_mark_event_timeout
-            drain_deadline = time.time() + drain_budget
-            while True:
-                try:
-                    if self.tools["output"].hangup_sent():
-                        logger.info("final hangup chunk is now sent. Breaking now")
-                        break
-                    if self.tools["output"].is_closed():
-                        logger.warning("output socket closed before the hangup chunk was acked, tearing down")
-                        break
-                    if time.time() >= drain_deadline:
-                        logger.warning(f"hangup drain timed out after {drain_budget:.1f}s, tearing down")
-                        break
-                    await asyncio.sleep(0.5)
-                except Exception as e:
-                    logger.error(f"Error while checking queue: {e}", exc_info=True)
-                    break
+            output = self.tools["output"]
+            deadline = time.time() + self._queued_playout_seconds() + self.hangup_mark_event_timeout
+            while not output.hangup_sent() and not output.is_closed() and time.time() < deadline:
+                await asyncio.sleep(0.5)
+            if not output.hangup_sent():
+                logger.warning(f"hangup chunk never acked (socket closed={output.is_closed()}), tearing down")
 
         if self.hangup_message_queued and not web_call_timeout:
             self.history.append(

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2218,7 +2218,7 @@ class TaskManager(BaseManager):
         return None
 
     def _has_interruptible_mark_activity(self):
-        for mark_data in self.mark_event_meta_data.mark_event_meta_data.values():
+        for mark_data in self.mark_event_meta_data.pending_marks.values():
             if mark_data.get("type") == "pre_mark_message":
                 continue
             if mark_data.get("turn_id") is not None:
@@ -2749,7 +2749,7 @@ class TaskManager(BaseManager):
         """Seconds of already-sent audio the provider has not acked playing yet."""
         return sum(
             mark.get("duration", 0)
-            for mark in self.mark_event_meta_data.mark_event_meta_data.values()
+            for mark in self.mark_event_meta_data.pending_marks.values()
             if mark.get("type") != "pre_mark_message" and mark.get("sent_ts")
         )
 
@@ -2761,7 +2761,7 @@ class TaskManager(BaseManager):
 
         entry_time = time.time()
         while not self.conversation_ended:
-            mark_events = self.mark_event_meta_data.mark_event_meta_data
+            mark_events = self.mark_event_meta_data.pending_marks
             mark_items_list = [{"mark_id": k, "mark_data": v} for k, v in mark_events.items()]
             logger.info(f"current_list: {mark_items_list}")
 
@@ -8236,11 +8236,11 @@ class TaskManager(BaseManager):
                 if self.hangup_triggered and not self.conversation_ended:
                     await self.wait_for_current_message()
 
-                has_pending_marks = len(self.mark_event_meta_data.mark_event_meta_data) > 0
+                has_pending_marks = len(self.mark_event_meta_data.pending_marks) > 0
                 has_response_heard = bool(self.tools["input"].response_heard_by_user)
                 if has_pending_marks or has_response_heard:
                     await self.sync_history(
-                        self.mark_event_meta_data.mark_event_meta_data.items(),
+                        self.mark_event_meta_data.pending_marks.items(),
                         time.time(),
                         extend_with_playback_estimate=True,
                     )

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -59,8 +59,8 @@ class MarkStats(BaseModel):
 
 class MarkEventMetaData:
     def __init__(self):
-        self.mark_event_meta_data = {}
-        self.previous_mark_event_meta_data = {}
+        self.pending_marks = {}
+        self.previous_pending_marks = {}
         self._mark_history: Dict[str, Dict] = {}
         self.counter = 0
         self.mark_changed = asyncio.Event()
@@ -93,7 +93,7 @@ class MarkEventMetaData:
         value.setdefault("acked", False)
         value.setdefault("ack_ts", None)
         self.counter += 1
-        self.mark_event_meta_data[mark_id] = value
+        self.pending_marks[mark_id] = value
         duration = value.get("duration") or 0
         if value.get("type") != "pre_mark_message":
             self._mark_history[mark_id] = value
@@ -171,17 +171,17 @@ class MarkEventMetaData:
     def drop_data(self, mark_id):
         """Remove a mark that was never played (cleared echo): no ack stamp, so last-ack
         playback crediting and chunk-mark analytics can't count it as heard."""
-        entry = self.mark_event_meta_data.pop(mark_id, {})
+        entry = self.pending_marks.pop(mark_id, {})
         if entry:
             entry["cleared"] = True
         return entry
 
     def fetch_data(self, mark_id):
-        entry = self.mark_event_meta_data.get(mark_id)
+        entry = self.pending_marks.get(mark_id)
         if entry is not None and entry.get("type") != "pre_mark_message":
             entry["acked"] = True
             entry["ack_ts"] = time.time()
-        result = self.mark_event_meta_data.pop(mark_id, {})
+        result = self.pending_marks.pop(mark_id, {})
         if result:
             logger.info(
                 "BOLNA_TRACE_MARK fetch mark_id=%s type=%s seq=%s turn=%s response_uid=%s group_uid=%s counter=%s",
@@ -200,21 +200,21 @@ class MarkEventMetaData:
         logger.info(f"Clearing mark meta data dict")
         logger.info(
             "BOLNA_TRACE_MARK clear pending=%s mark_ids=%s",
-            len(self.mark_event_meta_data),
-            list(self.mark_event_meta_data.keys()),
+            len(self.pending_marks),
+            list(self.pending_marks.keys()),
         )
         self.counter = 0
         self.drop_playout_estimate()
 
-        for mark_id, value in self.mark_event_meta_data.items():
+        for mark_id, value in self.pending_marks.items():
             if value.get("type") != "pre_mark_message":
                 value["cleared_on_interrupt"] = True
                 seq = value.get("sequence_id")
                 if seq is not None and seq in self._mark_stats.per_sequence:
                     self._mark_stats.per_sequence[seq].interrupted = True
 
-        self.previous_mark_event_meta_data = copy.deepcopy(self.mark_event_meta_data)
-        self.mark_event_meta_data = {}
+        self.previous_pending_marks = copy.deepcopy(self.pending_marks)
+        self.pending_marks = {}
         self.mark_changed.set()
 
     def get_mark_tracking_summary(self) -> dict:
@@ -255,7 +255,7 @@ class MarkEventMetaData:
         return summary.model_dump()
 
     def fetch_cleared_mark_event_data(self):
-        return self.previous_mark_event_meta_data
+        return self.previous_pending_marks
 
     def get_last_ack_ts_for_turn(self, turn_id) -> Optional[float]:
         """Wall-clock of the turn's last ACKed chunk — the playback clock's last confirmed point.
@@ -301,4 +301,4 @@ class MarkEventMetaData:
         return out
 
     def __str__(self):
-        return f"{self.mark_event_meta_data}"
+        return f"{self.pending_marks}"

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -221,7 +221,7 @@ class DefaultInputHandler:
                 self.is_welcome_message_played = True
                 self.welcome_message_played_ts = time.time() * 1000
                 pre_mark_id = self.mark_event_meta_data.welcome_pre_mark_id
-                if pre_mark_id and pre_mark_id in self.mark_event_meta_data.mark_event_meta_data:
+                if pre_mark_id and pre_mark_id in self.mark_event_meta_data.pending_marks:
                     self.mark_event_meta_data.fetch_data(pre_mark_id)
                     logger.info("Cleared stale welcome pre_mark %s (never acked by Plivo)", pre_mark_id)
 

--- a/bolna/input_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/input_handlers/telephony_providers/sip_trunk.py
@@ -167,7 +167,7 @@ class SipTrunkInputHandler(TelephonyInputHandler):
         meta = getattr(self, "mark_event_meta_data", None)
         if not meta:
             return 0.0
-        events = meta.mark_event_meta_data
+        events = meta.pending_marks
         return sum(v.get("duration") or 0.0 for v in events.values() if v.get("type") != "pre_mark_message")
 
     async def _await_playback_drained(self):

--- a/bolna/output_handlers/telephony_providers/sip_trunk.py
+++ b/bolna/output_handlers/telephony_providers/sip_trunk.py
@@ -189,7 +189,7 @@ class SipTrunkOutputHandler(TelephonyOutputHandler):
         """
         if not self.input_handler or not self.input_handler.mark_event_meta_data:
             return
-        remaining = list(self.input_handler.mark_event_meta_data.mark_event_meta_data.keys())
+        remaining = list(self.input_handler.mark_event_meta_data.pending_marks.keys())
         if not remaining and not self.input_handler.is_audio_being_played_to_user():
             logger.info(f"sip-trunk: playback completed by mark echo before the {reason} timer")
             return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.210"
+version = "0.10.211"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_hangup_drain_bounded_on_dead_socket.py
+++ b/tests/test_hangup_drain_bounded_on_dead_socket.py
@@ -44,6 +44,15 @@ class _InputStub:
         self.stopped = True
 
 
+class _MarksStub:
+    """Holds one goodbye chunk the provider has been sent but has not acked."""
+
+    def __init__(self, duration):
+        self.mark_event_meta_data = {
+            "aud1": {"type": "agent_hangup", "duration": duration, "sent_ts": time.time()}
+        }
+
+
 class _VoicemailStub:
     def cancel_task(self):
         pass
@@ -64,15 +73,7 @@ def _make_tm(output, *, pending_duration=0.0, grace=0.4):
     tm.llm_task = None
     tm.turn_based_conversation = False
     tm.voicemail_handler = _VoicemailStub()
-    tm.mark_event_meta_data = type(
-        "_Marks",
-        (),
-        {
-            "mark_event_meta_data": {
-                "aud1": {"type": "agent_hangup", "duration": pending_duration, "sent_ts": time.time()}
-            }
-        },
-    )()
+    tm.mark_event_meta_data = _MarksStub(pending_duration)
 
     async def _already_flushed():
         return

--- a/tests/test_hangup_drain_bounded_on_dead_socket.py
+++ b/tests/test_hangup_drain_bounded_on_dead_socket.py
@@ -48,9 +48,7 @@ class _MarksStub:
     """Holds one goodbye chunk the provider has been sent but has not acked."""
 
     def __init__(self, duration):
-        self.mark_event_meta_data = {
-            "aud1": {"type": "agent_hangup", "duration": duration, "sent_ts": time.time()}
-        }
+        self.pending_marks = {"aud1": {"type": "agent_hangup", "duration": duration, "sent_ts": time.time()}}
 
 
 class _VoicemailStub:

--- a/tests/test_hangup_drain_bounded_on_dead_socket.py
+++ b/tests/test_hangup_drain_bounded_on_dead_socket.py
@@ -1,0 +1,155 @@
+"""The hangup drain must never outlive the audio it is waiting on.
+
+Run 1e4980b0 (vobiz, 2026-08-13) logged "final hangup chunk has not been sent yet" every 500ms
+for 40 minutes: the media socket was already dead, so the mark ack that flips hangup_sent() could
+never arrive. Teardown never reached the final save and a full TaskManager stayed pinned until the
+pod died. The drain now carries its own deadline, and the completion watchdog no longer goes blind
+on a call where nothing was ever acked.
+"""
+
+import asyncio
+import time
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+
+GOODBYE = "Thank you for your time. Goodbye."
+
+
+class _OutputStub:
+    def __init__(self, *, acked=False, closed=False):
+        self._acked = acked
+        self._closed = closed
+        self.hangup_sent_forced = False
+
+    def hangup_sent(self):
+        return self._acked
+
+    def is_closed(self):
+        return self._closed
+
+    def set_hangup_sent(self):
+        self.hangup_sent_forced = True
+        self._acked = True
+
+    def close(self):
+        self._closed = True
+
+
+class _InputStub:
+    def __init__(self):
+        self.stopped = False
+
+    async def stop_handler(self):
+        self.stopped = True
+
+
+class _VoicemailStub:
+    def cancel_task(self):
+        pass
+
+
+def _make_tm(output, *, pending_duration=0.0, grace=0.4):
+    tm = TaskManager.__new__(TaskManager)
+    tm.tools = {"output": output, "input": _InputStub()}  # no transcriber: skips the 2s settle
+    tm.conversation_history = ConversationHistory()
+    tm.call_hangup_message_config = GOODBYE  # call_hangup_message is a language-aware property
+    tm.language = "en"
+    tm.hangup_triggered = True
+    tm.hangup_message_queued = True
+    tm.hangup_mark_event_timeout = grace
+    tm.conversation_ended = False
+    tm.ended_by_assistant = False
+    tm._end_of_conversation_in_progress = False
+    tm.llm_task = None
+    tm.turn_based_conversation = False
+    tm.voicemail_handler = _VoicemailStub()
+    tm.mark_event_meta_data = type(
+        "_Marks",
+        (),
+        {
+            "mark_event_meta_data": {
+                "aud1": {"type": "agent_hangup", "duration": pending_duration, "sent_ts": time.time()}
+            }
+        },
+    )()
+
+    async def _already_flushed():
+        return
+
+    tm.wait_for_current_message = _already_flushed  # covered by its own test module
+    return tm
+
+
+async def _teardown(tm):
+    # asyncio.wait_for is the assertion: an unbounded drain fails here instead of hanging the suite.
+    await asyncio.wait_for(tm._TaskManager__process_end_of_conversation(), timeout=5.0)
+
+
+async def test_dead_output_socket_aborts_the_drain_immediately():
+    tm = _make_tm(_OutputStub(closed=True), pending_duration=30.0, grace=10.0)
+
+    start = time.monotonic()
+    await _teardown(tm)
+
+    assert time.monotonic() - start < 0.5  # not the 40s the queued audio would imply
+    assert tm.conversation_ended is True
+    assert tm.tools["input"].stopped is True
+
+
+async def test_drain_is_bounded_when_the_ack_never_arrives():
+    # Live-looking socket that simply stops acking — the half-dead case is_closed() cannot see.
+    tm = _make_tm(_OutputStub(), pending_duration=0.1, grace=0.4)
+
+    start = time.monotonic()
+    await _teardown(tm)
+    elapsed = time.monotonic() - start
+
+    assert 0.4 < elapsed < 2.0  # waited out queued audio + grace, then gave up
+    assert tm.conversation_ended is True
+
+
+async def test_drain_returns_as_soon_as_the_ack_lands():
+    output = _OutputStub()
+    tm = _make_tm(output, pending_duration=5.0, grace=10.0)
+
+    async def _ack_soon():
+        await asyncio.sleep(0.05)
+        output._acked = True
+
+    acker = asyncio.create_task(_ack_soon())
+    start = time.monotonic()
+    await _teardown(tm)
+    await acker
+
+    assert time.monotonic() - start < 2.0  # broke on the ack, not on the 15s deadline
+    assert tm.history[-1]["content"] == GOODBYE
+    assert tm.history[-1]["message_category"] == "agent_hangup"
+
+
+async def test_watchdog_forces_teardown_when_no_mark_was_ever_acked():
+    # last_transmitted_timestamp stays 0 for a call whose socket died before the first ack.
+    # That idle guard used to swallow the hangup branch below it, so nothing ever forced the ack.
+    output = _OutputStub()
+    tm = TaskManager.__new__(TaskManager)
+    tm.tools = {"output": output}
+    tm.is_web_based_call = False
+    tm.last_transmitted_timestamp = 0
+    tm.hangup_triggered = True
+    tm.conversation_ended = False
+    tm.hangup_triggered_at = None  # goodbye synth never finished, so this was never stamped
+    tm.hangup_decision_at = time.time() - 100
+    tm.hangup_mark_event_timeout = 10
+
+    ended = asyncio.Event()
+
+    async def _fake_eoc():
+        tm.conversation_ended = True
+        ended.set()
+
+    tm._TaskManager__process_end_of_conversation = _fake_eoc
+
+    await asyncio.wait_for(tm._TaskManager__check_for_completion(), timeout=10.0)
+
+    assert output.hangup_sent_forced is True
+    assert ended.is_set()

--- a/tests/test_hangup_goodbye_drain_on_teardown.py
+++ b/tests/test_hangup_goodbye_drain_on_teardown.py
@@ -56,7 +56,7 @@ class _InputStub:
 
 class _MarkMetaStub:
     def __init__(self, marks=None):
-        self.mark_event_meta_data = dict(marks or {})
+        self.pending_marks = dict(marks or {})
         self.mark_changed = asyncio.Event()
 
     def get_heard_text_for_response(self, _uid):
@@ -66,7 +66,7 @@ class _MarkMetaStub:
         return ""
 
     def drain(self):
-        self.mark_event_meta_data.clear()
+        self.pending_marks.clear()
         self.mark_changed.set()
 
 
@@ -127,9 +127,9 @@ async def test_draining_before_teardown_keeps_full_goodbye():
 
     assert 0.04 < elapsed < 3.0  # waited for the drain, not zero and not the full grace
 
-    has_pending = len(tm.mark_event_meta_data.mark_event_meta_data) > 0
+    has_pending = len(tm.mark_event_meta_data.pending_marks) > 0
     if has_pending:
-        await tm.sync_history(tm.mark_event_meta_data.mark_event_meta_data.items(), time.time())
+        await tm.sync_history(tm.mark_event_meta_data.pending_marks.items(), time.time())
     assert _turn7(history)["content"] == FULL_GOODBYE.strip()
 
 
@@ -149,14 +149,14 @@ async def test_wait_is_bounded_when_marks_never_ack():
     elapsed = time.monotonic() - start
 
     assert elapsed < 2.0  # bounded by duration + grace, not endless
-    assert len(tm.mark_event_meta_data.mark_event_meta_data) > 0  # returned without the mark ever acking
+    assert len(tm.mark_event_meta_data.pending_marks) > 0  # returned without the mark ever acking
 
 
 def test_run_gates_terminal_sync_on_in_flight_hangup():
     src = inspect.getsource(TaskManager.run)
     gate_idx = src.find("if self.hangup_triggered and not self.conversation_ended:")
     sync_idx = src.find(
-        "await self.sync_history(\n                        self.mark_event_meta_data.mark_event_meta_data.items(),"
+        "await self.sync_history(\n                        self.mark_event_meta_data.pending_marks.items(),"
     )
     assert gate_idx != -1 and sync_idx != -1
     assert gate_idx < sync_idx

--- a/tests/test_mark_event_chunk_marks.py
+++ b/tests/test_mark_event_chunk_marks.py
@@ -60,7 +60,7 @@ class TestGetChunkMarks:
 
         assert popped["acked"] is True
         assert before <= popped["ack_ts"] <= after
-        assert "audio-1" not in m.mark_event_meta_data
+        assert "audio-1" not in m.pending_marks
 
         marks = m.get_chunk_marks()
         assert len(marks) == 1

--- a/tests/test_sip_trunk_hangup_drain.py
+++ b/tests/test_sip_trunk_hangup_drain.py
@@ -186,7 +186,7 @@ async def test_drain_timeout_scales_with_pending_mark_durations():
     handler = _make_handler(ws, listen_task)
 
     class _Meta:
-        mark_event_meta_data = {
+        pending_marks = {
             "m1": {"type": "agent_response", "duration": 0.5},
             "m2": {"type": "agent_response", "duration": 0.3},
         }

--- a/tests/test_sip_trunk_mark_events.py
+++ b/tests/test_sip_trunk_mark_events.py
@@ -50,7 +50,7 @@ class _FakeInputHandler:
     def process_mark_message(self, packet):
         mark_id = packet.get("name")
         self.acked.append(mark_id)
-        self.mark_event_meta_data.mark_event_meta_data.pop(mark_id, None)
+        self.mark_event_meta_data.pending_marks.pop(mark_id, None)
 
     def is_audio_being_played_to_user(self):
         return self.audio_playing
@@ -119,7 +119,7 @@ async def test_mark_media_is_sent_after_the_audio_it_marks():
     assert ws.frames[2][1].startswith("MARK_MEDIA ")
 
     mark_id = ws.frames[2][1].split(" ", 1)[1]
-    assert mark_id in out.mark_event_meta_data.mark_event_meta_data
+    assert mark_id in out.mark_event_meta_data.pending_marks
 
 
 async def test_mark_is_registered_before_the_first_frame_is_written():
@@ -134,7 +134,7 @@ async def test_mark_is_registered_before_the_first_frame_is_written():
 
         async def send_bytes(self, data):
             if self.marks_at_first_frame is None:
-                self.marks_at_first_frame = dict(meta.mark_event_meta_data)
+                self.marks_at_first_frame = dict(meta.pending_marks)
             await super().send_bytes(data)
 
     ws = _SnoopWS()

--- a/tests/test_sync_history_unacked_tail.py
+++ b/tests/test_sync_history_unacked_tail.py
@@ -79,7 +79,7 @@ def _assistant_content(history):
 async def test_end_of_call_credits_unacked_tail_played_after_last_ack():
     tm, history, marks = _make_tm()
     teardown_ts = marks.get_last_ack_ts_for_turn(8) + 20  # well past the 9.6s tail
-    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
+    await tm.sync_history(marks.pending_marks.items(), teardown_ts, extend_with_playback_estimate=True)
     assert _assistant_content(history) == FULL_TEXT
 
 
@@ -87,7 +87,7 @@ async def test_end_of_call_mid_chunk_hangup_credits_proportional_word_trimmed():
     # PR review replay: last ACK 6.97s before teardown vs 9.61s tail → ~72% heard, word-aligned.
     tm, history, marks = _make_tm()
     teardown_ts = marks.get_last_ack_ts_for_turn(8) + 6.97
-    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
+    await tm.sync_history(marks.pending_marks.items(), teardown_ts, extend_with_playback_estimate=True)
     content = _assistant_content(history)
     assert content.startswith(PREFIX + "rupees")  # tail partially credited
     assert len(content) < len(FULL_TEXT)
@@ -97,11 +97,11 @@ async def test_end_of_call_mid_chunk_hangup_credits_proportional_word_trimmed():
 async def test_end_of_call_zero_elapsed_keeps_strict_ack_trim():
     tm, history, marks = _make_tm()
     teardown_ts = marks.get_last_ack_ts_for_turn(8)  # hangup at the last confirmed instant
-    await tm.sync_history(marks.mark_event_meta_data.items(), teardown_ts, extend_with_playback_estimate=True)
+    await tm.sync_history(marks.pending_marks.items(), teardown_ts, extend_with_playback_estimate=True)
     assert _assistant_content(history) == PREFIX.strip()
 
 
 async def test_interruption_path_still_trims_to_acked_text():
     tm, history, marks = _make_tm()
-    await tm.sync_history(marks.mark_event_meta_data.items(), time.time())
+    await tm.sync_history(marks.pending_marks.items(), time.time())
     assert _assistant_content(history) == PREFIX.strip()


### PR DESCRIPTION
## Summary

`__process_end_of_conversation` waited for the goodbye's mark ack with no deadline. When a carrier media socket dies mid-call the ack never arrives, so the loop logged `final hangup chunk has not been sent yet` every 500ms until the pod terminated — the execution's final save never ran and a full TaskManager (transcriber, synthesizer, LLM connections) stayed pinned for the duration. Run `1e4980b0-4784-4e3d-b628-f16b9773e7a5` spun for 40 minutes this way.

The drain now carries a deadline of the audio still queued plus the mark grace, stamped once before the loop so it cannot recede with each iteration, and breaks early when the output handler already knows the socket is gone.

The completion watchdog meant to backstop this could not fire either. Its idle guard on `last_transmitted_timestamp` returned before reaching the hangup branch on a call where no mark was ever acked, and that branch keys off `hangup_triggered_at`, which is only stamped once the goodbye is queued — a hangup that stalls before that had no clock at all. It now falls back to the hangup decision timestamp.

Fixes BOLNA-2354.