### PR TITLE
feat: real playback marks for FreeSWITCH webcalls — in-band echoes replace the duration estimator

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.209"
+__version__ = "0.10.210"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/mark_event_meta_data.py
+++ b/bolna/helpers/mark_event_meta_data.py
@@ -168,6 +168,14 @@ class MarkEventMetaData:
             return ""
         return (self.heard_text_by_response.get(response_uid) or "").strip()
 
+    def drop_data(self, mark_id):
+        """Remove a mark that was never played (cleared echo): no ack stamp, so last-ack
+        playback crediting and chunk-mark analytics can't count it as heard."""
+        entry = self.mark_event_meta_data.pop(mark_id, {})
+        if entry:
+            entry["cleared"] = True
+        return entry
+
     def fetch_data(self, mark_id):
         entry = self.mark_event_meta_data.get(mark_id)
         if entry is not None and entry.get("type") != "pre_mark_message":

--- a/bolna/input_handlers/telephony_providers/freeswitch.py
+++ b/bolna/input_handlers/telephony_providers/freeswitch.py
@@ -33,11 +33,16 @@ class FreeSwitchInputHandler(DefaultInputHandler):
 
     async def process_message(self, message):
         if message.get("type") == "markPlayed":
-            # real per-chunk playback ack: registry ack here, turn-end in the output handler
             name = message.get("name")
+            # cleared = dropped unplayed (killAudio/ring overflow): pop the registry WITHOUT
+            # recording heard text or driving turn-end — the caller never heard this audio
+            if message.get("cleared"):
+                if self.mark_event_meta_data:
+                    self.mark_event_meta_data.fetch_data(name)
+                return
+            # real per-chunk playback ack: registry ack here, turn-end in the output handler
             self.process_mark_message({"type": "mark", "name": name})
-            # cleared = dropped unplayed (killAudio/ring overflow): ack registry, never drive turn-end
-            if not message.get("cleared") and self.on_mark_played:
+            if self.on_mark_played:
                 self.on_mark_played(name)
             return
         if message.get("type") == "playoutDone":

--- a/bolna/input_handlers/telephony_providers/freeswitch.py
+++ b/bolna/input_handlers/telephony_providers/freeswitch.py
@@ -34,11 +34,11 @@ class FreeSwitchInputHandler(DefaultInputHandler):
     async def process_message(self, message):
         if message.get("type") == "markPlayed":
             name = message.get("name")
-            # cleared = dropped unplayed (killAudio/ring overflow): pop the registry WITHOUT
-            # recording heard text or driving turn-end — the caller never heard this audio
+            # cleared = dropped unplayed (killAudio/ring overflow): drop from the registry with
+            # no ack stamp — heard text, tail-credit and turn-end must never count it
             if message.get("cleared"):
                 if self.mark_event_meta_data:
-                    self.mark_event_meta_data.fetch_data(name)
+                    self.mark_event_meta_data.drop_data(name)
                 return
             # real per-chunk playback ack: registry ack here, turn-end in the output handler
             self.process_mark_message({"type": "mark", "name": name})

--- a/bolna/input_handlers/telephony_providers/freeswitch.py
+++ b/bolna/input_handlers/telephony_providers/freeswitch.py
@@ -28,8 +28,22 @@ class FreeSwitchInputHandler(DefaultInputHandler):
         # set by FreeSwitchOutputHandler: called when mod_audio_stream reports its playout
         # buffer ACTUALLY drained (real playback-complete, vs the byte-count estimate)
         self.on_playout_done = None
+        # set by FreeSwitchOutputHandler: per-mark playback echoes from the patched module
+        self.on_mark_played = None
 
     async def process_message(self, message):
+        if message.get("type") == "markPlayed":
+            # the module's playhead crossed this in-band mark — a REAL per-chunk playback ack.
+            # Registry ack here (sync_history/latency read these), turn-end in the output
+            # handler. A mark cleared by killAudio arrives after handle_interruption already
+            # emptied the registry, so it no-ops — exactly like telephony's cleared marks.
+            name = message.get("name")
+            self.process_mark_message({"type": "mark", "name": name})
+            # cleared = the module dropped it unplayed (killAudio flush / ring overflow) — ack
+            # the registry but never drive turn-end off audio that was not actually heard
+            if not message.get("cleared") and self.on_mark_played:
+                self.on_mark_played(name)
+            return
         if message.get("type") == "playoutDone":
             # mod_audio_stream: all queued TTS has really been played to the caller — hand the
             # signal to the output handler so turn-taking state matches what was heard

