### PR TITLE
fix: don't fire inactivity prompt while a response awaits its first audio chunk

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.204"
+__version__ = "0.10.205"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -497,6 +497,7 @@ class TaskManager(BaseManager):
         self.consider_next_transcript_after = time.time()
         self.llm_response_generated = False
         self.response_in_pipeline = False
+        self._synthesis_awaiting_first_audio = False
         self._response_turn_id = 0
         self._turn_msg_map = {}  # turn_id → assistant message dict ref in _messages
         self._pending_assistant_history = {}  # sequence_id -> {content, turn_id, response_uid}
@@ -2520,6 +2521,7 @@ class TaskManager(BaseManager):
         self.interruption_manager.invalidate_pending_responses()
         self._drop_all_staged_assistant_history("cleanup_downstream_tasks")
         self.response_in_pipeline = False
+        self._synthesis_awaiting_first_audio = False
         await self.tools["synthesizer"].flush_synthesizer_stream()
 
         # Stop the output loop first so that we do not transmit anything else
@@ -3947,6 +3949,7 @@ class TaskManager(BaseManager):
         if empty_turn_detail:
             logger.info(f"{empty_turn_detail}; clearing response_in_pipeline")
             self.response_in_pipeline = False
+            self._synthesis_awaiting_first_audio = False
 
         # Collect RAG latency if present (from KnowledgeBaseAgent)
         if meta_info.get("rag_latency"):
@@ -4390,10 +4393,12 @@ class TaskManager(BaseManager):
             self.llm_task = None
         except BolnaComponentError as e:
             self.response_in_pipeline = False
+            self._synthesis_awaiting_first_audio = False
             await self._end_call_on_component_error(e, HangupReason.LLM_ERROR)
             raise
         except Exception as e:
             self.response_in_pipeline = False
