### PR TITLE
fix: barge-in leaves an orphaned function_call in the Responses-API chain — calls die mid-tool-call

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.206"
+__version__ = "0.10.207"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.204"
+__version__ = "0.10.205"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -289,7 +289,8 @@ class OpenAICompatibleLLM(BaseLLM):
         With previous_response_id set, only sends items after the last
         assistant. Falls back to full history when pending tool outputs are
         missing. Any pending interruption hint is consumed exactly once and
-        only prepended on the chain-alive happy path.
+        prepended on both the chained path and the chainless full-history path
+        (the latter is the normal post-barge-in path — cancel drops the chain).
         """
         hint = self._interruption_hint
         self._interruption_hint = None
@@ -305,7 +306,12 @@ class OpenAICompatibleLLM(BaseLLM):
             if hint is not None:
                 input_items = [self._build_interruption_hint_item(hint), *input_items]
             return instructions, input_items
-        return MessageFormatAdapter.chat_to_responses_input(messages)
+        # No chain — the post-barge-in path since cancel_in_flight_response drops it. The hint
+        # matters most exactly here, so it rides the full-history request too.
+        instructions, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
+        if hint is not None:
+            input_items = [self._build_interruption_hint_item(hint), *input_items]
+        return instructions, input_items
 
     @staticmethod
     def _build_interruption_hint_item(heard_text: str) -> dict:

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -289,24 +289,22 @@ class OpenAICompatibleLLM(BaseLLM):
         With previous_response_id set, only sends items after the last
         assistant. Falls back to full history when pending tool outputs are
         missing. Any pending interruption hint is consumed exactly once and
-        prepended on both the chained and chainless paths.
+        prepended on every path.
         """
         hint = self._interruption_hint
         self._interruption_hint = None
 
-        if self.previous_response_id:
-            if self._pending_call_ids:
-                completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
-                if not self._pending_call_ids.issubset(completed):
-                    logger.info("Pending tool call outputs missing, sending full context")
-                    self.previous_response_id = None
-                    return MessageFormatAdapter.chat_to_responses_input(messages)
+        chained = bool(self.previous_response_id)
+        if chained and self._pending_call_ids:
+            completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
+            if not self._pending_call_ids.issubset(completed):
+                logger.info("Pending tool call outputs missing, sending full context")
+                self.previous_response_id = None
+                chained = False
+        if chained:
             instructions, input_items = self._extract_new_input(messages)
-            if hint is not None:
-                input_items = [self._build_interruption_hint_item(hint), *input_items]
-            return instructions, input_items
-        # no chain = the post-barge-in path (cancel drops it) — the hint rides it too
-        instructions, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
+        else:
+            instructions, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
         if hint is not None:
             input_items = [self._build_interruption_hint_item(hint), *input_items]
         return instructions, input_items

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -289,8 +289,7 @@ class OpenAICompatibleLLM(BaseLLM):
         With previous_response_id set, only sends items after the last
         assistant. Falls back to full history when pending tool outputs are
         missing. Any pending interruption hint is consumed exactly once and