--- a/bolna/input_handlers/telephony_providers/freeswitch.py
+++ b/bolna/input_handlers/telephony_providers/freeswitch.py
@@ -28,19 +28,15 @@ class FreeSwitchInputHandler(DefaultInputHandler):
         # set by FreeSwitchOutputHandler: called when mod_audio_stream reports its playout
         # buffer ACTUALLY drained (real playback-complete, vs the byte-count estimate)
         self.on_playout_done = None
-        # set by FreeSwitchOutputHandler: per-mark playback echoes from the patched module
+        # set by FreeSwitchOutputHandler: per-mark playback echoes from the module
         self.on_mark_played = None
 
     async def process_message(self, message):
         if message.get("type") == "markPlayed":
-            # the module's playhead crossed this in-band mark — a REAL per-chunk playback ack.
-            # Registry ack here (sync_history/latency read these), turn-end in the output
-            # handler. A mark cleared by killAudio arrives after handle_interruption already
-            # emptied the registry, so it no-ops — exactly like telephony's cleared marks.
+            # real per-chunk playback ack: registry ack here, turn-end in the output handler
             name = message.get("name")
             self.process_mark_message({"type": "mark", "name": name})
-            # cleared = the module dropped it unplayed (killAudio flush / ring overflow) — ack
-            # the registry but never drive turn-end off audio that was not actually heard
+            # cleared = dropped unplayed (killAudio/ring overflow): ack registry, never drive turn-end
             if not message.get("cleared") and self.on_mark_played:
                 self.on_mark_played(name)
             return

--- a/bolna/output_handlers/telephony_providers/freeswitch.py
+++ b/bolna/output_handlers/telephony_providers/freeswitch.py
@@ -1,6 +1,7 @@
 import asyncio
 import base64
 import json
+import os
 import time
 import uuid
 
@@ -35,11 +36,39 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         self._finish_task = None
         self._finish_marks = []
         self.stream_sid = None
+        # In-band playback marks (Twilio semantics): each chunk's frames are followed by a
+        # {"type":"mark"} the patched module echoes as markPlayed when its playhead crosses that
+        # offset. The FINAL mark's echo ends the turn after a short settle for the browser's
+        # jitter buffer; the duration estimator below stays armed as the fallback (old module /
+        # lost echo), and registry acks are idempotent so whichever fires second is a no-op.
+        self.playback_settle_s = float(os.getenv("WEBCALL_PLAYBACK_SETTLE_S", "0.15"))
+        self._final_mark_id = None
+        self.marks_echoed = False  # first echo = module supports marks (observability)
+        if input_handler is not None:
+            input_handler.on_mark_played = self.on_mark_played
         # REAL playback-complete via mod_audio_stream's playoutDone is available (see
         # on_playout_done_event) but DISABLED: it finishes the turn at buffer-drain, which is
         # marginally before the caller's downstream jitter/browser buffer stops playing, risking
         # an early turn-end/tail clip. Turn-end uses the byte-count estimator (below) — proven,
         # and interruption does not depend on this. Re-enable by wiring on_playout_done here.
+
+    def on_mark_played(self, name):
+        """Echo from the patched module: the playhead crossed this mark (registry ack already
+        recorded by the input handler). The final mark's echo is real playback-complete."""
+        if self._closed:
+            return
+        self.marks_echoed = True
+        if name in self._pending_marks:
+            self._pending_marks.remove(name)
+        if name in self._finish_marks:
+            self._finish_marks.remove(name)
+        if self._final_mark_id is not None and name == self._final_mark_id:
+            self._final_mark_id = None
+            if self._finish_task and not self._finish_task.done():
+                self._finish_task.cancel()  # estimator superseded by the real playback clock
+            self._finish_task = asyncio.create_task(
+                self._complete_after_playout(self.playback_settle_s, list(self._finish_marks))
+            )
 
     def on_playout_done_event(self):
         # AVAILABLE, currently unwired (see __init__). Finish the response the instant the
@@ -51,6 +80,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         if self._finish_task and not self._finish_task.done():
             self._finish_task.cancel()
         marks, self._finish_marks = self._finish_marks, []
