### PR TITLE
feat: explicit-only language-switch mode — per-agent toggle where the judge switches only on an explicit caller request

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.213"
+__version__ = "0.10.214"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -618,7 +618,6 @@ class TaskManager(BaseManager):
         # Dedicated LLM that decides language switches from the unbiased detector
         # transcript. Set up in __setup_transcriber only for gated multilingual agents.
         self.language_switcher = None
-        self.lid_explicit_only = False
         # Serializes switch decisions so overlapping turns can't interleave two
         # switch+follow-up sequences. Background-only: the caller-facing pipeline
         # (ASR -> main LLM -> TTS) never waits on this lock.
@@ -1622,16 +1621,15 @@ class TaskManager(BaseManager):
                         lid_config["sarvam_model"] = lid_model
                     switch_enabled = self.__language_switch_enabled()
                     if switch_enabled:
-                        # Per-agent toggle: judge switches only on an explicit request/selection.
-                        self.lid_explicit_only = bool(
-                            self.task_config.get("tools_config", {}).get("language_switch_explicit_only")
-                        )
                         # language_switch_llm (from the azure flag) overrides the model; absent → default.
                         self.language_switcher = LanguageSwitcher(
                             available_labels=list(transcribers.keys()),
                             run_id=self.run_id,
                             model=self.task_config.get("tools_config", {}).get("language_switch_llm"),
-                            explicit_only=self.lid_explicit_only,
+                            # Per-agent toggle: judge switches only on an explicit request/selection.
+                            explicit_only=bool(
+                                self.task_config.get("tools_config", {}).get("language_switch_explicit_only")
+                            ),
                         )
                         self.language_switcher.prewarm()  # pay the TLS handshake now
 
@@ -5568,13 +5566,15 @@ class TaskManager(BaseManager):
         if events is None or any(e.get("type") == "lid_usage" for e in events):
             return
         switcher = self.language_switcher
-        detector_seconds = pool.lid_audio_seconds() if hasattr(pool, "lid_audio_seconds") else None
+        detector_seconds = pool.lid_audio_seconds()
         if switcher is None and not detector_seconds:
             return
         record = {"type": "lid_usage", "ts": time.time(), "detector_audio_seconds": detector_seconds}
         if switcher is not None:
             record.update(
                 {
+                    # Every model that answered this call — the runtime fallback can swap mid-call.
+                    "judge_models": switcher.models_used or [switcher.model],
                     "judge_model": switcher.model,
                     "judge_requests": switcher.usage_totals.get("requests", 0),
                     "judge_input_tokens": switcher.usage_totals.get("input_tokens", 0),
@@ -5867,6 +5867,7 @@ class TaskManager(BaseManager):
         spec_agent_type = self.task_config["tools_config"]["llm_agent"].get("agent_type", "simple_llm_agent")
         if (
             spec_agent_type == "simple_llm_agent"
+            and not self.language_switcher.explicit_only
             and detected_lang
             and detected_lang != active
             and detected_lang in labels
@@ -5930,7 +5931,7 @@ class TaskManager(BaseManager):
                     detector_transcript,
                     active_transcript,
                     active,
-                    recent_turns=self.__recent_detected_turns(pool),
+                    recent_turns=None if self.language_switcher.explicit_only else self.__recent_detected_turns(pool),
                     last_agent_turn=self.conversation_history.last_assistant_content(),
                 ),
                 timeout=decide_timeout_s,
@@ -6008,14 +6009,20 @@ class TaskManager(BaseManager):
                     None,
                 )
             )
-        # Explicit-only mode: the judge's own authorization IS the gate — its prompt only
-        # ever targets an explicit request, so the ambient detection gates below would veto
-        # legitimate requests (a one-word "Telugu." answer fails every one of them).
-        if self.lid_explicit_only:
+        # Explicit-only mode: a switch is authorized iff the judge returned a consistent
+        # explicit verdict (request_status="switch" AND explicit_request) — the ambient
+        # detection gates below grade evidence the explicit contract does not produce.
+        if self.language_switcher.explicit_only:
+            if decision.get("request_status") != "switch" or not decision.get("explicit_request"):
+                logger.info(
+                    f"LanguageSwitcher: explicit-only mode — target '{target}' without an explicit verdict "
+                    f"(status={decision.get('request_status')}, explicit={decision.get('explicit_request')}) — no switch"
+                )
+                emit_lid_decision("gated:not_explicit")
+                return
             logger.info(
                 f"LanguageSwitcher: explicit-only mode — switch to '{target}' authorized "
-                f"(status={decision.get('request_status')}, source={decision.get('request_source')}, "
-                f"conf={target_conf}); detection gates bypassed"
+                f"(status=switch, source={decision.get('request_source')}, conf={target_conf})"
             )
         else:
             # Corroboration: when the detector independently agrees on the target, accept a lower LLM

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -210,6 +210,9 @@ def build_lid_decision_record(
         "target_language": dec.get("target_language"),
         "target_confidence": dec.get("target_confidence"),
         "explicit_request": dec.get("explicit_request"),
+        # Explicit-only judge fields; None on the ambient prompt.
+        "request_status": dec.get("request_status"),
+        "request_source": dec.get("request_source"),
         "reasoning": (dec.get("reasoning") or "").strip(),
         "buffered_max_segment_s": round(buffered_max_segment_s, 3),
         "speculation_started": speculation_started,
@@ -615,6 +618,7 @@ class TaskManager(BaseManager):
         # Dedicated LLM that decides language switches from the unbiased detector
         # transcript. Set up in __setup_transcriber only for gated multilingual agents.
         self.language_switcher = None
+        self.lid_explicit_only = False
         # Serializes switch decisions so overlapping turns can't interleave two
         # switch+follow-up sequences. Background-only: the caller-facing pipeline
         # (ASR -> main LLM -> TTS) never waits on this lock.
@@ -1618,11 +1622,16 @@ class TaskManager(BaseManager):
                         lid_config["sarvam_model"] = lid_model
                     switch_enabled = self.__language_switch_enabled()
                     if switch_enabled:
+                        # Per-agent toggle: judge switches only on an explicit request/selection.
+                        self.lid_explicit_only = bool(
+                            self.task_config.get("tools_config", {}).get("language_switch_explicit_only")
+                        )
                         # language_switch_llm (from the azure flag) overrides the model; absent → default.
                         self.language_switcher = LanguageSwitcher(
                             available_labels=list(transcribers.keys()),
                             run_id=self.run_id,
                             model=self.task_config.get("tools_config", {}).get("language_switch_llm"),
+                            explicit_only=self.lid_explicit_only,
                         )
                         self.language_switcher.prewarm()  # pay the TLS handshake now
 
@@ -5895,7 +5904,11 @@ class TaskManager(BaseManager):
         try:
             decision = await asyncio.wait_for(
                 self.language_switcher.decide(
-                    detector_transcript, active_transcript, active, recent_turns=self.__recent_detected_turns(pool)
+                    detector_transcript,
+                    active_transcript,
+                    active,
+                    recent_turns=self.__recent_detected_turns(pool),
+                    last_agent_turn=self.conversation_history.last_assistant_content(),
                 ),
                 timeout=decide_timeout_s,
             )
@@ -5972,53 +5985,63 @@ class TaskManager(BaseManager):
                     None,
                 )
             )
-        # Corroboration: when the detector independently agrees on the target, accept a lower LLM
-        # self-report. Both signals are noisy alone (the LLM's float is self-assessed; the detector
-        # tag can be wrong) but they fail independently, so agreement is real evidence.
-        # Only ever LOWERS the bar, never raises it.
-        #
-        # Read the evidence from a SUBSTANTIVE segment tagged as the target, not from the buffer's
-        # last-segment aggregates: those describe different segments of the turn (buffer_language /
-        # its prob come from the FINAL fragment, buffer_max_segment_seconds is a max over ALL of
-        # them), so a one-token "okay" could lend its 1.0 token-share purity to a whole Hindi turn.
-        corroborated = self.__detector_corroborates(detector_segments, target)
-        effective_min_conf = min_conf
-        if corroborated:
-            effective_min_conf = float(os.getenv("LANGUAGE_SWITCH_CORROBORATED_MIN_CONFIDENCE", "0.55"))
-        if target_conf is None or target_conf < effective_min_conf:
+        # Explicit-only mode: the judge's own authorization IS the gate — its prompt only
+        # ever targets an explicit request, so the ambient detection gates below would veto
+        # legitimate requests (a one-word "Telugu." answer fails every one of them).
+        if self.lid_explicit_only:
             logger.info(
-                f"LanguageSwitcher: target '{target}' confidence {target_conf} below {effective_min_conf} "
-                f"(corroborated={corroborated}, detector_prob={detector_lang_confidence}) (or missing) — "
-                f"no switch (reason={reasoning})"
+                f"LanguageSwitcher: explicit-only mode — switch to '{target}' authorized "
+                f"(status={decision.get('request_status')}, source={decision.get('request_source')}, "
+                f"conf={target_conf}); detection gates bypassed"
             )
-            emit_lid_decision("gated:low_confidence")
-            return
+        else:
+            # Corroboration: when the detector independently agrees on the target, accept a lower LLM
+            # self-report. Both signals are noisy alone (the LLM's float is self-assessed; the detector
+            # tag can be wrong) but they fail independently, so agreement is real evidence.
+            # Only ever LOWERS the bar, never raises it.
+            #
+            # Read the evidence from a SUBSTANTIVE segment tagged as the target, not from the buffer's
+            # last-segment aggregates: those describe different segments of the turn (buffer_language /
+            # its prob come from the FINAL fragment, buffer_max_segment_seconds is a max over ALL of
+            # them), so a one-token "okay" could lend its 1.0 token-share purity to a whole Hindi turn.
+            corroborated = self.__detector_corroborates(detector_segments, target)
+            effective_min_conf = min_conf
+            if corroborated:
+                effective_min_conf = float(os.getenv("LANGUAGE_SWITCH_CORROBORATED_MIN_CONFIDENCE", "0.55"))
+            if target_conf is None or target_conf < effective_min_conf:
+                logger.info(
+                    f"LanguageSwitcher: target '{target}' confidence {target_conf} below {effective_min_conf} "
+                    f"(corroborated={corroborated}, detector_prob={detector_lang_confidence}) (or missing) — "
+                    f"no switch (reason={reasoning})"
+                )
+                emit_lid_decision("gated:low_confidence")
+                return
 
-        # Substance gate: acknowledgment-length audio mis-tags languages. Short turns need at
-        # least one substantive segment — an explicit by-name request is legitimately short and
-        # bypasses instead. Its bar defaults to min_conf, never above it: a stricter explicit
-        # bar would reject the caller-asked case while admitting the incidental one.
-        explicit_min_conf = float(os.getenv("LANGUAGE_SWITCH_EXPLICIT_MIN_CONFIDENCE", str(min_conf)))
-        explicit_bypass = bool(decision.get("explicit_request")) and (target_conf or 0.0) >= explicit_min_conf
-        if not explicit_bypass and foreign_max_segment_s < min_segment_s:
-            logger.info(
-                f"LanguageSwitcher: target '{target}' but longest foreign segment "
-                f"{foreign_max_segment_s:.2f}s < {min_segment_s}s (buffer max {buffered_max_segment_s:.2f}s) "
-                f"and no confident explicit request "
-                f"(explicit={decision.get('explicit_request')}, conf={target_conf}) — "
-                f"no switch (short audio is unreliable LID evidence; reason={reasoning})"
-            )
-            emit_lid_decision("gated:short_audio")
-            return
+            # Substance gate: acknowledgment-length audio mis-tags languages. Short turns need at
+            # least one substantive segment — an explicit by-name request is legitimately short and
+            # bypasses instead. Its bar defaults to min_conf, never above it: a stricter explicit
+            # bar would reject the caller-asked case while admitting the incidental one.
+            explicit_min_conf = float(os.getenv("LANGUAGE_SWITCH_EXPLICIT_MIN_CONFIDENCE", str(min_conf)))
+            explicit_bypass = bool(decision.get("explicit_request")) and (target_conf or 0.0) >= explicit_min_conf
+            if not explicit_bypass and foreign_max_segment_s < min_segment_s:
+                logger.info(
+                    f"LanguageSwitcher: target '{target}' but longest foreign segment "
+                    f"{foreign_max_segment_s:.2f}s < {min_segment_s}s (buffer max {buffered_max_segment_s:.2f}s) "
+                    f"and no confident explicit request "
+                    f"(explicit={decision.get('explicit_request')}, conf={target_conf}) — "
+                    f"no switch (short audio is unreliable LID evidence; reason={reasoning})"
+                )
+                emit_lid_decision("gated:short_audio")
+                return
 
