### PR TITLE
Add Kalpa Labs TTS synthesizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ https://github.com/bolna-ai/bolna/blob/c8a0d1428793d4df29133119e354bc2f85a7ca76/
 | Cartesia   | `CARTESIA_API_KEY`                            |
 | Smallest   | `SMALLEST_API_KEY`                            |
 | Maya       | `MAYA_API_KEY`                            |
+| Kalpa      | `KALPA_API_KEY`                            |
 
 </details>
 &nbsp;<br>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ graph LR;
 1. Initiating a phone call using telephony providers like `Twilio`, `Plivo`, `Exotel` (coming soon), `Vonage` (coming soon) etc.
 2. Transcribing the conversations using `Deepgram`, `Azure` etc.
 3. Using LLMs like `OpenAI`, `DeepSeek`, `Llama`, `Cohere`, `Mistral`,  etc to handle conversations
-4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest`, `Maya` etc.
+4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest`, `Maya`, `Kalpa` etc.
 
 
 Refer to the [docs](https://docs.bolna.ai/providers) for a deepdive into all supported providers.

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -62,6 +62,7 @@ class SynthesizerProvider(str, Enum):
     RIME = "rime"
     PIXA = "pixa"
     MAYA = "maya"
+    KALPA = "kalpa"
 
     @classmethod
     def all_values(cls):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -122,15 +122,9 @@ class MayaConfig(BaseModel):
 
 
 class KalpaConfig(BaseModel):
-    # Display name from GET /v1/voices (e.g. "Kiara (hindi)"; the base name "Kiara" also
-    # resolves). voice_id is the catalog's opaque id and wins when both are set.
     voice: Optional[str] = None
     voice_id: Optional[str] = None
-    # "kalpa-tts-multilingual-beta-v0.1" (English + Hindi, the default here) or
-    # "kalpa-tts-beta-v0.1" (English). No language parameter — the model detects it,
-    # code-switched Hinglish included.
     model: str = "kalpa-tts-multilingual-beta-v0.1"
-    # Optional sampling controls (Kalpa applies its tuned production defaults when omitted)
     temperature: Optional[float] = None
     top_k: Optional[int] = None
     acoustic_temperature: Optional[float] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -121,6 +121,23 @@ class MayaConfig(BaseModel):
     language: Optional[str] = "en"
 
 
+class KalpaConfig(BaseModel):
+    # Display name from GET /v1/voices (e.g. "Kiara (hindi)"; the base name "Kiara" also
+    # resolves). voice_id is the catalog's opaque id and wins when both are set.
+    voice: Optional[str] = None
+    voice_id: Optional[str] = None
+    # "kalpa-tts-multilingual-beta-v0.1" (English + Hindi, the default here) or
+    # "kalpa-tts-beta-v0.1" (English). No language parameter — the model detects it,
+    # code-switched Hinglish included.
+    model: str = "kalpa-tts-multilingual-beta-v0.1"
+    # Optional sampling controls (Kalpa applies its tuned production defaults when omitted)
+    temperature: Optional[float] = None
+    top_k: Optional[int] = None
+    acoustic_temperature: Optional[float] = None
+    max_new_tokens: Optional[int] = None
+    audio_quality: Optional[str] = None
+
+
 class AzureConfig(BaseModel):
     voice: str
     model: str
@@ -169,6 +186,7 @@ class Synthesizer(BaseModel):
         DeepgramConfig,
         OpenAIConfig,
         MayaConfig,
+        KalpaConfig,
     ] = Field(union_mode="smart")
     stream: bool = False
     buffer_size: Optional[int] = 40  # 40 characters in a buffer
@@ -215,6 +233,9 @@ class Synthesizer(BaseModel):
         elif provider == "maya":
             if isinstance(config, dict):
                 values["provider_config"] = MayaConfig(**config)
+        elif provider == "kalpa":
+            if isinstance(config, dict):
+                values["provider_config"] = KalpaConfig(**config)
 
         return values
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -11,6 +11,7 @@ from .synthesizer import (
     RimeSynthesizer,
     PixaSynthesizer,
     MayaSynthesizer,
+    KalpaSynthesizer,
 )
 from .transcriber import (
     DeepgramTranscriber,
@@ -68,6 +69,7 @@ SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.RIME.value: RimeSynthesizer,
     SynthesizerProvider.PIXA.value: PixaSynthesizer,
     SynthesizerProvider.MAYA.value: MayaSynthesizer,
+    SynthesizerProvider.KALPA.value: KalpaSynthesizer,
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -11,4 +11,5 @@ from .smallest_synthesizer import SmallestSynthesizer
 from .sarvam_synthesizer import SarvamSynthesizer
 from .pixa_synthesizer import PixaSynthesizer
 from .maya_synthesizer import MayaSynthesizer
+from .kalpa_synthesizer import KalpaSynthesizer
 from .synthesizer_pool import SynthesizerPool

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -11,15 +11,19 @@ Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM,
 flushed utterance terminates with exactly one responseDone (status "completed", or
 "cancelled" after a cancelResponse).
 
-Two server-side properties shape this integration:
+Two transport behaviors shape this integration:
 
-  * One response in flight per connection — a flush while a previous response is still
-    generating is rejected with a non-fatal error, not queued. The sender therefore waits
-    for the previous turn's responseDone (tracked client-side) before flushing.
-  * cancelResponse stops generation but does not clear the server-side text buffer, so
-    fragments streamed before a barge-in would silently prepend onto the next turn's
-    utterance. The sender aggregates a whole assistant turn client-side and sends it as a
-    single text+flush frame, keeping every turn atomic on the wire.
+  * One response generates at a time per connection. Current gateways queue one flush that
+    arrives mid-generation (older deployments rejected it outright), and this integration
+    leans on neither: the sender waits for the previous turn's responseDone (a cancelled
+    turn still gets one) before flushing, which serializes turns without ever risking the
+    one-slot queue's rejection and stays correct on older gateways.
+  * On current gateways a bare cancelResponse abandons everything undelivered server-side
+    — the in-flight generation, the queued flush, and buffered text; older deployments
+    only stopped the generation and kept the text buffer. Aggregating a whole assistant
+    turn client-side and sending it as a single text+flush frame keeps every turn atomic
+    on the wire — exactly one responseDone per turn — and never leaves an abandoned
+    turn's fragments in a server buffer on any gateway version.
 
 Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
 chunk down to the target rate and, for telephony, mu-law encode it.
@@ -54,7 +58,8 @@ MAX_TEXT_CHARS = 8000
 
 # How long a flush waits for the previous response's responseDone. Cancels settle in
 # milliseconds, so hitting this means something is wrong — flush anyway and let the
-# server arbitrate rather than silently dropping the turn.
+# server arbitrate rather than silently dropping the turn (current gateways queue the
+# flush in that case, so nothing is lost even then).
 RESPONSE_IDLE_TIMEOUT = 10.0
 
 AUDIO_QUALITIES = {"low", "medium", "high"}