+        self._final_mark_id = None  # same stale-echo guard as the estimator path
         for mark_id in marks:
             if self.input_handler:
                 self.input_handler.process_mark_message({"type": "mark", "name": mark_id})
@@ -80,6 +110,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
             self._finish_task.cancel()
         self._pending_marks = []
         self._finish_marks = []
+        self._final_mark_id = None
         self._response_bytes = 0
         self._response_first_send = None
         if self.input_handler and self.input_handler.is_audio_being_played_to_user():
@@ -97,6 +128,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
             self._finish_task.cancel()
         self._pending_marks = []
         self._finish_marks = []
+        self._final_mark_id = None
         self._response_bytes = 0
         self._response_first_send = None
         if self.mark_event_meta_data:
@@ -110,6 +142,9 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
             if remaining > 0:
                 await asyncio.sleep(remaining)
             self._finish_marks = []  # estimator finishing — a later playoutDone must not re-ack
+            # a late final-mark echo (estimator ran early, module still draining) must not match
+            # into the NEXT response and clear is_audio_being_played mid-speech
+            self._final_mark_id = None
             for mark_id in marks:
                 if self.input_handler:
                     self.input_handler.process_mark_message({"type": "mark", "name": mark_id})
@@ -186,11 +221,15 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
                     },
                 )
             self._pending_marks.append(mark_id)
+            # in-band mark AFTER the chunk's frames: the WS is ordered, so the module records
+            # the marker at exactly this chunk's tail. An unpatched module ignores the type.
+            await self.websocket.send_text(json.dumps({"type": "mark", "name": mark_id}))
 
-            # on the final chunk, arm completion: the module's playoutDone event finishes the
-            # response at the REAL drain moment; the estimated timer is the fallback if the
-            # event is lost (WS blip) — whichever fires first wins, both are idempotent.
+            # on the final chunk, arm completion: the final mark's echo finishes the response at
+            # the REAL playhead (+settle); the estimated timer is the fallback if echoes never
+            # arrive (old module / WS blip) — whichever fires first wins, both are idempotent.
             if is_final:
+                self._final_mark_id = mark_id
                 total_dur = self._response_bytes / self.bytes_per_second
                 # a no-audio final (e.g. language-switch handoff) has no first-send ts
                 first_send = self._response_first_send if self._response_first_send is not None else time.time()

--- a/bolna/output_handlers/telephony_providers/freeswitch.py
+++ b/bolna/output_handlers/telephony_providers/freeswitch.py
@@ -36,11 +36,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         self._finish_task = None
         self._finish_marks = []
         self.stream_sid = None
-        # In-band playback marks (Twilio semantics): each chunk's frames are followed by a
-        # {"type":"mark"} the patched module echoes as markPlayed when its playhead crosses that
-        # offset. The FINAL mark's echo ends the turn after a short settle for the browser's
-        # jitter buffer; the duration estimator below stays armed as the fallback (old module /
-        # lost echo), and registry acks are idempotent so whichever fires second is a no-op.
+        # in-band marks (Twilio semantics): final mark's echo ends the turn (+settle); estimator stays as fallback
         self.playback_settle_s = float(os.getenv("WEBCALL_PLAYBACK_SETTLE_S", "0.15"))
         self._final_mark_id = None
         self.marks_echoed = False  # first echo = module supports marks (observability)
@@ -53,8 +49,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         # and interruption does not depend on this. Re-enable by wiring on_playout_done here.
 
     def on_mark_played(self, name):
-        """Echo from the patched module: the playhead crossed this mark (registry ack already
-        recorded by the input handler). The final mark's echo is real playback-complete."""
+        """Playhead crossed this mark (registry ack already done); the final mark's echo is real playback-complete."""
         if self._closed:
             return
         self.marks_echoed = True
@@ -65,7 +60,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         if self._final_mark_id is not None and name == self._final_mark_id:
             self._final_mark_id = None
             if self._finish_task and not self._finish_task.done():
-                self._finish_task.cancel()  # estimator superseded by the real playback clock
+                self._finish_task.cancel()  # real playback clock supersedes the estimator
             self._finish_task = asyncio.create_task(
                 self._complete_after_playout(self.playback_settle_s, list(self._finish_marks))
             )
