### PR TITLE
Lid explicit requests

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.207"
+__version__ = "0.10.208"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.204"
+__version__ = "0.10.205"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6009,7 +6009,7 @@ class TaskManager(BaseManager):
             self.lid_playback_gate = None
             logger.info("LanguageSwitcher: in-flight function call — switching in parallel, not truncating the action")
             if target != self.language:
-                context_note = self.__switch_context_note(target, detector_transcript, reasoning)
+                context_note = self.__language_directive(target)
                 await self.switch_language(target, triggered_by="lid_llm", context_note=context_note)
                 emit_lid_decision("switched", switched_to=target, context_note=context_note, inflight_activity=activity)
             else:
@@ -6048,7 +6048,7 @@ class TaskManager(BaseManager):
             emit_lid_decision("gated:concurrent_switch", inflight_activity=activity)
             return
 
-        context_note = self.__switch_context_note(target, detector_transcript, reasoning)
+        context_note = self.__language_directive(target)
         logger.info(
             f"LanguageSwitcher: switching '{current}' → '{target}' (confidence={target_conf}, langs={languages}, reason={reasoning})"
         )
@@ -6322,13 +6322,7 @@ class TaskManager(BaseManager):
         return clip
 
     def __language_directive(self, label: str) -> str:
-        """Generic standing order pinned to the system prompt: reply ONLY in the active language.
-
-        Used whenever a richer switch-time note isn't available — tool-driven switches
-        (which pass no context_note) and the call's starting language. Starts with the
-        same "## Language note:" header as __switch_context_note so replacement logic
-        can find and strip whichever variant is currently installed.
-        """
+        """The one standing language order, installed at setup and on every switch."""
         name = LANGUAGE_NAMES.get(label, label)
         return (
             f"## Language note:\nThe user is now speaking {name} ('{label}'). From this point onward, "
@@ -6361,30 +6355,6 @@ class TaskManager(BaseManager):
         new_prompt = f"{base}\n\n{context_note or self.__language_directive(label)}"
         self.conversation_history.update_system_prompt(new_prompt)
         self.system_prompt["content"] = new_prompt
-
-    def __switch_context_note(self, target: str, detector_transcript: str, reasoning: str = None) -> str:
-        """Build the language note installed in the system prompt on a switch.
-
-        Must be a DIRECTIVE, not a description: with history dominated by the old
-        language (and customer prompts often written in one language), the main LLM
-        follows conversation momentum and keeps replying in the OLD language unless
-        explicitly ordered (QA 16db0968: pipeline switched hi→en but every reply
-        stayed Hindi). Shared by the real switch path and the speculative follow-up
-        so the committed speculation obeys the same directive. The reasoning line is
-        omitted on the speculative path — the decision hasn't returned yet there.
-        """
-        target_name = LANGUAGE_NAMES.get(target, target)
-        note = (
-            f"## Language note:\nThe caller is now speaking {target_name} ('{target}'). "
-            f"From this point, respond ONLY in {target_name} — every reply must be in {target_name}, "
-            f"regardless of the language of earlier conversation turns or the language these "
-            f"instructions are written in. In your NEXT reply only, first briefly restate your "
-            f"previous line in {target_name} so the caller can follow, then continue from there. "
-            f'Their latest message: "{detector_transcript}".'
-        )
-        if reasoning:
-            note += f" Reason: {reasoning}"
-        return note
 
     def __log_committed_speculation(self, spec_text: str, capture):
         """Log a committed speculative follow-up exactly like a normal turn:
@@ -6491,7 +6461,7 @@ class TaskManager(BaseManager):
         """
         messages = self.conversation_history.get_copy()
         target_prompt = self.multilingual_prompts.get(target_label)
-        note = self.__switch_context_note(target_label, detector_transcript)
+        note = self.__language_directive(target_label)
         target_prompt = f"{target_prompt}\n\n{note}" if target_prompt else note
         if messages and messages[0].get("role") == "system":
             messages[0]["content"] = target_prompt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.204"
+version = "0.10.205"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.207"
+version = "0.10.208"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def language_switch_tm(monkeypatch):
         )
         tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
         tm.switch_language = AsyncMock()
-        tm._TaskManager__switch_context_note = MagicMock(return_value="note")
+        tm._TaskManager__language_directive = MagicMock(return_value="note")
         tm._TaskManager__play_switch_handoff = AsyncMock()
         tm._TaskManager__prepare_followup_generation = MagicMock(return_value=None)
         tm.conversation_history = MagicMock()