+            self._synthesis_awaiting_first_audio = False
             await self._end_call_on_component_error(
                 LLMError(
                     str(e), provider=self.llm_config.get("provider", "unknown"), model=self.llm_config.get("model")
@@ -6896,6 +6901,8 @@ class TaskManager(BaseManager):
                 and meta_info["is_first_message"]
                 or self.interruption_manager.is_valid_sequence(message["meta_info"]["sequence_id"])
             ):
+                if meta_info.get("sequence_id") not in (None, -1):
+                    self._synthesis_awaiting_first_audio = True
                 if meta_info["is_md5_hash"]:
                     logger.info(
                         "sending preprocessed audio response to {}".format(
@@ -7021,6 +7028,7 @@ class TaskManager(BaseManager):
                         self._commit_staged_assistant_history(sequence_id)
                         self.tools["input"].update_is_audio_being_played(True)
                         self.response_in_pipeline = False
+                        self._synthesis_awaiting_first_audio = False
                         await self.tools["output"].handle(message)
                         # Track when agent audio first starts flowing for this sequence.
                         # Only fire on real audio bytes — BOS/EOS control packets are strings
@@ -7068,6 +7076,7 @@ class TaskManager(BaseManager):
                             # the SEND path that normally resets this flag. Clear it here so
                             # subsequent user speech is not permanently treated as an interruption.
                             self.response_in_pipeline = False
+                            self._synthesis_awaiting_first_audio = False
                         should_continue_outer_loop = True
                         break  # Exit inner loop, skip to next message
 
@@ -7187,6 +7196,10 @@ class TaskManager(BaseManager):
             and time_since_user_last_spoke > stall_timeout
         )
 
+    def _pipeline_busy(self, audio_playing):
+        """True while the agent is speaking or about to: response_in_pipeline can read False in the gap between a response's synth push and its first audio chunk, so _synthesis_awaiting_first_audio covers it."""
+        return audio_playing or self.response_in_pipeline or self._synthesis_awaiting_first_audio
+
     def compute_last_ai_audio_timestamp(self):
         """Most recent moment agent audio was still reaching the user.
 
@@ -7276,7 +7289,7 @@ class TaskManager(BaseManager):
 
             # Draining audio needs no term here: every branch below is gated on
             # time_since_last_spoken_ai_word, which stays at 0 while the caller can still hear.
-            if self.tools["input"].is_audio_being_played_to_user() or self.response_in_pipeline:
+            if self._pipeline_busy(self.tools["input"].is_audio_being_played_to_user()):
                 continue
 
             if (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.204"
+version = "0.10.205"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_check_completion_awaiting_first_audio.py
+++ b/tests/test_check_completion_awaiting_first_audio.py
@@ -1,0 +1,42 @@
+"""Tests for the __check_for_completion idle gate (_pipeline_busy).
+
+Regression for the inactivity prompt ("are you still there?") being synthesized onto a
+response that had already been pushed to the synthesizer but whose first audio chunk had not
+yet reached the SEND path. In that gap response_in_pipeline can read False (e.g. right after a
+tool-call follow-up), so without _synthesis_awaiting_first_audio the checker saw the whole
+pipeline idle and merged the prompt into the open synth stream.
+"""
+
+from types import SimpleNamespace
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+# _pipeline_busy only reads three flags, so we exercise the pure predicate on a lightweight
+# stand-in via the unbound method (same pattern as test_check_completion_stall_backstop).
+def _busy(*, audio_playing, response_in_pipeline, synthesis_awaiting_first_audio):
+    fake = SimpleNamespace(
+        response_in_pipeline=response_in_pipeline,
+        _synthesis_awaiting_first_audio=synthesis_awaiting_first_audio,
+    )
+    return TaskManager._pipeline_busy(fake, audio_playing)
+
+
+def test_busy_when_synthesis_pushed_but_no_audio_yet():
+    # The bug window: response text pushed to the synthesizer, response_in_pipeline already
+    # flipped False, first audio chunk not yet in the SEND path. Must read busy so the checker
+    # does not emit the inactivity prompt onto the still-open stream.
+    assert _busy(audio_playing=False, response_in_pipeline=False, synthesis_awaiting_first_audio=True) is True
+
+
+def test_idle_when_nothing_in_flight():
+    # Genuine idle: no audio, no response, no synthesis pending -> checker may act.
+    assert _busy(audio_playing=False, response_in_pipeline=False, synthesis_awaiting_first_audio=False) is False
+
+
+def test_busy_during_audio_playback():
+    assert _busy(audio_playing=True, response_in_pipeline=False, synthesis_awaiting_first_audio=False) is True
+
+
+def test_busy_while_response_generating():
+    assert _busy(audio_playing=False, response_in_pipeline=True, synthesis_awaiting_first_audio=False) is True

--- a/tests/test_s2s_task_manager.py
+++ b/tests/test_s2s_task_manager.py
@@ -662,6 +662,7 @@ class TestUserOnlinePrompt:
         tm.asked_if_user_is_still_there = False
         tm.hangup_triggered = False
         tm.response_in_pipeline = False
+        tm._synthesis_awaiting_first_audio = False
         tm.llm_task = None
         tm.execute_function_call_task = None
         return tm


### PR DESCRIPTION
The inactivity prompt ("are you still there?") could be synthesized onto a response that had already been pushed to the synthesizer but whose first audio chunk had not yet reached the SEND path. In that gap `response_in_pipeline` reads False (e.g. right after a tool-call follow-up) and `has_pending_generation` is False, so `__check_for_completion` saw the whole pipeline idle and pushed a `sequence_id=-1` prompt into the still-open synthesizer stream. The two texts rendered as one continuous utterance, and the caller heard the answer with "are you still there?" tacked on the end.

Fix adds `_synthesis_awaiting_first_audio`, set when a real (non `-1`) response is pushed in `_synthesize` and cleared everywhere `response_in_pipeline` clears (first-audio SEND, fully-blocked turn, barge-in cleanup, empty turn, LLM error). It is OR'd into the checker's idle gate via a new pure predicate `_pipeline_busy`. Only the completion checker reads it, so barge-in and interruption behaviour are unchanged, and the stall backstop still runs above the gate so a genuinely wedged synth cannot produce an endless call.