@@ -142,9 +137,7 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
             if remaining > 0:
                 await asyncio.sleep(remaining)
             self._finish_marks = []  # estimator finishing — a later playoutDone must not re-ack
-            # a late final-mark echo (estimator ran early, module still draining) must not match
-            # into the NEXT response and clear is_audio_being_played mid-speech
-            self._final_mark_id = None
+            self._final_mark_id = None  # a late final echo must not match into the next response
             for mark_id in marks:
                 if self.input_handler:
                     self.input_handler.process_mark_message({"type": "mark", "name": mark_id})
@@ -221,13 +214,10 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
                     },
                 )
             self._pending_marks.append(mark_id)
-            # in-band mark AFTER the chunk's frames: the WS is ordered, so the module records
-            # the marker at exactly this chunk's tail. An unpatched module ignores the type.
+            # in-band mark after the chunk's frames (ordered WS); an unpatched module ignores the type
             await self.websocket.send_text(json.dumps({"type": "mark", "name": mark_id}))
 
-            # on the final chunk, arm completion: the final mark's echo finishes the response at
-            # the REAL playhead (+settle); the estimated timer is the fallback if echoes never
-            # arrive (old module / WS blip) — whichever fires first wins, both are idempotent.
+            # on the final chunk, arm completion: final-mark echo wins, estimated timer is the fallback
             if is_final:
                 self._final_mark_id = mark_id
                 total_dur = self._response_bytes / self.bytes_per_second

--- a/bolna/output_handlers/telephony_providers/freeswitch.py
+++ b/bolna/output_handlers/telephony_providers/freeswitch.py
@@ -38,6 +38,8 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         self.stream_sid = None
         # in-band marks (Twilio semantics): final mark's echo ends the turn (+settle); estimator stays as fallback
         self.playback_settle_s = float(os.getenv("WEBCALL_PLAYBACK_SETTLE_S", "0.15"))
+        # once echoes are confirmed, the estimator gets this grace so the real echo wins the race
+        self.estimator_grace_s = float(os.getenv("WEBCALL_ESTIMATOR_GRACE_S", "1.5"))
         self._final_mark_id = None
         self.marks_echoed = False  # first echo = module supports marks (observability)
         if input_handler is not None:
@@ -136,6 +138,8 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
         try:
             if remaining > 0:
                 await asyncio.sleep(remaining)
+            if self.marks_echoed:
+                logger.warning("freeswitch: estimator watchdog fired despite mark echoes (echo lost?)")
             self._finish_marks = []  # estimator finishing — a later playoutDone must not re-ack
             self._final_mark_id = None  # a late final echo must not match into the next response
             for mark_id in marks:
@@ -208,7 +212,11 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
                         "is_first_chunk": meta_info.get("is_first_chunk", False),
                         "is_final_chunk": is_final,
                         "sequence_id": meta_info.get("sequence_id"),
-                        # record_ack / latency tracking require these (same contract as sip_trunk)
+                        # turn mapping fields (same contract as telephony.py) — without turn_id,
+                        # sync_history can't map acked marks to a turn and skips barge-in trims
+                        "turn_id": meta_info.get("turn_id"),
+                        "response_uid": meta_info.get("response_uid"),
+                        "response_group_uid": meta_info.get("response_group_uid"),
                         "duration": (len(audio) / self.bytes_per_second) if has_audio else 0.0,
                         "sent_ts": time.time(),
                     },
@@ -224,6 +232,11 @@ class FreeSwitchOutputHandler(DefaultOutputHandler):
                 # a no-audio final (e.g. language-switch handoff) has no first-send ts
                 first_send = self._response_first_send if self._response_first_send is not None else time.time()
                 remaining = (first_send + total_dur) - time.time()
+                # bare `remaining` is a LOWER bound on real playback end (startup + jitter land
+                # later), so an ungraced estimator always beats the echo and the settle never
+                # applies. With echoes confirmed, demote the estimator to a watchdog.
+                if self.marks_echoed:
+                    remaining = max(remaining, 0) + self.estimator_grace_s
                 marks, self._pending_marks = self._pending_marks, []
                 self._response_bytes = 0
                 self._response_first_send = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.209"