--- a/tests/test_simple_agent_language_directive.py
+++ b/tests/test_simple_agent_language_directive.py
@@ -1,17 +1,14 @@
 """Simple-agent language directive text.
 
-The standing pin (`__language_directive`) is installed at call start AND on tool-driven
-switches, so it must carry the verbatim carve-out (parity with the graph directive) and must
-NOT contain one-shot switch instructions — at call start there is no previous line to restate.
-The restate instruction lives in `__switch_context_note`, which only exists after a real switch.
-"""
+`__language_directive` is the ONLY language note: installed at call start and reinstalled on
+every switch, so it must carry the verbatim carve-out and no one-shot switch instructions —
+it outlives the moment it was written for."""
 
 from unittest.mock import MagicMock
 
 from bolna.agent_manager.task_manager import TaskManager
 
 DIRECTIVE = TaskManager._TaskManager__language_directive
-CONTEXT_NOTE = TaskManager._TaskManager__switch_context_note
 
 
 def test_standing_directive_has_the_verbatim_carve_out():
@@ -26,7 +23,15 @@ def test_standing_directive_has_no_repeat_instruction():
     assert "last line" not in text
 
 
-def test_switch_note_carries_the_one_shot_restate():
-    note = CONTEXT_NOTE(MagicMock(), "en", "can you speak english")
-    assert "restate your previous line" in note
-    assert "NEXT reply only" in note
+def test_directive_carries_no_switch_moment_text():
+    # A switch installs this same text, so anything about "this reply" or the caller's
+    # latest message would keep applying for the rest of the call.
+    text = DIRECTIVE(MagicMock(), "en")
+    assert "NEXT reply" not in text
+    assert "latest message" not in text
+    assert "Reason:" not in text
+
+
+def test_switch_and_setup_install_identical_text():
+    assert DIRECTIVE(MagicMock(), "te") == DIRECTIVE(MagicMock(), "te")
+    assert "Telugu" in DIRECTIVE(MagicMock(), "te")

--- a/tests/test_speculation_commit_logging.py
+++ b/tests/test_speculation_commit_logging.py
@@ -22,7 +22,7 @@ def _make_tm(history, generate):
     tm = MagicMock()
     tm.conversation_history = history
     tm.multilingual_prompts = {"en": "You are a helpful agent.", "te": "Telugu prompt"}
-    tm._TaskManager__switch_context_note = TaskManager._TaskManager__switch_context_note.__get__(tm, TaskManager)
+    tm._TaskManager__language_directive = TaskManager._TaskManager__language_directive.__get__(tm, TaskManager)
     tm.tools = {"llm_agent": MagicMock()}
     tm.tools["llm_agent"].generate = generate
     return tm

--- a/tests/test_speculative_followup_history.py
+++ b/tests/test_speculative_followup_history.py
@@ -28,7 +28,7 @@ def _make_tm(history, generate):
     tm.conversation_history = history
     tm.multilingual_prompts = {"en": "You are a helpful agent.", "hi": "Hindi prompt"}
     # Bind the real note builder so the speculative system prompt mirrors production.
-    tm._TaskManager__switch_context_note = TaskManager._TaskManager__switch_context_note.__get__(tm, TaskManager)
+    tm._TaskManager__language_directive = TaskManager._TaskManager__language_directive.__get__(tm, TaskManager)
     tm.tools = {"llm_agent": MagicMock()}
     tm.tools["llm_agent"].generate = generate
     return tm

--- a/tests/test_substance_gate_foreign_max.py
+++ b/tests/test_substance_gate_foreign_max.py
@@ -46,7 +46,7 @@ def _tm(monkeypatch, segments, buffer_max):
     tm._inflight_response_activity = MagicMock(return_value={"audio_playing": False})
     tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
     tm.switch_language = AsyncMock()
-    tm._TaskManager__switch_context_note = MagicMock(return_value="note")
+    tm._TaskManager__language_directive = MagicMock(return_value="note")
     tm._TaskManager__play_switch_handoff = AsyncMock()
     tm._TaskManager__prepare_followup_generation = MagicMock(return_value=None)
     tm.conversation_history = MagicMock()


### PR DESCRIPTION
One language note instead of two
Problem

Multilingual agents were running two different language instructions at different points in the same call. At setup we install __language_directive (the long standing order). On the first LID switch, that gets replaced by __switch_context_note — a shorter, switch-specific note. Two prod calls show what that costs.

772a996b — agent switched te→en, and the entire reply was:

You said, "Yeah, tell me."

Then it switched back en→te and said "You said you want to speak in Telugu, OK I'll continue in Telugu" — and repeated that same meta line on the next turn. Two turns burned, no content.

bb8e8fb3 — same echo, and it persisted for the rest of the call. Pulling the actual request payload for turn 4 shows why. Forty seconds and three turns after the switch, the system prompt still read:

"…In your NEXT reply only, first briefly restate your previous line in English… Their latest message: "Tell me". Reason: Caller speaking English substantively. LIVE confirms. Switch from Telugu."

Root cause

The switch note is one-shot text living in a permanent slot:

"In your NEXT reply only" — nothing ever removes the note, so every turn is "the next reply". The echo is a standing instruction, not the model drifting.
Their latest message: "Tell me" — turn 1's text, still presented as the caller's latest on turn 4, when they had just described a driver accident in Hindi.
Reason: … — the judge's internal reasoning, left in the prompt, which is what gets the agent talking about languages instead of just switching.

And because it replaces the standing directive, a switch also silently drops that directive's rules: use the target-language version of every question/FAQ/objection/closing line, translate when a variant is missing, and never translate proper nouns, brand names, alphanumeric identifiers, digits or codes — lost at exactly the moment language handling matters most.

Change

Delete __switch_context_note. Every path now installs __language_directive:

both LID switch sites (including the in-flight-function-call path)
the legacy switch_language tool path (already fell through to it)
the speculative follow-up's prompt copy, so a committed speculation and a real switch are identical

Nothing is lost by dropping the caller's message from the note — it was a duplicate of what the switch already writes into conversation history as the user turn, which the follow-up generation reads. The agent still answers what the caller said; it just stops narrating it.

Tests

test_simple_agent_language_directive.py rewritten: the third test now asserts the installed text carries no switch-moment wording (NEXT reply, latest message, Reason:), so re-introducing this fails CI. Four other test doubles repointed at the surviving builder.