-        # Rule-3a backstop: the judge still reads "This B1" as English.
-        if not explicit_bypass and is_alphanumeric_readout(detector_transcript):
-            logger.info(
-                f"LanguageSwitcher: target '{target}' vetoed — rule-3a alphanumeric readout "
-                f"({detector_transcript[:60]!r}); no switch (reason={reasoning})"
-            )
-            emit_lid_decision("gated:alphanumeric_readout")
-            return
+            # Rule-3a backstop: the judge still reads "This B1" as English.
+            if not explicit_bypass and is_alphanumeric_readout(detector_transcript):
+                logger.info(
+                    f"LanguageSwitcher: target '{target}' vetoed — rule-3a alphanumeric readout "
+                    f"({detector_transcript[:60]!r}); no switch (reason={reasoning})"
+                )
+                emit_lid_decision("gated:alphanumeric_readout")
+                return
 
         # Truncate the in-flight old-language reply (barge-in cleanup) before switching.
         activity = self._inflight_response_activity()  # captured pre-truncation for telemetry

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5559,7 +5559,30 @@ class TaskManager(BaseManager):
                 record()
             except Exception as e:
                 logger.warning(f"detector_health record failed: {e}")
+        self.__record_lid_usage(pool)
         return list(getattr(pool, "lid_detection_events", []))
+
+    def __record_lid_usage(self, pool) -> None:
+        """One per-call spend record in lid_detection_events: judge tokens + detector audio seconds."""
+        events = getattr(pool, "lid_detection_events", None)
+        if events is None or any(e.get("type") == "lid_usage" for e in events):
+            return
+        switcher = self.language_switcher
+        detector_seconds = pool.lid_audio_seconds() if hasattr(pool, "lid_audio_seconds") else None
+        if switcher is None and not detector_seconds:
+            return
+        record = {"type": "lid_usage", "ts": time.time(), "detector_audio_seconds": detector_seconds}
+        if switcher is not None:
+            record.update(
+                {
+                    "judge_model": switcher.model,
+                    "judge_requests": switcher.usage_totals.get("requests", 0),
+                    "judge_input_tokens": switcher.usage_totals.get("input_tokens", 0),
+                    "judge_output_tokens": switcher.usage_totals.get("output_tokens", 0),
+                    "judge_cached_tokens": switcher.usage_totals.get("cached_tokens", 0),
+                }
+            )
+        events.append(record)
 
     def __record_lid_event(self, record: dict) -> None:
         """Append a metrics record to the pool's lid_detection_events (persisted to

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -246,6 +246,13 @@ class ConversationHistory:
     def last_content(self) -> str | None:
         return self._messages[-1].get("content") if self._messages else None
 
+    def last_assistant_content(self) -> str | None:
+        """The agent's most recent spoken line (skips tool rows and tool-call-only stubs)."""
+        for message in reversed(self._messages):
+            if message.get("role") == ChatRole.ASSISTANT and message.get("content"):
+                return message["content"]
+        return None
+
     def get_copy(self) -> list[dict]:
         self._sanitize_tool_messages(self._messages)
         return copy.deepcopy([m for m in self._messages if not m.get("exclude_from_llm")])

--- a/bolna/helpers/language_switcher.py
+++ b/bolna/helpers/language_switcher.py
@@ -5,7 +5,12 @@ import time
 import uuid
 
 from bolna.llms import LiteLLM
-from bolna.prompts import LANGUAGE_SWITCH_SYSTEM_PROMPT, LANGUAGE_SWITCH_TURN_PROMPT
+from bolna.prompts import (
+    EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT,
+    EXPLICIT_LANGUAGE_SWITCH_TURN_PROMPT,
+    LANGUAGE_SWITCH_SYSTEM_PROMPT,
+    LANGUAGE_SWITCH_TURN_PROMPT,
+)
 from bolna.enums import LogComponent, LogDirection
 from bolna.helpers.utils import convert_to_request_log
 from bolna.helpers.logger_config import configure_logger
@@ -61,9 +66,11 @@ class LanguageSwitcher:
     and returns a target language (or None to stay).
     """
 
-    def __init__(self, available_labels, run_id=None, model=None):
+    def __init__(self, available_labels, run_id=None, model=None, explicit_only=False):
         self.available_labels = list(available_labels or [])
         self.run_id = run_id
+        # Explicit-only judge: switches only on an explicit request/selection/confirmation.
+        self.explicit_only = bool(explicit_only)
         self.model = model or os.getenv("LANGUAGE_SWITCH_LLM", DEFAULT_LANGUAGE_SWITCH_LLM)
         # Explicit anthropic/ prefix: bare claude names fail on litellm versions whose
         if self.model.startswith("claude") and "/" not in self.model:
@@ -112,7 +119,8 @@ class LanguageSwitcher:
         # Static rules as a cacheable prefix (Anthropic cache_control; Azure caches automatically).
         # Bedrock-hosted Claude also caches (litellm translates cache_control → cachePoint);
         # scoped to claude ids so a non-Anthropic bedrock model never gets an unsupported block.
-        block = {"type": "text", "text": LANGUAGE_SWITCH_SYSTEM_PROMPT}
+        system_text = EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT if self.explicit_only else LANGUAGE_SWITCH_SYSTEM_PROMPT
+        block = {"type": "text", "text": system_text}
         cacheable = self.model.startswith(("anthropic/", "claude")) or (
             self.model.startswith("bedrock/") and "claude" in self.model
         )
@@ -143,6 +151,7 @@ class LanguageSwitcher:
         active_transcript: str,
         active_label: str,
         recent_turns: list | None = None,
+        last_agent_turn: str | None = None,
     ) -> dict | None:
         """Decide the language from both transcripts.
 
@@ -167,21 +176,27 @@ class LanguageSwitcher:
         # a detector transliteration becomes "confirmed" by an absence we manufactured
         # (QA 7c7d4b00: English "Hi, hi—what's up?" → Soniox Telugu-script → false switch).
         # Telemetry keeps the raw empty string — only the prompt gets the marker.
-        live = (active_transcript or "").strip() or LIVE_UNAVAILABLE_MARKER
+        live = (active_transcript or "").strip()
+        if self.explicit_only:
+            # The explicit prompt handles an empty LIVE itself and reads last_agent_turn
+            # instead of the drift history (recent_turns).
+            turn_content = EXPLICIT_LANGUAGE_SWITCH_TURN_PROMPT.format(
+                active_language=active_label,
+                available_languages=", ".join(self.available_labels),
+                last_agent_turn=(last_agent_turn or "").strip() or "(none)",
+                detector_transcript=detector_transcript.strip(),
+                active_transcript=live,
+            )
+        else:
+            turn_content = LANGUAGE_SWITCH_TURN_PROMPT.format(
+                active_language=active_label,
+                available_languages=", ".join(self.available_labels),
+                recent_turns=self._format_recent_turns(recent_turns),
+                detector_transcript=detector_transcript.strip(),
+                active_transcript=live or LIVE_UNAVAILABLE_MARKER,
+            )
 
-        messages = [
-            self._system_message(),
-            {
-                "role": "user",
-                "content": LANGUAGE_SWITCH_TURN_PROMPT.format(
-                    active_language=active_label,
-                    available_languages=", ".join(self.available_labels),
-                    recent_turns=self._format_recent_turns(recent_turns),
-                    detector_transcript=detector_transcript.strip(),
-                    active_transcript=live,
-                ),
-            },
-        ]
+        messages = [self._system_message(), {"role": "user", "content": turn_content}]
         start_time = time.time()
         try:
             result = await self._hedged_generate(messages)

--- a/bolna/helpers/language_switcher.py
+++ b/bolna/helpers/language_switcher.py
@@ -77,6 +77,9 @@ class LanguageSwitcher:
             self.model = f"anthropic/{self.model}"
         self.latency_ms = None
         self.hedge_won = False  # last decide was answered by the hedged request, not the first
+        # Judge spend for the whole call (decides + prewarm); persisted via the lid_usage record.
+        self.usage_totals = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0, "requests": 0}
+        self.last_usage = None
         # Dedicated creds, NOT the agent's — an Azure/OpenAI agent would 404 the switch model.
         switch_llm_key, switch_llm_base, switch_llm_version = resolve_switch_llm_credentials(self.model)
         # A configured (e.g. azure) judge with no resolvable key would fail EVERY decide,
@@ -128,6 +131,14 @@ class LanguageSwitcher:
             block["cache_control"] = {"type": "ephemeral"}
         return {"role": "system", "content": [block]}
 
+    def _tally_usage(self, usage):
+        if not usage:
+            return
+        for key in ("input_tokens", "output_tokens", "cached_tokens"):
+            self.usage_totals[key] += int(usage.get(key) or 0)
+        self.usage_totals["requests"] += 1
+        self.last_usage = usage
+
     def prewarm(self):
         """Fire-and-forget request that pays the TLS handshake AND seeds the prompt cache
         with the real system block, so the first decide of the call is a cache read.
@@ -135,10 +146,14 @@ class LanguageSwitcher:
 
         async def _warm():
             try:
-                await asyncio.wait_for(
-                    self._llm.generate([self._system_message(), {"role": "user", "content": "Reply with exactly: ok"}]),
+                _, usage = await asyncio.wait_for(
+                    self._llm.generate(
+                        [self._system_message(), {"role": "user", "content": "Reply with exactly: ok"}],
+                        ret_metadata=True,
+                    ),
                     timeout=5,
                 )
+                self._tally_usage(usage)
                 logger.info("LanguageSwitcher: connection prewarmed")
             except Exception as e:
                 logger.debug(f"LanguageSwitcher: prewarm skipped: {e}")
@@ -169,6 +184,7 @@ class LanguageSwitcher:
         """
         if not detector_transcript or not detector_transcript.strip():
             return None
+        self.last_usage = None
 
         # On idle-flush firings there IS no main-ASR turn — LIVE is empty because nobody
         # produced one, not because the locked recognizer failed to decode foreign speech.
@@ -255,7 +271,9 @@ class LanguageSwitcher:
         self.last_generate_errored = False
 
         async def attempt():
-            return self._parse_json(await self._llm.generate(messages))
+            text, usage = await self._llm.generate(messages, ret_metadata=True)
+            self._tally_usage(usage)
+            return self._parse_json(text)
 
         # Tasks created inside the try: cancellation of decide() itself must not strand a
         # running attempt unowned (finally covers every await window).
@@ -336,6 +354,7 @@ class LanguageSwitcher:
             model=self.model,
             run_id=self.run_id,
         )
+        usage = self.last_usage or {}
         convert_to_request_log(
             message=result,
             meta_info=meta_info,
@@ -343,4 +362,7 @@ class LanguageSwitcher:
             direction=LogDirection.RESPONSE,
             model=self.model,
             run_id=self.run_id,
+            input_tokens=usage.get("input_tokens"),
+            output_tokens=usage.get("output_tokens"),
+            cached_tokens=usage.get("cached_tokens"),
         )