+version = "0.10.210"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_freeswitch_marks.py
+++ b/tests/test_freeswitch_marks.py
@@ -1,0 +1,144 @@
+"""In-band playback marks on the FreeSWITCH webcall path.
+
+Each TTS chunk's streamAudio frames are followed by a {"type":"mark"} the patched
+mod_audio_stream echoes as markPlayed when its playhead crosses that offset. The final
+mark's echo ends the turn (+settle); the duration estimator stays as the fallback for an
+unpatched module, so every test here pins one side of that dual path.
+"""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.input_handlers.telephony_providers.freeswitch import FreeSwitchInputHandler
+from bolna.output_handlers.telephony_providers.freeswitch import FreeSwitchOutputHandler
+
+
+def _make_output(settle=0.01):
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    input_handler = MagicMock()
+    input_handler.is_audio_being_played_to_user = MagicMock(return_value=True)
+    handler = FreeSwitchOutputHandler(websocket=ws, mark_event_meta_data=None, input_handler=input_handler)
+    handler.playback_settle_s = settle
+    return handler, ws, input_handler
+
+
+def _sent_types(ws):
+    return [json.loads(c.args[0])["type"] for c in ws.send_text.await_args_list]
+
+
+PCM = b"\x01\x02" * 1600  # 3200B of L16
+
+
+def _packet(final=False, mark_id=None):
+    meta = {"type": "audio", "sequence_id": 2, "mark_id": mark_id}
+    if final:
+        meta["end_of_llm_stream"] = True
+        meta["end_of_synthesizer_stream"] = True
+    return {"data": PCM, "meta_info": meta}
+
+
+@pytest.mark.asyncio
+async def test_mark_sent_in_band_after_audio_frames():
+    handler, ws, _ = _make_output()
+    await handler.handle(_packet(mark_id="m-1"))
+    types = _sent_types(ws)
+    assert types[-1] == "mark", types
+    assert all(t == "streamAudio" for t in types[:-1])
+    assert json.loads(ws.send_text.await_args_list[-1].args[0])["name"] == "m-1"
+
+
+@pytest.mark.asyncio
+async def test_final_mark_echo_completes_turn_and_supersedes_estimator():
+    handler, ws, input_handler = _make_output()
+    await handler.handle(_packet(final=True, mark_id="m-final"))
+    estimator = handler._finish_task
+    assert estimator is not None and not estimator.done()
+    assert handler._final_mark_id == "m-final"
+
+    handler.on_mark_played("m-final")
+    assert handler.marks_echoed is True
+    assert handler._final_mark_id is None
+    await asyncio.sleep(0.05)  # settle (0.01) elapses
+    assert estimator.cancelled()
+    input_handler.update_is_audio_being_played.assert_called_with(False)
+
+
+@pytest.mark.asyncio
+async def test_no_echoes_falls_back_to_estimator():
+    handler, ws, input_handler = _make_output()
+    await handler.handle(_packet(final=True, mark_id="m-final"))
+    # unpatched module: no echoes ever arrive; the estimator (audio is 3200B @48kBps -> ~66ms)
+    await asyncio.wait_for(handler._finish_task, timeout=2)
+    assert handler.marks_echoed is False
+    input_handler.update_is_audio_being_played.assert_called_with(False)
+
+
+@pytest.mark.asyncio
+async def test_mid_response_echo_does_not_complete_turn():
+    handler, ws, input_handler = _make_output()
+    await handler.handle(_packet(mark_id="m-1"))
+    await handler.handle(_packet(final=True, mark_id="m-2"))
+    handler.on_mark_played("m-1")
+    assert handler._final_mark_id == "m-2"  # still armed
+    input_handler.update_is_audio_being_played.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_interruption_resets_final_mark():
+    handler, ws, _ = _make_output()
+    await handler.handle(_packet(final=True, mark_id="m-final"))
+    await handler.handle_interruption()
+    assert handler._final_mark_id is None
+    # a stale echo after barge-in must not restart completion
+    handler.on_mark_played("m-final")
+    assert handler._final_mark_id is None
+
+
+@pytest.mark.asyncio
+async def test_input_handler_routes_mark_played():
+    handler = FreeSwitchInputHandler.__new__(FreeSwitchInputHandler)
+    handler.on_mark_played = MagicMock()
+    handler.on_playout_done = None
+    handler.process_mark_message = MagicMock()
+    await handler.process_message({"type": "markPlayed", "name": "m-9"})
+    handler.process_mark_message.assert_called_once_with({"type": "mark", "name": "m-9"})
+    handler.on_mark_played.assert_called_once_with("m-9")
+
+
+def test_output_handler_wires_callback_onto_input_handler():
+    handler, _, input_handler = _make_output()
+    assert input_handler.on_mark_played == handler.on_mark_played
+
+
+@pytest.mark.asyncio
+async def test_stale_final_echo_after_estimator_completion_is_ignored():
+    # estimator finishes the turn early while the module is still draining; the late final
+    # echo must not match into the next response and clear is_audio_being_played mid-speech
+    handler, ws, input_handler = _make_output()
+    await handler.handle(_packet(final=True, mark_id="m-old-final"))
+    await asyncio.wait_for(handler._finish_task, timeout=2)  # estimator completes the turn
+    assert handler._final_mark_id is None
+    input_handler.update_is_audio_being_played.reset_mock()
+
+    # next response is mid-flight (not yet final) when the stale echo lands
+    await handler.handle(_packet(mark_id="m-next-1"))
+    handler.on_mark_played("m-old-final")
+    await asyncio.sleep(0.05)
+    input_handler.update_is_audio_being_played.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleared_echo_acks_registry_but_never_ends_turn():
+    # "cleared":true = dropped unplayed (killAudio / ring overflow); a cleared FINAL echo must
+    # not complete the turn while real audio is still queued
+    handler = FreeSwitchInputHandler.__new__(FreeSwitchInputHandler)
+    handler.on_mark_played = MagicMock()
+    handler.on_playout_done = None
+    handler.process_mark_message = MagicMock()
+    await handler.process_message({"type": "markPlayed", "name": "m-final", "cleared": True})
+    handler.process_mark_message.assert_called_once()
+    handler.on_mark_played.assert_not_called()