-        prepended on both the chained path and the chainless full-history path
-        (the latter is the normal post-barge-in path — cancel drops the chain).
+        prepended on both the chained and chainless paths.
         """
         hint = self._interruption_hint
         self._interruption_hint = None
@@ -306,8 +305,7 @@ class OpenAICompatibleLLM(BaseLLM):
             if hint is not None:
                 input_items = [self._build_interruption_hint_item(hint), *input_items]
             return instructions, input_items
-        # No chain — the post-barge-in path since cancel_in_flight_response drops it. The hint
-        # matters most exactly here, so it rides the full-history request too.
+        # no chain = the post-barge-in path (cancel drops it) — the hint rides it too
         instructions, input_items = MessageFormatAdapter.chat_to_responses_input(messages)
         if hint is not None:
             input_items = [self._build_interruption_hint_item(hint), *input_items]

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -554,12 +554,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         ):
                             yield chunk
                         return
-                    # Any other rejection of a CHAINED request gets one full-history retry: the
-                    # server-side lineage can be unsatisfiable in ways the client can't see (e.g.
-                    # a cancelled response that committed a function_call nobody will ever answer
-                    # -> "No tool output found for function call ..."). Full history carries every
-                    # function_call/output pair inline, so it is always self-consistent. Gated on
-                    # nothing-yielded so a retry can never duplicate speech.
+                    # a rejected CHAINED request gets one full-history retry (nothing yielded yet)
                     if (
                         self.previous_response_id
                         and error_info.get("type") == "invalid_request_error"
@@ -754,14 +749,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.started_streaming = False
 
     def cancel_in_flight_response(self):
-        """Cancel the in-flight WS response and drop the response chain. The cancel can lose the
-        race with generation: the server may commit output items — including a function_call this
-        client never consumed — before acting on it, and chaining onto such a response makes every
-        later request owe a tool output the client doesn't know exists (the server 400s with
-        "No tool output found for function call ...", which killed live calls mid-tool-call).
-        Cost: one full-history request after each barge-in; the chain re-establishes on that
-        response. Only the chain state is dropped — NOT invalidate_response_chain(), which would
-        also clear the interruption hint that sync_history set moments before this runs."""
+        """Cancel the in-flight WS response and drop the chain — a lost cancel race can leave a
+        server-committed function_call this client never saw, poisoning every later chained
+        request. Chain state only: the interruption hint was just set by sync_history."""
         if self._ws_transport and self.previous_response_id:
             asyncio.ensure_future(self._ws_transport.cancel_response(self.previous_response_id))
             self.previous_response_id = None

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -503,6 +503,14 @@ class OpenAiLLM(OpenAICompatibleLLM):
         else:
             return {"type": "text"}
 
+    async def _retry_full_history(self, messages, synthesize, request_json, meta_info, tool_choice, tools):
+        """Drop the chain and re-run the turn on full history (single home for both WS retries)."""
+        self.previous_response_id = None
+        async for chunk in self._generate_stream_ws_responses(
+            messages, synthesize, request_json, meta_info, tool_choice, tools
+        ):
+            yield chunk
+
     async def _generate_stream_ws_responses(
         self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
@@ -548,16 +556,19 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     error_code = error_info.get("code", "")
                     if error_code == "previous_response_not_found" and self.previous_response_id:
                         logger.warning(f"WS previous_response_id not found, retrying with full history")
-                        self.previous_response_id = None
-                        async for chunk in self._generate_stream_ws_responses(
+                        async for chunk in self._retry_full_history(
                             messages, synthesize, request_json, meta_info, tool_choice, tools
                         ):
                             yield chunk
                         return
-                    # a rejected CHAINED request gets one full-history retry (nothing yielded yet)
+                    # lineage/pairing rejection of a CHAINED request (code None, param input — e.g.
+                    # "No tool output found ...") gets one full-history retry; nothing yielded yet.
+                    # Coded errors like context_length_exceeded raise — a retry can't fix those.
                     if (
                         self.previous_response_id
                         and error_info.get("type") == "invalid_request_error"
+                        and not error_code
+                        and error_info.get("param") == "input"
                         and not answer
                         and not func_call_args
                         and not gave_pre_call_msg
@@ -565,8 +576,15 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         logger.warning(
                             f"WS chained request rejected ({error_info.get('message')}), retrying with full history"
                         )
-                        self.previous_response_id = None
-                        async for chunk in self._generate_stream_ws_responses(
+                        if isinstance(meta_info, dict):
+                            meta_info.setdefault("_non_fatal_errors", []).append(
+                                {
+                                    "error_type": "chained_request_rejected",
+                                    "error": error_info.get("message"),
+                                    "model": self.model,
+                                }
+                            )
+                        async for chunk in self._retry_full_history(
                             messages, synthesize, request_json, meta_info, tool_choice, tools
                         ):
                             yield chunk
@@ -751,7 +769,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
     def cancel_in_flight_response(self):
         """Cancel the in-flight WS response and drop the chain — a lost cancel race can leave a
         server-committed function_call this client never saw, poisoning every later chained