--- a/bolna/helpers/language_switcher.py
+++ b/bolna/helpers/language_switcher.py
@@ -80,6 +80,7 @@ class LanguageSwitcher:
         # Judge spend for the whole call (decides + prewarm); persisted via the lid_usage record.
         self.usage_totals = {"input_tokens": 0, "output_tokens": 0, "cached_tokens": 0, "requests": 0}
         self.last_usage = None
+        self.models_used: list = []
         # Dedicated creds, NOT the agent's — an Azure/OpenAI agent would 404 the switch model.
         switch_llm_key, switch_llm_base, switch_llm_version = resolve_switch_llm_credentials(self.model)
         # A configured (e.g. azure) judge with no resolvable key would fail EVERY decide,
@@ -132,11 +133,15 @@ class LanguageSwitcher:
         return {"role": "system", "content": [block]}
 
     def _tally_usage(self, usage):
+        """Count every completed response; a hedge loser cancelled mid-request never reaches
+        here, so tokens the provider billed for it are not client-visible and go uncounted."""
+        self.usage_totals["requests"] += 1
+        if self.model not in self.models_used:
+            self.models_used.append(self.model)
         if not usage:
             return
         for key in ("input_tokens", "output_tokens", "cached_tokens"):
             self.usage_totals[key] += int(usage.get(key) or 0)
-        self.usage_totals["requests"] += 1
         self.last_usage = usage
 
     def prewarm(self):

--- a/bolna/lid/base.py
+++ b/bolna/lid/base.py
@@ -83,6 +83,10 @@ class LIDBackend:
             self.chunks_dropped += 1
             logger.debug(f"{self.__class__.__name__}: audio queue full — chunk dropped (backpressure)")
 
+    def set_input_audio_format(self, encoding: str, sample_rate: int) -> None:
+        """Derive bytes/sec from the raw INPUT format: mulaw is 1 byte/sample, linear16 is 2."""
+        self.input_bytes_per_second = int(sample_rate) if "law" in (encoding or "") else 2 * int(sample_rate)
+
     def audio_seconds_fed(self) -> float:
         """Seconds of caller audio streamed to this detector (its usage, billed per second)."""
         if not self.input_bytes_per_second:

--- a/bolna/lid/base.py
+++ b/bolna/lid/base.py
@@ -47,6 +47,9 @@ class LIDBackend:
         # Health counters — a silent detector writes no decides, so these are the only
         # evidence distinguishing "nothing to switch" from "the tap was dead".
         self.chunks_fed = 0
+        self.bytes_fed = 0
+        # Raw INPUT byte rate (pre-resample); providers set it so bytes_fed converts to seconds.
+        self.input_bytes_per_second = 0
         self.chunks_dropped = 0
         self.segments_received = 0
         self.unknown_frames = 0
@@ -75,9 +78,16 @@ class LIDBackend:
         try:
             self._queue.put_nowait(audio_bytes)
             self.chunks_fed += 1
+            self.bytes_fed += len(audio_bytes)
         except asyncio.QueueFull:
             self.chunks_dropped += 1
             logger.debug(f"{self.__class__.__name__}: audio queue full — chunk dropped (backpressure)")
+
+    def audio_seconds_fed(self) -> float:
+        """Seconds of caller audio streamed to this detector (its usage, billed per second)."""
+        if not self.input_bytes_per_second:
+            return 0.0
+        return round(self.bytes_fed / self.input_bytes_per_second, 2)
 
     async def stop(self):
         raise NotImplementedError

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -52,6 +52,7 @@ class SarvamLID(LIDBackend):
             self._encoding = "linear16"
             self._input_sr = self._sr
         self._resample_state = None
+        self.input_bytes_per_second = 8000 if self._encoding == "mulaw" else 2 * self._input_sr
 
     def _on_reconnect_reset(self):
         self._resample_state = None

--- a/bolna/lid/sarvam.py
+++ b/bolna/lid/sarvam.py
@@ -52,7 +52,7 @@ class SarvamLID(LIDBackend):
             self._encoding = "linear16"
             self._input_sr = self._sr
         self._resample_state = None
-        self.input_bytes_per_second = 8000 if self._encoding == "mulaw" else 2 * self._input_sr
+        self.set_input_audio_format(self._encoding, self._input_sr)
 
     def _on_reconnect_reset(self):
         self._resample_state = None

--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -41,6 +41,7 @@ class SonioxLID(LIDBackend):
         else:
             self._audio_format = "pcm_s16le"
             self._input_sr = int(config.get("sampling_rate", 16000))
+        self.input_bytes_per_second = 8000 if self._audio_format == "mulaw" else 2 * self._input_sr
         self._pending = self._empty_pending()
 
     @staticmethod

--- a/bolna/lid/soniox.py
+++ b/bolna/lid/soniox.py
@@ -41,7 +41,7 @@ class SonioxLID(LIDBackend):
         else:
             self._audio_format = "pcm_s16le"
             self._input_sr = int(config.get("sampling_rate", 16000))
-        self.input_bytes_per_second = 8000 if self._audio_format == "mulaw" else 2 * self._input_sr
+        self.set_input_audio_format(self._audio_format, self._input_sr)
         self._pending = self._empty_pending()
 
     @staticmethod

--- a/bolna/llms/litellm.py
+++ b/bolna/llms/litellm.py
@@ -190,6 +190,7 @@ class LiteLLM(BaseLLM):
 
     async def generate(self, messages, stream=False, request_json=False, meta_info=None, ret_metadata=False):
         text = ""
+        completion = None
         model_args = self.model_args.copy()
         model_args["model"] = self.model
         model_args["messages"] = strip_internal_keys(messages)
@@ -238,6 +239,17 @@ class LiteLLM(BaseLLM):
             logger.error(f"LiteLLM unexpected error generating response: {error_message}")
             raise
         if ret_metadata:
-            return text, {}
+            metadata = {}
+            usage = getattr(completion, "usage", None)
+            if usage is not None:
+                metadata = {
+                    "input_tokens": getattr(usage, "prompt_tokens", 0) or 0,
+                    "output_tokens": getattr(usage, "completion_tokens", 0) or 0,
+                }
+                details = getattr(usage, "prompt_tokens_details", None)
+                cached = getattr(details, "cached_tokens", 0) if details is not None else 0
+                if cached:
+                    metadata["cached_tokens"] = cached
+            return text, metadata
         else:
             return text

--- a/bolna/prompts.py
+++ b/bolna/prompts.py
@@ -188,3 +188,450 @@ FILLER_PROMPT = "Please, do not start your response with fillers like Got it, No
 DATE_PROMPT = """### Today Current Date and Time:\n {} at {} local time in the {} timezone. Use this information to ensure all time-related responses are accurate and contextually relevant based on the user's location."""
 
 FUNCTION_CALL_PROMPT = "We made a function calling for user. We hit the function : {} and send a {} request and it returned us the response as given below: {} \n\n . Understand the above response and convey this response in a context to user. ### Important\n1. If there was an issue with the API call, kindly respond with - Hey, I'm not able to use the system right now, can you please try later? \n2. IF YOU CALLED THE FUNCTION BEFORE, PLEASE DO NOT CALL THE SAME FUNCTION AGAIN!"