--- a/tests/test_freeswitch_marks.py
+++ b/tests/test_freeswitch_marks.py
@@ -46,18 +46,34 @@ async def test_mark_sent_in_band_after_audio_frames():
 
 
 @pytest.mark.asyncio
-async def test_final_mark_echo_completes_turn_and_supersedes_estimator():
+async def test_final_mark_echo_wins_the_real_race_once_echoes_confirmed():
+    # prod ordering: real playback ends AFTER the bare estimate, so the echo arrives late;
+    # with echoes confirmed the estimator is a graced watchdog and the echo must win
     handler, ws, input_handler = _make_output()
+    handler.estimator_grace_s = 0.5
+    handler.marks_echoed = True  # module confirmed patched (first echo already seen)
     await handler.handle(_packet(final=True, mark_id="m-final"))
     estimator = handler._finish_task
-    assert estimator is not None and not estimator.done()
-    assert handler._final_mark_id == "m-final"
 
-    handler.on_mark_played("m-final")
-    assert handler.marks_echoed is True
+    await asyncio.sleep(0.1)  # past the bare ~66ms estimate — watchdog grace must be holding
+    assert not estimator.done()
+    input_handler.update_is_audio_being_played.assert_not_called()
+
+    handler.on_mark_played("m-final")  # the late real echo
     assert handler._final_mark_id is None
+    assert handler._finish_task is not estimator  # settle task replaced the watchdog
     await asyncio.sleep(0.05)  # settle (0.01) elapses
-    assert estimator.cancelled()
+    assert estimator.done()  # cancelled mid-sleep (the coro swallows CancelledError by design)
+    input_handler.update_is_audio_being_played.assert_called_once_with(False)
+
+
+@pytest.mark.asyncio
+async def test_watchdog_completes_turn_when_echo_is_lost():
+    handler, ws, input_handler = _make_output()
+    handler.estimator_grace_s = 0.05
+    handler.marks_echoed = True
+    await handler.handle(_packet(final=True, mark_id="m-final"))
+    await asyncio.wait_for(handler._finish_task, timeout=2)  # ~66ms estimate + 50ms grace
     input_handler.update_is_audio_being_played.assert_called_with(False)
 
 
@@ -125,12 +141,38 @@ async def test_stale_final_echo_after_estimator_completion_is_ignored():
 
 
 @pytest.mark.asyncio