-        request. Chain state only: the interruption hint was just set by sync_history."""
+        request. Chain state only: the hint sync_history sets right after this must survive."""
         if self._ws_transport and self.previous_response_id:
             asyncio.ensure_future(self._ws_transport.cancel_response(self.previous_response_id))
             self.previous_response_id = None

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -550,7 +550,29 @@ class OpenAiLLM(OpenAICompatibleLLM):
                         logger.warning(f"WS previous_response_id not found, retrying with full history")
                         self.previous_response_id = None
                         async for chunk in self._generate_stream_ws_responses(
-                            messages, synthesize, request_json, meta_info, tool_choice
+                            messages, synthesize, request_json, meta_info, tool_choice, tools
+                        ):
+                            yield chunk
+                        return
+                    # Any other rejection of a CHAINED request gets one full-history retry: the
+                    # server-side lineage can be unsatisfiable in ways the client can't see (e.g.
+                    # a cancelled response that committed a function_call nobody will ever answer
+                    # -> "No tool output found for function call ..."). Full history carries every
+                    # function_call/output pair inline, so it is always self-consistent. Gated on
+                    # nothing-yielded so a retry can never duplicate speech.
+                    if (
+                        self.previous_response_id
+                        and error_info.get("type") == "invalid_request_error"
+                        and not answer
+                        and not func_call_args
+                        and not gave_pre_call_msg
+                    ):
+                        logger.warning(
+                            f"WS chained request rejected ({error_info.get('message')}), retrying with full history"
+                        )
+                        self.previous_response_id = None
+                        async for chunk in self._generate_stream_ws_responses(
+                            messages, synthesize, request_json, meta_info, tool_choice, tools
                         ):
                             yield chunk
                         return
@@ -732,9 +754,18 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.started_streaming = False
 
     def cancel_in_flight_response(self):
-        """Cancel the in-flight WS response; keeps previous_response_id alive."""
+        """Cancel the in-flight WS response and drop the response chain. The cancel can lose the
+        race with generation: the server may commit output items — including a function_call this
+        client never consumed — before acting on it, and chaining onto such a response makes every
+        later request owe a tool output the client doesn't know exists (the server 400s with
+        "No tool output found for function call ...", which killed live calls mid-tool-call).
+        Cost: one full-history request after each barge-in; the chain re-establishes on that
+        response. Only the chain state is dropped — NOT invalidate_response_chain(), which would
+        also clear the interruption hint that sync_history set moments before this runs."""
         if self._ws_transport and self.previous_response_id:
             asyncio.ensure_future(self._ws_transport.cancel_response(self.previous_response_id))
+            self.previous_response_id = None
+            self._pending_call_ids = set()
 
     async def close(self):
         # httpx client is shared via pool, don't close it here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.204"
+version = "0.10.205"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.206"
+version = "0.10.207"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1318,10 +1318,7 @@ class TestOpenAIWSConnection:
 
 
 class TestChainedRequestRejectionRetry:
-    """A cancelled response can leave a function_call committed server-side that this client
-    never saw; every later chained request then 400s with "No tool output found for function
-    call ..." and, before the retry existed, the APIError tore down the whole live call.
-    The WS path must recover by resending the FULL history unchained."""
+    """A rejected chained request must retry unchained with full history, not kill the call."""
 
     TOOL_HISTORY = [
         {"role": "system", "content": "sys"},
@@ -1375,20 +1372,17 @@ class TestChainedRequestRejectionRetry:
             chunks.append(chunk)
 
         assert len(seen_params) == 2
-        # first attempt was chained (delta after the last assistant = just the tool output)
         assert seen_params[0].get("previous_response_id") == "resp_fc"
-        # retry is unchained and self-consistent: full history with the call/output PAIR inline
+        # retry is unchained, full history with the call/output pair inline
         assert "previous_response_id" not in seen_params[1]
         types = [getattr(item.get("type"), "value", item.get("type")) for item in seen_params[1]["input"]]
         assert "function_call_output" in types
         assert "function_call" in types
         # the call survives and the answer streams from the retry
         assert any("785" in c.data for c in chunks if isinstance(c.data, str))
-        # the retry's response re-establishes a clean chain
-        assert llm.previous_response_id == "resp_retry"
+        assert llm.previous_response_id == "resp_retry"  # clean chain re-established
 
     async def test_unchained_invalid_request_still_raises(self):
-        # with no chain there is nothing to heal by retrying — the error must surface
         error_event = {
             "type": "error",
             "error": {"type": "invalid_request_error", "code": None, "message": "bad input", "param": "input"},
@@ -1401,8 +1395,7 @@ class TestChainedRequestRejectionRetry:
         assert len(seen_params) == 1
 
     async def test_prev_response_not_found_retry_keeps_tools(self):
-        # the pre-existing retry dropped `tools` on recursion — a retried turn silently lost
-        # its function-calling ability; pin the passthrough
+        # the pre-existing retry dropped `tools` on recursion
         error_event = {
             "type": "error",
             "error": {"type": "invalid_request_error", "code": "previous_response_not_found", "message": "gone"},

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1310,3 +1310,122 @@ class TestOpenAIWSConnection:
         assert "response.failed" in OpenAIWSConnection.TERMINAL_EVENTS
         assert "response.incomplete" in OpenAIWSConnection.TERMINAL_EVENTS
         assert "error" in OpenAIWSConnection.TERMINAL_EVENTS
+
+
+# ===================================================================
+# Chained-request rejection recovery (the mid-tool-call hangup bug)
+# ===================================================================
+
+
+class TestChainedRequestRejectionRetry:
+    """A cancelled response can leave a function_call committed server-side that this client
+    never saw; every later chained request then 400s with "No tool output found for function
+    call ..." and, before the retry existed, the APIError tore down the whole live call.
+    The WS path must recover by resending the FULL history unchained."""
+
+    TOOL_HISTORY = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "mera loan remove karo"},
+        {
+            "role": "assistant",
+            "content": "ek moment",
+            "tool_calls": [
+                {
+                    "id": "call_7aYe",
+                    "type": "function",
+                    "function": {"name": "get_ctx", "arguments": '{"uid":"x"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_7aYe", "content": '{"score": 785}'},
+    ]
+
+    def _llm_with_flaky_ws(self, error_event, previous_response_id="resp_fc"):
+        llm = _make_llm(use_responses_api=True, previous_response_id=previous_response_id)
+        seen_params = []
+
+        async def fake_stream(params):
+            seen_params.append(params)
+            if len(seen_params) == 1:
+                yield error_event
+                return
+            yield {"type": "response.created", "response": {"id": "resp_retry", "service_tier": None}}
+            yield {"type": "response.output_text.delta", "delta": "aapka score 785 hai", "item_id": "m1"}
+            yield {"type": "response.completed", "response": {"id": "resp_retry", "usage": None}}
+
+        mock_ws = MagicMock()
+        mock_ws.stream_response = fake_stream
+        llm._ws_transport = mock_ws
+        return llm, seen_params
+
+    async def test_no_tool_output_rejection_retries_full_history(self):
+        error_event = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": None,
+                "message": "No tool output found for function call call_7aYe.",
+                "param": "input",
+            },
+        }
+        llm, seen_params = self._llm_with_flaky_ws(error_event)
+
+        chunks = []
+        async for chunk in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info()):
+            chunks.append(chunk)
+
+        assert len(seen_params) == 2
+        # first attempt was chained (delta after the last assistant = just the tool output)
+        assert seen_params[0].get("previous_response_id") == "resp_fc"
+        # retry is unchained and self-consistent: full history with the call/output PAIR inline
+        assert "previous_response_id" not in seen_params[1]
+        types = [getattr(item.get("type"), "value", item.get("type")) for item in seen_params[1]["input"]]
+        assert "function_call_output" in types
+        assert "function_call" in types
+        # the call survives and the answer streams from the retry
+        assert any("785" in c.data for c in chunks if isinstance(c.data, str))
+        # the retry's response re-establishes a clean chain
+        assert llm.previous_response_id == "resp_retry"
+
+    async def test_unchained_invalid_request_still_raises(self):
+        # with no chain there is nothing to heal by retrying — the error must surface
+        error_event = {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "code": None, "message": "bad input", "param": "input"},
+        }
+        llm, seen_params = self._llm_with_flaky_ws(error_event, previous_response_id=None)
+
+        with pytest.raises(APIError):
+            async for _ in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info()):
+                pass
+        assert len(seen_params) == 1
+
+    async def test_prev_response_not_found_retry_keeps_tools(self):
+        # the pre-existing retry dropped `tools` on recursion — a retried turn silently lost
+        # its function-calling ability; pin the passthrough
+        error_event = {
+            "type": "error",
+            "error": {"type": "invalid_request_error", "code": "previous_response_not_found", "message": "gone"},
+        }
+        llm, seen_params = self._llm_with_flaky_ws(error_event)
+        llm.trigger_function_call = True  # _parse_tools drops tools otherwise
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_ctx",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}, "required": []},
+                },
+            }
+        ]
+
+        chunks = []
+        async for chunk in llm.generate_stream(
+            self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info(), tools=tools
+        ):
+            chunks.append(chunk)
+
+        assert len(seen_params) == 2
+        assert "tools" in seen_params[0]
+        assert "tools" in seen_params[1], "retry must carry the turn's tools"

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -1368,11 +1368,13 @@ class TestChainedRequestRejectionRetry:
         llm, seen_params = self._llm_with_flaky_ws(error_event)
 
         chunks = []