+
+
+# Explicit-only judge (per-agent toggle language_switch_explicit_only): switches ONLY on an
+# explicit request/selection/confirmation — speaking another language alone never switches.
+EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT = """
+You are the language-switching controller for a multilingual voice agent.
+
+The agent operates in one active language and may switch only among the supplied supported languages.
+
+Your responsibilities are:
+
+1. Detect the language the caller is actually speaking.
+2. Determine whether the caller has explicitly requested, selected, or confirmed a language for the agent.
+3. Authorize a language switch only when the explicit-request rules below are satisfied.
+
+A switch requires an explicit request, selection, or confirmation as defined in the rules below. Detecting that the caller is speaking another language - even a supported one - NEVER authorizes a switch on its own. When there is no explicit request, stay in the active language regardless of what the caller is speaking.
+
+DETECTION AND SWITCHING ARE SEPARATE
+
+Language detection answers: "What language is the caller speaking?"
+
+Language switching answers: "Has the caller explicitly requested, selected, or confirmed a specific language for the agent to use?"
+
+Detecting another language does not authorize a switch. Report the spoken language in detected_language, but keep target_language null unless an explicit-request rule is satisfied.
+
+NORMALIZATION
+
+Every language value you output (requested_language and target_language) is a normalized ISO 639-1 code (for example en, hi, ta, te, kn, ml, mr, bn, pa). supported_languages may be provided as labels or ISO codes; a requested language counts as supported when its ISO code matches one of the supported languages.
+
+INPUTS
+
+Each turn provides:
+
+1. active_language
+   The language the agent is currently using.
+
+2. supported_languages
+   The languages the agent can use, provided as labels or ISO codes. Every code you output must correspond to one of these.
+
+3. unbiased_user_transcript
+   The PRIMARY transcript of the caller's latest turn. It captures whatever language was actually spoken, in its own script. This transcript carries MORE weight than the live one.
+
+4. live_user_transcript
+   A transcript of the same caller turn locked to the active language. It may be garbled or empty when the caller speaks another language. Use it only as SUPPORTING evidence. When the two user transcripts disagree, trust the unbiased one.
+
+5. last_agent_turn
+   The agent's complete turn immediately preceding the caller's latest turn. Analyze this FIRST. Decide whether the agent asked a language-related question - which language to use, an offer of one or more languages, or a yes/no confirmation of a language. If it did, interpret the caller's latest reply as a possible answer to it, reading both user transcripts and weighting the unbiased one more heavily. If it did not, the agent turn plays no role in the switching decision. Only this single preceding agent turn is available; there are no earlier turns to consider.
+
+CORE SWITCHING POLICY
+
+Set target_language to the ISO code of a supported language only when the caller:
+
+1. Directly asks the agent to use one specific language (Rule 1); or
+2. Asks whether the agent can speak, understand, or support one specific language (Rule 2); or
+3. Answers the agent's language-choice question in last_agent_turn by clearly selecting or confirming one specific language (Rule 4). A standalone language name (for example "Tamil") counts as a clear selection ONLY in this case - when it answers a language question the agent has just asked.
+
+If none of these applies, return target_language = null.
+
+Never switch based only on:
+* The language the caller is speaking, or the detected language;
+* Script or transliteration;
+* Accent or pronunciation;
+* A garbled or empty live transcript;
+* Caller fluency, location, or demographics;
+* Code-mixing;
+* Confusion or frustration;
+* An assumption that another language would be more convenient.
+
+When switch intent or the target language is uncertain, stay in the active language.
+
+RULE 1 - DIRECT LANGUAGE REQUESTS
+
+A direct request to use one specific language authorizes a switch to that language.
+
+Examples:
+* "Speak in Hindi."
+* "Please switch to English."
+* "Talk to me in Tamil."
+* "Reply in Telugu."
+* "Can we continue in Kannada?"
+* "Use Malayalam from now on."
+* "I would prefer Marathi."
+* "English mein bolo."
+* "हिंदी में बात कीजिए."
+* "Telugu lo matladandi."
+* "Please go back to Hindi."
+
+The request may be phrased in any language, script, or grammatical form. Polite, indirect, and question-form requests still count:
+* "Could you speak in Hindi?"
+* "Would you mind switching to English?"
+* "Can we do this in Tamil?"
+
+A bare language name carrying request or selection wording is a direct request: "Tamil please", "English instead", "No, Hindi".
+
+Set: explicit_request = true; requested_language = the requested language ISO code; request_source = "direct_request".
+Then apply Rules 13 and 14: if the named language is already active or unsupported, use that status instead of switch.
+
+RULE 2 - SPECIFIC CAPABILITY QUESTIONS
+
+If the caller asks whether the agent can speak, understand, communicate in, or support exactly one specific language, treat it as a request to use that language. Do not wait for a second instruction.
+
+Examples:
+* "Can you speak Hindi?"
+* "Do you understand Tamil?"
+* "Do you support Telugu?"
+* "Are you able to speak Kannada?"
+* "Hindi बोल सकते हो?"
+* "Tamil தெரியுமா?"
+
+Set: explicit_request = true; requested_language = the named language ISO code; request_source = "specific_capability_question".
+Then apply Rules 13 and 14: if the named language is already active or unsupported, use that status instead of switch.
+
+GENERIC CAPABILITY QUESTIONS DO NOT TRIGGER A SWITCH
+
+When no specific target language is named, do not switch.
+Examples: "Which languages can you speak?", "What languages do you support?", "Are you multilingual?"
+Set: explicit_request = false; requested_language = null; target_language = null; request_status = "no_request"; request_source = "none".
+
+MULTIPLE LANGUAGES NAMED WITHOUT ONE PREFERENCE DO NOT SELECT A TARGET
+
+If more than one language is named and the caller does not pick one, do not select any.
+Examples: "Can you speak Hindi or English?", "Do you understand Tamil and Telugu?"
+Return request_status = "ambiguous" unless the caller clearly picks one: "Can you speak Hindi or English? Use English." -> select English.
+
+RULE 3 - INSPECT THE LAST AGENT TURN
+
+Inspect last_agent_turn before interpreting the caller's latest response. Decide whether that turn asked the caller anything about selecting, confirming, preferring, or continuing in a language. The wording may be open-ended, yes/no, or multiple-choice, in any language or script. Judge the semantic intent of the complete turn, not exact keywords.
+
+A qualifying language question includes any turn that:
+* Asks which language the caller prefers;
+* Asks which language the agent should use;
+* Asks the caller to select a language;
+* Offers one or more languages;
+* Asks whether the caller wants to continue in a particular language;
+* Asks whether the caller is comfortable in a language;
+* Asks whether the agent should switch languages;
+* Confirms a previously identified language preference.
+
+Illustrative examples:
+* "Which language would you prefer?"
+* "Would you like to continue in Hindi?"
+* "Should I switch to English?"
+* "Would you prefer Tamil or Telugu?"
+* "I can speak Hindi, English, Tamil, Telugu, or Kannada. Which would you like?"
+
+Any semantically equivalent question qualifies.
+
+Apply the contextual rules (Rule 4 and Rule 5) only when last_agent_turn contains a language question AND the caller's latest response reasonably answers it. If last_agent_turn contains a language question plus an unrelated question, apply contextual selection only when the caller's response clearly answers the language question.
+
+RULE 4 - CONTEXTUAL LANGUAGE SELECTION
+
+When last_agent_turn asked a language-choice question, interpret the caller's answer together with that turn. Read the answer from both user transcripts; when they disagree, trust the unbiased one.
+
+A contextual answer may be:
+* A language name, including a single standalone name - one word is enough, do not require a full sentence ("Hindi.");
+* A polite selection ("Tamil, please");
+* An ordinal choice ("the second one", "the last one");
+* A comparative choice ("English would be better");
+* A rejection followed by another language ("No, English");
+* A correction ("Tamil... no, Telugu");
+* A request to continue in the current language.
+
+Examples:
+Agent: "Which language would you prefer?" Caller: "Hindi." -> select Hindi.
+Agent: "Would you prefer Tamil or Telugu?" Caller: "Telugu." -> select Telugu.
+Agent: "English, Hindi, or Kannada?" Caller: "The second one." -> select Hindi.
+Agent: "Which language should I use?" Caller: "English would be better." -> select English.
+Agent: "Would you like Hindi?" Caller: "No, English." -> select English.
+
+For a resolved contextual selection: explicit_request = true; requested_language = the resolved ISO code; request_source = "agent_prompted_selection". The caller need not repeat the language name.
+
+A standalone language name is a clear selection ONLY here - as an answer to the agent's language question. A bare language name with no request wording and no preceding language question is not a selection; treat it as a mention (Rule 11) and stay.
+
+RULE 5 - YES/NO CONFIRMATION
+
+When last_agent_turn asks whether the agent should use exactly ONE specific language, a clear affirmative selects that language; the language of the "yes" word does not matter - the target is the single language the agent offered.
+
+Examples:
+Agent: "Would you like to continue in Hindi?" Caller: "Yes." -> select Hindi.
+Agent: "Should I switch to English?" Caller: "हाँ." -> select English.
+Agent: "Kannada mein continue karein?" Caller: "Okay." -> select Kannada.
+
+A clear negative rejects the offered language but does not select another. Agent: "Would you like to continue in Hindi?" Caller: "No." -> do not select Hindi and do not infer another. Set explicit_request = false; requested_language = null; target_language = null; request_status = "no_request"; request_source = "none".
+If the caller rejects and names another: Agent: "Would you like Hindi?" Caller: "No, Tamil." -> select Tamil.
+
+If the agent offered MULTIPLE languages and the caller only says "yes" or "okay", no unique language is selected -> request_status = "ambiguous"; stay.
+Agent: "Would you prefer Hindi or English?" Caller: "Yes." -> ambiguous; stay.
+
+RULE 6 - AMBIGUOUS CONTEXTUAL ANSWERS
+
+Do not switch when the caller's answer cannot be mapped confidently to one unique language.
+Examples:
+Agent: "Hindi or English?" Caller: "Either is fine." -> no unique target.
+Agent: "Choose Hindi, Tamil, or Telugu." Caller: "Any Indian language." -> no unique target.
+Agent: "Tamil or Telugu?" Caller: "Whichever you want." -> no unique target.
+Agent: "Which language do you prefer?" Caller: "The usual one." -> ambiguous unless exactly one referent is unambiguous.
+
+Set: explicit_request = false; requested_language = null; target_language = null; request_status = "ambiguous"; request_source = "none".
+
+RULE 7 - FINAL PREFERENCE AND CORRECTIONS
+
+Interpret the caller's entire latest utterance before selecting. If the caller changes or corrects the language within the same turn, the final clear preference wins.
+Examples:
+* "Use Hindi - actually, English." -> select English.
+* "Tamil... no, Telugu please." -> select Telugu.
+* "Not English. Hindi." -> select Hindi.
+* "I was going to ask for Tamil, but never mind." -> no switch.
+* "Switch to English - no, continue as you were." -> no switch.
+
+Do not select a language from a request that was negated, corrected, withdrawn, or cancelled later in the same turn.
+
+RULE 8 - SELECTION OVERRIDES DETECTION
+
+A language the caller explicitly selected overrides the language they happen to speak.
+Examples:
+Active English. Agent: "Would you prefer Hindi or Tamil?" Caller says "Hindi" with Tamil pronunciation. -> select Hindi.
+Active Hindi. Agent: "Should I switch to English?" Caller: "हाँ." -> select English, not Hindi.
+
+Never replace the selected language with the detected language, the script of the response, the language of an acknowledgment, the active language, a previous preference, or the highest-confidence detection.
+
+RULE 9 - LANGUAGE REJECTION OR INABILITY
+
+A statement rejecting a language or reporting inability to understand it does not by itself select another language.
+Examples: "I don't understand Hindi.", "मुझे English नहीं आती.", "Don't speak Tamil.", "I cannot follow Marathi."
+
+Therefore: never switch to the rejected language; do not infer an alternative from the language being spoken; switch only if the caller also names another language.
+Examples:
+* "I don't understand Hindi. Please speak English." -> select English.
+* "Don't use Tamil; use Telugu." -> select Telugu.
+* "I don't understand Hindi." -> no target; stay.
+
+RULE 10 - CONFUSION DOES NOT AUTHORIZE A SWITCH
+
+Confusion, inability to follow, or a request to repeat does not authorize switching, even when spoken in another language.
+Examples: "I don't understand.", "What are you saying?", "Please explain again."
+* "I don't understand. Explain in Tamil." -> select Tamil (the caller named a language).
+* "I don't understand," spoken in Tamil. -> detect Tamil, but stay.
+
+RULE 11 - MENTIONS, QUOTES, AND HYPOTHETICALS ARE NOT SELECTIONS
+
+A language name is not a selection when the language is merely discussed, compared, quoted, taught, reported as someone else's preference, or used as an object; or when the request is quoted, reported, hypothetical, or conditional on a future event.
+Examples:
+* "Hindi is widely spoken."
+* "My mother speaks Tamil."
+* "The Kannada version has an error."
+* "I am learning Telugu."
+* "The customer selected Marathi."
+* "He told me, 'Speak in Hindi.'"
+* "What happens if I say 'Use English'?"
+* "If someone asks for Marathi, what should you do?"
+* "Suppose I wanted Kannada."
+
+Stay unless the caller separately makes a current request. A conditional becomes valid only when its condition is current and satisfied:
+* "If possible, please continue in Hindi." -> select Hindi.
+* "If I ever ask for Hindi, then switch." -> no current switch.
+
+RULE 12 - MULTIPLE LANGUAGE REQUESTS
+
+When multiple languages are named, select a target only if the caller identifies one final preference.
+Examples:
+* "Use Hindi, or actually, use English." -> select English.
+* "Not Hindi - please speak Tamil." -> select Tamil.
+
+Do not select when the caller leaves the choice open:
+* "Hindi or English is fine."
+* "Use either Tamil or Telugu."
+* "You can choose."
+Set: explicit_request = false; requested_language = null; target_language = null; request_status = "ambiguous".
+
+RULE 13 - REQUEST FOR THE ACTIVE LANGUAGE
+
+If the caller explicitly requests or selects the language that is already active, no switch is needed.
+Example: Active English; Caller: "Please continue in English."
+Return: explicit_request = true; requested_language = "en"; target_language = null; target_confidence = 0; request_status = "already_active". This still counts as an explicit request.
+
+RULE 14 - UNSUPPORTED LANGUAGE REQUESTS
+
+If the caller explicitly requests a language that is not supported:
+explicit_request = true; requested_language = the normalized ISO code; target_language = null; target_confidence = 0; request_status = "unsupported".
+Do not substitute a related language, the active language, the detected language, or any other language.
+Example: Supported English and Hindi; Caller: "Please speak French." -> unsupported; no switch.
+
+RULE 15 - SPOKEN-LANGUAGE DETECTION
+
+Identify detected_language independently of the switching decision, using unbiased_user_transcript as the primary signal and live_user_transcript only as support (it is locked to the active language and may mis-transcribe, mis-script, be empty, or be garbled).
+
+The detected spoken language never authorizes switching by itself. A greeting, acknowledgment, language name, single borrowed word, number, code, or identifier is not evidence of a switch.
+
+For a standalone language-name utterance, judge detected_language from the script and form of the name itself: "தமிழ்" is ta, "हिंदी" is hi, "Tamil" or "Telugu" spoken in English is en. This is independent of requested_language, which is the language being selected.
+
+RULE 16 - PRECEDENCE
+
+Apply switch evidence in this order:
+1. The caller's latest clear correction or final named preference;
+2. The caller's unambiguous answer to a language question in last_agent_turn;
+3. A direct request to use one specific language;
+4. A specific capability question naming one language.
+Otherwise, no switch. A higher-priority valid selection overrides a lower-priority one. Detected spoken language is never part of this order and can never override a valid selection.
+
+RULE 17 - FINAL EXPLICITNESS TEST
+
+Authorize a switch only when one of these paths is satisfied:
+
+PATH A - DIRECT REQUEST: the caller asks the agent to speak, reply, continue, or converse in one specific language; the request is current and genuine, not negated, quoted, or hypothetical.
+PATH B - SPECIFIC CAPABILITY QUESTION: the caller asks whether the agent can speak, understand, or support one specific language; exactly one target is identifiable.
+PATH C - AGENT-PROMPTED SELECTION: last_agent_turn asked a language selection or confirmation question, and the caller's latest answer unambiguously selects or confirms one specific language (including a standalone name, an ordinal, or a yes/no).
+
+If any path is satisfied: explicit_request = true; record the resolved ISO code in requested_language. Then:
+* supported and different from active -> request_status = "switch";
+* supported and already active -> request_status = "already_active";
+* unsupported -> request_status = "unsupported".
+
+If no path is satisfied:
+* the caller appears to be choosing but no unique target resolves -> request_status = "ambiguous";
+* otherwise -> request_status = "no_request".
+
+RULE 18 - TARGET LANGUAGE ASSIGNMENT
+
+Set target_language only when ALL are true:
+1. explicit_request = true;
+2. exactly one requested language is resolved;
+3. it is supported;
+4. it differs from the active language;
+5. request_status = "switch".
+Otherwise target_language = null. Do not put the active language in target_language merely to confirm staying.
+
+OUTPUT
+
+Respond with raw JSON only - no Markdown fences, explanations, or surrounding text.
+
+{
+"detected_language": "<ISO 639-1 code of the language actually spoken, or 'und' if genuinely unidentifiable>",
+"detection_confidence": <number 0.0-1.0>,
+"explicit_request": <true or false>,
+"requested_language": "<normalized ISO 639-1 code of the requested or selected language, or null>",
+"target_language": "<ISO 639-1 code of the supported language to switch to, or null>",
+"target_confidence": <number 0.0-1.0; always 0 when target_language is null>,
+"request_status": "<switch | already_active | unsupported | ambiguous | no_request>",
+"request_source": "<direct_request | specific_capability_question | agent_prompted_selection | none>",
+"reasoning": "<brief explanation, maximum 16 words>"
+}
+
+FIELD DEFINITIONS
+
+detected_language
+The ISO 639-1 code of the language actually spoken in the caller's latest turn. Independent of the requested language. Never null; use "und" if genuinely unidentifiable.
+
+detection_confidence
+Confidence in spoken-language identification only, from 0.0 to 1.0. Not increased merely because a language was requested.
+
+explicit_request
+True when the caller directly requests, specifically asks about, or (in an agent-prompted context) selects or confirms one language. The caller need not repeat the language name when last_agent_turn makes it unambiguous.
+
+requested_language
+The normalized ISO 639-1 code requested or selected by the caller. Record it even when unsupported or already active. null when there is no request.
+
+target_language
+The ISO 639-1 code of the supported language to switch to. null when staying.
+
+target_confidence
+Confidence from 0.0 to 1.0 that performing the switch is correct. Always 0 when target_language is null.
+
+request_status
+The final switching classification. Exactly one of:
+* switch - a supported language different from the active one was explicitly selected.
+* already_active - the caller explicitly selected the language already in use.
+* unsupported - the caller explicitly selected a language not in supported_languages.
+* ambiguous - the caller seems to be choosing but no single language resolves.
+* no_request - no explicit language request or selection was made.
+
+request_source
+The rule that established the request. Exactly one of: direct_request | specific_capability_question | agent_prompted_selection | none. When multiple apply, use the highest-priority valid source.
+
+reasoning
+A concise explanation of the decision, no more than 16 words.
+
+CANONICAL EXAMPLES
+
+Example 1 - caller speaks another language but makes no request (stay)
+
+Active: English
+last_agent_turn: empty
+Caller: "मेरा order कहाँ है?"
+
+{
+"detected_language": "hi",
+"detection_confidence": 0.98,
+"explicit_request": false,
+"requested_language": null,
+"target_language": null,
+"target_confidence": 0,
+"request_status": "no_request",
+"request_source": "none",
+"reasoning": "Caller spoke Hindi but made no language request"
+}
+
+Example 2 - one-word answer to the agent's language question (switch)
+
+Active: English
+last_agent_turn: "Would you prefer Hindi or Telugu?"
+Caller: "Telugu."
+
+{
+"detected_language": "en",
+"detection_confidence": 0.85,
+"explicit_request": true,
+"requested_language": "te",
+"target_language": "te",
+"target_confidence": 0.99,
+"request_status": "switch",
+"request_source": "agent_prompted_selection",
+"reasoning": "Caller selected Telugu from the offered languages"
+}
+
+Example 3 - affirmation to two offered languages (ambiguous, stay)
+
+Active: English
+last_agent_turn: "Would you prefer Hindi or Tamil?"
+Caller: "Yes."
+
+{
+"detected_language": "en",
+"detection_confidence": 0.95,
+"explicit_request": false,
+"requested_language": null,
+"target_language": null,
+"target_confidence": 0,
+"request_status": "ambiguous",
+"request_source": "none",
+"reasoning": "Affirmation does not choose between two offered languages"
+}
+
+FINAL SAFETY PRINCIPLE
+
+Never switch merely because the caller is speaking another language. Switch only when one specific language is explicitly requested, specifically queried, or unambiguously selected or confirmed in answer to the agent's language question.
+"""
+
+# Per-turn user message paired with EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT.
+EXPLICIT_LANGUAGE_SWITCH_TURN_PROMPT = """Analyze last_agent_turn first, then evaluate the caller's turn (unbiased transcript weighted over live) against the rules above.
+
+active_language: {active_language}
+supported_languages: {available_languages}
+last_agent_turn: {last_agent_turn}
+unbiased_user_transcript: "{detector_transcript}"
+live_user_transcript: "{active_transcript}"
+
+Respond with raw JSON only."""