-async def test_cleared_echo_acks_registry_but_never_ends_turn():
-    # cleared = dropped unplayed; a cleared FINAL echo must not complete the turn
+async def test_cleared_echo_pops_registry_without_heard_text_or_turn_end():
+    # cleared = dropped unplayed; must not record heard text nor complete the turn
     handler = FreeSwitchInputHandler.__new__(FreeSwitchInputHandler)
     handler.on_mark_played = MagicMock()
     handler.on_playout_done = None
     handler.process_mark_message = MagicMock()
+    handler.mark_event_meta_data = MagicMock()
     await handler.process_message({"type": "markPlayed", "name": "m-final", "cleared": True})
-    handler.process_mark_message.assert_called_once()
+    handler.mark_event_meta_data.fetch_data.assert_called_once_with("m-final")
+    handler.process_mark_message.assert_not_called()
     handler.on_mark_played.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_mark_registration_carries_turn_mapping_fields():
+    # sync_history maps acked marks -> turn via these; without them barge-in trims are skipped
+    ws = MagicMock()
+    ws.send_text = AsyncMock()
+    registry = MagicMock()
+    handler = FreeSwitchOutputHandler(websocket=ws, mark_event_meta_data=registry, input_handler=None)
+    meta = {
+        "type": "audio",
+        "sequence_id": 2,
+        "mark_id": "m-1",
+        "turn_id": 7,
+        "response_uid": "r-uid",
+        "response_group_uid": "g-uid",
+        "text_synthesized": "hello",
+    }
+    await handler.handle({"data": PCM, "meta_info": meta})
+    entry = registry.update_data.call_args[0][1]
+    assert entry["turn_id"] == 7
+    assert entry["response_uid"] == "r-uid"
+    assert entry["response_group_uid"] == "g-uid"
+    assert entry["text_synthesized"] == "hello"

--- a/tests/test_freeswitch_marks.py
+++ b/tests/test_freeswitch_marks.py
@@ -141,17 +141,24 @@ async def test_stale_final_echo_after_estimator_completion_is_ignored():
 
 
 @pytest.mark.asyncio
-async def test_cleared_echo_pops_registry_without_heard_text_or_turn_end():
-    # cleared = dropped unplayed; must not record heard text nor complete the turn
+async def test_cleared_echo_drops_mark_without_ack_heard_text_or_turn_end():
+    # cleared = dropped unplayed; no heard text, no turn-end, and NO ack stamp (an acked
+    # cleared mark would advance last-ack tail crediting for audio never played)
+    from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+
+    registry = MarkEventMetaData()
+    registry.update_data("m-x", {"type": "", "sequence_id": 2, "turn_id": 2, "text_synthesized": "never played"})
     handler = FreeSwitchInputHandler.__new__(FreeSwitchInputHandler)
     handler.on_mark_played = MagicMock()
     handler.on_playout_done = None
     handler.process_mark_message = MagicMock()
-    handler.mark_event_meta_data = MagicMock()
-    await handler.process_message({"type": "markPlayed", "name": "m-final", "cleared": True})
-    handler.mark_event_meta_data.fetch_data.assert_called_once_with("m-final")
+    handler.mark_event_meta_data = registry
+    await handler.process_message({"type": "markPlayed", "name": "m-x", "cleared": True})
     handler.process_mark_message.assert_not_called()
     handler.on_mark_played.assert_not_called()
+    assert registry.fetch_data("m-x") == {}  # popped
+    assert registry.get_last_ack_ts_for_turn(2) is None  # never stamped as acked
+    assert registry.get_heard_text_for_turn(2) == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_freeswitch_marks.py
+++ b/tests/test_freeswitch_marks.py
@@ -1,10 +1,4 @@
-"""In-band playback marks on the FreeSWITCH webcall path.
-
-Each TTS chunk's streamAudio frames are followed by a {"type":"mark"} the patched
-mod_audio_stream echoes as markPlayed when its playhead crosses that offset. The final
-mark's echo ends the turn (+settle); the duration estimator stays as the fallback for an
-unpatched module, so every test here pins one side of that dual path.
-"""
+"""In-band playback marks on the FreeSWITCH webcall path: echoes end the turn, estimator is the fallback."""
 
 import asyncio
 import json
@@ -116,8 +110,7 @@ def test_output_handler_wires_callback_onto_input_handler():
 
 @pytest.mark.asyncio
 async def test_stale_final_echo_after_estimator_completion_is_ignored():