-        async for chunk in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info()):
+        meta_info = _make_meta_info()
+        async for chunk in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=meta_info):
             chunks.append(chunk)
 
         assert len(seen_params) == 2
         assert seen_params[0].get("previous_response_id") == "resp_fc"
+        assert meta_info["_non_fatal_errors"][0]["error_type"] == "chained_request_rejected"
         # retry is unchained, full history with the call/output pair inline
         assert "previous_response_id" not in seen_params[1]
         types = [getattr(item.get("type"), "value", item.get("type")) for item in seen_params[1]["input"]]
@@ -1388,6 +1390,24 @@ class TestChainedRequestRejectionRetry:
             "error": {"type": "invalid_request_error", "code": None, "message": "bad input", "param": "input"},
         }
         llm, seen_params = self._llm_with_flaky_ws(error_event, previous_response_id=None)
+
+        with pytest.raises(APIError):
+            async for _ in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info()):
+                pass
+        assert len(seen_params) == 1
+
+    async def test_coded_invalid_request_does_not_retry(self):
+        # context_length_exceeded etc. are invalid_request_error too; a retry can't fix them
+        error_event = {
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "code": "context_length_exceeded",
+                "message": "too long",
+                "param": "input",
+            },
+        }
+        llm, seen_params = self._llm_with_flaky_ws(error_event)
 
         with pytest.raises(APIError):
             async for _ in llm.generate_stream(self.TOOL_HISTORY, synthesize=False, meta_info=_make_meta_info()):

--- a/tests/test_responses_api_interruption_hint.py
+++ b/tests/test_responses_api_interruption_hint.py
@@ -69,13 +69,16 @@ class TestInterruptionHintInjection:
         assert items_second[0]["role"] == "user"
         assert llm._interruption_hint is None
 
-    def test_hint_not_injected_without_chain(self):
+    def test_hint_injected_without_chain(self):
+        # the chainless full-history request IS the normal post-barge-in request now that
+        # cancel_in_flight_response drops the chain — the hint must ride it
         llm = _make_llm(previous_response_id=None)
-        llm.set_interruption_hint("ignored")
+        llm.set_interruption_hint("hello th")
 
         _, items = llm._build_responses_input(SYSTEM_USER_ASSISTANT_USER)
 
-        assert all(item.get("role") != "developer" for item in items)
+        assert items[0]["role"] == "developer"
+        assert "hello th" in items[0]["content"]
         assert llm._interruption_hint is None
 
     def test_hint_consumed_on_pending_tool_fallback(self):
@@ -160,10 +163,15 @@ class TestCancelInFlightResponse:
         llm.cancel_in_flight_response()
         llm._ws_transport.cancel_response.assert_not_called()
 