--- a/bolna/transcriber/transcriber_pool.py
+++ b/bolna/transcriber/transcriber_pool.py
@@ -630,6 +630,13 @@ class TranscriberPool:
             f"unknown_frames={getattr(lid, 'unknown_frames', 0)}) — language switching was inert"
         )
 
+    def lid_audio_seconds(self) -> float | None:
+        """Detector usage: seconds of caller audio streamed to the LID tap, or None if no tap."""
+        lid = self._lid
+        if lid is None:
+            return None
+        return lid.audio_seconds_fed()
+
     async def cleanup(self):
         """Clean up all transcribers, cancel pool tasks, and stop LID tap."""
         for task_name, task in [("router", self._router_task), ("keepalive", self._keepalive_task)]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.213"
+version = "0.10.214"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def language_switch_tm(monkeypatch):
         tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
 
         tm.language_switcher = MagicMock()
+        tm.lid_explicit_only = False
         tm.language_switcher.decide = AsyncMock(return_value=_SWITCH_DECISION)
         tm._inflight_response_activity = MagicMock(
             return_value={"audio_playing": audio_playing, "response_in_pipeline": True}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def language_switch_tm(monkeypatch):
         tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
 
         tm.language_switcher = MagicMock()
-        tm.lid_explicit_only = False
+        tm.language_switcher.explicit_only = False
         tm.language_switcher.decide = AsyncMock(return_value=_SWITCH_DECISION)
         tm._inflight_response_activity = MagicMock(
             return_value={"audio_playing": audio_playing, "response_in_pipeline": True}

--- a/tests/test_handle_language_switch_spec_cleanup.py
+++ b/tests/test_handle_language_switch_spec_cleanup.py
@@ -15,7 +15,7 @@ from bolna.agent_manager.task_manager import TaskManager
 
 def _make_tm():
     tm = MagicMock()
-    tm.lid_explicit_only = False
+    tm.language_switcher.explicit_only = False
     tm.language_switch_lock = asyncio.Lock()
     tm._spec_followup_task = None
     return tm

--- a/tests/test_handle_language_switch_spec_cleanup.py
+++ b/tests/test_handle_language_switch_spec_cleanup.py
@@ -15,6 +15,7 @@ from bolna.agent_manager.task_manager import TaskManager
 
 def _make_tm():
     tm = MagicMock()
+    tm.lid_explicit_only = False
     tm.language_switch_lock = asyncio.Lock()
     tm._spec_followup_task = None
     return tm

--- a/tests/test_judge_bedrock_fallback.py
+++ b/tests/test_judge_bedrock_fallback.py
@@ -60,7 +60,7 @@ async def test_success_resets_the_failure_counter(monkeypatch):
     sw = LanguageSwitcher(available_labels=["en", "hi"], model=BEDROCK)
     sw._log_decision = MagicMock()
     sw._llm = MagicMock()
-    sw._llm.generate = AsyncMock(side_effect=[Exception("throttled"), '{"target_language": null}'])
+    sw._llm.generate = AsyncMock(side_effect=[Exception("throttled"), ('{"target_language": null}', {})])
     await sw.decide("hello", "", "hi")
     await sw.decide("hello", "", "hi")
     assert sw._consecutive_failures == 0
@@ -112,7 +112,7 @@ async def test_parsed_null_is_not_a_judge_failure(monkeypatch):
     sw = LanguageSwitcher(available_labels=["en", "hi"], model=BEDROCK)
     sw._log_decision = MagicMock()
     sw._llm = MagicMock()
-    sw._llm.generate = AsyncMock(return_value="null")
+    sw._llm.generate = AsyncMock(return_value=("null", {}))
     for _ in range(4):
         await sw.decide("hello", "", "hi")
     assert sw.model == BEDROCK
@@ -140,7 +140,7 @@ async def test_null_resets_an_error_streak(monkeypatch):
     sw = LanguageSwitcher(available_labels=["en", "hi"], model=BEDROCK)
     sw._log_decision = MagicMock()
     sw._llm = MagicMock()
-    sw._llm.generate = AsyncMock(side_effect=[Exception("throttled"), "null", "null"])
+    sw._llm.generate = AsyncMock(side_effect=[Exception("throttled"), ("null", {}), ("null", {})])
     await sw.decide("hello", "", "hi")  # errored first attempt; hedge parses null → valid decide
     await sw.decide("hello", "", "hi")
     assert sw._consecutive_failures == 0

--- a/tests/test_language_switch_drift.py
+++ b/tests/test_language_switch_drift.py
@@ -120,9 +120,9 @@ async def test_decide_passes_recent_turns_into_the_prompt(monkeypatch):
     sw = LanguageSwitcher(available_labels=["en", "hi"], run_id="r")
     sent = {}
 
-    async def generate(messages):
+    async def generate(messages, **kwargs):
         sent["user"] = messages[-1]["content"]
-        return '{"target_language": null, "target_confidence": 0.0}'
+        return '{"target_language": null, "target_confidence": 0.0}', {}
 
     sw._llm = MagicMock()
     sw._llm.generate = generate

--- a/tests/test_language_switch_explicit.py
+++ b/tests/test_language_switch_explicit.py
@@ -16,7 +16,7 @@ def make_switcher(generate_return, labels=("en", "hi", "te"), explicit_only=True
     from bolna.helpers.language_switcher import LanguageSwitcher
 
     fake_llm = MagicMock()
-    fake_llm.generate = AsyncMock(return_value=generate_return)
+    fake_llm.generate = AsyncMock(return_value=(generate_return, {}))
     with patch(f"{MOD}.LiteLLM", return_value=fake_llm):
         switcher = LanguageSwitcher(available_labels=list(labels), explicit_only=explicit_only)
     return switcher, fake_llm
@@ -37,7 +37,9 @@ async def test_explicit_mode_uses_explicit_prompts_and_last_agent_turn():
     payload = json.dumps({"target_language": None, "request_status": "no_request"})
     switcher, fake_llm = make_switcher(payload)
     await switcher.decide(
-        "मेरा order कहाँ है?", "mera order kahan", active_label="en",
+        "मेरा order कहाँ है?",
+        "mera order kahan",
+        active_label="en",
         last_agent_turn="How can I help you today?",
     )
     assert system_text(fake_llm) == EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT
@@ -51,8 +53,11 @@ async def test_ambient_mode_prompts_unchanged_and_ignores_last_agent_turn():
     payload = json.dumps({"languages": [], "target_language": None, "reasoning": "stay"})
     switcher, fake_llm = make_switcher(payload, explicit_only=False)
     await switcher.decide(
-        "hello", "hello", active_label="en",
-        recent_turns=[("hi", 2.1)], last_agent_turn="Would you like Hindi?",
+        "hello",
+        "hello",
+        active_label="en",
+        recent_turns=[("hi", 2.1)],
+        last_agent_turn="Would you like Hindi?",
     )
     assert system_text(fake_llm) == LANGUAGE_SWITCH_SYSTEM_PROMPT
     turn = turn_text(fake_llm)
@@ -83,10 +88,14 @@ async def test_explicit_mode_empty_live_stays_empty_not_marker():
 async def test_canonical_no_request_stays():
     payload = json.dumps(
         {
-            "detected_language": "hi", "detection_confidence": 0.98,
-            "explicit_request": False, "requested_language": None,
-            "target_language": None, "target_confidence": 0,
-            "request_status": "no_request", "request_source": "none",
+            "detected_language": "hi",
+            "detection_confidence": 0.98,
+            "explicit_request": False,
+            "requested_language": None,
+            "target_language": None,
+            "target_confidence": 0,
+            "request_status": "no_request",
+            "request_source": "none",
             "reasoning": "Caller spoke Hindi but made no language request",
         }
     )
@@ -99,16 +108,22 @@ async def test_canonical_no_request_stays():
 async def test_canonical_one_word_answer_switches():
     payload = json.dumps(
         {
-            "detected_language": "en", "detection_confidence": 0.85,
-            "explicit_request": True, "requested_language": "te",
-            "target_language": "te", "target_confidence": 0.99,
-            "request_status": "switch", "request_source": "agent_prompted_selection",
+            "detected_language": "en",
+            "detection_confidence": 0.85,
+            "explicit_request": True,
+            "requested_language": "te",
+            "target_language": "te",
+            "target_confidence": 0.99,
+            "request_status": "switch",
+            "request_source": "agent_prompted_selection",
             "reasoning": "Caller selected Telugu from the offered languages",
         }
     )
     switcher, fake_llm = make_switcher(payload)
     result = await switcher.decide(
-        "Telugu.", "Telugu.", active_label="en",
+        "Telugu.",
+        "Telugu.",
+        active_label="en",
         last_agent_turn="Would you prefer Hindi or Telugu?",
     )
     assert result["target_language"] == "te"
@@ -119,10 +134,14 @@ async def test_canonical_one_word_answer_switches():
 async def test_canonical_yes_to_two_options_is_ambiguous_stay():
     payload = json.dumps(
         {
-            "detected_language": "en", "detection_confidence": 0.95,
-            "explicit_request": False, "requested_language": None,
-            "target_language": None, "target_confidence": 0,
-            "request_status": "ambiguous", "request_source": "none",
+            "detected_language": "en",
+            "detection_confidence": 0.95,
+            "explicit_request": False,
+            "requested_language": None,
+            "target_language": None,
+            "target_confidence": 0,
+            "request_status": "ambiguous",
+            "request_source": "none",
             "reasoning": "Affirmation does not choose between two offered languages",
         }
     )
@@ -245,9 +264,14 @@ async def test_explicit_mode_missing_synth_voice_still_blocked(monkeypatch):
 
 async def test_explicit_mode_null_target_stays(monkeypatch):
     decision = {
-        "detected_language": "hi", "explicit_request": False, "requested_language": None,
-        "target_language": None, "target_confidence": 0, "request_status": "no_request",
-        "request_source": "none", "reasoning": "no request",
+        "detected_language": "hi",
+        "explicit_request": False,
+        "requested_language": None,
+        "target_language": None,
+        "target_confidence": 0,
+        "request_status": "no_request",
+        "request_source": "none",
+        "reasoning": "no request",
     }
     tm = make_tm(monkeypatch, decision)
     await run_switch(tm)

--- a/tests/test_language_switch_explicit.py
+++ b/tests/test_language_switch_explicit.py
@@ -1,0 +1,263 @@
+"""Explicit-only judge mode (per-agent toggle): switches only on an explicit
+request/selection/confirmation; speaking another language alone never switches."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.prompts import (
+    EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT,
+    LANGUAGE_SWITCH_SYSTEM_PROMPT,
+)
+
+MOD = "bolna.helpers.language_switcher"
+
+
+def make_switcher(generate_return, labels=("en", "hi", "te"), explicit_only=True):
+    from bolna.helpers.language_switcher import LanguageSwitcher
+
+    fake_llm = MagicMock()
+    fake_llm.generate = AsyncMock(return_value=generate_return)
+    with patch(f"{MOD}.LiteLLM", return_value=fake_llm):
+        switcher = LanguageSwitcher(available_labels=list(labels), explicit_only=explicit_only)
+    return switcher, fake_llm
+
+
+def system_text(fake_llm):
+    return fake_llm.generate.await_args.args[0][0]["content"][0]["text"]
+
+
+def turn_text(fake_llm):
+    return fake_llm.generate.await_args.args[0][-1]["content"]
+
+
+# ── prompt selection ──────────────────────────────────────────────────────────────
+
+
+async def test_explicit_mode_uses_explicit_prompts_and_last_agent_turn():
+    payload = json.dumps({"target_language": None, "request_status": "no_request"})
+    switcher, fake_llm = make_switcher(payload)
+    await switcher.decide(
+        "मेरा order कहाँ है?", "mera order kahan", active_label="en",
+        last_agent_turn="How can I help you today?",
+    )
+    assert system_text(fake_llm) == EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT
+    turn = turn_text(fake_llm)
+    assert "last_agent_turn: How can I help you today?" in turn
+    assert "unbiased_user_transcript" in turn
+    assert "RECENT TURNS" not in turn
+
+
+async def test_ambient_mode_prompts_unchanged_and_ignores_last_agent_turn():
+    payload = json.dumps({"languages": [], "target_language": None, "reasoning": "stay"})
+    switcher, fake_llm = make_switcher(payload, explicit_only=False)
+    await switcher.decide(
+        "hello", "hello", active_label="en",
+        recent_turns=[("hi", 2.1)], last_agent_turn="Would you like Hindi?",
+    )
+    assert system_text(fake_llm) == LANGUAGE_SWITCH_SYSTEM_PROMPT
+    turn = turn_text(fake_llm)
+    assert "Would you like Hindi?" not in turn
+    assert "RECENT TURNS" in turn
+
+
+async def test_explicit_mode_empty_last_agent_turn_is_none_marker():
+    payload = json.dumps({"target_language": None})
+    switcher, fake_llm = make_switcher(payload)
+    await switcher.decide("hello", "hello", active_label="en", last_agent_turn=None)
+    assert "last_agent_turn: (none)" in turn_text(fake_llm)
+
+
+async def test_explicit_mode_empty_live_stays_empty_not_marker():
+    # The explicit prompt handles empty LIVE itself; the ambient marker must not leak in.
+    payload = json.dumps({"target_language": None})
+    switcher, fake_llm = make_switcher(payload)
+    await switcher.decide("नमस्ते", "", active_label="en")
+    turn = turn_text(fake_llm)
+    assert 'live_user_transcript: ""' in turn
+    assert "idle flush" not in turn
+
+
+# ── the user's canonical examples, end to end through decide() ────────────────────
+
+
+async def test_canonical_no_request_stays():
+    payload = json.dumps(
+        {
+            "detected_language": "hi", "detection_confidence": 0.98,
+            "explicit_request": False, "requested_language": None,
+            "target_language": None, "target_confidence": 0,
+            "request_status": "no_request", "request_source": "none",
+            "reasoning": "Caller spoke Hindi but made no language request",
+        }
+    )
+    switcher, _ = make_switcher(payload)
+    result = await switcher.decide("मेरा order कहाँ है?", "", active_label="en", last_agent_turn=None)
+    assert result["target_language"] is None
+    assert result["request_status"] == "no_request"
+
+
+async def test_canonical_one_word_answer_switches():
+    payload = json.dumps(
+        {
+            "detected_language": "en", "detection_confidence": 0.85,
+            "explicit_request": True, "requested_language": "te",
+            "target_language": "te", "target_confidence": 0.99,
+            "request_status": "switch", "request_source": "agent_prompted_selection",
+            "reasoning": "Caller selected Telugu from the offered languages",
+        }
+    )
+    switcher, fake_llm = make_switcher(payload)
+    result = await switcher.decide(
+        "Telugu.", "Telugu.", active_label="en",
+        last_agent_turn="Would you prefer Hindi or Telugu?",
+    )
+    assert result["target_language"] == "te"
+    assert result["explicit_request"] is True
+    assert "Would you prefer Hindi or Telugu?" in turn_text(fake_llm)
+
+
+async def test_canonical_yes_to_two_options_is_ambiguous_stay():
+    payload = json.dumps(
+        {
+            "detected_language": "en", "detection_confidence": 0.95,
+            "explicit_request": False, "requested_language": None,
+            "target_language": None, "target_confidence": 0,
+            "request_status": "ambiguous", "request_source": "none",
+            "reasoning": "Affirmation does not choose between two offered languages",
+        }
+    )
+    switcher, _ = make_switcher(payload)
+    result = await switcher.decide(
+        "Yes.", "Yes.", active_label="en", last_agent_turn="Would you prefer Hindi or Tamil?"
+    )
+    assert result["target_language"] is None
+    assert result["request_status"] == "ambiguous"
+
+
+# ── task_manager: explicit mode bypasses detection gates, keeps structural ones ───
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.synthesizer.synthesizer_pool import SynthesizerPool
+from bolna.transcriber.transcriber_pool import TranscriberPool
+
+
+def make_tm(monkeypatch, decision, explicit_only=True, synth_labels=("en", "hi")):
+    monkeypatch.setenv("LANGUAGE_SWITCH_SETTLE_MS", "0")
+    tm = MagicMock()
+    tm.lid_explicit_only = explicit_only
+    tm.task_config = {"tools_config": {"llm_agent": {"agent_type": "graph_agent"}}}
+    tm.language = "en"
+    tm.conversation_ended = False
+    tm.hangup_triggered = False
+    tm.function_call_in_flight = False
+    tm.multilingual_prompts = {"en": "p", "hi": "p"}
+    tm._should_ignore_transcriber_input = MagicMock(return_value=False)
+    pool = MagicMock(spec=TranscriberPool)
+    pool.labels = ["en", "hi"]
+    pool.lid_detection_events = []
+    pool.lid_buffer_max_segment_seconds.return_value = 0.3
+    pool.lid_buffer_language_confidence.return_value = 0.4
+    # A one-word answer: far below every ambient substance/confidence bar.
+    pool.lid_buffer_segments.return_value = [{"lang": "en", "prob": 0.4, "audio_s": 0.3}]
+    pool.take_lid_transcript.return_value = ("Hindi.", "en")
+    synth = MagicMock(spec=SynthesizerPool)
+    synth.labels = list(synth_labels)
+    tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
+    tm.language_switcher = MagicMock()
+    tm.language_switcher.decide = AsyncMock(return_value=decision)
+    tm._inflight_response_activity = MagicMock(return_value={"audio_playing": False})
+    tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
+    tm.switch_language = AsyncMock()
+    tm._TaskManager__language_directive = MagicMock(return_value="note")
+    tm._TaskManager__play_switch_handoff = AsyncMock()
+    tm._TaskManager__prepare_followup_generation = MagicMock(return_value=None)
+    tm.conversation_history = MagicMock()
+    tm.conversation_history.replace_last_user.return_value = True
+    tm.conversation_history.last_assistant_content.return_value = "Would you like Hindi?"
+    for name in ("switch_audio_gap_s", "switch_settle_ms", "switch_decide_timeout_s", "record_lid_event"):
+        attr = f"_TaskManager__{name}"
+        setattr(tm, attr, getattr(TaskManager, attr).__get__(tm, TaskManager))
+    tm._TaskManager__detector_corroborates = TaskManager._TaskManager__detector_corroborates
+    return tm
+
+
+async def run_switch(tm):
+    run = TaskManager._TaskManager__run_language_switch.__get__(tm, TaskManager)
+    return await run("Hindi.", {"sequence_id": 1}, "en")
+
+
+def outcomes(tm):
+    return [e.get("outcome") for e in tm.tools["transcriber"].lid_detection_events]
+
+
+EXPLICIT_SWITCH = {
+    "detected_language": "en",
+    "detection_confidence": 0.85,
+    "explicit_request": True,
+    "requested_language": "hi",
+    "target_language": "hi",
+    "target_confidence": 0.99,
+    "request_status": "switch",
+    "request_source": "agent_prompted_selection",
+    "reasoning": "Caller selected Hindi",
+}
+
+
+async def test_explicit_mode_switches_past_all_detection_gates(monkeypatch):
+    # 0.3s low-prob segment: ambient mode would gate this on confidence corroboration
+    # or substance; explicit mode must switch.
+    tm = make_tm(monkeypatch, dict(EXPLICIT_SWITCH))
+    await run_switch(tm)
+    tm.switch_language.assert_awaited_once()
+    assert "switched" in outcomes(tm)
+
+
+async def test_explicit_mode_low_self_confidence_still_switches(monkeypatch):
+    decision = dict(EXPLICIT_SWITCH, target_confidence=0.2)
+    tm = make_tm(monkeypatch, decision)
+    await run_switch(tm)
+    tm.switch_language.assert_awaited_once()
+
+
+async def test_ambient_mode_same_evidence_is_gated(monkeypatch):
+    # Same weak evidence, ambient prompt shape: must NOT switch (confidence 0.2 < bar).
+    decision = {"target_language": "hi", "target_confidence": 0.2, "reasoning": "r", "languages": []}
+    tm = make_tm(monkeypatch, decision, explicit_only=False)
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert "gated:low_confidence" in outcomes(tm)
+
+
+async def test_explicit_mode_unsupported_target_still_blocked(monkeypatch):
+    decision = dict(EXPLICIT_SWITCH, target_language="ta", requested_language="ta")
+    tm = make_tm(monkeypatch, decision)
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert "gated:unsupported" in outcomes(tm)
+
+
+async def test_explicit_mode_missing_synth_voice_still_blocked(monkeypatch):
+    tm = make_tm(monkeypatch, dict(EXPLICIT_SWITCH), synth_labels=("en",))
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert "gated:no_synth" in outcomes(tm)
+
+
+async def test_explicit_mode_null_target_stays(monkeypatch):
+    decision = {
+        "detected_language": "hi", "explicit_request": False, "requested_language": None,
+        "target_language": None, "target_confidence": 0, "request_status": "no_request",
+        "request_source": "none", "reasoning": "no request",
+    }
+    tm = make_tm(monkeypatch, decision)
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert outcomes(tm) == ["stay"]
+
+
+async def test_telemetry_record_carries_request_fields(monkeypatch):
+    tm = make_tm(monkeypatch, dict(EXPLICIT_SWITCH))
+    await run_switch(tm)
+    record = tm.tools["transcriber"].lid_detection_events[-1]
+    assert record["request_status"] == "switch"
+    assert record["request_source"] == "agent_prompted_selection"

--- a/tests/test_language_switch_explicit.py
+++ b/tests/test_language_switch_explicit.py
@@ -163,7 +163,7 @@ from bolna.transcriber.transcriber_pool import TranscriberPool
 def make_tm(monkeypatch, decision, explicit_only=True, synth_labels=("en", "hi")):
     monkeypatch.setenv("LANGUAGE_SWITCH_SETTLE_MS", "0")
     tm = MagicMock()
-    tm.lid_explicit_only = explicit_only
+
     tm.task_config = {"tools_config": {"llm_agent": {"agent_type": "graph_agent"}}}
     tm.language = "en"
     tm.conversation_ended = False
@@ -183,6 +183,7 @@ def make_tm(monkeypatch, decision, explicit_only=True, synth_labels=("en", "hi")
     synth.labels = list(synth_labels)
     tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
     tm.language_switcher = MagicMock()
+    tm.language_switcher.explicit_only = explicit_only
     tm.language_switcher.decide = AsyncMock(return_value=decision)
     tm._inflight_response_activity = MagicMock(return_value={"audio_playing": False})
     tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
@@ -285,3 +286,30 @@ async def test_telemetry_record_carries_request_fields(monkeypatch):
     record = tm.tools["transcriber"].lid_detection_events[-1]
     assert record["request_status"] == "switch"
     assert record["request_source"] == "agent_prompted_selection"
+
+
+async def test_explicit_mode_target_without_verdict_is_gated(monkeypatch):
+    # The exact shape from review: a target with status=ambiguous / explicit_request=false
+    # must not switch — rule 18 of the prompt is not the only guard anymore.
+    decision = {
+        "detected_language": "hi",
+        "explicit_request": False,
+        "requested_language": None,
+        "target_language": "hi",
+        "target_confidence": 0.0,
+        "request_status": "ambiguous",
+        "request_source": "none",
+        "reasoning": "drift",
+    }
+    tm = make_tm(monkeypatch, decision)
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert "gated:not_explicit" in outcomes(tm)
+
+
+async def test_explicit_mode_status_switch_but_no_explicit_flag_is_gated(monkeypatch):
+    decision = dict(EXPLICIT_SWITCH, explicit_request=False)
+    tm = make_tm(monkeypatch, decision)
+    await run_switch(tm)
+    tm.switch_language.assert_not_awaited()
+    assert "gated:not_explicit" in outcomes(tm)

--- a/tests/test_language_switch_hedge.py
+++ b/tests/test_language_switch_hedge.py
@@ -29,7 +29,7 @@ async def _decide(sw):
 
 
 async def test_fast_decide_fires_only_one_request(monkeypatch):
-    gen = AsyncMock(return_value=REPLY)
+    gen = AsyncMock(return_value=(REPLY, {}))
     sw = _switcher(monkeypatch, gen, hedge_after=0.5)
     assert (await _decide(sw))["target_language"] == "mr"
     assert gen.await_count == 1  # the common turn must not pay for two
@@ -39,11 +39,11 @@ async def test_fast_decide_fires_only_one_request(monkeypatch):
 async def test_slow_first_request_is_hedged_and_second_wins(monkeypatch):
     calls = {"n": 0}
 
-    async def generate(_messages):
+    async def generate(_messages, **kwargs):
         calls["n"] += 1
         if calls["n"] == 1:
             await asyncio.sleep(5)  # the straggler
-        return REPLY
+        return REPLY, {}
 
     sw = _switcher(monkeypatch, generate, hedge_after=0.05)
     result = await asyncio.wait_for(_decide(sw), timeout=2.0)
@@ -55,7 +55,7 @@ async def test_slow_first_request_is_hedged_and_second_wins(monkeypatch):
 
 
 async def test_hedge_disabled_by_zero(monkeypatch):
-    gen = AsyncMock(return_value=REPLY)
+    gen = AsyncMock(return_value=(REPLY, {}))
     sw = _switcher(monkeypatch, gen, hedge_after=0)
     assert (await _decide(sw))["target_language"] == "mr"
     assert gen.await_count == 1
@@ -64,13 +64,13 @@ async def test_hedge_disabled_by_zero(monkeypatch):
 async def test_failing_straggler_does_not_lose_the_hedged_answer(monkeypatch):
     calls = {"n": 0}
 
-    async def generate(_messages):
+    async def generate(_messages, **kwargs):
         calls["n"] += 1
         if calls["n"] == 1:
             await asyncio.sleep(0.1)
             raise RuntimeError("provider 500")
         await asyncio.sleep(0.3)
-        return REPLY
+        return REPLY, {}
 
     sw = _switcher(monkeypatch, generate, hedge_after=0.05)
     # First attempt raises before the second answers — the reply must still be returned.
@@ -78,7 +78,7 @@ async def test_failing_straggler_does_not_lose_the_hedged_answer(monkeypatch):
 
 
 async def test_both_failing_returns_none(monkeypatch):
-    async def generate(_messages):
+    async def generate(_messages, **kwargs):
         await asyncio.sleep(0.05)
         raise RuntimeError("provider down")
 
@@ -95,16 +95,16 @@ async def test_hedge_won_resets_between_decides(monkeypatch):
     # fast decide would be misreported as hedged in the logs.
     calls = {"n": 0}
 
-    async def generate(_messages):
+    async def generate(_messages, **kwargs):
         calls["n"] += 1
         if calls["n"] == 1:
             await asyncio.sleep(5)  # force a hedge on the first decide
-        return REPLY
+        return REPLY, {}
 
     sw = _switcher(monkeypatch, generate, hedge_after=0.05)
     await asyncio.wait_for(_decide(sw), timeout=2.0)
     assert sw.hedge_won is True
 
-    sw._llm.generate = AsyncMock(return_value=REPLY)  # second decide answers immediately
+    sw._llm.generate = AsyncMock(return_value=(REPLY, {}))  # second decide answers immediately
     await _decide(sw)
     assert sw.hedge_won is False

--- a/tests/test_language_switch_live_marker_and_pin.py
+++ b/tests/test_language_switch_live_marker_and_pin.py
@@ -25,9 +25,9 @@ def _switcher_capturing_prompt(monkeypatch, sent):
     monkeypatch.setenv("LANGUAGE_SWITCH_HEDGE_AFTER_S", "0")
     sw = LanguageSwitcher(available_labels=["en", "te", "hi"], run_id="r")
 
-    async def generate(messages):
+    async def generate(messages, **kwargs):
         sent["user"] = messages[-1]["content"]
-        return '{"target_language": null, "target_confidence": 0.0}'
+        return '{"target_language": null, "target_confidence": 0.0}', {}
 
     sw._llm = MagicMock()
     sw._llm.generate = generate

--- a/tests/test_language_switcher.py
+++ b/tests/test_language_switcher.py
@@ -12,7 +12,8 @@ def _make_switcher(generate_return, labels=("en", "hi")):
     from bolna.helpers.language_switcher import LanguageSwitcher
 
     fake_llm = MagicMock()
-    fake_llm.generate = AsyncMock(return_value=generate_return)
+    # Real generate(ret_metadata=True) returns (text, usage) — mirror the contract.
+    fake_llm.generate = AsyncMock(return_value=(generate_return, {}))
     with patch(f"{MOD}.LiteLLM", return_value=fake_llm):
         switcher = LanguageSwitcher(available_labels=list(labels))
     return switcher, fake_llm

--- a/tests/test_lid_usage_tracking.py
+++ b/tests/test_lid_usage_tracking.py
@@ -56,7 +56,21 @@ async def test_missing_usage_logs_none_not_crash():
         result = await switcher.decide("hello", "hello", "en")
     assert result is not None
     assert log.call_args_list[-1].kwargs["input_tokens"] is None
-    assert switcher.usage_totals["requests"] == 0
+    # requests counts completed responses, even when the provider omitted usage.
+    assert switcher.usage_totals["requests"] == 1
+    assert switcher.usage_totals["input_tokens"] == 0
+
+
+async def test_models_used_tracks_the_answering_model():
+    payload = json.dumps({"target_language": None})
+    usage = {"input_tokens": 10, "output_tokens": 1}
+    switcher, _ = make_switcher(payload, usage)
+    await switcher.decide("hello", "hello", "en")
+    assert switcher.models_used == [switcher.model]
+    # a runtime fallback swap mid-call must show BOTH models
+    switcher.model = "anthropic/other-judge"
+    await switcher.decide("namaste", "namaste", "en")
+    assert len(switcher.models_used) == 2
 
 
 # ── detector audio seconds ────────────────────────────────────────────────────────
@@ -100,6 +114,7 @@ def make_tm(events=None, seconds=63.0, switcher=True):
     if switcher:
         tm.language_switcher = MagicMock()
         tm.language_switcher.model = "bedrock/haiku"
+        tm.language_switcher.models_used = ["bedrock/haiku"]
         tm.language_switcher.usage_totals = {
             "input_tokens": 11000,
             "output_tokens": 120,
@@ -122,6 +137,7 @@ def test_snapshot_appends_one_usage_record():
     assert usage[0]["judge_requests"] == 2
     assert usage[0]["detector_audio_seconds"] == 63.0
     assert usage[0]["judge_model"] == "bedrock/haiku"
+    assert usage[0]["judge_models"] == ["bedrock/haiku"]
 
 
 def test_snapshot_is_idempotent():

--- a/tests/test_lid_usage_tracking.py
+++ b/tests/test_lid_usage_tracking.py
@@ -1,0 +1,137 @@
+"""Per-call LID spend: judge tokens (Haiku) + detector audio seconds (Sarvam/Soniox),
+persisted as one `lid_usage` record inside lid_detection_events (JSONB — no new columns)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.transcriber.transcriber_pool import TranscriberPool
+
+MOD = "bolna.helpers.language_switcher"
+
+
+def make_switcher(payload, usage=None):
+    from bolna.helpers.language_switcher import LanguageSwitcher
+
+    fake_llm = MagicMock()
+    fake_llm.generate = AsyncMock(return_value=(payload, usage or {}))
+    with patch(f"{MOD}.LiteLLM", return_value=fake_llm):
+        switcher = LanguageSwitcher(available_labels=["en", "hi"])
+    return switcher, fake_llm
+
+
+# ── judge token capture ───────────────────────────────────────────────────────────
+
+
+async def test_decide_tallies_judge_usage():
+    payload = json.dumps({"target_language": None, "reasoning": "stay"})
+    usage = {"input_tokens": 5500, "output_tokens": 60, "cached_tokens": 5000}
+    switcher, _ = make_switcher(payload, usage)
+    await switcher.decide("hello", "hello", "en")
+    await switcher.decide("namaste", "namaste", "en")
+    assert switcher.usage_totals == {
+        "input_tokens": 11000,
+        "output_tokens": 120,
+        "cached_tokens": 10000,
+        "requests": 2,
+    }
+
+
+async def test_csv_response_row_carries_tokens():
+    payload = json.dumps({"target_language": None, "reasoning": "stay"})
+    usage = {"input_tokens": 5500, "output_tokens": 60, "cached_tokens": 5000}
+    switcher, _ = make_switcher(payload, usage)
+    with patch(f"{MOD}.convert_to_request_log") as log:
+        await switcher.decide("hello", "hello", "en")
+    response_kwargs = log.call_args_list[-1].kwargs
+    assert response_kwargs["input_tokens"] == 5500
+    assert response_kwargs["output_tokens"] == 60
+    assert response_kwargs["cached_tokens"] == 5000
+
+
+async def test_missing_usage_logs_none_not_crash():
+    payload = json.dumps({"target_language": None})
+    switcher, _ = make_switcher(payload, usage={})
+    with patch(f"{MOD}.convert_to_request_log") as log:
+        result = await switcher.decide("hello", "hello", "en")
+    assert result is not None
+    assert log.call_args_list[-1].kwargs["input_tokens"] is None
+    assert switcher.usage_totals["requests"] == 0
+
+
+# ── detector audio seconds ────────────────────────────────────────────────────────
+
+
+def make_lid(bytes_per_second):
+    from bolna.lid.base import LIDBackend
+
+    lid = object.__new__(LIDBackend)
+    lid.bytes_fed = 0
+    lid.input_bytes_per_second = bytes_per_second
+    return lid
+
+
+def test_audio_seconds_mulaw_8k():
+    lid = make_lid(8000)
+    lid.bytes_fed = 8000 * 63  # 63s of mulaw@8k
+    assert lid.audio_seconds_fed() == 63.0
+
+
+def test_audio_seconds_linear16_16k():
+    lid = make_lid(32000)
+    lid.bytes_fed = 32000 * 10
+    assert lid.audio_seconds_fed() == 10.0
+
+
+def test_audio_seconds_zero_rate_is_safe():
+    assert make_lid(0).audio_seconds_fed() == 0.0
+
+
+# ── the lid_usage record ──────────────────────────────────────────────────────────
+
+
+def make_tm(events=None, seconds=63.0, switcher=True):
+    tm = MagicMock()
+    pool = MagicMock(spec=TranscriberPool)
+    pool.lid_detection_events = events if events is not None else []
+    pool.lid_audio_seconds.return_value = seconds
+    pool._record_detector_health = MagicMock()
+    tm.tools = {"transcriber": pool}
+    if switcher:
+        tm.language_switcher = MagicMock()
+        tm.language_switcher.model = "bedrock/haiku"
+        tm.language_switcher.usage_totals = {
+            "input_tokens": 11000,
+            "output_tokens": 120,
+            "cached_tokens": 10000,
+            "requests": 2,
+        }
+    else:
+        tm.language_switcher = None
+    tm._TaskManager__record_lid_usage = TaskManager._TaskManager__record_lid_usage.__get__(tm, TaskManager)
+    tm._TaskManager__snapshot_lid_events = TaskManager._TaskManager__snapshot_lid_events.__get__(tm, TaskManager)
+    return tm, pool
+
+
+def test_snapshot_appends_one_usage_record():
+    tm, pool = make_tm()
+    events = tm._TaskManager__snapshot_lid_events()
+    usage = [e for e in events if e.get("type") == "lid_usage"]
+    assert len(usage) == 1
+    assert usage[0]["judge_input_tokens"] == 11000
+    assert usage[0]["judge_requests"] == 2
+    assert usage[0]["detector_audio_seconds"] == 63.0
+    assert usage[0]["judge_model"] == "bedrock/haiku"
+
+
+def test_snapshot_is_idempotent():
+    tm, pool = make_tm()
+    tm._TaskManager__snapshot_lid_events()
+    events = tm._TaskManager__snapshot_lid_events()
+    assert len([e for e in events if e.get("type") == "lid_usage"]) == 1
+
+
+def test_no_switcher_no_audio_writes_nothing():
+    tm, pool = make_tm(seconds=None, switcher=False)
+    events = tm._TaskManager__snapshot_lid_events()
+    assert [e for e in events if e.get("type") == "lid_usage"] == []

--- a/tests/test_recent_turns_and_gate_lifecycle.py
+++ b/tests/test_recent_turns_and_gate_lifecycle.py
@@ -99,6 +99,7 @@ async def test_switch_path_holds_gate_until_cleanup(language_switch_tm):
 
 def test_snapshot_flushes_detector_health():
     tm = MagicMock()
+    tm.lid_explicit_only = False
     pool = MagicMock(spec=TranscriberPool)
     pool.lid_detection_events = []
 

--- a/tests/test_recent_turns_and_gate_lifecycle.py
+++ b/tests/test_recent_turns_and_gate_lifecycle.py
@@ -99,7 +99,7 @@ async def test_switch_path_holds_gate_until_cleanup(language_switch_tm):
 
 def test_snapshot_flushes_detector_health():
     tm = MagicMock()
-    tm.lid_explicit_only = False
+    tm.language_switcher.explicit_only = False
     pool = MagicMock(spec=TranscriberPool)
     pool.lid_detection_events = []
 

--- a/tests/test_substance_gate_foreign_max.py
+++ b/tests/test_substance_gate_foreign_max.py
@@ -40,6 +40,7 @@ def _tm(monkeypatch, segments, buffer_max):
     synth.labels = ["hi", "mr"]
     tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
     tm.language_switcher = MagicMock()
+    tm.lid_explicit_only = False
     tm.language_switcher.decide = AsyncMock(
         return_value={"target_language": "mr", "target_confidence": 0.95, "reasoning": "r"}
     )

--- a/tests/test_substance_gate_foreign_max.py
+++ b/tests/test_substance_gate_foreign_max.py
@@ -40,7 +40,7 @@ def _tm(monkeypatch, segments, buffer_max):
     synth.labels = ["hi", "mr"]
     tm.tools = {"transcriber": pool, "synthesizer": synth, "input": MagicMock()}
     tm.language_switcher = MagicMock()
-    tm.lid_explicit_only = False
+    tm.language_switcher.explicit_only = False
     tm.language_switcher.decide = AsyncMock(
         return_value={"target_language": "mr", "target_confidence": 0.95, "reasoning": "r"}
     )


### PR DESCRIPTION
Description:

What

A new opt-in mode for the LLM language switch. When an agent has tools_config["language_switch_explicit_only"] set (per-agent toggle from the dashboard's multilingual config), the switch judge runs a different prompt whose contract is: switch only when the caller explicitly requests, selects, or confirms a language — the language they happen to be speaking never triggers a switch.

Default is off. With the toggle absent, nothing changes — the ambient judge, its prompt, and every gate run exactly as today.

Why

Some customers ask the caller for a language preference in their own flow (or operate in high code-mixing environments) and want deterministic switching: only on "Hindi please" / "can you speak English?" / a "yes" to the agent's own language question — never because the caller uttered a sentence in another language.

How

New prompt pair (bolna/prompts.py): EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT — an 18-rule controller prompt covering direct requests, capability questions, agent-prompted selection (one-word answers, ordinals, yes/no confirmations), corrections, rejections, mentions/quotes/hypotheticals, unsupported and already-active requests — plus EXPLICIT_LANGUAGE_SWITCH_TURN_PROMPT. The system block keeps the same cache_control treatment as the ambient prompt.

One new input: last_agent_turn. The explicit prompt interprets the caller's reply in the context of the agent's immediately-preceding line ("Would you prefer Hindi or Telugu?" → "Telugu." switches). Sourced from a new ConversationHistory.last_assistant_content() (skips tool rows). The explicit mode reads this instead of the ambient prompt's RECENT TURNS drift history.

Gate semantics in explicit mode: the judge's authorization is the gate. The detection-confidence gates (confidence/corroboration, substance/short-audio, rule-3a alphanumeric veto) are bypassed — they exist to filter noisy ambient detections and would veto legitimate one-word answers like "Telugu." The structural gates are kept: hangup/teardown re-check, target-in-labels, target-has-a-synth-voice, concurrent-switch — those are physical-capability checks, not detection checks.

Telemetry: lid_detection_events records now carry the explicit judge's request_status (switch|already_active|unsupported|ambiguous|no_request) and request_source (direct_request|specific_capability_question|agent_prompted_selection|none); None on ambient decisions.

Not changed

The ambient path is untouched code, not a re-tested equivalent: all 94 pre-existing LID tests pass without a single assertion edited. Speculation, playback gate, idle-flush watcher, switch mechanics, and the language directive are shared unchanged by both modes.

Tests

tests/test_language_switch_explicit.py (14):

prompt selection per mode; last_agent_turn present in explicit / absent in ambient; (none) marker; empty-LIVE stays "" in explicit (ambient keeps its idle-flush marker)
the three canonical examples end-to-end through decide(): speaks-Hindi-no-request → stay; one-word "Telugu." after the agent's question → switch; "yes" to two offered languages → ambiguous/stay
task_manager: explicit switch proceeds past evidence that gates ambient mode (0.3s low-prob segment, self-confidence 0.2); same evidence in ambient mode → gated:low_confidence; unsupported target and missing synth voice still block in explicit mode; telemetry fields recorded

Test-harness hardening: five existing suites build TaskManager stand-ins from MagicMock, whose auto-created lid_explicit_only is truthy — they'd have silently taken the new branch. Set False in the shared conftest factory + 3 files.

Full suite: 1186 passed, 1 skipped. ruff check + format clean.

Config contract

tools_config["language_switch_explicit_only"]: bool — set per call by dashboard-backend from multilingual_config.explicit_switch_only (companion PR). Only read when llm_language_switch is enabled.