@@ -241,7 +246,9 @@ class KalpaSynthesizer(StreamSynthesizer):
         """Drop the buffered turn and cancel the in-flight response. Cancel is idempotent
         server-side, so it is unconditionally safe to fire; the cancelled response still
         terminates with its own responseDone (status "cancelled"), which frees the
-        in-flight slot without emitting an end-of-stream sentinel."""
+        in-flight slot without emitting an end-of-stream sentinel. On current gateways a
+        bare cancel also wipes undelivered server-side state (queued flush, buffered
+        text) — moot here, since this integration never leaves either behind."""
         self._text_buffer = []
         self._buffer_seq = None
         try:

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -1,0 +1,539 @@
+"""
+Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.
+
+Kalpa's conversational speech models render named voices from GET /v1/voices
+(kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi — including code-switched
+Hinglish — with no language parameter; kalpa-tts-beta-v0.1 is English-only). Everything on
+the socket is JSON text frames: the client authenticates with an initializeConnection
+frame (the handshake itself is unauthenticated), the server confirms with sessionCreated,
+then each sendText frame appends text and flush=true renders the buffered utterance.
+Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM, and every
+flushed utterance terminates with exactly one responseDone (status "completed", or
+"cancelled" after a cancelResponse).
+
+Two server-side properties shape this integration:
+
+  * One response in flight per connection — a flush while a previous response is still
+    generating is rejected with a non-fatal error, not queued. The sender therefore waits
+    for the previous turn's responseDone (tracked client-side) before flushing.
+  * cancelResponse stops generation but does not clear the server-side text buffer, so
+    fragments streamed before a barge-in would silently prepend onto the next turn's
+    utterance. The sender aggregates a whole assistant turn client-side and sends it as a
+    single text+flush frame, keeping every turn atomic on the wire.
+
+Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
+chunk down to the target rate and, for telephony, mu-law encode it.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import time
+
+import aiohttp
+import websockets
+from websockets.exceptions import InvalidHandshake
+
+from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
+from bolna.helpers.utils import audio_to_mulaw8k, pcm_to_ulaw, resample
+from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
+
+logger = configure_logger(__name__)
+
+# The session's true rate arrives in sessionCreated; this is the documented default.
+KALPA_NATIVE_SAMPLE_RATE = 24000
+MULAW_SAMPLE_RATE = 8000
+
+KALPA_DEFAULT_MODEL = "kalpa-tts-multilingual-beta-v0.1"
+
+# Kalpa rejects utterances longer than this; we truncate rather than fail a live turn.
+MAX_TEXT_CHARS = 8000
+
+# How long a flush waits for the previous response's responseDone. Cancels settle in
+# milliseconds, so hitting this means something is wrong — flush anyway and let the
+# server arbitrate rather than silently dropping the turn.
+RESPONSE_IDLE_TIMEOUT = 10.0
+
+AUDIO_QUALITIES = {"low", "medium", "high"}
+
+
+class KalpaSynthesizer(StreamSynthesizer):
+    def __init__(
+        self,
+        voice=None,
+        voice_id=None,
+        model=KALPA_DEFAULT_MODEL,
+        temperature=None,
+        top_k=None,
+        acoustic_temperature=None,
+        max_new_tokens=None,
+        audio_quality=None,
+        audio_format="pcm",
+        sampling_rate="8000",
+        stream=False,
+        buffer_size=400,
+        caching=True,
+        synthesizer_key=None,
+        **kwargs,
+    ):
+        super().__init__(
+            stream=stream,
+            provider_name="kalpa",
+            buffer_size=buffer_size,
+            **kwargs,
+        )
+        self.api_key = os.environ["KALPA_API_KEY"] if synthesizer_key is None else synthesizer_key
+        if not self.api_key:
+            raise ValueError("Kalpa API key is required, either as synthesizer_key or KALPA_API_KEY")
+
+        self.voice = voice
+        # The API addresses voices by opaque id; a bare display name ("Kiara") is resolved
+        # against GET /v1/voices on first connect.
+        self.voice_id = voice_id
+        if not self.voice_id and not self.voice:
+            raise ValueError("Kalpa needs a voice_id or a voice name (see GET /v1/voices)")
+
+        self.model = model
+        # Only explicitly-configured knobs are sent; Kalpa's defaults are the tuned
+        # production sampling.
+        self.params = {
+            key: value
+            for key, value in (
+                ("temperature", temperature),
+                ("top_k", top_k),
+                ("acoustic_temperature", acoustic_temperature),
+                ("max_new_tokens", max_new_tokens),
+                ("audio_quality", audio_quality),
+            )
+            if value is not None
+        }
+
+        self.use_mulaw = kwargs.get("use_mulaw", False)
+        # Telephony always renders at 8 kHz mu-law; web keeps the configured PCM rate.
+        self.target_sample_rate = MULAW_SAMPLE_RATE if self.use_mulaw else int(sampling_rate)
+        self.sampling_rate = self.target_sample_rate
+        self.native_sample_rate = KALPA_NATIVE_SAMPLE_RATE
+
+        self.caching = caching
+        if caching:
+            self.cache = InmemoryScalarCache()
+
+        self.kalpa_host = os.getenv("KALPA_API_HOST", "api.kalpalabs.ai")
+
+        # Fail fast on a misconfigured agent rather than mid-call.
+        self._validate_options()
+
+        # Aggregation state: buffer a whole turn's chunks, flush once on end_of_llm_stream.
+        # _buffer_seq tracks which turn owns the buffer so a superseded turn (new
+        # sequence_id before its end_of_llm_stream) can't leak its half-buffered text.
+        self._text_buffer = []
+        self._buffer_seq = None
+        # Set while no response is generating on the socket (one in flight per connection).
+        self._response_idle = asyncio.Event()
+        self._response_idle.set()
+
+    def get_sleep_time(self):
+        return 0.01
+
+    # ------------------------------------------------------------------
+    # Config validation
+    # ------------------------------------------------------------------
+
+    def _validate_options(self):
+        """Mirror the server's GenParams ranges so a typo fails at agent setup, not on the
+        first turn of a live call. The model id is deliberately not validated against a
+        fixed list — the catalog (GET /v1/models) evolves server-side."""
+        temperature = self.params.get("temperature")
+        if temperature is not None and not 0.0 <= float(temperature) <= 1.5:
+            raise ValueError("Kalpa temperature must be between 0.0 and 1.5")
+        acoustic = self.params.get("acoustic_temperature")
+        if acoustic is not None and not 0.0 <= float(acoustic) <= 1.5:
+            raise ValueError("Kalpa acoustic_temperature must be between 0.0 and 1.5")
+        top_k = self.params.get("top_k")
+        if top_k is not None and int(top_k) < 1:
+            raise ValueError("Kalpa top_k must be >= 1")
+        max_new_tokens = self.params.get("max_new_tokens")
+        if max_new_tokens is not None and not 16 <= int(max_new_tokens) <= 2048:
+            raise ValueError("Kalpa max_new_tokens must be between 16 and 2048")
+        audio_quality = self.params.get("audio_quality")
+        if audio_quality is not None and audio_quality not in AUDIO_QUALITIES:
+            raise ValueError(f"Kalpa audio_quality must be one of {sorted(AUDIO_QUALITIES)}")
+
+    # ------------------------------------------------------------------
+    # StreamSynthesizer hooks
+    # ------------------------------------------------------------------
+
+    def _get_audio_format(self):
+        return "mulaw" if self.use_mulaw else "pcm"
+
+    def _process_audio_chunk(self, chunk):
+        """Resample Kalpa's 24 kHz PCM to the target rate; mu-law encode for telephony."""
+        if not chunk:
+            return None
+        try:
+            audio = resample(
+                chunk,
+                self.target_sample_rate,
+                format="pcm",
+                original_sample_rate=self.native_sample_rate,
+            )
+        except Exception as e:
+            logger.error(f"Error resampling Kalpa audio: {e}")
+            return None
+        return pcm_to_ulaw(audio) if self.use_mulaw else audio
+
+    def _on_push(self, meta_info, text):
+        """Runs synchronously in push order (before the sender task): if a new turn starts
+        while the previous one is still buffered, drop the stale buffer so it can't prepend
+        onto this turn's text."""
+        seq = meta_info.get("sequence_id")
+        if self._buffer_seq is not None and self._buffer_seq != seq and self._text_buffer:
+            logger.info(
+                f"Dropping {len(self._text_buffer)} unflushed Kalpa chunk(s) from superseded seq={self._buffer_seq}"
+            )
+            self._text_buffer = []
+        self._buffer_seq = seq
+
+    # ------------------------------------------------------------------
+    # Voice resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_voice_id(self):
+        """Return the opaque voice id, resolving a display name via GET /v1/voices once.
+
+        Names match case-insensitively, on the full name ("Kiara (hindi)") or its base
+        before the qualifier ("Kiara") — so agent configs don't have to carry UUIDs.
+        """
+        if self.voice_id:
+            return self.voice_id
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        url = f"https://{self.kalpa_host}/v1/voices"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(f"Kalpa GET /v1/voices failed: {resp.status} - {await resp.text()}")
+                body = await resp.json()
+        voices = body.get("data", []) if isinstance(body, dict) else body
+
+        wanted = self.voice.strip().lower()
+        matches = [v for v in voices if v.get("name", "").lower() == wanted]
+        if not matches:
+            matches = [v for v in voices if v.get("name", "").split(" (")[0].lower() == wanted]
+        if len(matches) == 1:
+            self.voice_id = matches[0]["id"]
+            logger.info(f"Resolved Kalpa voice {self.voice!r} -> {matches[0]['name']!r} ({self.voice_id})")
+            return self.voice_id
+
+        names = sorted(v.get("name", "") for v in voices)
+        if not matches:
+            raise ValueError(f"Unknown Kalpa voice {self.voice!r}. Available: {names}")
+        raise ValueError(f"Ambiguous Kalpa voice {self.voice!r} matches {[v['name'] for v in matches]}")
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
+    async def handle_interruption(self):
+        """Drop the buffered turn and cancel the in-flight response. Cancel is idempotent
+        server-side, so it is unconditionally safe to fire; the cancelled response still
+        terminates with its own responseDone (status "cancelled"), which frees the
+        in-flight slot without emitting an end-of-stream sentinel."""
+        self._text_buffer = []
+        self._buffer_seq = None
+        try:
+            ws = self.websocket
+            if ws is not None and ws.state is websockets.protocol.State.OPEN:
+                await ws.send(json.dumps({"type": "cancelResponse"}))
+                logger.info("Sent cancelResponse to Kalpa TTS WebSocket")
+            # The cancelled turn's end-of-stream is never forwarded, so the next turn must
+            # be re-detected as new for stale text_queue entries to be pruned.
+            self.current_turn_start_time = None
+        except Exception as e:
+            logger.error(f"Error handling Kalpa interruption: {e}")
+
+    # ------------------------------------------------------------------
+    # sender / receiver
+    # ------------------------------------------------------------------
+
+    async def sender(self, text, sequence_id, end_of_llm_stream=False):
+        try:
+            if self.conversation_ended:
+                return
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
+                return
+
+            await self._wait_for_ws()
+
+            if text:
+                self._text_buffer.append(text)
+
+            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn
+            # (see the module docstring for why fragments are never streamed server-side).
+            if not end_of_llm_stream:
+                return
+
+            # LLM chunks carry their own spacing, so they concatenate verbatim.
+            full_text = "".join(self._text_buffer).strip()
+            self._text_buffer = []
+            self._buffer_seq = None
+            self.last_text_sent = True
+
+            if not full_text:
+                return
+            if len(full_text) > MAX_TEXT_CHARS:
+                logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
+                full_text = full_text[:MAX_TEXT_CHARS]
+
+            # One response in flight per connection: wait for the previous turn's
+            # responseDone (a cancelled turn still gets one) before flushing.
+            try:
+                await asyncio.wait_for(self._response_idle.wait(), timeout=RESPONSE_IDLE_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning("Kalpa: previous response still in flight after 10s; flushing anyway")
+
+            # The waits above can span a barge-in that retires this sequence without
+            # cancelling the task; re-check before anything reaches the socket.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                return
+
+            try:
+                self._response_idle.clear()
+                if self.ws_send_time is None:
+                    self.ws_send_time = time.perf_counter()
+                await self._send_json({"type": "sendText", "text": full_text, "flush": True})
+            except Exception as e:
+                logger.error(f"Error sending text to Kalpa: {e}")
+                self.connection_error = str(e)
+
+        except asyncio.CancelledError:
+            logger.info("Kalpa sender task was cancelled.")
+        except Exception as e:
+            logger.error(f"Unexpected error in Kalpa sender: {e}")
+
+    async def receiver(self):
+        not_connected_since = None
+        while True:
+            try:
+                if self.conversation_ended:
+                    return
+                if not self._is_ws_connected():
+                    if self.connection_error:
+                        return
+                    now = time.perf_counter()
+                    if not_connected_since is None:
+                        not_connected_since = now
+                    elif now - not_connected_since > 30:
+                        logger.error("Kalpa receiver: WebSocket never connected after 30s, giving up.")
+                        self.connection_error = self.connection_error or "WebSocket never connected"
+                        return
+                    logger.info("Kalpa WebSocket is not connected, skipping receive.")
+                    await asyncio.sleep(0.1)
+                    continue
+                else:
+                    not_connected_since = None
+
+                response = await self.websocket.recv()
+                data = self._loads_event(response)
+                if data is None:
+                    continue
+
+                event = data.get("type")
+                if event == "responseAudio":
+                    chunk = self._decode_audio(data.get("pcm_b64"))
+                    if chunk:
+                        yield chunk
+                elif event == "responseDone":
+                    self._response_idle.set()
+                    status = data.get("status")
+                    logger.info(f"Kalpa responseDone status={status} response_id={data.get('response_id')}")
+                    if status == "completed":
+                        yield b"\x00"
+                    # "cancelled" terminates a turn we interrupted; handle_interruption()
+                    # already abandoned it, so forwarding a sentinel would stamp
+                    # end-of-stream on a turn the pipeline dropped.
+                elif event == "error":
+                    err = data.get("error") or {}
+                    if data.get("fatal"):
+                        # The server closes the socket after a fatal error; ConnectionClosed
+                        # is what ends this loop, and auth failures won't fix themselves.
+                        logger.error(f"Kalpa fatal error: {err}")
+                        if err.get("type") == "authentication_error":
+                            self.connection_error = err.get("message") or "authentication error"
+                    else:
+                        # A non-fatal error is a rejected client frame. This integration only
+                        # sends whole-turn flushes, so the rejected turn will never produce
+                        # audio or a responseDone — terminate it and free the in-flight slot.
+                        logger.error(f"Kalpa TTS error: {err}")
+                        self._response_idle.set()
+                        yield b"\x00"
+                elif event == "sessionCreated":
+                    # Normally consumed inside establish_connection; tolerated here in case
+                    # a future server pushes an unsolicited session update.
+                    self.native_sample_rate = int(data.get("sample_rate") or self.native_sample_rate)
+                elif event == "responseCreated":
+                    logger.info(f"Kalpa responseCreated response_id={data.get('response_id')}")
+                else:
+                    logger.info(f"Ignoring Kalpa event: {data}")
+
+            except websockets.exceptions.ConnectionClosed:
+                logger.info("Kalpa WebSocket connection closed")
+                break
+            except Exception as e:
+                logger.error(f"Error occurred in Kalpa receiver - {e}")
+
+    def _decode_audio(self, pcm_b64):
+        if not pcm_b64:
+            return None
+        try:
+            return base64.b64decode(pcm_b64)
+        except Exception as e:
+            logger.error(f"Kalpa sent undecodable audio: {e}")
+            return None
+
+    @staticmethod
+    def _loads_event(data):
+        try:
+            parsed = json.loads(data)
+        except (TypeError, ValueError):
+            logger.error(f"Kalpa sent a non-JSON frame: {data!r}")
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def _initialize_message(self):
+        message = {"type": "initializeConnection", "api_key": self.api_key}
+        if self.model:
+            message["model"] = self.model
+        if self.params:
+            message["params"] = self.params
+        return message
+
+    async def establish_connection(self):
+        """Connect, authenticate, and consume the init reply — so receiver() only ever sees
+        response frames. Returns the ready websocket, or None (monitor_connection retries;
+        deterministic rejections also set connection_error so it doesn't retry a bad key)."""
+        try:
+            start_time = time.perf_counter()
+            voice_id = await self._resolve_voice_id()
+            ws_url = f"wss://{self.kalpa_host}/v1/tts/{voice_id}/stream"
+            websocket_conn = await asyncio.wait_for(
+                websockets.connect(ws_url, ssl=get_ssl_context(ws_url)),
+                timeout=10.0,
+            )
+            try:
+                # The handshake is unauthenticated by design; auth rides the first frame.
+                await websocket_conn.send(json.dumps(self._initialize_message()))
+                reply = self._loads_event(await asyncio.wait_for(websocket_conn.recv(), timeout=10.0)) or {}
+            except Exception:
+                await websocket_conn.close()
+                raise
+
+            if reply.get("type") != "sessionCreated":
+                err = reply.get("error") or {}
+                message = err.get("message") or f"unexpected init reply: {reply}"
+                logger.error(f"Kalpa session rejected: {message}")
+                # A bad key, model, or voice won't fix itself on retry; an inference-side
+                # outage (e.g. voice seed temporarily unavailable) might.
+                if err.get("type") in ("authentication_error", "invalid_request", "not_found"):
+                    self.connection_error = message
+                await websocket_conn.close()
+                return None
+
+            self.native_sample_rate = int(reply.get("sample_rate") or self.native_sample_rate)
+            # A fresh connection has nothing in flight.
+            self._response_idle.set()
+            if not self.connection_time:
+                self.connection_time = round((time.perf_counter() - start_time) * 1000)
+            logger.info(
+                f"Connected to Kalpa TTS (model={reply.get('model')}, voice={reply.get('voice_id')}, "
+                f"{self.native_sample_rate} Hz)"
+            )
+            return websocket_conn
+        except asyncio.TimeoutError:
+            logger.error("Timeout while connecting to Kalpa TTS websocket")
+            return None
+        except ValueError as e:
+            # Voice resolution failed against the live catalog — retrying won't change it.
+            logger.error(str(e))
+            self.connection_error = str(e)
+            return None
+        except InvalidHandshake as e:
+            logger.error(f"Kalpa TTS handshake failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to connect to Kalpa TTS: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # HTTP (one-shot renders: non-streaming loop, prewarm/handoff clips, caching)
+    # ------------------------------------------------------------------
+
+    async def _generate_http(self, text):
+        """POST /v1/tts/{voice_id}; the response JSON carries base64 16-bit PCM WAV."""
+        try:
+            voice_id = await self._resolve_voice_id()
+        except Exception as e:
+            logger.error(f"Kalpa voice resolution failed: {e}")
+            return None
+
+        payload = {"text": text}
+        if self.model:
+            payload["model"] = self.model
+        if self.params:
+            payload["params"] = self.params
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"https://{self.kalpa_host}/v1/tts/{voice_id}"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                request_id = response.headers.get("X-Request-ID")
+                if response.status != 200:
+                    logger.error(
+                        f"Kalpa TTS HTTP error: {response.status} request_id={request_id} - {await response.text()}"
+                    )
+                    return None
+                data = await response.json()
+        audio = (data.get("audio") or {}).get("data_b64")
+        if not audio:
+            logger.error(f"Kalpa TTS HTTP response carried no audio (request_id={request_id})")
+            return None
+        return self._decode_audio(audio)
+
+    async def synthesize(self, text):
+        """One-shot render used by prewarm/handoff paths. The API returns WAV, whose
+        self-describing header lets downstream mu-law conversion pick the right rate."""
+        return await self._generate_http(text)
+
+    async def synthesize_telephony_clip(self, text):
+        """Mu-law 8000 one-shot for handoff/prewarm clips, converted in-process so the
+        caller skips the pydub/ffmpeg decode. None on non-telephony configs."""
+        if not self.use_mulaw:
+            return None
+        audio = await self._generate_http(text)
+        if not audio:
+            return None
+        return self._process_http_audio(audio)
+
+    def _process_http_audio(self, audio):
+        """Convert the one-shot WAV to the format the non-streaming loop should emit."""
+        if not audio:
+            return audio
+        if self.use_mulaw:
+            return audio_to_mulaw8k(audio, rate_hint=self.native_sample_rate, format_hint="wav")
+        if self.target_sample_rate != self.native_sample_rate:
+            return resample(audio, self.target_sample_rate, format="wav")
+        return audio
+
+    def _get_http_audio_format(self):
+        return "mulaw" if self.use_mulaw else "wav"

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -2,31 +2,19 @@
 Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.
 
 Kalpa's conversational speech models render named voices from GET /v1/voices
-(kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi — including code-switched
-Hinglish — with no language parameter; kalpa-tts-beta-v0.1 is English-only). Everything on
-the socket is JSON text frames: the client authenticates with an initializeConnection
-frame (the handshake itself is unauthenticated), the server confirms with sessionCreated,
-then each sendText frame appends text and flush=true renders the buffered utterance.
-Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM, and every
-flushed utterance terminates with exactly one responseDone (status "completed", or
-"cancelled" after a cancelResponse).
 
-Two transport behaviors shape this integration:
+Models:
+1. kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi, including code-switched
+Hinglish with no language parameter
+2. kalpa-tts-beta-v0.1 is English-only.
 
-  * One response generates at a time per connection. Current gateways queue one flush that
-    arrives mid-generation (older deployments rejected it outright), and this integration
-    leans on neither: the sender waits for the previous turn's responseDone (a cancelled
-    turn still gets one) before flushing, which serializes turns without ever risking the
-    one-slot queue's rejection and stays correct on older gateways.
-  * On current gateways a bare cancelResponse abandons everything undelivered server-side
-    — the in-flight generation, the queued flush, and buffered text; older deployments
-    only stopped the generation and kept the text buffer. Aggregating a whole assistant
-    turn client-side and sending it as a single text+flush frame keeps every turn atomic
-    on the wire — exactly one responseDone per turn — and never leaves an abandoned
-    turn's fragments in a server buffer on any gateway version.
-
-Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
-chunk down to the target rate and, for telephony, mu-law encode it.
+Flow
+1. The client authenticates with an initializeConnection frame (the handshake itself is unauthenticated),
+2. The server confirms with sessionCreated
+3. Each sendText frame appends text and flush=true renders the buffered utterance.
+4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM.
+5. Every flushed utterance terminates with exactly one responseDone (status "completed", or "cancelled" after a cancelResponse).
+6. For telephony, mu-law encodes audio from 24KHz to 8KHz
 """
 
 import asyncio
@@ -276,11 +264,19 @@ class KalpaSynthesizer(StreamSynthesizer):
 
             await self._wait_for_ws()
 
+            # The wait suspends for real while the socket is reconnecting, and a barge-in can
+            # retire this sequence (and clear the shared buffer) in that gap — appending after
+            # it would leak this turn's fragment into the next turn's utterance.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (post-wait): sequence_id {sequence_id} not current")
+                return
+
             if text:
                 self._text_buffer.append(text)
 
-            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn
-            # (see the module docstring for why fragments are never streamed server-side).
+            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn, so
+            # an abandoned turn's fragments never sit in a server-side buffer and every turn
+            # settles with exactly one responseDone.
             if not end_of_llm_stream:
                 return
 
@@ -390,6 +386,12 @@ class KalpaSynthesizer(StreamSynthesizer):
 
             except websockets.exceptions.ConnectionClosed:
                 logger.info("Kalpa WebSocket connection closed")
+                # A response that dies with the socket will never get its responseDone: free
+                # the single-flight slot and terminate the turn so playback doesn't hang on
+                # it (monitor_connection re-establishes the socket for the next turn).
+                if not self._response_idle.is_set():
+                    self._response_idle.set()
+                    yield b"\x00"
                 break
             except Exception as e:
                 logger.error(f"Error occurred in Kalpa receiver - {e}")

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -296,9 +296,10 @@ def test_stale_sequence_sends_nothing():
 
 
 def test_the_flush_waits_for_the_previous_responses_done():
-    """One response in flight per connection: flushing while the previous turn is still
-    generating is rejected by the server (and the turn lost), so the sender must park on
-    the idle event until responseDone frees the slot."""
+    """One response generates at a time per connection: older gateways rejected a flush
+    sent mid-generation (losing the turn) and current ones queue exactly one, so the
+    sender parks on the idle event until responseDone frees the slot — serializing turns
+    without relying on either behavior."""
     s = _synth()
     s._response_idle.clear()  # a previous flush is still generating
     order = []

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -1,0 +1,687 @@
+"""Kalpa TTS: whole-turn aggregation + single-flight flushing, the JSON/base64 wire
+protocol, 24 kHz -> telephony conversion, voice-name resolution, and the init handshake
+that establish_connection() must complete before the receiver ever sees the socket."""
+
+import asyncio
+import audioop
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.helpers.utils import audio_to_mulaw8k
+from bolna.models import KalpaConfig, Synthesizer
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
+from bolna.synthesizer.kalpa_synthesizer import (
+    KALPA_DEFAULT_MODEL,
+    KALPA_NATIVE_SAMPLE_RATE,
+    MAX_TEXT_CHARS,
+    KalpaSynthesizer,
+)
+
+KEY = "kalpa_sk_test_dummy"
+VOICE_ID = "5e0c5704-590f-483b-b291-00a2415cb67e"
+
+# GET /v1/voices wraps the catalog in {"data": [...]}, exactly as the live API does.
+CATALOG = {
+    "data": [
+        {"id": VOICE_ID, "name": "Kiara (hindi)", "gender": "feminine"},
+        {"id": "id-ruby", "name": "Ruby", "gender": "feminine"},
+        {"id": "id-wren", "name": "Wren (human-like)", "gender": "feminine"},
+        {"id": "id-arjun", "name": "Arjun (hindi)", "gender": "masculine"},
+    ]
+}
+
+
+def _synth(**kwargs):
+    """A real synthesizer with the websocket stubbed out — no env var, no network."""
+    kwargs.setdefault("voice_id", VOICE_ID)
+    kwargs.setdefault("stream", True)
+    kwargs.setdefault("use_mulaw", True)
+    s = KalpaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock(), **kwargs)
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = True
+    s.websocket = MagicMock()
+    s.websocket.send = AsyncMock()
+    s._wait_for_ws = AsyncMock()
+    s._is_ws_connected = MagicMock(return_value=True)
+    s.sent = []
+    s._send_json = AsyncMock(side_effect=lambda p: s.sent.append(p))
+    return s
+
+
+def _pcm(seconds, rate=KALPA_NATIVE_SAMPLE_RATE):
+    """A silent-but-nonzero 16-bit mono buffer of a known length."""
+    return (b"\x10\x00") * int(seconds * rate)
+
+
+class _FakeResp:
+    def __init__(self, body, status=200):
+        self._body = body
+        self.status = status
+        self.headers = {}
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return json.dumps(self._body)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    """Stands in for aiohttp.ClientSession; serves one canned response for get and post."""
+
+    def __init__(self, body, status=200):
+        self._body = body
+        self._status = status
+
+    def get(self, *a, **k):
+        return _FakeResp(self._body, self._status)
+
+    def post(self, *a, **k):
+        return _FakeResp(self._body, self._status)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _patch_http(monkeypatch, body, status=200):
+    monkeypatch.setattr(
+        "bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession",
+        lambda *a, **k: _FakeSession(body, status),
+    )
+
+
+# ----------------------------------------------------------------------
+# Wiring
+# ----------------------------------------------------------------------
+
+
+def test_provider_is_registered():
+    assert SUPPORTED_SYNTHESIZER_MODELS["kalpa"] is KalpaSynthesizer
+
+
+def test_synthesizer_model_builds_kalpa_config():
+    synth = Synthesizer(
+        provider="kalpa",
+        provider_config={"voice": "Kiara", "voice_id": VOICE_ID},
+        stream=True,
+    )
+    assert isinstance(synth.provider_config, KalpaConfig)
+    assert synth.provider_config.model == KALPA_DEFAULT_MODEL
+
+
+def test_config_survives_the_model_and_reaches_the_synthesizer():
+    """The dashboard round-trips provider_config through the pydantic model; a field the
+    model drops silently would leave the synthesizer on defaults."""
+    cfg = Synthesizer(
+        provider="kalpa",
+        provider_config={"voice_id": VOICE_ID, "model": "kalpa-tts-beta-v0.1", "temperature": 0.7},
+        stream=True,
+    ).model_dump()
+    cfg.pop("caching", None)
+    cfg.pop("provider")
+    provider_config = cfg.pop("provider_config")
+
+    s = SUPPORTED_SYNTHESIZER_MODELS["kalpa"](
+        **cfg, **provider_config, caching=True, synthesizer_key=KEY, task_manager_instance=MagicMock()
+    )
+    assert s.voice_id == VOICE_ID
+    assert s.model == "kalpa-tts-beta-v0.1"
+    assert s.params == {"temperature": 0.7}
+
+
+# ----------------------------------------------------------------------
+# Construction and validation
+# ----------------------------------------------------------------------
+
+
+def test_a_voice_or_voice_id_is_required():
+    with pytest.raises(ValueError):
+        KalpaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock())
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"temperature": 2.0},
+        {"acoustic_temperature": -0.1},
+        {"top_k": 0},
+        {"max_new_tokens": 4},
+        {"max_new_tokens": 99999},
+        {"audio_quality": "ultra"},
+    ],
+)
+def test_out_of_range_params_raise_at_construction_not_mid_call(bad):
+    # Kalpa rejects these too, but only once the session initializes on a live call.
+    with pytest.raises(ValueError):
+        _synth(**bad)
+
+
+def test_mulaw_is_off_unless_task_manager_asks_for_it():
+    s = KalpaSynthesizer(voice_id=VOICE_ID, stream=True, synthesizer_key=KEY, task_manager_instance=MagicMock())
+    assert s.use_mulaw is False
+    assert s._get_audio_format() == "pcm"
+
+
+def test_telephony_pins_8k_mulaw_and_web_keeps_the_configured_rate():
+    tel = _synth(use_mulaw=True)
+    assert (tel.target_sample_rate, tel._get_audio_format()) == (8000, "mulaw")
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert (web.target_sample_rate, web._get_audio_format()) == (24000, "pcm")
+
+
+# ----------------------------------------------------------------------
+# Init frame / payload
+# ----------------------------------------------------------------------
+
+
+def test_initialize_message_carries_auth_model_and_only_set_params():
+    s = _synth(temperature=0.8, top_k=50)
+    assert s._initialize_message() == {
+        "type": "initializeConnection",
+        "api_key": KEY,
+        "model": KALPA_DEFAULT_MODEL,
+        "params": {"temperature": 0.8, "top_k": 50},
+    }
+
+
+def test_initialize_message_omits_params_when_none_are_configured():
+    # Kalpa's server defaults are the tuned production sampling; sending an empty params
+    # object is harmless but sending none keeps the contract explicit.
+    assert "params" not in _synth()._initialize_message()
+
+
+# ----------------------------------------------------------------------
+# Voice resolution
+# ----------------------------------------------------------------------
+
+
+def test_a_configured_voice_id_is_used_without_touching_the_catalog(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("should not fetch /v1/voices when voice_id is set")
+
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession", boom)
+    s = _synth(voice_id=VOICE_ID)
+    assert asyncio.run(s._resolve_voice_id()) == VOICE_ID
+
+
+@pytest.mark.parametrize("name", ["Kiara (hindi)", "kiara (hindi)", "Kiara", "kiara", " KIARA "])
+def test_voice_names_resolve_case_insensitively_with_or_without_the_qualifier(monkeypatch, name):
+    """The catalog names carry qualifiers ("Kiara (hindi)") but an agent config saying
+    just "Kiara" should work — nobody should have to hunt down a UUID."""
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice=name)
+    assert asyncio.run(s._resolve_voice_id()) == VOICE_ID
+    assert s.voice_id == VOICE_ID  # cached: later reconnects skip the catalog fetch
+
+
+def test_an_unknown_voice_raises_with_the_available_names(monkeypatch):
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice="Priya")
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(s._resolve_voice_id())
+    assert "Kiara (hindi)" in str(exc.value)
+
+
+def test_a_catalog_error_raises_rather_than_guessing(monkeypatch):
+    _patch_http(monkeypatch, {"error": "nope"}, status=500)
+    s = _synth(voice_id=None, voice="Kiara")
+    with pytest.raises(RuntimeError):
+        asyncio.run(s._resolve_voice_id())
+
+
+# ----------------------------------------------------------------------
+# sender: whole-turn aggregation + single-flight
+# ----------------------------------------------------------------------
+
+
+def test_sender_aggregates_the_turn_and_flushes_once_on_eos():
+    s = _synth()
+    asyncio.run(s.sender("Namaste! ", sequence_id=1, end_of_llm_stream=False))
+    asyncio.run(s.sender("Kaise hain aap?", sequence_id=1, end_of_llm_stream=False))
+    assert s.sent == []  # nothing reaches the socket while the turn is still streaming
+
+    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent == [{"type": "sendText", "text": "Namaste! Kaise hain aap?", "flush": True}]
+    assert s.last_text_sent is True
+    assert s._text_buffer == []
+    assert not s._response_idle.is_set()  # the flush occupies the single in-flight slot
+
+
+def test_an_empty_turn_sends_nothing():
+    # The server rejects an empty flush outright, so it must never be sent.
+    s = _synth()
+    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent == []
+
+
+def test_an_overlong_turn_is_truncated_to_the_server_cap():
+    s = _synth()
+    asyncio.run(s.sender("a" * (MAX_TEXT_CHARS + 500), sequence_id=1, end_of_llm_stream=True))
+    assert len(s.sent[0]["text"]) == MAX_TEXT_CHARS
+
+
+def test_chunks_concatenate_verbatim_because_the_llm_owns_spacing():
+    s = _synth()
+    asyncio.run(s.sender("Sure, I can", sequence_id=1))
+    asyncio.run(s.sender(" help with that.", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent[0]["text"] == "Sure, I can help with that."
+
+
+def test_on_push_drops_a_superseded_turns_buffer():
+    s = _synth()
+    s._on_push({"sequence_id": 1}, "hi")
+    s._text_buffer = ["first turn, never flushed"]
+    s._on_push({"sequence_id": 2}, "second turn")  # a new turn arrives before eos
+    assert s._text_buffer == []
+    assert s._buffer_seq == 2
+
+
+def test_stale_sequence_sends_nothing():
+    s = _synth()
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = False
+    asyncio.run(s.sender("dropped", sequence_id=7, end_of_llm_stream=True))
+    assert s.sent == []
+
+
+def test_the_flush_waits_for_the_previous_responses_done():
+    """One response in flight per connection: flushing while the previous turn is still
+    generating is rejected by the server (and the turn lost), so the sender must park on
+    the idle event until responseDone frees the slot."""
+    s = _synth()
+    s._response_idle.clear()  # a previous flush is still generating
+    order = []
+
+    async def go():
+        async def flush():
+            await s.sender("next turn", sequence_id=2, end_of_llm_stream=True)
+            order.append("flushed")
+
+        task = asyncio.create_task(flush())
+        await asyncio.sleep(0.05)
+        assert s.sent == []  # still parked
+        order.append("done arrived")
+        s._response_idle.set()  # receiver saw responseDone
+        await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(go())
+    assert order == ["done arrived", "flushed"]
+    assert s.sent == [{"type": "sendText", "text": "next turn", "flush": True}]
+
+
+def test_a_barge_in_during_the_idle_wait_stops_the_sender():
+    """The idle wait can span a barge-in that retires this sequence without cancelling the
+    task; without the re-check the sender would flush a turn the pipeline already dropped."""
+    s = _synth()
+    s._response_idle.clear()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def go():
+        async def flush():
+            await s.sender("text for an interrupted turn", sequence_id=1, end_of_llm_stream=True)
+
+        task = asyncio.create_task(flush())
+        await asyncio.sleep(0.05)
+        retired["yet"] = True  # the barge-in lands while the sender is parked
+        s._response_idle.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(go())
+    assert s.sent == []
+
+
+def test_sender_stamps_ws_send_time_at_the_flush():
+    # Generation only starts at the flush, so TTFB measured from here is true synth latency.
+    s = _synth()
+    asyncio.run(s.sender("first chunk", sequence_id=1))
+    assert s.ws_send_time is None
+    asyncio.run(s.sender(" last chunk", sequence_id=1, end_of_llm_stream=True))
+    assert s.ws_send_time is not None
+
+
+# ----------------------------------------------------------------------
+# receiver
+# ----------------------------------------------------------------------
+
+
+def _drain(s, frames):
+    """Feed `frames` through receiver() and collect what it yields.
+
+    receiver() loops forever by design, so once the scripted frames run out we raise
+    CancelledError — it is a BaseException, so the receiver's broad `except Exception`
+    does not swallow it and the loop unwinds instead of spinning on a dead mock.
+    """
+    remaining = list(frames)
+    out = []
+
+    async def recv():
+        if not remaining:
+            raise asyncio.CancelledError
+        return remaining.pop(0)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        async for item in s.receiver():
+            out.append(item)
+
+    try:
+        asyncio.run(asyncio.wait_for(go(), timeout=5))
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+    return out
+
+
+def test_receiver_decodes_audio_frames_and_maps_done_to_the_eos_sentinel():
+    s = _synth()
+    s._response_idle.clear()
+    pcm = _pcm(0.1)
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(pcm).decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "hi", "usage": {}}),
+        ],
+    )
+    assert out == [pcm, b"\x00"]
+    assert s._response_idle.is_set()  # done freed the in-flight slot
+
+
+def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
+    """A cancelled response terminates a turn handle_interruption() already abandoned;
+    forwarding a sentinel would stamp end-of-stream onto the wrong turn's meta_info."""
+    s = _synth()
+    s._response_idle.clear()
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
+            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"go").decode()}),
+        ],
+    )
+    assert out == [b"go"]
+    assert s._response_idle.is_set()
+
+
+def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
+    """Non-fatal errors are rejected client frames. This integration only sends whole-turn
+    flushes, so a rejected turn will never produce audio or a responseDone — without the
+    sentinel the pipeline would wait on it forever."""
+    s = _synth()
+    s._response_idle.clear()
+    out = _drain(
+        s,
+        [
+            json.dumps(
+                {
+                    "type": "error",
+                    "fatal": False,
+                    "error": {"type": "invalid_request", "message": "utterance text exceeds the limit"},
+                }
+            )
+        ],
+    )
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+    assert s.connection_error is None  # the socket stays usable
+
+
+def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
+    # The server closes the socket after a fatal error; a bad key would just fail again,
+    # so connection_error stops monitor_connection from burning its retries.
+    s = _synth()
+    _drain(
+        s,
+        [json.dumps({"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "bad key"}})],
+    )
+    assert s.connection_error == "bad key"
+
+
+def test_an_unsolicited_session_created_updates_the_native_rate():
+    s = _synth()
+    _drain(s, [json.dumps({"type": "sessionCreated", "sample_rate": 48000})])
+    assert s.native_sample_rate == 48000
+
+
+def test_receiver_survives_malformed_and_unknown_frames():
+    s = _synth()
+    out = _drain(
+        s,
+        [
+            "not json at all",
+            json.dumps(["a", "list"]),
+            json.dumps({"type": "something_new"}),
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": "@@not-base64@@"}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == [b"\x00"]
+    assert s.connection_error is None
+
+
+# ----------------------------------------------------------------------
+# Audio conversion
+# ----------------------------------------------------------------------
+
+
+def test_telephony_chunks_are_resampled_to_8k_and_mulaw_encoded():
+    s = _synth(use_mulaw=True)
+    out = s._process_audio_chunk(_pcm(1.0))
+    # 24k 16-bit in -> 8k 8-bit out: one sixth of the bytes, and decodable as mu-law.
+    assert len(out) == 8000
+    assert len(audioop.ulaw2lin(out, 2)) == 16000
+
+
+def test_web_chunks_pass_through_untouched_at_the_native_rate():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    chunk = _pcm(0.5)
+    assert s._process_audio_chunk(chunk) == chunk  # no resample, no encode
+
+
+def test_the_session_rate_from_session_created_drives_the_resample():
+    s = _synth(use_mulaw=True)
+    s.native_sample_rate = 48000  # as a future sessionCreated might report
+    out = s._process_audio_chunk(_pcm(1.0, rate=48000))
+    assert len(out) == 8000
+
+
+def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
+    s = _synth()
+    assert s._process_audio_chunk(b"") is None
+    # An odd-length buffer can't be whole 16-bit samples; drop it instead of raising
+    # inside the audio path.
+    assert s._process_audio_chunk(b"\x01") is None
+
+
+# ----------------------------------------------------------------------
+# Interruption
+# ----------------------------------------------------------------------
+
+
+def test_interruption_cancels_and_clears_the_buffered_turn():
+    import websockets as _ws
+
+    s = _synth()
+    s._text_buffer = ["partial turn"]
+    s.current_turn_start_time = 123.0
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())
+    assert s._text_buffer == []
+    assert json.loads(ws.send.call_args[0][0]) == {"type": "cancelResponse"}
+    # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
+    # re-detected as new for stale text_queue entries to be pruned.
+    assert s.current_turn_start_time is None
+
+
+def test_interruption_on_a_dead_socket_is_a_no_op():
+    s = _synth()
+    s.websocket = None
+    asyncio.run(s.handle_interruption())  # must not raise
+
+
+# ----------------------------------------------------------------------
+# Connection
+# ----------------------------------------------------------------------
+
+
+def _fake_connect(monkeypatch, replies):
+    """Patch websockets.connect with a socket that records sends and scripts recvs."""
+    ws = MagicMock()
+    ws.sent = []
+    ws.send = AsyncMock(side_effect=lambda p: ws.sent.append(json.loads(p)))
+    ws.recv = AsyncMock(side_effect=[json.dumps(r) for r in replies])
+    ws.close = AsyncMock()
+
+    async def fake(*a, **k):
+        return ws
+
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.websockets.connect", fake)
+    return ws
+
+
+def test_establish_connection_authenticates_and_consumes_session_created(monkeypatch):
+    """The init frame must be the first thing on the wire, and its reply must be consumed
+    here — receiver() knows nothing about sessionCreated-or-error init semantics."""
+    s = _synth(temperature=0.8)
+    ws = _fake_connect(
+        monkeypatch,
+        [
+            {
+                "type": "sessionCreated",
+                "session_id": "sess_1",
+                "model": KALPA_DEFAULT_MODEL,
+                "voice_id": VOICE_ID,
+                "output_format": "pcm_s16le",
+                "sample_rate": 24000,
+                "channels": 1,
+                "audio_quality": "high",
+            }
+        ],
+    )
+    s._response_idle.clear()  # a stale in-flight marker from a dead socket
+
+    result = asyncio.run(s.establish_connection())
+    assert result is ws
+    assert ws.sent[0]["type"] == "initializeConnection"
+    assert ws.sent[0]["api_key"] == KEY
+    assert ws.sent[0]["params"] == {"temperature": 0.8}
+    assert s.native_sample_rate == 24000
+    assert s._response_idle.is_set()  # a fresh connection has nothing in flight
+
+
+def test_a_rejected_init_returns_none_and_pins_deterministic_failures(monkeypatch):
+    s = _synth()
+    ws = _fake_connect(
+        monkeypatch,
+        [{"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "Invalid API key."}}],
+    )
+    assert asyncio.run(s.establish_connection()) is None
+    assert s.connection_error == "Invalid API key."  # monitor_connection must not retry a bad key
+    ws.close.assert_awaited()
+
+
+def test_a_retryable_init_failure_returns_none_without_pinning(monkeypatch):
+    s = _synth()
+    _fake_connect(
+        monkeypatch,
+        [{"type": "error", "fatal": True, "error": {"type": "inference_error", "message": "Seed audio unavailable."}}],
+    )
+    assert asyncio.run(s.establish_connection()) is None
+    assert s.connection_error is None  # transient: leave monitor_connection its retries
+
+
+def test_an_unresolvable_voice_fails_the_connection_permanently(monkeypatch):
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice="Priya")
+    assert asyncio.run(s.establish_connection()) is None
+    assert "Priya" in s.connection_error
+
+
+# ----------------------------------------------------------------------
+# One-shot HTTP (prewarm / handoff / non-streaming loop)
+# ----------------------------------------------------------------------
+
+
+def _wav(seconds=1.0):
+    from bolna.helpers.utils import pcm_to_wav_bytes
+
+    return pcm_to_wav_bytes(_pcm(seconds), sample_rate=KALPA_NATIVE_SAMPLE_RATE)
+
+
+def _tts_response(wav):
+    return {
+        "request_id": "req_1",
+        "model": KALPA_DEFAULT_MODEL,
+        "text": "hi",
+        "audio": {
+            "sample_rate": KALPA_NATIVE_SAMPLE_RATE,
+            "audio_quality": "high",
+            "format": "wav",
+            "data_b64": base64.b64encode(wav).decode(),
+        },
+        "usage": {"input_chars": 2, "output_audio_seconds": 1.0},
+    }
+
+
+def test_synthesize_returns_the_apis_wav_which_is_self_describing(monkeypatch):
+    """The handoff path calls audio_to_mulaw8k(rate_hint=getattr(synth, 'sampling_rate')).
+    Kalpa's REST body is already RIFF WAV, so the hint stops mattering."""
+    wav = _wav(1.0)
+    _patch_http(monkeypatch, _tts_response(wav))
+    s = _synth(use_mulaw=True)
+    out = asyncio.run(s.synthesize("hi"))
+    assert out == wav
+    assert out[:4] == b"RIFF"
+
+    # One second in must stay one second out (8000 mu-law bytes) even with a wrong hint.
+    clip = audio_to_mulaw8k(out, rate_hint=8000, format_hint="")
+    assert len(clip) == 8000
+
+
+def test_telephony_one_shot_returns_mulaw_and_skips_the_transcode(monkeypatch):
+    _patch_http(monkeypatch, _tts_response(_wav(1.0)))
+    s = _synth(use_mulaw=True)
+    clip = asyncio.run(s.synthesize_telephony_clip("hi"))
+    assert len(clip) == 8000  # 1s of mu-law @8k, no pydub/ffmpeg involved downstream
+
+
+def test_telephony_one_shot_defers_to_synthesize_on_non_telephony_configs():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    assert asyncio.run(s.synthesize_telephony_clip("hi")) is None
+
+
+def test_http_error_and_empty_body_return_none(monkeypatch):
+    s = _synth()
+    _patch_http(monkeypatch, {"error": {"type": "rate_limit_error", "message": "slow down"}}, status=429)
+    assert asyncio.run(s.synthesize("hi")) is None
+
+    _patch_http(monkeypatch, {"request_id": "r", "model": "m", "text": "hi", "usage": {}})
+    assert asyncio.run(s.synthesize("hi")) is None
+
+
+def test_http_conversion_matches_the_declared_http_format():
+    s = _synth(use_mulaw=True)
+    assert s._get_http_audio_format() == "mulaw"
+    assert len(s._process_http_audio(_wav(1.0))) == 8000
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert web._get_http_audio_format() == "wav"
+    wav = _wav(0.5)
+    assert web._process_http_audio(wav) == wav  # already at the target rate

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -343,6 +343,64 @@ def test_a_barge_in_during_the_idle_wait_stops_the_sender():
     assert s.sent == []
 
 
+def test_a_barge_in_during_the_ws_wait_never_buffers_stale_text():
+    """_wait_for_ws() suspends for real while the socket reconnects; a barge-in in that gap
+    retires the sequence and clears the shared buffer. The resumed sender must not append
+    its stale fragment into the next turn's buffer (it would flush as OLD-NEW text)."""
+    s = _synth()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def wait_then_barge_in():
+        retired["yet"] = True  # the barge-in lands while the sender is parked here
+
+    s._wait_for_ws = AsyncMock(side_effect=wait_then_barge_in)
+    asyncio.run(s.sender("stale fragment", sequence_id=1, end_of_llm_stream=False))
+    assert s._text_buffer == []
+    assert s.sent == []
+
+
+def test_a_dead_socket_settles_the_in_flight_turn():
+    """A response that dies with the socket never gets its responseDone. The receiver must
+    free the single-flight slot and emit the end-of-stream sentinel so playback terminates
+    instead of waiting on a frame that will never arrive."""
+    import websockets as _ws
+
+    s = _synth()
+    s._response_idle.clear()  # a flush is in flight when the socket drops
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    out = asyncio.run(asyncio.wait_for(go(), timeout=5))
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+
+
+def test_a_dead_socket_with_nothing_in_flight_stays_silent():
+    # No sentinel when idle: a spurious one would pop the next turn's meta_info.
+    import websockets as _ws
+
+    s = _synth()
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == []
+
+
 def test_sender_stamps_ws_send_time_at_the_flush():
     # Generation only starts at the flush, so TTFB measured from here is true synth latency.
     s = _synth()


### PR DESCRIPTION
Following up on the Bolna team's request to Kalpa Labs for a provider integration.

Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.

Kalpa's conversational speech models render named voices from GET /v1/voices

Models:
1. kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi, including code-switched Hinglish with no language parameter
2. kalpa-tts-beta-v0.1 is English-only.

Flow
1. The client authenticates with an initializeConnection frame (the handshake itself is unauthenticated),
2. The server confirms with sessionCreated
3. Each sendText frame appends text and flush=true renders the buffered utterance.
4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM.
5. Every flushed utterance terminates with exactly one responseDone (status "completed", or "cancelled" after a cancelResponse).
6. For telephony, mu-law encodes audio from 24KHz to 8KHz

## Config

```json
{
  "provider": "kalpa",
  "provider_config": {
    "voice": "Kiara",
    "model": "kalpa-tts-multilingual-beta-v0.1"
  },
  "stream": true
}
```

Voices resolve by display name against GET /v1/voices ("Kiara" → catalog UUID, cached), or pass `voice_id` directly. Optional sampling controls: `temperature`, `top_k`, `acoustic_temperature`, `max_new_tokens`, `audio_quality` — omitted by default so Kalpa's tuned production sampling applies. Env: `KALPA_API_KEY` (or `synthesizer_key`), `KALPA_API_HOST` to override the host.

## Testing

- `pytest`: full suite passes (1220 passed, 1 skipped), including 55 new tests covering the wire protocol, whole-turn aggregation, barge-in semantics, voice resolution, telephony conversion, and the init handshake. `ruff check` clean.
- Live smoke against api.kalpalabs.ai with the real class: chunked Hinglish turn (~550 ms TTFA warm), back-to-back turns, barge-in cancel mid-generation (same socket serves the next turn), HTTP one-shot, telephony mu-law clip — outputs verified by blind transcription.
- Full end-to-end conversation through `local_setup/quickstart_server.py` + `AssistantManager` (ElevenLabs STT → LLM → Kalpa TTS over the playground websocket): a 3-turn English-question → Hindi-reply call including a live mid-generation barge-in — the user's speech triggered the interruption manager, `cancelResponse` was answered with `responseDone status=cancelled` in ~250 ms, and the same socket served the next turn.