-    def test_cancel_in_flight_does_not_invalidate_chain(self):
+    def test_cancel_in_flight_drops_chain_but_keeps_hint(self):
+        # A cancel can lose the race with generation: the server may commit a function_call
+        # this client never saw, and chaining onto that response 400s every later request
+        # ("No tool output found for function call ..."). So cancel drops the chain — but NOT
+        # the interruption hint, which sync_history sets immediately before cancelling.
         import asyncio
 
-        llm = _make_llm(previous_response_id="resp_1")
+        llm = _make_llm(previous_response_id="resp_1", _pending_call_ids={"call_ghost"})
+        llm.set_interruption_hint("hello th")
         llm._ws_transport = MagicMock()
         llm._ws_transport.cancel_response = AsyncMock()
 
@@ -177,6 +185,10 @@ class TestCancelInFlightResponse:
             loop.close()
             asyncio.set_event_loop(None)
 
-        assert llm.previous_response_id == "resp_1"
+        # the cancel frame still targeted the old id
+        llm._ws_transport.cancel_response.assert_awaited_once_with("resp_1")
+        assert llm.previous_response_id is None
+        assert llm._pending_call_ids == set()
+        assert llm._interruption_hint == "hello th"
         assert llm._pending_call_ids == set()
         llm._ws_transport.cancel_response.assert_called_once_with("resp_1")

--- a/tests/test_responses_api_interruption_hint.py
+++ b/tests/test_responses_api_interruption_hint.py
@@ -80,7 +80,7 @@ class TestInterruptionHintInjection:
         assert "hello th" in items[0]["content"]
         assert llm._interruption_hint is None
 