-    # estimator finishes the turn early while the module is still draining; the late final
-    # echo must not match into the next response and clear is_audio_being_played mid-speech
+    # a late final echo must not match into the next response and clear is_audio_being_played
     handler, ws, input_handler = _make_output()
     await handler.handle(_packet(final=True, mark_id="m-old-final"))
     await asyncio.wait_for(handler._finish_task, timeout=2)  # estimator completes the turn
@@ -133,8 +126,7 @@ async def test_stale_final_echo_after_estimator_completion_is_ignored():
 
 @pytest.mark.asyncio
 async def test_cleared_echo_acks_registry_but_never_ends_turn():
-    # "cleared":true = dropped unplayed (killAudio / ring overflow); a cleared FINAL echo must
-    # not complete the turn while real audio is still queued
+    # cleared = dropped unplayed; a cleared FINAL echo must not complete the turn
     handler = FreeSwitchInputHandler.__new__(FreeSwitchInputHandler)
     handler.on_mark_played = MagicMock()
     handler.on_playout_done = None


### PR DESCRIPTION
## What

Webcall (FreeSWITCH) playback tracking is simulated today: every TTS chunk's mark is
acked in ONE batch when a duration estimate (`first_send + audio_bytes/rate`) elapses.
Telephony gets real per-chunk acks (Twilio/Plivo echo marks at the playhead; sip-trunk
mirrors it via Asterisk's MEDIA_MARK_PROCESSED). Prod evidence of the simulation
(run `daceca18…`): 19 marks sent over ~130ms, all 19 "acked" in the same 10ms window
2.9s later — `avg_delay 2.921s` is an artifact, not latency.

What the simulation costs:
- **Barge-in truncation is blind mid-response** — `sync_history` reconstructs "what the
  caller heard" from per-mark ack timestamps; a mid-response barge-in has zero acked
  marks, so the truncated transcript (and the interruption hint fed to the LLM) is wrong.
- **Turn-end drifts** — the estimator assumes playout starts at first send; FS injection
  timing + the browser jitter buffer + slow TTS all push real playback later, so the
  "agent is speaking" window closes early and real barge-ins aren't classified.
- **Tool/hangup gating rides the same clock** (`wait_for_current_message`).
- mark_tracking stats are noise on webcalls — nothing alertable.

## How

Twilio's documented mark semantics, adapted to the fork protocol (paired
fs-media-server PR adds the module side):

- **Output handler** sends `{"type":"mark","name":id}` in-band after each chunk's
  streamAudio frames (mark registered before the send, so an echo can never race it).
  The patched module echoes `{"type":"markPlayed"}` when its playhead crosses that
  offset — sample-accurate, per chunk.
- **Input handler** routes echoes to the existing generic `process_mark_message`
  (real per-chunk ack timestamps for sync_history/latency) and notifies the output
  handler. `"cleared":true` echoes (killAudio flush / ring overflow = dropped unplayed)
  ack the registry but NEVER drive turn-end.
- **Turn-end** = the final mark's echo + `WEBCALL_PLAYBACK_SETTLE_S` (env, default
  0.15s) covering the browser's jitter buffer — the exact reason the module's
  `playoutDone` was left unwired. Completion reuses `_complete_after_playout`, so it
  stays cancellable and idempotent.
- **Estimator demoted to fallback, not removed**: with an unpatched module no echoes
  arrive and behavior is byte-identical to today (verified: the old module's
  processMessage ignores unknown types, and registry acks pop-on-fetch so the second
  ack no-ops). No version negotiation needed; either side deploys first.

Stale-echo hardening (both found in self-review, regression-tested): `_final_mark_id`
is cleared in EVERY completion path, so a late final echo (estimator ran early, module
still draining) can't match into the next response and clear `is_audio_being_played`
mid-speech.

## Not touched

Telephony handlers, sip_trunk, `mark_event_meta_data` API, task_manager, `playoutDone`
handling, dashboard-backend (handlers are constructed via bolna's provider registry;
deploying needs only the usual version bump there).

## Tests

New `tests/test_freeswitch_marks.py` (9): in-band send ordering; final-echo completes
the turn and cancels the estimator; no-echo falls back to the estimator; mid-response
echo does not complete; interruption resets; stale-final-echo after estimator
completion is ignored; cleared echo acks but never ends the turn; input routing;
callback wiring. Full suite: **1174 passed**, ruff check + format clean.