-    def test_hint_consumed_on_pending_tool_fallback(self):
+    def test_hint_injected_on_pending_tool_fallback(self):
         messages = [
             {"role": "system", "content": "sys"},
             {"role": "user", "content": "check order"},
@@ -100,7 +100,7 @@ class TestInterruptionHintInjection:
 
         assert llm.previous_response_id is None
         assert llm._interruption_hint is None
-        assert all(item.get("role") != "developer" for item in items)
+        assert items[0]["role"] == "developer"  # hint rides every path, this fallback included
 
     def test_hint_injected_when_tool_outputs_present(self):
         messages = [

--- a/tests/test_responses_api_interruption_hint.py
+++ b/tests/test_responses_api_interruption_hint.py
@@ -70,8 +70,7 @@ class TestInterruptionHintInjection:
         assert llm._interruption_hint is None
 
     def test_hint_injected_without_chain(self):
-        # the chainless full-history request IS the normal post-barge-in request now that
-        # cancel_in_flight_response drops the chain — the hint must ride it
+        # chainless full history is the normal post-barge-in request — the hint must ride it
         llm = _make_llm(previous_response_id=None)
         llm.set_interruption_hint("hello th")
 
@@ -164,10 +163,7 @@ class TestCancelInFlightResponse:
         llm._ws_transport.cancel_response.assert_not_called()
 
     def test_cancel_in_flight_drops_chain_but_keeps_hint(self):
-        # A cancel can lose the race with generation: the server may commit a function_call
-        # this client never saw, and chaining onto that response 400s every later request
-        # ("No tool output found for function call ..."). So cancel drops the chain — but NOT
-        # the interruption hint, which sync_history sets immediately before cancelling.
+        # a lost cancel race can leave a server-committed fc — drop the chain, keep the hint
         import asyncio
 
         llm = _make_llm(previous_response_id="resp_1", _pending_call_ids={"call_ghost"})
@@ -185,7 +181,6 @@ class TestCancelInFlightResponse:
             loop.close()
             asyncio.set_event_loop(None)
 
-        # the cancel frame still targeted the old id
         llm._ws_transport.cancel_response.assert_awaited_once_with("resp_1")
         assert llm.previous_response_id is None
         assert llm._pending_call_ids == set()


### PR DESCRIPTION
## What

A web call died right after its tool call SUCCEEDED: the agent spoke the filler, the
API returned the data, and instead of answering, the agent hung up (~25s,
`hangup_by=Agent`). Example prod run: `daceca18-6647-4065-b50f-a958c42c6b90`
(GoodScore, 21 Aug 18:11 IST).

## Root cause — reproduced live against wss://api.openai.com/v1/responses

The agent's prompt makes the LLM call its context tool on the caller's FIRST turn, so
the turn-1 generation was mid-function-call when the caller barged in. We cancelled the
generation, but `cancel_in_flight_response` deliberately kept `previous_response_id` —
and the cancel can lose the race with generation: the server commits a `function_call`
item that this client never consumed, so no tool ever runs for it and no output is ever
recorded.

Every later request chained onto a lineage carrying that orphaned, unanswerable
function call. When turn-2's real tool finished and we sent its output back, OpenAI's
validator counted one output against TWO unanswered calls and rejected the request in
21ms:

    invalid_request_error: "No tool output found for function call call_7aYe…" (param: input)

The `APIError` escaped `task_manager.run` → full pipeline teardown → fork closed → FS
hung up the call. A recoverable validation error killed a live call whose tool had
already succeeded.

Ruled out along the way: the follow-up request itself was well-formed (the execution's
request-log CSV shows the `function_call_output` present), and the deployed 0.10.200
wheel is byte-identical to master on this path (not a version drift). Live replays
reproduce the byte-identical error whenever an unanswered function_call sits anywhere
in the chained lineage, and confirm the canonical chain works when the lineage is clean.

## Fix

`bolna/llms/openai_llm.py` + `bolna/llms/openai_base.py` (+178 / −10 incl. tests):

1. **A cancel drops the response chain.** After `response.cancel`, the server-side
   state is unknowable — the fc may or may not be committed. `cancel_in_flight_response`
   now clears `previous_response_id` + `_pending_call_ids` after sending the cancel
   frame (which still targets the old id). Cost: one full-history request per barge-in;
   the chain re-establishes on that response. Deliberately NOT
   `invalidate_response_chain()` — that would also wipe the interruption hint, which
   `sync_history` sets immediately before cancelling.

2. **The interruption hint rides the chainless path.** `_build_responses_input` only
   prepended the "*the user only heard: …*" hint on the chain-alive path — but after
   (1), the chainless full-history request IS the normal post-barge-in request. The
   hint is now prepended there too, so what the LLM learns about the interruption is
   unchanged.

3. **Chained rejections retry with full history instead of killing the call.**
   `_generate_stream_ws_responses` already recovers from `previous_response_not_found`
   by dropping the chain and retrying; that same recovery now covers any
   `invalid_request_error` on a CHAINED request. Full history carries every
   `function_call`/`function_call_output` pair inline, so it is self-consistent by
   construction. Gated on nothing-yielded (no text, no fc args, no pre-call message),
   so a retry can never duplicate speech; an UNCHAINED invalid request still raises —
   no retry loop.

Also fixed in passing: the pre-existing `previous_response_not_found` retry dropped
`tools` on recursion, silently disabling function calling for the retried turn.

## Why this is safe

- Nothing the caller hears changes: the chain is a token-saving delta mechanism, and
  full-history requests already run in prod today (WS 60-min reconnects, `not_found`
  retries, HTTP SSE fallback, the pending-tool-output guard). `store=True` prompt
  caching absorbs most of the latency of the one extra full upload per barge-in.
- Calls without interruptions are completely unaffected.
- Two tests that pinned the old behavior are inverted deliberately, with comments
  explaining why (`cancel_in_flight_does_not_invalidate_chain` →
  `cancel_in_flight_drops_chain_but_keeps_hint`; `hint_not_injected_without_chain` →
  `hint_injected_without_chain`).

## Tests

- New `TestChainedRequestRejectionRetry` (3): a replay of this incident's event
  sequence asserting the retry goes out unchained with the fc/output pair inline, the
  answer streams, and a clean chain re-establishes; unchained errors still raise after
  exactly one attempt; the retry carries the turn's `tools`.
- Updated hint/cancel pins (2): cancel sends the frame for the old id, drops the chain,
  keeps the hint; the hint is injected on the chainless path.
- Full suite: **1150 passed, 1 skipped** — no regressions. `ruff check` +
  `ruff format --check` clean.
