### PR TITLE
Add Kalpa Labs TTS synthesizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ https://github.com/bolna-ai/bolna/blob/c8a0d1428793d4df29133119e354bc2f85a7ca76/
 | Cartesia   | `CARTESIA_API_KEY`                            |
 | Smallest   | `SMALLEST_API_KEY`                            |
 | Maya       | `MAYA_API_KEY`                            |
+| Kalpa      | `KALPA_API_KEY`                            |
 
 </details>
 &nbsp;<br>

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ graph LR;
 1. Initiating a phone call using telephony providers like `Twilio`, `Plivo`, `Exotel` (coming soon), `Vonage` (coming soon) etc.
 2. Transcribing the conversations using `Deepgram`, `Azure` etc.
 3. Using LLMs like `OpenAI`, `DeepSeek`, `Llama`, `Cohere`, `Mistral`,  etc to handle conversations
-4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest`, `Maya` etc.
+4. Synthesizing LLM responses back to telephony using `AWS Polly`, `ElevenLabs`, `Deepgram`, `OpenAI`, `Azure`, `Cartesia`, `Smallest`, `Maya`, `Kalpa` etc.
 
 
 Refer to the [docs](https://docs.bolna.ai/providers) for a deepdive into all supported providers.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3046,9 +3046,17 @@ class TaskManager(BaseManager):
             meta_info["message_category"] = "filler"
 
         if next_step == "synthesizer" and not should_bypass_synth:
-            if not text_chunk or not text_chunk.strip():
+            if text_chunk and text_chunk.strip():
+                self._turn_audio_flushed.clear()
+            elif self.stream and meta_info.get("end_of_llm_stream") and not self._turn_audio_flushed.is_set():
+                # The turn's last LLM buffer is often empty (the wrapper's rsplit leaves no
+                # remainder for the final flush); dropping it would swallow end_of_llm_stream
+                # and a streaming synthesizer would never flush the turn. Forward the bare
+                # marker — but only for a turn that actually sent text (_turn_audio_flushed
+                # cleared above), so a fully empty turn stays silent as before.
+                text_chunk = ""
+            else:
                 return
-            self._turn_audio_flushed.clear()
             task = asyncio.create_task(self._synthesize(create_ws_data_packet(text_chunk, meta_info)))
             self.synthesizer_tasks.append(asyncio.ensure_future(task))
         elif self.tools["output"] is not None:

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -62,6 +62,7 @@ class SynthesizerProvider(str, Enum):
     RIME = "rime"
     PIXA = "pixa"
     MAYA = "maya"
+    KALPA = "kalpa"
 
     @classmethod
     def all_values(cls):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -126,7 +126,6 @@ class KalpaConfig(BaseModel):
     voice_id: Optional[str] = None
     model: str = "kalpa-tts-multilingual-beta-v0.1"
     temperature: Optional[float] = None
-    top_k: Optional[int] = None
     acoustic_temperature: Optional[float] = None
     max_new_tokens: Optional[int] = None
     audio_quality: Optional[str] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -129,6 +129,7 @@ class KalpaConfig(BaseModel):
     acoustic_temperature: Optional[float] = None
     max_new_tokens: Optional[int] = None
     audio_quality: Optional[str] = None
+    chunk_length_schedule: Optional[List[int]] = None
 
 
 class AzureConfig(BaseModel):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -122,15 +122,9 @@ class MayaConfig(BaseModel):
 
 
 class KalpaConfig(BaseModel):
-    # Display name from GET /v1/voices (e.g. "Kiara (hindi)"; the base name "Kiara" also
-    # resolves). voice_id is the catalog's opaque id and wins when both are set.
     voice: Optional[str] = None
     voice_id: Optional[str] = None
-    # "kalpa-tts-multilingual-beta-v0.1" (English + Hindi, the default here) or
-    # "kalpa-tts-beta-v0.1" (English). No language parameter — the model detects it,
-    # code-switched Hinglish included.
     model: str = "kalpa-tts-multilingual-beta-v0.1"
-    # Optional sampling controls (Kalpa applies its tuned production defaults when omitted)
     temperature: Optional[float] = None
     top_k: Optional[int] = None
     acoustic_temperature: Optional[float] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -122,7 +122,7 @@ class MayaConfig(BaseModel):
 
 
 class KalpaConfig(BaseModel):
-    voice: Optional[str] = None
+    voice: str = "Kiara"
     voice_id: Optional[str] = None
     model: str = "kalpa-tts-multilingual-beta-v0.1"
     temperature: Optional[float] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -121,6 +121,23 @@ class MayaConfig(BaseModel):
     language: Optional[str] = "en"
 
 
+class KalpaConfig(BaseModel):
+    # Display name from GET /v1/voices (e.g. "Kiara (hindi)"; the base name "Kiara" also
+    # resolves). voice_id is the catalog's opaque id and wins when both are set.
+    voice: Optional[str] = None
+    voice_id: Optional[str] = None
+    # "kalpa-tts-multilingual-beta-v0.1" (English + Hindi, the default here) or
+    # "kalpa-tts-beta-v0.1" (English). No language parameter — the model detects it,
+    # code-switched Hinglish included.
+    model: str = "kalpa-tts-multilingual-beta-v0.1"
+    # Optional sampling controls (Kalpa applies its tuned production defaults when omitted)
+    temperature: Optional[float] = None
+    top_k: Optional[int] = None
+    acoustic_temperature: Optional[float] = None
+    max_new_tokens: Optional[int] = None
+    audio_quality: Optional[str] = None
+
+
 class AzureConfig(BaseModel):
     voice: str
     model: str
@@ -169,6 +186,7 @@ class Synthesizer(BaseModel):
         DeepgramConfig,
         OpenAIConfig,
         MayaConfig,
+        KalpaConfig,
     ] = Field(union_mode="smart")
     stream: bool = False
     buffer_size: Optional[int] = 40  # 40 characters in a buffer
@@ -215,6 +233,9 @@ class Synthesizer(BaseModel):
         elif provider == "maya":
             if isinstance(config, dict):
                 values["provider_config"] = MayaConfig(**config)
+        elif provider == "kalpa":
+            if isinstance(config, dict):
+                values["provider_config"] = KalpaConfig(**config)
 
         return values
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -11,6 +11,7 @@ from .synthesizer import (
     RimeSynthesizer,
     PixaSynthesizer,
     MayaSynthesizer,
+    KalpaSynthesizer,
 )
 from .transcriber import (
     DeepgramTranscriber,
@@ -68,6 +69,7 @@ SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.RIME.value: RimeSynthesizer,
     SynthesizerProvider.PIXA.value: PixaSynthesizer,
     SynthesizerProvider.MAYA.value: MayaSynthesizer,
+    SynthesizerProvider.KALPA.value: KalpaSynthesizer,
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -11,4 +11,5 @@ from .smallest_synthesizer import SmallestSynthesizer
 from .sarvam_synthesizer import SarvamSynthesizer
 from .pixa_synthesizer import PixaSynthesizer
 from .maya_synthesizer import MayaSynthesizer
+from .kalpa_synthesizer import KalpaSynthesizer
 from .synthesizer_pool import SynthesizerPool

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -64,8 +64,7 @@ class KalpaSynthesizer(StreamSynthesizer):
         acoustic_temperature=None,
         max_new_tokens=None,
         audio_quality=None,
-        audio_format="pcm",
-        sampling_rate="8000",
+        sampling_rate="24000",
         stream=False,
         buffer_size=400,
         caching=True,
@@ -125,8 +124,19 @@ class KalpaSynthesizer(StreamSynthesizer):
         self._text_buffer = []
         self._buffer_seq = None
         # Set while no response is generating on the socket (one in flight per connection).
+        # The counter tracks outstanding flushes: normally 0/1, briefly 2 when the idle
+        # timeout lets a newer turn flush past a wedged response — responses settle in
+        # flush order, so only the done that drains it back to 0 owns the slot.
         self._response_idle = asyncio.Event()
         self._response_idle.set()
+        self._inflight_flushes = 0
+        # After a cancel, audio frames already on the wire keep arriving until the
+        # response's own responseDone; ids in this set are dropped instead of played.
+        self._ignored_response_ids = set()
+        self._current_response_id = None
+        # A barge-in can land before responseCreated delivers the in-flight response's id;
+        # this flag marks the abandonment id-independently until that response settles.
+        self._abandoned_in_flight = False
 
     def get_sleep_time(self):
         return 0.01
@@ -239,14 +249,19 @@ class KalpaSynthesizer(StreamSynthesizer):
         text) — moot here, since this integration never leaves either behind."""
         self._text_buffer = []
         self._buffer_seq = None
+        if not self._response_idle.is_set():
+            self._abandoned_in_flight = True
+            if self._current_response_id is not None:
+                self._ignored_response_ids.add(self._current_response_id)
+        # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
+        # re-detected as new for stale text_queue entries to be pruned — even when the
+        # cancel send below fails with the socket.
+        self.current_turn_start_time = None
         try:
             ws = self.websocket
             if ws is not None and ws.state is websockets.protocol.State.OPEN:
                 await ws.send(json.dumps({"type": "cancelResponse"}))
                 logger.info("Sent cancelResponse to Kalpa TTS WebSocket")
-            # The cancelled turn's end-of-stream is never forwarded, so the next turn must
-            # be re-detected as new for stale text_queue entries to be pruned.
-            self.current_turn_start_time = None
         except Exception as e:
             logger.error(f"Error handling Kalpa interruption: {e}")
 
@@ -262,16 +277,15 @@ class KalpaSynthesizer(StreamSynthesizer):
                 logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
                 return
 
-            await self._wait_for_ws()
-
-            # The wait suspends for real while the socket is reconnecting, and a barge-in can
-            # retire this sequence (and clear the shared buffer) in that gap — appending after
-            # it would leak this turn's fragment into the next turn's utterance.
-            if not self.should_synthesize_response(sequence_id):
-                logger.info(f"Not synthesizing (post-wait): sequence_id {sequence_id} not current")
-                return
-
+            # Appends happen before any await: sender tasks start in push order and a
+            # non-EOS sender never suspends, so chunks cannot aggregate out of order even
+            # while the socket is reconnecting. Only the EOS task below ever waits.
             if text:
+                # Guard the ownership invariant: a chunk whose turn's buffer was already
+                # dropped (barge-in between task creation and start) must not append.
+                if self._buffer_seq != sequence_id:
+                    logger.info(f"Dropping Kalpa chunk for superseded seq={sequence_id} (buffer seq={self._buffer_seq})")
+                    return
                 self._text_buffer.append(text)
 
             # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn, so
@@ -280,8 +294,9 @@ class KalpaSynthesizer(StreamSynthesizer):
             if not end_of_llm_stream:
                 return
 
-            # LLM chunks carry their own spacing, so they concatenate verbatim.
-            full_text = "".join(self._text_buffer).strip()
+            # The streaming LLM wrappers split chunks with rsplit(" ", 1) and drop the
+            # boundary space, so it has to be restored here.
+            full_text = " ".join(self._text_buffer).strip()
             self._text_buffer = []
             self._buffer_seq = None
             self.last_text_sent = True
@@ -290,14 +305,37 @@ class KalpaSynthesizer(StreamSynthesizer):
                 return
             if len(full_text) > MAX_TEXT_CHARS:
                 logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
-                full_text = full_text[:MAX_TEXT_CHARS]
+                # Cut at a word boundary so the caller doesn't hear a clipped syllable.
+                cut = full_text.rfind(" ", 0, MAX_TEXT_CHARS + 1)
+                full_text = full_text[:cut] if cut > 0 else full_text[:MAX_TEXT_CHARS]
+
+            await self._wait_for_ws()
+
+            # The wait suspends for real while the socket reconnects, and a barge-in can
+            # retire this sequence in that gap — the captured turn must not flush then.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (post-wait): sequence_id {sequence_id} not current")
+                return
 
             # One response in flight per connection: wait for the previous turn's
-            # responseDone (a cancelled turn still gets one) before flushing.
-            try:
-                await asyncio.wait_for(self._response_idle.wait(), timeout=RESPONSE_IDLE_TIMEOUT)
-            except asyncio.TimeoutError:
-                logger.warning("Kalpa: previous response still in flight after 10s; flushing anyway")
+            # responseDone (a cancelled turn still gets one) before flushing. Event.set()
+            # wakes every parked sender, so re-check and re-park until the slot is truly
+            # free — otherwise two turns could ride one done into overlapping flushes.
+            deadline = time.perf_counter() + RESPONSE_IDLE_TIMEOUT
+            while not self._response_idle.is_set():
+                remaining = deadline - time.perf_counter()
+                if remaining <= 0:
+                    logger.warning("Kalpa: previous response still in flight after 10s; flushing anyway")
+                    # Giving up on the wedged response retires its abandonment too —
+                    # otherwise this turn's response would inherit it at responseCreated
+                    # and lose its audio and completion sentinel. Its id (when known)
+                    # stays ignored.
+                    self._abandoned_in_flight = False
+                    break
+                try:
+                    await asyncio.wait_for(self._response_idle.wait(), timeout=remaining)
+                except asyncio.TimeoutError:
+                    pass
 
             # The waits above can span a barge-in that retires this sequence without
             # cancelling the task; re-check before anything reaches the socket.
@@ -305,19 +343,37 @@ class KalpaSynthesizer(StreamSynthesizer):
                 logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
                 return
 
+            self._inflight_flushes += 1
+            self._response_idle.clear()
+            if self.ws_send_time is None:
+                self.ws_send_time = time.perf_counter()
             try:
-                self._response_idle.clear()
-                if self.ws_send_time is None:
-                    self.ws_send_time = time.perf_counter()
                 await self._send_json({"type": "sendText", "text": full_text, "flush": True})
-            except Exception as e:
-                logger.error(f"Error sending text to Kalpa: {e}")
-                self.connection_error = str(e)
+            except Exception:
+                # _send_json already logged and set connection_error. Nothing was flushed,
+                # so no responseDone will free the slot — release it here.
+                self._inflight_flushes -= 1
+                if self._inflight_flushes == 0:
+                    self._response_idle.set()
 
         except asyncio.CancelledError:
             logger.info("Kalpa sender task was cancelled.")
         except Exception as e:
             logger.error(f"Unexpected error in Kalpa sender: {e}")
+
+    def _settle_lost_flushes(self):
+        """The socket died with responses outstanding: free the slot, reset the flush
+        bookkeeping, and return how many end-of-stream sentinels settle the lost turns
+        (oldest first; an abandoned turn is skipped — its pipeline already dropped it)."""
+        lost = 0
+        if not self._response_idle.is_set():
+            self._response_idle.set()
+            lost = max(1, self._inflight_flushes)
+            if self._abandoned_in_flight:
+                lost -= 1
+        self._inflight_flushes = 0
+        self._abandoned_in_flight = False
+        return lost
 
     async def receiver(self):
         not_connected_since = None
@@ -326,6 +382,10 @@ class KalpaSynthesizer(StreamSynthesizer):
                 if self.conversation_ended:
                     return
                 if not self._is_ws_connected():
+                    # A socket that dies between recvs is seen here, not by the
+                    # ConnectionClosed handler below — settle its turns here too.
+                    for _ in range(self._settle_lost_flushes()):
+                        yield b"\x00"
                     if self.connection_error:
                         return
                     now = time.perf_counter()
@@ -348,14 +408,34 @@ class KalpaSynthesizer(StreamSynthesizer):
 
                 event = data.get("type")
                 if event == "responseAudio":
+                    if data.get("response_id") in self._ignored_response_ids:
+                        continue
                     chunk = self._decode_audio(data.get("pcm_b64"))
                     if chunk:
                         yield chunk
                 elif event == "responseDone":
-                    self._response_idle.set()
+                    if self._inflight_flushes:
+                        self._inflight_flushes -= 1
+                    rid = data.get("response_id")
+                    if rid == self._current_response_id:
+                        self._current_response_id = None
                     status = data.get("status")
-                    logger.info(f"Kalpa responseDone status={status} response_id={data.get('response_id')}")
-                    if status == "completed":
+                    logger.info(f"Kalpa responseDone status={status} response_id={rid}")
+                    if self._inflight_flushes:
+                        # A late done for a retired response (the idle-timeout overlap):
+                        # the newer flush still owns the slot — releasing it or emitting
+                        # a sentinel would finish the newer turn before its audio.
+                        self._ignored_response_ids.discard(rid)
+                        continue
+                    self._response_idle.set()
+                    was_abandoned = self._abandoned_in_flight
+                    self._abandoned_in_flight = False
+                    if rid in self._ignored_response_ids or was_abandoned:
+                        # This response's turn was abandoned at the barge-in; even a
+                        # "completed" done (the cancel lost the race) must not stamp
+                        # end-of-stream onto the next turn.
+                        self._ignored_response_ids.discard(rid)
+                    elif status == "completed":
                         yield b"\x00"
                     # "cancelled" terminates a turn we interrupted; handle_interruption()
                     # already abandoned it, so forwarding a sentinel would stamp
@@ -369,28 +449,38 @@ class KalpaSynthesizer(StreamSynthesizer):
                         if err.get("type") == "authentication_error":
                             self.connection_error = err.get("message") or "authentication error"
                     else:
-                        # A non-fatal error is a rejected client frame. This integration only
-                        # sends whole-turn flushes, so the rejected turn will never produce
-                        # audio or a responseDone — terminate it and free the in-flight slot.
+                        # A non-fatal error with a flush in flight means that turn will
+                        # never produce audio — terminate it and free the slot. When idle
+                        # (e.g. a rejected cancelResponse) a sentinel would pop the next
+                        # turn's meta_info, so just log.
                         logger.error(f"Kalpa TTS error: {err}")
-                        self._response_idle.set()
-                        yield b"\x00"
+                        if not self._response_idle.is_set():
+                            if self._inflight_flushes:
+                                self._inflight_flushes -= 1
+                            if self._inflight_flushes == 0:
+                                self._response_idle.set()
+                                if not self._abandoned_in_flight:
+                                    yield b"\x00"
+                                self._abandoned_in_flight = False
                 elif event == "sessionCreated":
                     # Normally consumed inside establish_connection; tolerated here in case
                     # a future server pushes an unsolicited session update.
                     self.native_sample_rate = int(data.get("sample_rate") or self.native_sample_rate)
                 elif event == "responseCreated":
-                    logger.info(f"Kalpa responseCreated response_id={data.get('response_id')}")
+                    self._current_response_id = data.get("response_id")
+                    if self._abandoned_in_flight:
+                        # The barge-in landed before this frame delivered the id; the
+                        # response is already abandoned, so its audio must not play.
+                        self._ignored_response_ids.add(self._current_response_id)
+                    logger.info(f"Kalpa responseCreated response_id={self._current_response_id}")
                 else:
                     logger.info(f"Ignoring Kalpa event: {data}")
 
             except websockets.exceptions.ConnectionClosed:
                 logger.info("Kalpa WebSocket connection closed")
-                # A response that dies with the socket will never get its responseDone: free
-                # the single-flight slot and terminate the turn so playback doesn't hang on
-                # it (monitor_connection re-establishes the socket for the next turn).
-                if not self._response_idle.is_set():
-                    self._response_idle.set()
+                # Responses that die with the socket never get their responseDone;
+                # monitor_connection re-establishes the socket for the next turn.
+                for _ in range(self._settle_lost_flushes()):
                     yield b"\x00"
                 break
             except Exception as e:
@@ -460,6 +550,10 @@ class KalpaSynthesizer(StreamSynthesizer):
             self.native_sample_rate = int(reply.get("sample_rate") or self.native_sample_rate)
             # A fresh connection has nothing in flight.
             self._response_idle.set()
+            self._inflight_flushes = 0
+            self._ignored_response_ids.clear()
+            self._current_response_id = None
+            self._abandoned_in_flight = False
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(
@@ -537,7 +631,9 @@ class KalpaSynthesizer(StreamSynthesizer):
     def _process_http_audio(self, audio):
         """Convert the one-shot WAV to the format the non-streaming loop should emit."""
         if not audio:
-            return audio
+            # The non-streaming loop has no None guard: a None packet crashes the output
+            # handler's b64encode and mutes the session. b"\x00" just ends the turn.
+            return b"\x00"
         if self.use_mulaw:
             return audio_to_mulaw8k(audio, rate_hint=self.native_sample_rate, format_hint="wav")
         if self.target_sample_rate != self.native_sample_rate:

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -150,18 +150,25 @@ class KalpaSynthesizer(StreamSynthesizer):
         # A superseded turn can leave un-flushed text in the server buffer (no interruption
         # ran); the generation it happened on gates a defensive wipe before the next turn.
         self._dirty_conn_gen = None
-        # Set while no utterance occupies the connection; _slot_seq names the sequence that
-        # claimed it (it outlives the turn state, which resets at the flush).
+        # Bumped by handle_interruption() before anything else. Senders capture it at entry
+        # and retire at their next await boundary on a mismatch — including on task-manager
+        # paths that cancel first and only invalidate the sequence later.
+        self._interrupt_gen = 0
+        # THE SLOT: one utterance occupies the connection from its first sendText until its
+        # settle. _slot_seq names the owning sequence; _slot_abandoned marks a barge-in on
+        # it (its completion then settles silently). Freed ONLY by _settle_slot() (and the
+        # establish_connection reset) so the state cannot half-change.
         self._response_idle = asyncio.Event()
         self._response_idle.set()
         self._slot_seq = None
-        # After a cancel, audio frames already on the wire keep arriving until the
-        # response's own responseDone; ids in this set are dropped instead of played.
-        self._ignored_response_ids = set()
-        self._current_response_id = None
-        # A barge-in can land before responseCreated delivers the in-flight response's id;
-        # this flag marks the abandonment id-independently until that response settles.
-        self._abandoned_in_flight = False
+        self._slot_abandoned = False
+        # THE WIRE RESPONSE: the server serializes responses on a connection, so at most
+        # one is open (responseCreated..responseDone). Whether it serves the slot-owning
+        # utterance is decided ONCE, at its responseCreated; audio, done, and error frames
+        # all correlate against this single record, so a stale or foreign frame can never
+        # touch the active slot.
+        self._wire_rid = None
+        self._wire_serves_slot = False
 
     def get_sleep_time(self):
         return 0.01
@@ -266,21 +273,28 @@ class KalpaSynthesizer(StreamSynthesizer):
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
-        """Abandon the open utterance and whatever the server holds for it. Three states
-        need three moves:
+        """Abandon the open utterance and whatever the server holds for it.
 
-        - A response is known (responseCreated arrived): bare cancelResponse. It aborts the
-          generation and wipes buffered text, and the response still settles with its own
-          responseDone (status "cancelled"), which frees the connection slot.
-        - The utterance was flushed but its responseCreated hasn't arrived yet: same cancel.
-          The flush committed the utterance server-side, so a responseDone is guaranteed;
-          the abandonment flag keeps that late settle from finishing the next turn.
-        - Text was streamed but never flushed and no response has been seen: the server may
-          or may not have started rendering it (segmentation decides), and a cancel that
-          lands before any response exists settles with no responseDone at all — the slot
-          would hang until the idle timeout. Close the socket instead: the server treats
-          disconnect as barge-in, and the fresh connection's state is deterministic.
+        The epoch bump comes first: it retires every pending sender at its next await
+        boundary, so this cancel cannot race a parked sender into the socket even on
+        task-manager paths that interrupt before invalidating the sequence (it is why this
+        method is safe without taking the send lock, which a parked sender may hold).
+
+        Then three states need three moves:
+        - A response is open on the wire: bare cancelResponse. It aborts the generation
+          and wipes buffered text; the response still settles with its own responseDone,
+          and _slot_abandoned keeps that settle silent (even a "completed" done when the
+          cancel lost the race) and drops its still-arriving audio.
+        - The utterance was flushed but its responseCreated hasn't arrived yet: same
+          cancel. The flush committed the utterance server-side, so a response (and its
+          done) is guaranteed.
+        - Text was streamed but never flushed and no response has been seen: the server
+          may or may not have started rendering it (segmentation decides), and a cancel
+          that lands before any response exists settles with no responseDone at all — the
+          slot would hang until the idle timeout. Close the socket instead: the server
+          treats disconnect as barge-in, and the fresh connection's state is deterministic.
         """
+        self._interrupt_gen += 1
         turn_open = self._turn_seq is not None and not self._turn_dead
         self._reset_turn()
         self._dirty_conn_gen = None
@@ -290,10 +304,8 @@ class KalpaSynthesizer(StreamSynthesizer):
         self.current_turn_start_time = None
         try:
             if not self._response_idle.is_set():
-                self._abandoned_in_flight = True
-                if self._current_response_id is not None:
-                    self._ignored_response_ids.add(self._current_response_id)
-                elif turn_open:
+                self._slot_abandoned = True
+                if self._wire_rid is None and turn_open:
                     await self._close_ws("barge-in on an un-flushed utterance with no response yet")
                     return
             ws = self.websocket
@@ -347,15 +359,26 @@ class KalpaSynthesizer(StreamSynthesizer):
         except Exception as e:
             logger.error(f"Error closing Kalpa TTS socket: {e}")
 
-    async def _wait_for_idle_slot(self, sequence_id):
-        """Wait for the previous utterance's responseDone to free the connection; returns
-        "free", "retired", or "reset". Cancels settle in milliseconds, so hitting the
-        timeout means a done that is wedged or can never arrive; the socket is closed to
+    def _retired(self, sequence_id, interrupt_gen):
+        """True once a sender's work must not reach the socket: the conversation ended, an
+        interruption ran after the sender started (the epoch moved), or the pipeline
+        retired the sequence. Re-checked after every await — a parked sender can resume
+        long after the world changed."""
+        return (
+            self.conversation_ended
+            or interrupt_gen != self._interrupt_gen
+            or not self.should_synthesize_response(sequence_id)
+        )
+
+    async def _wait_for_idle_slot(self, sequence_id, interrupt_gen):
+        """Wait for the previous utterance's settle to free the connection; returns
+        "free", "retired", or "reset". Settles arrive in milliseconds, so hitting the
+        timeout means one that is wedged or can never arrive; the socket is closed to
         reset the session ("reset" — the caller parks on the reconnect, after which this
         turn's text is replayed on the fresh connection)."""
         deadline = time.perf_counter() + RESPONSE_IDLE_TIMEOUT
         while not self._response_idle.is_set():
-            if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+            if self._retired(sequence_id, interrupt_gen):
                 return "retired"
             remaining = deadline - time.perf_counter()
             if remaining <= 0:
@@ -367,30 +390,27 @@ class KalpaSynthesizer(StreamSynthesizer):
                 pass
         return "free"
 
-    async def _open_utterance(self, sequence_id):
+    async def _open_utterance(self, sequence_id, interrupt_gen):
         """Ensure `sequence_id` owns an open utterance on a live connection; returns
         (opened, replay). replay=True means this turn's earlier chunks were sent on a
         connection that died — the server lost them, so the caller resends the whole turn."""
         while True:
-            if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+            if self._retired(sequence_id, interrupt_gen):
                 return False, False
             if self._turn_dead and self._turn_seq == sequence_id:
                 return False, False
             if self._turn_seq == sequence_id and self._turn_conn_gen == self._conn_gen and self._is_ws_connected():
                 return True, False
             await self._wait_for_ws()
-            if self.conversation_ended or self.connection_error:
-                return False, False
-            if not self.should_synthesize_response(sequence_id):
+            if self.connection_error or self._retired(sequence_id, interrupt_gen):
                 return False, False
             if self._turn_dead and not self._response_idle.is_set():
                 # A superseded turn holds the slot but can never settle it (it will never
                 # flush); run the barge-in triage handle_interruption never got to run:
-                # cancel when its response is known — the done frees the slot in
+                # cancel when its response is on the wire — the done frees the slot in
                 # milliseconds — and reset the socket when none may ever exist.
-                self._abandoned_in_flight = True
-                if self._current_response_id is not None:
-                    self._ignored_response_ids.add(self._current_response_id)
+                self._slot_abandoned = True
+                if self._wire_rid is not None:
                     self._dirty_conn_gen = None  # the cancel wipes the buffered text too
                     try:
                         await self._send_frame({"type": "cancelResponse"})
@@ -403,8 +423,8 @@ class KalpaSynthesizer(StreamSynthesizer):
                     await self._close_ws("superseded utterance holds the slot with no response")
                     continue
             # A new utterance (or a replay after a reconnect) claims the connection's slot.
-            slot = await self._wait_for_idle_slot(sequence_id)
-            if slot == "retired" or not self.should_synthesize_response(sequence_id):
+            slot = await self._wait_for_idle_slot(sequence_id, interrupt_gen)
+            if slot == "retired" or self._retired(sequence_id, interrupt_gen):
                 # the wait can span a barge-in that retires this sequence; the wake-up on
                 # the freed slot must not claim it for a turn the pipeline dropped
                 return False, False
@@ -425,6 +445,7 @@ class KalpaSynthesizer(StreamSynthesizer):
             self._turn_conn_gen = self._conn_gen
             self._response_idle.clear()
             self._slot_seq = sequence_id
+            self._slot_abandoned = False
             # Generation may start at any segment boundary from here on, so synth latency
             # is measured from the turn's first text frame.
             if self.ws_send_time is None:
@@ -458,21 +479,22 @@ class KalpaSynthesizer(StreamSynthesizer):
 
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
-            if self.conversation_ended:
-                return
-            if not self.should_synthesize_response(sequence_id):
+            # Captured before any await: an interruption bumps the epoch first, so a
+            # sender that started before the barge-in retires at its next await boundary
+            # even when the sequence is only invalidated later.
+            interrupt_gen = self._interrupt_gen
+            if self._retired(sequence_id, interrupt_gen):
                 logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
                 return
 
             async with self._send_lock:
-                # The lock wait can span a barge-in that retires this sequence without
-                # cancelling the task; nothing may reach the socket after that.
-                if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+                # The lock wait can span a barge-in; nothing may reach the socket after it.
+                if self._retired(sequence_id, interrupt_gen):
                     logger.info(f"Not synthesizing (post-lock): sequence_id {sequence_id} not current")
                     return
 
                 if text and not (self._turn_dead and self._turn_seq == sequence_id):
-                    opened, replay = await self._open_utterance(sequence_id)
+                    opened, replay = await self._open_utterance(sequence_id, interrupt_gen)
                     if not opened:
                         return
                     wire_text = self._wire_text(text, replay)
@@ -486,14 +508,14 @@ class KalpaSynthesizer(StreamSynthesizer):
                             pass
 
                 if end_of_llm_stream:
-                    await self._finish_utterance(sequence_id)
+                    await self._finish_utterance(sequence_id, interrupt_gen)
 
         except asyncio.CancelledError:
             logger.info("Kalpa sender task was cancelled.")
         except Exception as e:
             logger.error(f"Unexpected error in Kalpa sender: {e}")
 
-    async def _finish_utterance(self, sequence_id):
+    async def _finish_utterance(self, sequence_id, interrupt_gen):
         """The LLM turn ended: flush the utterance. A turn that never opened (the LLM's last
         buffer is often empty) has nothing to flush; a dead one is finally forgotten."""
         if self._turn_seq != sequence_id:
@@ -501,7 +523,7 @@ class KalpaSynthesizer(StreamSynthesizer):
         if self._turn_dead:
             self._reset_turn()
             return
-        opened, replay = await self._open_utterance(sequence_id)
+        opened, replay = await self._open_utterance(sequence_id, interrupt_gen)
         if not opened:
             return
         frame = {"type": "sendText", "flush": True}
@@ -532,30 +554,41 @@ class KalpaSynthesizer(StreamSynthesizer):
         )
         return False
 
-    def _settle_lost_utterance(self):
-        """The socket died. Free the connection slot and return how many end-of-stream
-        sentinels settle the lost turn (0 or 1):
+    def _settle_slot(self, emit):
+        """THE transition that frees the connection slot — every settle path (done, error,
+        socket death) funnels through here so the state cannot half-change. Returns 1 when
+        the settling turn's end-of-stream sentinel should be emitted: never for an
+        abandoned (barged-in) turn — its pipeline already dropped it — and never when the
+        queue head already belongs to a newer turn (the sentinel is positional)."""
+        if self._response_idle.is_set():
+            return 0
+        emit = emit and not self._slot_abandoned and self._sentinel_owns_queue_head()
+        self._response_idle.set()
+        self._slot_seq = None
+        self._slot_abandoned = False
+        return 1 if emit else 0
 
-        - a flushed utterance awaiting its responseDone settles now (unless a barge-in had
-          already abandoned it — its pipeline dropped the turn, so it settles silently);
+    def _settle_lost_utterance(self):
+        """The socket died. Settle whatever it was carrying and return how many
+        end-of-stream sentinels to emit (0 or 1):
+
+        - a flushed utterance awaiting its responseDone settles now (an abandoned one
+          settles silently via _settle_slot);
         - an open utterance whose response had started already played audio; replaying its
           text would repeat what the caller heard, so the turn ends here instead — it is
           marked dead and settled;
         - an open utterance with no response yet lost nothing audible: keep its text for
-          replay and stay silent — the turn is still live."""
-        lost = 0
+          replay and settle silently — the turn is still live."""
+        emit = False
         if not self._response_idle.is_set():
-            self._response_idle.set()
-            if self._abandoned_in_flight or self._turn_dead:
-                lost = 0
-            elif self._turn_seq is None or self._current_response_id is not None:
-                if self._turn_seq is not None:
-                    self._turn_dead = True
-                lost = 1 if self._sentinel_owns_queue_head() else 0
-        self._slot_seq = None
-        self._abandoned_in_flight = False
-        self._current_response_id = None
-        self._ignored_response_ids.clear()
+            if self._turn_seq is None:
+                emit = True
+            elif not self._turn_dead and self._wire_rid is not None and self._wire_serves_slot:
+                self._turn_dead = True
+                emit = True
+        lost = self._settle_slot(emit)
+        self._wire_rid = None
+        self._wire_serves_slot = False
         return lost
 
     async def receiver(self):
@@ -601,7 +634,10 @@ class KalpaSynthesizer(StreamSynthesizer):
 
                 event = data.get("type")
                 if event == "responseAudio":
-                    if data.get("response_id") in self._ignored_response_ids:
+                    # Only the open wire response, and only while it serves a live
+                    # (un-abandoned) slot: stale, foreign, orphaned, or barged-in audio
+                    # never plays.
+                    if data.get("response_id") != self._wire_rid or not self._wire_serves_slot or self._slot_abandoned:
                         continue
                     chunk = self._decode_audio(data.get("pcm_b64"))
                     if chunk:
@@ -610,31 +646,20 @@ class KalpaSynthesizer(StreamSynthesizer):
                     rid = data.get("response_id")
                     status = data.get("status")
                     logger.info(f"Kalpa responseDone status={status} response_id={rid}")
-                    if rid is None or rid != self._current_response_id:
+                    if rid is None or rid != self._wire_rid:
                         # created always precedes done on this ordered socket, so a done
-                        # that does not name the response being served is stale or foreign
-                        # (e.g. a late settle after an error already freed its turn) — it
-                        # must not free, or positionally complete, a slot a newer turn may
-                        # own. If it strands the connection, the idle timeout resets it.
+                        # that does not name the open wire response is stale or foreign —
+                        # it must not free, or positionally complete, a slot a newer turn
+                        # may own. If it strands the connection, the idle timeout resets it.
                         logger.warning(f"Ignoring Kalpa responseDone for unmatched response_id={rid}")
-                        self._ignored_response_ids.discard(rid)
                         continue
-                    self._current_response_id = None
-                    self._response_idle.set()
-                    owns_head = self._sentinel_owns_queue_head()
-                    self._slot_seq = None
-                    was_abandoned = self._abandoned_in_flight
-                    self._abandoned_in_flight = False
-                    if rid in self._ignored_response_ids or was_abandoned:
-                        # This response's turn was abandoned at the barge-in; even a
-                        # "completed" done (the cancel lost the race) must not stamp
-                        # end-of-stream onto the next turn.
-                        self._ignored_response_ids.discard(rid)
-                    elif status == "completed" and owns_head:
+                    serves = self._wire_serves_slot
+                    self._wire_rid = None
+                    self._wire_serves_slot = False
+                    # A "cancelled" done (or any done of an abandoned turn, even
+                    # "completed" when the cancel lost the race) settles silently.
+                    if serves and self._settle_slot(emit=status == "completed"):
                         yield b"\x00"
-                    # "cancelled" terminates a turn we interrupted; handle_interruption()
-                    # already abandoned it, so forwarding a sentinel would stamp
-                    # end-of-stream on a turn the pipeline dropped.
                 elif event == "error":
                     err = data.get("error") or {}
                     if data.get("fatal"):
@@ -644,40 +669,46 @@ class KalpaSynthesizer(StreamSynthesizer):
                         if err.get("type") == "authentication_error":
                             self.connection_error = err.get("message") or "authentication error"
                     else:
-                        # A non-fatal error with an utterance on the connection means that
-                        # turn will never finish normally — terminate it and free the slot.
-                        # When idle (e.g. a rejected cancelResponse) a sentinel would pop
-                        # the next turn's meta_info, so just log.
                         logger.error(f"Kalpa TTS error: {err}")
-                        if not self._response_idle.is_set():
-                            self._response_idle.set()
-                            owns_head = self._sentinel_owns_queue_head()
-                            self._slot_seq = None
-                            if self._current_response_id is not None:
-                                # The failed response may still have frames on the wire:
-                                # ignore its late audio, and retire its id so a delayed
-                                # done cannot match as current after a newer turn claims
-                                # the slot — that would finish the newer turn early.
-                                self._ignored_response_ids.add(self._current_response_id)
-                                self._current_response_id = None
+                        rid = data.get("response_id")
+                        if rid is not None:
+                            # Response-scoped: only the open wire response can be killed —
+                            # a delayed error for an already-settled response touches
+                            # nothing.
+                            if rid == self._wire_rid:
+                                serves = self._wire_serves_slot
+                                self._wire_rid = None
+                                self._wire_serves_slot = False
+                                if self._turn_seq is not None:
+                                    self._turn_dead = True  # drop the broken turn's stragglers
+                                if serves and self._settle_slot(emit=True):
+                                    yield b"\x00"
+                        elif not self._response_idle.is_set() and self._wire_rid is None:
+                            # Connection-scoped rejection (e.g. a rejected flush) with no
+                            # response to carry the settle: the slot-owning utterance can
+                            # never finish — end it. With a response open its own done
+                            # still arrives, and when idle a sentinel would pop the next
+                            # turn's meta_info, so both just log.
                             if self._turn_seq is not None:
-                                self._turn_dead = True  # drop the broken turn's stragglers
-                            if not self._abandoned_in_flight and owns_head:
+                                self._turn_dead = True
+                            if self._settle_slot(emit=True):
                                 yield b"\x00"
-                            self._abandoned_in_flight = False
                 elif event == "sessionCreated":
                     # Normally consumed inside establish_connection; tolerated here in case
                     # a future server pushes an unsolicited session update.
                     self.native_sample_rate = int(data.get("sample_rate") or self.native_sample_rate)
                 elif event == "responseCreated":
-                    # With segmentation this can arrive well before the flush — the server
-                    # started rendering the open utterance's first complete sentences.
-                    self._current_response_id = data.get("response_id")
-                    if self._abandoned_in_flight:
-                        # The barge-in landed before this frame delivered the id; the
-                        # response is already abandoned, so its audio must not play.
-                        self._ignored_response_ids.add(self._current_response_id)
-                    logger.info(f"Kalpa responseCreated response_id={self._current_response_id}")
+                    # With segmentation this can arrive well before the flush. Whether the
+                    # response serves the slot-owning utterance is decided HERE, once: the
+                    # server serializes responses, so a response created while our slot is
+                    # claimed can only be ours (and one created while the slot is idle is
+                    # an orphan whose frames must not play). A barge-in after this point
+                    # flips _slot_abandoned rather than rewriting this record.
+                    self._wire_rid = data.get("response_id")
+                    self._wire_serves_slot = not self._response_idle.is_set()
+                    logger.info(
+                        f"Kalpa responseCreated response_id={self._wire_rid} serves_slot={self._wire_serves_slot}"
+                    )
                 else:
                     logger.info(f"Ignoring Kalpa event: {data}")
 
@@ -689,10 +720,12 @@ class KalpaSynthesizer(StreamSynthesizer):
                     continue
                 logger.info("Kalpa WebSocket connection closed")
                 # A turn that dies with the socket never gets its responseDone;
-                # monitor_connection re-establishes the socket for what remains.
+                # monitor_connection re-establishes the socket. Keep looping rather than
+                # returning: SynthesizerPool iterates generate() exactly once, so a
+                # receiver that ends on a transient closure would leave that language
+                # silent for the rest of the call.
                 for _ in range(self._settle_lost_utterance()):
                     yield b"\x00"
-                break
             except Exception as e:
                 logger.error(f"Error occurred in Kalpa receiver - {e}")
 
@@ -766,9 +799,10 @@ class KalpaSynthesizer(StreamSynthesizer):
             # its sender sees the new generation and replays it here.
             self._conn_gen += 1
             self._response_idle.set()
-            self._ignored_response_ids.clear()
-            self._current_response_id = None
-            self._abandoned_in_flight = False
+            self._slot_seq = None
+            self._slot_abandoned = False
+            self._wire_rid = None
+            self._wire_serves_slot = False
             if not self.connection_time:
                 self.connection_time = round((time.perf_counter() - start_time) * 1000)
             logger.info(

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -9,11 +9,18 @@ Hinglish with no language parameter
 2. kalpa-tts-beta-v0.1 is English-only.
 
 Flow
-1. The client authenticates with an initializeConnection frame (the handshake itself is unauthenticated),
-2. The server confirms with sessionCreated
-3. Each sendText frame appends text and flush=true renders the buffered utterance.
-4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM.
-5. Every flushed utterance terminates with exactly one responseDone (status "completed", or "cancelled" after a cancelResponse).
+1. The client authenticates with an initializeConnection frame (the handshake itself is
+   unauthenticated). Its generation_config.chunk_length_schedule opts the connection into
+   server-side segmentation: once buffered text crosses the schedule's next threshold and ends
+   at a complete sentence, that part starts rendering while the rest is still arriving.
+2. The server confirms with sessionCreated.
+3. LLM chunks are streamed as sendText frames the moment they arrive; flush=true (sent at
+   end_of_llm_stream) ends the utterance and renders whatever remains.
+4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM. The whole
+   utterance stays one response on the wire — one responseCreated, one responseDone — but its
+   first audio can arrive long before the flush.
+5. Every utterance terminates with exactly one responseDone (status "completed", or
+   "cancelled" after a cancelResponse).
 6. For telephony, mu-law encodes audio from 24KHz to 8KHz
 """
 
@@ -44,10 +51,16 @@ KALPA_DEFAULT_MODEL = "kalpa-tts-multilingual-beta-v0.1"
 # Kalpa rejects utterances longer than this; we truncate rather than fail a live turn.
 MAX_TEXT_CHARS = 8000
 
-# How long a flush waits for the previous response's responseDone. Cancels settle in
-# milliseconds, so hitting this means something is wrong — flush anyway and let the
-# server arbitrate rather than silently dropping the turn (current gateways queue the
-# flush in that case, so nothing is lost even then).
+# Buffered-character thresholds before each successive part of an utterance may start
+# rendering (the last value repeats). The same schedule ElevenLabs runs in this codebase, and
+# also Kalpa's server-side default — sent explicitly, because omitting generation_config
+# altogether falls back to generate-only-on-flush and loses the early first audio.
+DEFAULT_CHUNK_LENGTH_SCHEDULE = [50, 80, 120, 150]
+
+# How long a new utterance waits for the previous response's responseDone. Cancels settle in
+# milliseconds, so hitting this means the connection's state is wedged or unknowable; the
+# socket is closed to reset it (the receiver settles the lost turn, monitor_connection
+# redials) rather than flushing into a session we no longer understand.
 RESPONSE_IDLE_TIMEOUT = 10.0
 
 AUDIO_QUALITIES = {"low", "medium", "high"}
@@ -60,10 +73,10 @@ class KalpaSynthesizer(StreamSynthesizer):
         voice_id=None,
         model=KALPA_DEFAULT_MODEL,
         temperature=None,
-        top_k=None,
         acoustic_temperature=None,
         max_new_tokens=None,
         audio_quality=None,
+        chunk_length_schedule=None,
         sampling_rate="24000",
         stream=False,
         buffer_size=400,
@@ -95,13 +108,13 @@ class KalpaSynthesizer(StreamSynthesizer):
             key: value
             for key, value in (
                 ("temperature", temperature),
-                ("top_k", top_k),
                 ("acoustic_temperature", acoustic_temperature),
                 ("max_new_tokens", max_new_tokens),
                 ("audio_quality", audio_quality),
             )
             if value is not None
         }
+        self.chunk_length_schedule = list(chunk_length_schedule or DEFAULT_CHUNK_LENGTH_SCHEDULE)
 
         self.use_mulaw = kwargs.get("use_mulaw", False)
         # Telephony always renders at 8 kHz mu-law; web keeps the configured PCM rate.
@@ -118,18 +131,27 @@ class KalpaSynthesizer(StreamSynthesizer):
         # Fail fast on a misconfigured agent rather than mid-call.
         self._validate_options()
 
-        # Aggregation state: buffer a whole turn's chunks, flush once on end_of_llm_stream.
-        # _buffer_seq tracks which turn owns the buffer so a superseded turn (new
-        # sequence_id before its end_of_llm_stream) can't leak its half-buffered text.
-        self._text_buffer = []
-        self._buffer_seq = None
-        # Set while no response is generating on the socket (one in flight per connection).
-        # The counter tracks outstanding flushes: normally 0/1, briefly 2 when the idle
-        # timeout lets a newer turn flush past a wedged response — responses settle in
-        # flush order, so only the done that drains it back to 0 owns the slot.
+        # Text is streamed to the server as the LLM produces it (segmentation renders it
+        # early), so the client tracks the open utterance rather than a local buffer. One
+        # utterance occupies the connection from its first sendText to its responseDone.
+        # The lock releases senders in acquisition order, so frames leave in push order even
+        # when an earlier sender suspends mid-await (slot wait, reconnect).
+        self._send_lock = asyncio.Lock()
+        self._turn_seq = None  # sequence that owns the open (un-flushed) utterance
+        self._turn_chunks = []  # wire fragments already sent for it (reconnect replay)
+        self._turn_chars = 0
+        self._turn_truncated = False
+        self._turn_dead = False  # utterance abandoned mid-stream; drop its stragglers
+        # A connection generation stamps which socket the turn's text went to; a mismatch at
+        # send time means the server lost its buffer and the whole turn must be resent.
+        self._conn_gen = 0
+        self._turn_conn_gen = 0
+        # A superseded turn can leave un-flushed text in the server buffer (no interruption
+        # ran); the generation it happened on gates a defensive wipe before the next turn.
+        self._dirty_conn_gen = None
+        # Set while no utterance occupies the connection.
         self._response_idle = asyncio.Event()
         self._response_idle.set()
-        self._inflight_flushes = 0
         # After a cancel, audio frames already on the wire keep arriving until the
         # response's own responseDone; ids in this set are dropped instead of played.
         self._ignored_response_ids = set()
@@ -146,24 +168,24 @@ class KalpaSynthesizer(StreamSynthesizer):
     # ------------------------------------------------------------------
 
     def _validate_options(self):
-        """Mirror the server's GenParams ranges so a typo fails at agent setup, not on the
-        first turn of a live call. The model id is deliberately not validated against a
-        fixed list — the catalog (GET /v1/models) evolves server-side."""
+        """Mirror the server's ranges so a typo fails at agent setup, not on the first turn
+        of a live call. The model id is deliberately not validated against a fixed list —
+        the catalog (GET /v1/models) evolves server-side."""
         temperature = self.params.get("temperature")
         if temperature is not None and not 0.0 <= float(temperature) <= 1.5:
             raise ValueError("Kalpa temperature must be between 0.0 and 1.5")
         acoustic = self.params.get("acoustic_temperature")
         if acoustic is not None and not 0.0 <= float(acoustic) <= 1.5:
             raise ValueError("Kalpa acoustic_temperature must be between 0.0 and 1.5")
-        top_k = self.params.get("top_k")
-        if top_k is not None and int(top_k) < 1:
-            raise ValueError("Kalpa top_k must be >= 1")
         max_new_tokens = self.params.get("max_new_tokens")
         if max_new_tokens is not None and not 16 <= int(max_new_tokens) <= 2048:
             raise ValueError("Kalpa max_new_tokens must be between 16 and 2048")
         audio_quality = self.params.get("audio_quality")
         if audio_quality is not None and audio_quality not in AUDIO_QUALITIES:
             raise ValueError(f"Kalpa audio_quality must be one of {sorted(AUDIO_QUALITIES)}")
+        schedule = self.chunk_length_schedule
+        if not 1 <= len(schedule) <= 10 or any(not 50 <= int(t) <= 2000 for t in schedule):
+            raise ValueError("Kalpa chunk_length_schedule must be 1-10 thresholds between 50 and 2000")
 
     # ------------------------------------------------------------------
     # StreamSynthesizer hooks
@@ -189,16 +211,16 @@ class KalpaSynthesizer(StreamSynthesizer):
         return pcm_to_ulaw(audio) if self.use_mulaw else audio
 
     def _on_push(self, meta_info, text):
-        """Runs synchronously in push order (before the sender task): if a new turn starts
-        while the previous one is still buffered, drop the stale buffer so it can't prepend
-        onto this turn's text."""
+        """Runs synchronously in push order (before the sender task): a new turn starting
+        while an older utterance is still open means that turn was retired without an
+        interruption. Mark it dead so its stragglers drop instead of appending to this
+        turn's utterance, and remember that its text may still sit in the server buffer."""
         seq = meta_info.get("sequence_id")
-        if self._buffer_seq is not None and self._buffer_seq != seq and self._text_buffer:
-            logger.info(
-                f"Dropping {len(self._text_buffer)} unflushed Kalpa chunk(s) from superseded seq={self._buffer_seq}"
-            )
-            self._text_buffer = []
-        self._buffer_seq = seq
+        if self._turn_seq is not None and self._turn_seq != seq and not self._turn_dead:
+            logger.info(f"Marking un-flushed Kalpa utterance from superseded seq={self._turn_seq} dead")
+            self._turn_dead = True
+            if self._turn_chunks and self._turn_conn_gen == self._conn_gen:
+                self._dirty_conn_gen = self._conn_gen
 
     # ------------------------------------------------------------------
     # Voice resolution
@@ -241,23 +263,36 @@ class KalpaSynthesizer(StreamSynthesizer):
     # ------------------------------------------------------------------
 
     async def handle_interruption(self):
-        """Drop the buffered turn and cancel the in-flight response. Cancel is idempotent
-        server-side, so it is unconditionally safe to fire; the cancelled response still
-        terminates with its own responseDone (status "cancelled"), which frees the
-        in-flight slot without emitting an end-of-stream sentinel. On current gateways a
-        bare cancel also wipes undelivered server-side state (queued flush, buffered
-        text) — moot here, since this integration never leaves either behind."""
-        self._text_buffer = []
-        self._buffer_seq = None
-        if not self._response_idle.is_set():
-            self._abandoned_in_flight = True
-            if self._current_response_id is not None:
-                self._ignored_response_ids.add(self._current_response_id)
+        """Abandon the open utterance and whatever the server holds for it. Three states
+        need three moves:
+
+        - A response is known (responseCreated arrived): bare cancelResponse. It aborts the
+          generation and wipes buffered text, and the response still settles with its own
+          responseDone (status "cancelled"), which frees the connection slot.
+        - The utterance was flushed but its responseCreated hasn't arrived yet: same cancel.
+          The flush committed the utterance server-side, so a responseDone is guaranteed;
+          the abandonment flag keeps that late settle from finishing the next turn.
+        - Text was streamed but never flushed and no response has been seen: the server may
+          or may not have started rendering it (segmentation decides), and a cancel that
+          lands before any response exists settles with no responseDone at all — the slot
+          would hang until the idle timeout. Close the socket instead: the server treats
+          disconnect as barge-in, and the fresh connection's state is deterministic.
+        """
+        turn_open = self._turn_seq is not None and not self._turn_dead
+        self._reset_turn()
+        self._dirty_conn_gen = None
         # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
         # re-detected as new for stale text_queue entries to be pruned — even when the
         # cancel send below fails with the socket.
         self.current_turn_start_time = None
         try:
+            if not self._response_idle.is_set():
+                self._abandoned_in_flight = True
+                if self._current_response_id is not None:
+                    self._ignored_response_ids.add(self._current_response_id)
+                elif turn_open:
+                    await self._close_ws("barge-in on an un-flushed utterance with no response yet")
+                    return
             ws = self.websocket
             if ws is not None and ws.state is websockets.protocol.State.OPEN:
                 await ws.send(json.dumps({"type": "cancelResponse"}))
@@ -269,6 +304,109 @@ class KalpaSynthesizer(StreamSynthesizer):
     # sender / receiver
     # ------------------------------------------------------------------
 
+    def _reset_turn(self):
+        self._turn_seq = None
+        self._turn_chunks = []
+        self._turn_chars = 0
+        self._turn_truncated = False
+        self._turn_dead = False
+
+    async def _close_ws(self, reason):
+        """Deterministic reset: the receiver notices the closure and settles the lost turn,
+        monitor_connection redials, and establish_connection reinitializes the state."""
+        ws = self.websocket
+        if ws is None:
+            return
+        logger.warning(f"Closing Kalpa TTS socket: {reason}")
+        try:
+            await ws.close()
+        except Exception as e:
+            logger.error(f"Error closing Kalpa TTS socket: {e}")
+
+    async def _wait_for_idle_slot(self, sequence_id):
+        """Wait for the previous utterance's responseDone to free the connection; returns
+        "free", "retired", or "reset". Cancels settle in milliseconds, so hitting the
+        timeout means a done that is wedged or can never arrive; the socket is closed to
+        reset the session ("reset" — the caller parks on the reconnect, after which this
+        turn's text is replayed on the fresh connection)."""
+        deadline = time.perf_counter() + RESPONSE_IDLE_TIMEOUT
+        while not self._response_idle.is_set():
+            if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+                return "retired"
+            remaining = deadline - time.perf_counter()
+            if remaining <= 0:
+                await self._close_ws("previous response still unsettled after 10s")
+                return "reset"
+            try:
+                await asyncio.wait_for(self._response_idle.wait(), timeout=remaining)
+            except asyncio.TimeoutError:
+                pass
+        return "free"
+
+    async def _open_utterance(self, sequence_id):
+        """Ensure `sequence_id` owns an open utterance on a live connection; returns
+        (opened, replay). replay=True means this turn's earlier chunks were sent on a
+        connection that died — the server lost them, so the caller resends the whole turn."""
+        while True:
+            if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+                return False, False
+            if self._turn_dead and self._turn_seq == sequence_id:
+                return False, False
+            if self._turn_seq == sequence_id and self._turn_conn_gen == self._conn_gen and self._is_ws_connected():
+                return True, False
+            await self._wait_for_ws()
+            if self.conversation_ended or self.connection_error:
+                return False, False
+            if not self.should_synthesize_response(sequence_id):
+                return False, False
+            # A new utterance (or a replay after a reconnect) claims the connection's slot.
+            slot = await self._wait_for_idle_slot(sequence_id)
+            if slot == "retired" or not self.should_synthesize_response(sequence_id):
+                # the wait can span a barge-in that retires this sequence; the wake-up on
+                # the freed slot must not claim it for a turn the pipeline dropped
+                return False, False
+            if slot == "reset" or not self._is_ws_connected():
+                continue  # the socket died (or was reset) while parked; redial and retry
+            if self._turn_seq != sequence_id:
+                self._reset_turn()
+                self._turn_seq = sequence_id
+            if self._dirty_conn_gen == self._conn_gen:
+                # A superseded turn left un-flushed text in the server buffer; wipe it
+                # before this turn's first chunk or the utterances merge.
+                self._dirty_conn_gen = None
+                await self._send_json({"type": "cancelResponse"})
+            replay = bool(self._turn_chunks)
+            self._turn_conn_gen = self._conn_gen
+            self._response_idle.clear()
+            # Generation may start at any segment boundary from here on, so synth latency
+            # is measured from the turn's first text frame.
+            if self.ws_send_time is None:
+                self.ws_send_time = time.perf_counter()
+            return True, replay
+
+    def _wire_text(self, text, replay):
+        """Account `text` against the open utterance and return what should go on the wire.
+
+        The streaming LLM wrappers split chunks with rsplit(" ", 1) and drop the boundary
+        space, so every chunk after the turn's first gets it restored. The utterance cap is
+        enforced across the whole turn: the chunk that crosses it is cut at a word boundary
+        and everything after is dropped (the flush still lands). A replay returns the whole
+        turn so far — the reconnect handed us a server with an empty buffer."""
+        if not self._turn_truncated:
+            piece = (" " if self._turn_chars else "") + text
+            budget = MAX_TEXT_CHARS - self._turn_chars
+            if len(piece) > budget:
+                logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
+                cut = piece.rfind(" ", 0, budget + 1)
+                piece = piece[:cut] if cut > 0 else piece[:budget]
+                self._turn_truncated = True
+            if piece:
+                self._turn_chunks.append(piece)
+                self._turn_chars += len(piece)
+        else:
+            piece = ""
+        return "".join(self._turn_chunks) if replay else piece
+
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
             if self.conversation_ended:
@@ -277,102 +415,82 @@ class KalpaSynthesizer(StreamSynthesizer):
                 logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
                 return
 
-            # Appends happen before any await: sender tasks start in push order and a
-            # non-EOS sender never suspends, so chunks cannot aggregate out of order even
-            # while the socket is reconnecting. Only the EOS task below ever waits.
-            if text:
-                # Guard the ownership invariant: a chunk whose turn's buffer was already
-                # dropped (barge-in between task creation and start) must not append.
-                if self._buffer_seq != sequence_id:
-                    logger.info(f"Dropping Kalpa chunk for superseded seq={sequence_id} (buffer seq={self._buffer_seq})")
+            async with self._send_lock:
+                # The lock wait can span a barge-in that retires this sequence without
+                # cancelling the task; nothing may reach the socket after that.
+                if self.conversation_ended or not self.should_synthesize_response(sequence_id):
+                    logger.info(f"Not synthesizing (post-lock): sequence_id {sequence_id} not current")
                     return
-                self._text_buffer.append(text)
 
-            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn, so
-            # an abandoned turn's fragments never sit in a server-side buffer and every turn
-            # settles with exactly one responseDone.
-            if not end_of_llm_stream:
-                return
+                if text and not (self._turn_dead and self._turn_seq == sequence_id):
+                    opened, replay = await self._open_utterance(sequence_id)
+                    if not opened:
+                        return
+                    wire_text = self._wire_text(text, replay)
+                    if wire_text:
+                        try:
+                            await self._send_json({"type": "sendText", "text": wire_text})
+                        except Exception:
+                            # The socket died mid-send; the chunk stays in _turn_chunks, so
+                            # the next send (or this call's flush below) replays the turn
+                            # on the fresh connection.
+                            pass
 
-            # The streaming LLM wrappers split chunks with rsplit(" ", 1) and drop the
-            # boundary space, so it has to be restored here.
-            full_text = " ".join(self._text_buffer).strip()
-            self._text_buffer = []
-            self._buffer_seq = None
-            self.last_text_sent = True
-
-            if not full_text:
-                return
-            if len(full_text) > MAX_TEXT_CHARS:
-                logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
-                # Cut at a word boundary so the caller doesn't hear a clipped syllable.
-                cut = full_text.rfind(" ", 0, MAX_TEXT_CHARS + 1)
-                full_text = full_text[:cut] if cut > 0 else full_text[:MAX_TEXT_CHARS]
-
-            await self._wait_for_ws()
-
-            # The wait suspends for real while the socket reconnects, and a barge-in can
-            # retire this sequence in that gap — the captured turn must not flush then.
-            if not self.should_synthesize_response(sequence_id):
-                logger.info(f"Not synthesizing (post-wait): sequence_id {sequence_id} not current")
-                return
-
-            # One response in flight per connection: wait for the previous turn's
-            # responseDone (a cancelled turn still gets one) before flushing. Event.set()
-            # wakes every parked sender, so re-check and re-park until the slot is truly
-            # free — otherwise two turns could ride one done into overlapping flushes.
-            deadline = time.perf_counter() + RESPONSE_IDLE_TIMEOUT
-            while not self._response_idle.is_set():
-                remaining = deadline - time.perf_counter()
-                if remaining <= 0:
-                    logger.warning("Kalpa: previous response still in flight after 10s; flushing anyway")
-                    # Giving up on the wedged response retires its abandonment too —
-                    # otherwise this turn's response would inherit it at responseCreated
-                    # and lose its audio and completion sentinel. Its id (when known)
-                    # stays ignored.
-                    self._abandoned_in_flight = False
-                    break
-                try:
-                    await asyncio.wait_for(self._response_idle.wait(), timeout=remaining)
-                except asyncio.TimeoutError:
-                    pass
-
-            # The waits above can span a barge-in that retires this sequence without
-            # cancelling the task; re-check before anything reaches the socket.
-            if not self.should_synthesize_response(sequence_id):
-                logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
-                return
-
-            self._inflight_flushes += 1
-            self._response_idle.clear()
-            if self.ws_send_time is None:
-                self.ws_send_time = time.perf_counter()
-            try:
-                await self._send_json({"type": "sendText", "text": full_text, "flush": True})
-            except Exception:
-                # _send_json already logged and set connection_error. Nothing was flushed,
-                # so no responseDone will free the slot — release it here.
-                self._inflight_flushes -= 1
-                if self._inflight_flushes == 0:
-                    self._response_idle.set()
+                if end_of_llm_stream:
+                    await self._finish_utterance(sequence_id)
 
         except asyncio.CancelledError:
             logger.info("Kalpa sender task was cancelled.")
         except Exception as e:
             logger.error(f"Unexpected error in Kalpa sender: {e}")
 
-    def _settle_lost_flushes(self):
-        """The socket died with responses outstanding: free the slot, reset the flush
-        bookkeeping, and return how many end-of-stream sentinels settle the lost turns
-        (oldest first; an abandoned turn is skipped — its pipeline already dropped it)."""
+    async def _finish_utterance(self, sequence_id):
+        """The LLM turn ended: flush the utterance. A turn that never opened (the LLM's last
+        buffer is often empty) has nothing to flush; a dead one is finally forgotten."""
+        if self._turn_seq != sequence_id:
+            return
+        if self._turn_dead:
+            self._reset_turn()
+            return
+        opened, replay = await self._open_utterance(sequence_id)
+        if not opened:
+            return
+        frame = {"type": "sendText", "flush": True}
+        if replay:
+            frame["text"] = "".join(self._turn_chunks)
+        self.last_text_sent = True
+        try:
+            await self._send_json(frame)
+        except Exception:
+            # Died at the flush: the receiver's settle path terminates the turn (the slot
+            # stays claimed until then, so nothing else flushes into the gap).
+            pass
+        self._reset_turn()
+
+    def _settle_lost_utterance(self):
+        """The socket died. Free the connection slot and return how many end-of-stream
+        sentinels settle the lost turn (0 or 1):
+
+        - a flushed utterance awaiting its responseDone settles now (unless a barge-in had
+          already abandoned it — its pipeline dropped the turn, so it settles silently);
+        - an open utterance whose response had started already played audio; replaying its
+          text would repeat what the caller heard, so the turn ends here instead — it is
+          marked dead and settled;
+        - an open utterance with no response yet lost nothing audible: keep its text for
+          replay and stay silent — the turn is still live."""
         lost = 0
         if not self._response_idle.is_set():
             self._response_idle.set()
-            lost = max(1, self._inflight_flushes)
-            if self._abandoned_in_flight:
-                lost -= 1
-        self._inflight_flushes = 0
+            if self._abandoned_in_flight or self._turn_dead:
+                lost = 0
+            elif self._turn_seq is None:
+                lost = 1
+            elif self._current_response_id is not None:
+                self._turn_dead = True
+                lost = 1
         self._abandoned_in_flight = False
+        self._current_response_id = None
+        self._ignored_response_ids.clear()
         return lost
 
     async def receiver(self):
@@ -383,8 +501,8 @@ class KalpaSynthesizer(StreamSynthesizer):
                     return
                 if not self._is_ws_connected():
                     # A socket that dies between recvs is seen here, not by the
-                    # ConnectionClosed handler below — settle its turns here too.
-                    for _ in range(self._settle_lost_flushes()):
+                    # ConnectionClosed handler below — settle its turn here too.
+                    for _ in range(self._settle_lost_utterance()):
                         yield b"\x00"
                     if self.connection_error:
                         return
@@ -414,19 +532,11 @@ class KalpaSynthesizer(StreamSynthesizer):
                     if chunk:
                         yield chunk
                 elif event == "responseDone":
-                    if self._inflight_flushes:
-                        self._inflight_flushes -= 1
                     rid = data.get("response_id")
                     if rid == self._current_response_id:
                         self._current_response_id = None
                     status = data.get("status")
                     logger.info(f"Kalpa responseDone status={status} response_id={rid}")
-                    if self._inflight_flushes:
-                        # A late done for a retired response (the idle-timeout overlap):
-                        # the newer flush still owns the slot — releasing it or emitting
-                        # a sentinel would finish the newer turn before its audio.
-                        self._ignored_response_ids.discard(rid)
-                        continue
                     self._response_idle.set()
                     was_abandoned = self._abandoned_in_flight
                     self._abandoned_in_flight = False
@@ -449,24 +559,25 @@ class KalpaSynthesizer(StreamSynthesizer):
                         if err.get("type") == "authentication_error":
                             self.connection_error = err.get("message") or "authentication error"
                     else:
-                        # A non-fatal error with a flush in flight means that turn will
-                        # never produce audio — terminate it and free the slot. When idle
-                        # (e.g. a rejected cancelResponse) a sentinel would pop the next
-                        # turn's meta_info, so just log.
+                        # A non-fatal error with an utterance on the connection means that
+                        # turn will never finish normally — terminate it and free the slot.
+                        # When idle (e.g. a rejected cancelResponse) a sentinel would pop
+                        # the next turn's meta_info, so just log.
                         logger.error(f"Kalpa TTS error: {err}")
                         if not self._response_idle.is_set():
-                            if self._inflight_flushes:
-                                self._inflight_flushes -= 1
-                            if self._inflight_flushes == 0:
-                                self._response_idle.set()
-                                if not self._abandoned_in_flight:
-                                    yield b"\x00"
-                                self._abandoned_in_flight = False
+                            self._response_idle.set()
+                            if self._turn_seq is not None:
+                                self._turn_dead = True  # drop the broken turn's stragglers
+                            if not self._abandoned_in_flight:
+                                yield b"\x00"
+                            self._abandoned_in_flight = False
                 elif event == "sessionCreated":
                     # Normally consumed inside establish_connection; tolerated here in case
                     # a future server pushes an unsolicited session update.
                     self.native_sample_rate = int(data.get("sample_rate") or self.native_sample_rate)
                 elif event == "responseCreated":
+                    # With segmentation this can arrive well before the flush — the server
+                    # started rendering the open utterance's first complete sentences.
                     self._current_response_id = data.get("response_id")
                     if self._abandoned_in_flight:
                         # The barge-in landed before this frame delivered the id; the
@@ -478,9 +589,9 @@ class KalpaSynthesizer(StreamSynthesizer):
 
             except websockets.exceptions.ConnectionClosed:
                 logger.info("Kalpa WebSocket connection closed")
-                # Responses that die with the socket never get their responseDone;
-                # monitor_connection re-establishes the socket for the next turn.
-                for _ in range(self._settle_lost_flushes()):
+                # A turn that dies with the socket never gets its responseDone;
+                # monitor_connection re-establishes the socket for what remains.
+                for _ in range(self._settle_lost_utterance()):
                     yield b"\x00"
                 break
             except Exception as e:
@@ -509,7 +620,11 @@ class KalpaSynthesizer(StreamSynthesizer):
     # ------------------------------------------------------------------
 
     def _initialize_message(self):
-        message = {"type": "initializeConnection", "api_key": self.api_key}
+        message = {
+            "type": "initializeConnection",
+            "api_key": self.api_key,
+            "generation_config": {"chunk_length_schedule": self.chunk_length_schedule},
+        }
         if self.model:
             message["model"] = self.model
         if self.params:
@@ -548,9 +663,10 @@ class KalpaSynthesizer(StreamSynthesizer):
                 return None
 
             self.native_sample_rate = int(reply.get("sample_rate") or self.native_sample_rate)
-            # A fresh connection has nothing in flight.
+            # A fresh connection has nothing in flight; an open turn's text is NOT reset —
+            # its sender sees the new generation and replays it here.
+            self._conn_gen += 1
             self._response_idle.set()
-            self._inflight_flushes = 0
             self._ignored_response_ids.clear()
             self._current_response_id = None
             self._abandoned_in_flight = False

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -11,15 +11,19 @@ Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM,
 flushed utterance terminates with exactly one responseDone (status "completed", or
 "cancelled" after a cancelResponse).
 
-Two server-side properties shape this integration:
+Two transport behaviors shape this integration:
 
-  * One response in flight per connection — a flush while a previous response is still
-    generating is rejected with a non-fatal error, not queued. The sender therefore waits
-    for the previous turn's responseDone (tracked client-side) before flushing.
-  * cancelResponse stops generation but does not clear the server-side text buffer, so
-    fragments streamed before a barge-in would silently prepend onto the next turn's
-    utterance. The sender aggregates a whole assistant turn client-side and sends it as a
-    single text+flush frame, keeping every turn atomic on the wire.
+  * One response generates at a time per connection. Current gateways queue one flush that
+    arrives mid-generation (older deployments rejected it outright), and this integration
+    leans on neither: the sender waits for the previous turn's responseDone (a cancelled
+    turn still gets one) before flushing, which serializes turns without ever risking the
+    one-slot queue's rejection and stays correct on older gateways.
+  * On current gateways a bare cancelResponse abandons everything undelivered server-side
+    — the in-flight generation, the queued flush, and buffered text; older deployments
+    only stopped the generation and kept the text buffer. Aggregating a whole assistant
+    turn client-side and sending it as a single text+flush frame keeps every turn atomic
+    on the wire — exactly one responseDone per turn — and never leaves an abandoned
+    turn's fragments in a server buffer on any gateway version.
 
 Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
 chunk down to the target rate and, for telephony, mu-law encode it.
@@ -54,7 +58,8 @@ MAX_TEXT_CHARS = 8000
 
 # How long a flush waits for the previous response's responseDone. Cancels settle in
 # milliseconds, so hitting this means something is wrong — flush anyway and let the
-# server arbitrate rather than silently dropping the turn.
+# server arbitrate rather than silently dropping the turn (current gateways queue the
+# flush in that case, so nothing is lost even then).
 RESPONSE_IDLE_TIMEOUT = 10.0
 
 AUDIO_QUALITIES = {"low", "medium", "high"}
@@ -241,7 +246,9 @@ class KalpaSynthesizer(StreamSynthesizer):
         """Drop the buffered turn and cancel the in-flight response. Cancel is idempotent
         server-side, so it is unconditionally safe to fire; the cancelled response still
         terminates with its own responseDone (status "cancelled"), which frees the
-        in-flight slot without emitting an end-of-stream sentinel."""
+        in-flight slot without emitting an end-of-stream sentinel. On current gateways a
+        bare cancel also wipes undelivered server-side state (queued flush, buffered
+        text) — moot here, since this integration never leaves either behind."""
         self._text_buffer = []
         self._buffer_seq = None
         try:

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -66,6 +66,13 @@ RESPONSE_IDLE_TIMEOUT = 10.0
 
 AUDIO_QUALITIES = {"low", "medium", "high"}
 
+# Voice display names resolve to catalog ids once per process, not once per call: the task
+# manager builds a fresh synthesizer for every call, and the GET /v1/voices round trip sits
+# on the connect path. The catalog is global (never key-scoped), so (host, name) is the
+# whole key; failures are never cached, so a typo keeps failing loudly and a voice added to
+# the catalog later is picked up without a restart.
+_VOICE_IDS = {}  # (host, lowercased display name) -> voice id
+
 
 class KalpaSynthesizer(StreamSynthesizer):
     def __init__(
@@ -245,13 +252,20 @@ class KalpaSynthesizer(StreamSynthesizer):
     # ------------------------------------------------------------------
 
     async def _resolve_voice_id(self):
-        """Return the opaque voice id, resolving a display name via GET /v1/voices once.
+        """Return the opaque voice id, resolving a display name via GET /v1/voices once
+        per process (see _VOICE_IDS).
 
         Names match case-insensitively, on the full name ("Kiara (hindi)") or its base
         before the qualifier ("Kiara") — so agent configs don't have to carry UUIDs.
         """
         if self.voice_id:
             return self.voice_id
+
+        wanted = self.voice.strip().lower()
+        cached = _VOICE_IDS.get((self.kalpa_host, wanted))
+        if cached:
+            self.voice_id = cached
+            return cached
 
         headers = {"Authorization": f"Bearer {self.api_key}"}
         url = f"https://{self.kalpa_host}/v1/voices"
@@ -262,12 +276,12 @@ class KalpaSynthesizer(StreamSynthesizer):
                 body = await resp.json()
         voices = body.get("data", []) if isinstance(body, dict) else body
 
-        wanted = self.voice.strip().lower()
         matches = [v for v in voices if v.get("name", "").lower() == wanted]
         if not matches:
             matches = [v for v in voices if v.get("name", "").split(" (")[0].lower() == wanted]
         if len(matches) == 1:
             self.voice_id = matches[0]["id"]
+            _VOICE_IDS[(self.kalpa_host, wanted)] = self.voice_id
             logger.info(f"Resolved Kalpa voice {self.voice!r} -> {matches[0]['name']!r} ({self.voice_id})")
             return self.voice_id
 
@@ -288,7 +302,7 @@ class KalpaSynthesizer(StreamSynthesizer):
         task-manager paths that interrupt before invalidating the sequence (it is why this
         method is safe without taking the send lock, which a parked sender may hold).
 
-        Then three states need three moves:
+        Then three states, two moves:
         - A response is open on the wire: bare cancelResponse. It aborts the generation
           and wipes buffered text; the response still settles with its own responseDone,
           and _slot_abandoned keeps that settle silent (even a "completed" done when the
@@ -296,11 +310,12 @@ class KalpaSynthesizer(StreamSynthesizer):
         - The utterance was flushed but its responseCreated hasn't arrived yet: same
           cancel. The flush committed the utterance server-side, so a response (and its
           done) is guaranteed.
-        - Text was streamed but never flushed and no response has been seen: the server
-          may or may not have started rendering it (segmentation decides), and a cancel
-          that lands before any response exists settles with no responseDone at all — the
-          slot would hang until the idle timeout. Close the socket instead: the server
-          treats disconnect as barge-in, and the fresh connection's state is deterministic.
+        - Text was streamed but never flushed and no response has been seen: a cancel
+          alone could settle with no responseDone at all (segmentation decides whether
+          the server started rendering), wedging the slot until the idle timeout. Flush
+          first: that commits the utterance and reduces this to the previous case — the
+          cancel's done frees the slot in milliseconds on the same connection, where a
+          socket reset here cost the next turn the full reconnect.
         """
         self._interrupt_gen += 1
         turn_open = self._turn_seq is not None and not self._turn_dead
@@ -311,16 +326,18 @@ class KalpaSynthesizer(StreamSynthesizer):
         # cancel send below fails with the socket.
         self.current_turn_start_time = None
         try:
+            flush_first = False
             if not self._response_idle.is_set():
                 self._slot_abandoned = True
-                if self._wire_rid is None and turn_open:
-                    await self._close_ws("barge-in on an un-flushed utterance with no response yet")
-                    return
+                flush_first = self._wire_rid is None and turn_open
             ws = self.websocket
             if ws is not None and ws.state is websockets.protocol.State.OPEN:
+                if flush_first:
+                    await ws.send(json.dumps({"type": "sendText", "flush": True}))
                 await ws.send(json.dumps({"type": "cancelResponse"}))
                 logger.info("Sent cancelResponse to Kalpa TTS WebSocket")
         except Exception as e:
+            # The send died with the socket; the receiver's closure path settles the turn.
             logger.error(f"Error handling Kalpa interruption: {e}")
 
     # ------------------------------------------------------------------
@@ -415,20 +432,18 @@ class KalpaSynthesizer(StreamSynthesizer):
             if self._turn_dead and not self._response_idle.is_set():
                 # A superseded turn holds the slot but can never settle it (it will never
                 # flush); run the barge-in triage handle_interruption never got to run:
-                # cancel when its response is on the wire — the done frees the slot in
-                # milliseconds — and reset the socket when none may ever exist.
+                # flush first when no response is known (a bare cancel there could settle
+                # nothing) — either way the cancel's done frees the slot in milliseconds.
                 self._slot_abandoned = True
-                if self._wire_rid is not None:
-                    self._dirty_conn_gen = None  # the cancel wipes the buffered text too
-                    try:
-                        await self._send_frame({"type": "cancelResponse"})
-                    except Exception:
-                        # the cancel died with the socket, and with it the dead turn's
-                        # residue; park on the redial and retry — bailing out here would
-                        # lose the new turn's chunk before anything retained it
-                        continue
-                else:
-                    await self._close_ws("superseded utterance holds the slot with no response")
+                self._dirty_conn_gen = None  # the cancel wipes the buffered text too
+                try:
+                    if self._wire_rid is None:
+                        await self._send_frame({"type": "sendText", "flush": True})
+                    await self._send_frame({"type": "cancelResponse"})
+                except Exception:
+                    # the send died with the socket, and with it the dead turn's
+                    # residue; park on the redial and retry — bailing out here would
+                    # lose the new turn's chunk before anything retained it
                     continue
             # A new utterance (or a replay after a reconnect) claims the connection's slot.
             slot = await self._wait_for_idle_slot(sequence_id, interrupt_gen)

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -142,6 +142,7 @@ class KalpaSynthesizer(StreamSynthesizer):
         self._turn_chars = 0
         self._turn_truncated = False
         self._turn_dead = False  # utterance abandoned mid-stream; drop its stragglers
+        self._turn_glue = " "  # what the wrappers' split consumed before the next chunk
         # A connection generation stamps which socket the turn's text went to; a mismatch at
         # send time means the server lost its buffer and the whole turn must be resent.
         self._conn_gen = 0
@@ -312,6 +313,7 @@ class KalpaSynthesizer(StreamSynthesizer):
         self._turn_chars = 0
         self._turn_truncated = False
         self._turn_dead = False
+        self._turn_glue = " "
 
     async def _send_frame(self, payload):
         """Send one frame. Unlike the shared _send_json, a failure here is not recorded as
@@ -390,7 +392,13 @@ class KalpaSynthesizer(StreamSynthesizer):
                 if self._current_response_id is not None:
                     self._ignored_response_ids.add(self._current_response_id)
                     self._dirty_conn_gen = None  # the cancel wipes the buffered text too
-                    await self._send_frame({"type": "cancelResponse"})
+                    try:
+                        await self._send_frame({"type": "cancelResponse"})
+                    except Exception:
+                        # the cancel died with the socket, and with it the dead turn's
+                        # residue; park on the redial and retry — bailing out here would
+                        # lose the new turn's chunk before anything retained it
+                        continue
                 else:
                     await self._close_ws("superseded utterance holds the slot with no response")
                     continue
@@ -409,7 +417,10 @@ class KalpaSynthesizer(StreamSynthesizer):
                 # A superseded turn left un-flushed text in the server buffer; wipe it
                 # before this turn's first chunk or the utterances merge.
                 self._dirty_conn_gen = None
-                await self._send_frame({"type": "cancelResponse"})
+                try:
+                    await self._send_frame({"type": "cancelResponse"})
+                except Exception:
+                    continue  # died with the socket (which wiped the buffer); redial and retry
             replay = bool(self._turn_chunks)
             self._turn_conn_gen = self._conn_gen
             self._response_idle.clear()
@@ -423,13 +434,17 @@ class KalpaSynthesizer(StreamSynthesizer):
     def _wire_text(self, text, replay):
         """Account `text` against the open utterance and return what should go on the wire.
 
-        The streaming LLM wrappers split chunks with rsplit(" ", 1) and drop the boundary
-        space, so every chunk after the turn's first gets it restored. The utterance cap is
-        enforced across the whole turn: the chunk that crosses it is cut at a word boundary
-        and everything after is dropped (the flush still lands). A replay returns the whole
-        turn so far — the reconnect handed us a server with an empty buffer."""
+        The streaming LLM wrappers split chunks with rsplit(" ", 1): when the buffer had a
+        space, the boundary space is consumed and must be restored before the next chunk —
+        but a chunk with no space at all was an unbreakable token (long URL, number) cut
+        mid-way, and the next chunk continues it directly, so gluing a space in would
+        mispronounce it. The utterance cap is enforced across the whole turn: the chunk
+        that crosses it is cut at a word boundary and everything after is dropped (the
+        flush still lands). A replay returns the whole turn so far — the reconnect handed
+        us a server with an empty buffer."""
         if not self._turn_truncated:
-            piece = (" " if self._turn_chars else "") + text
+            piece = (self._turn_glue if self._turn_chars else "") + text
+            self._turn_glue = " " if " " in text else ""
             budget = MAX_TEXT_CHARS - self._turn_chars
             if len(piece) > budget:
                 piece = self._truncate_at_word(piece, budget)

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -514,6 +514,7 @@ class KalpaSynthesizer(StreamSynthesizer):
 
     async def receiver(self):
         not_connected_since = None
+        ws = None
         while True:
             try:
                 if self.conversation_ended:
@@ -538,7 +539,16 @@ class KalpaSynthesizer(StreamSynthesizer):
                 else:
                     not_connected_since = None
 
-                response = await self.websocket.recv()
+                # Pin the iteration to the socket it reads from: a closed socket drains its
+                # buffered frames before raising ConnectionClosed, so after a reset this
+                # loop can still be reading the replaced socket while the new connection
+                # already serves the next turn. A stale done freeing (and "completing") the
+                # newer turn's slot is exactly the corruption this guard prevents.
+                ws = self.websocket
+                response = await ws.recv()
+                if ws is not self.websocket:
+                    logger.info("Dropping frame from a replaced Kalpa socket")
+                    continue
                 data = self._loads_event(response)
                 if data is None:
                     continue
@@ -611,6 +621,11 @@ class KalpaSynthesizer(StreamSynthesizer):
                     logger.info(f"Ignoring Kalpa event: {data}")
 
             except websockets.exceptions.ConnectionClosed:
+                if ws is not None and ws is not self.websocket:
+                    # A socket we already replaced finished dying; the live connection's
+                    # state was reset at establish, so there is nothing to settle here.
+                    logger.info("Kalpa: replaced socket finished closing")
+                    continue
                 logger.info("Kalpa WebSocket connection closed")
                 # A turn that dies with the socket never gets its responseDone;
                 # monitor_connection re-establishes the socket for what remains.

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -1,0 +1,539 @@
+"""
+Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.
+
+Kalpa's conversational speech models render named voices from GET /v1/voices
+(kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi — including code-switched
+Hinglish — with no language parameter; kalpa-tts-beta-v0.1 is English-only). Everything on
+the socket is JSON text frames: the client authenticates with an initializeConnection
+frame (the handshake itself is unauthenticated), the server confirms with sessionCreated,
+then each sendText frame appends text and flush=true renders the buffered utterance.
+Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM, and every
+flushed utterance terminates with exactly one responseDone (status "completed", or
+"cancelled" after a cancelResponse).
+
+Two server-side properties shape this integration:
+
+  * One response in flight per connection — a flush while a previous response is still
+    generating is rejected with a non-fatal error, not queued. The sender therefore waits
+    for the previous turn's responseDone (tracked client-side) before flushing.
+  * cancelResponse stops generation but does not clear the server-side text buffer, so
+    fragments streamed before a barge-in would silently prepend onto the next turn's
+    utterance. The sender aggregates a whole assistant turn client-side and sends it as a
+    single text+flush frame, keeping every turn atomic on the wire.
+
+Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
+chunk down to the target rate and, for telephony, mu-law encode it.
+"""
+
+import asyncio
+import base64
+import json
+import os
+import time
+
+import aiohttp
+import websockets
+from websockets.exceptions import InvalidHandshake
+
+from .stream_synthesizer import StreamSynthesizer
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
+from bolna.helpers.utils import audio_to_mulaw8k, pcm_to_ulaw, resample
+from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
+
+logger = configure_logger(__name__)
+
+# The session's true rate arrives in sessionCreated; this is the documented default.
+KALPA_NATIVE_SAMPLE_RATE = 24000
+MULAW_SAMPLE_RATE = 8000
+
+KALPA_DEFAULT_MODEL = "kalpa-tts-multilingual-beta-v0.1"
+
+# Kalpa rejects utterances longer than this; we truncate rather than fail a live turn.
+MAX_TEXT_CHARS = 8000
+
+# How long a flush waits for the previous response's responseDone. Cancels settle in
+# milliseconds, so hitting this means something is wrong — flush anyway and let the
+# server arbitrate rather than silently dropping the turn.
+RESPONSE_IDLE_TIMEOUT = 10.0
+
+AUDIO_QUALITIES = {"low", "medium", "high"}
+
+
+class KalpaSynthesizer(StreamSynthesizer):
+    def __init__(
+        self,
+        voice=None,
+        voice_id=None,
+        model=KALPA_DEFAULT_MODEL,
+        temperature=None,
+        top_k=None,
+        acoustic_temperature=None,
+        max_new_tokens=None,
+        audio_quality=None,
+        audio_format="pcm",
+        sampling_rate="8000",
+        stream=False,
+        buffer_size=400,
+        caching=True,
+        synthesizer_key=None,
+        **kwargs,
+    ):
+        super().__init__(
+            stream=stream,
+            provider_name="kalpa",
+            buffer_size=buffer_size,
+            **kwargs,
+        )
+        self.api_key = os.environ["KALPA_API_KEY"] if synthesizer_key is None else synthesizer_key
+        if not self.api_key:
+            raise ValueError("Kalpa API key is required, either as synthesizer_key or KALPA_API_KEY")
+
+        self.voice = voice
+        # The API addresses voices by opaque id; a bare display name ("Kiara") is resolved
+        # against GET /v1/voices on first connect.
+        self.voice_id = voice_id
+        if not self.voice_id and not self.voice:
+            raise ValueError("Kalpa needs a voice_id or a voice name (see GET /v1/voices)")
+
+        self.model = model
+        # Only explicitly-configured knobs are sent; Kalpa's defaults are the tuned
+        # production sampling.
+        self.params = {
+            key: value
+            for key, value in (
+                ("temperature", temperature),
+                ("top_k", top_k),
+                ("acoustic_temperature", acoustic_temperature),
+                ("max_new_tokens", max_new_tokens),
+                ("audio_quality", audio_quality),
+            )
+            if value is not None
+        }
+
+        self.use_mulaw = kwargs.get("use_mulaw", False)
+        # Telephony always renders at 8 kHz mu-law; web keeps the configured PCM rate.
+        self.target_sample_rate = MULAW_SAMPLE_RATE if self.use_mulaw else int(sampling_rate)
+        self.sampling_rate = self.target_sample_rate
+        self.native_sample_rate = KALPA_NATIVE_SAMPLE_RATE
+
+        self.caching = caching
+        if caching:
+            self.cache = InmemoryScalarCache()
+
+        self.kalpa_host = os.getenv("KALPA_API_HOST", "api.kalpalabs.ai")
+
+        # Fail fast on a misconfigured agent rather than mid-call.
+        self._validate_options()
+
+        # Aggregation state: buffer a whole turn's chunks, flush once on end_of_llm_stream.
+        # _buffer_seq tracks which turn owns the buffer so a superseded turn (new
+        # sequence_id before its end_of_llm_stream) can't leak its half-buffered text.
+        self._text_buffer = []
+        self._buffer_seq = None
+        # Set while no response is generating on the socket (one in flight per connection).
+        self._response_idle = asyncio.Event()
+        self._response_idle.set()
+
+    def get_sleep_time(self):
+        return 0.01
+
+    # ------------------------------------------------------------------
+    # Config validation
+    # ------------------------------------------------------------------
+
+    def _validate_options(self):
+        """Mirror the server's GenParams ranges so a typo fails at agent setup, not on the
+        first turn of a live call. The model id is deliberately not validated against a
+        fixed list — the catalog (GET /v1/models) evolves server-side."""
+        temperature = self.params.get("temperature")
+        if temperature is not None and not 0.0 <= float(temperature) <= 1.5:
+            raise ValueError("Kalpa temperature must be between 0.0 and 1.5")
+        acoustic = self.params.get("acoustic_temperature")
+        if acoustic is not None and not 0.0 <= float(acoustic) <= 1.5:
+            raise ValueError("Kalpa acoustic_temperature must be between 0.0 and 1.5")
+        top_k = self.params.get("top_k")
+        if top_k is not None and int(top_k) < 1:
+            raise ValueError("Kalpa top_k must be >= 1")
+        max_new_tokens = self.params.get("max_new_tokens")
+        if max_new_tokens is not None and not 16 <= int(max_new_tokens) <= 2048:
+            raise ValueError("Kalpa max_new_tokens must be between 16 and 2048")
+        audio_quality = self.params.get("audio_quality")
+        if audio_quality is not None and audio_quality not in AUDIO_QUALITIES:
+            raise ValueError(f"Kalpa audio_quality must be one of {sorted(AUDIO_QUALITIES)}")
+
+    # ------------------------------------------------------------------
+    # StreamSynthesizer hooks
+    # ------------------------------------------------------------------
+
+    def _get_audio_format(self):
+        return "mulaw" if self.use_mulaw else "pcm"
+
+    def _process_audio_chunk(self, chunk):
+        """Resample Kalpa's 24 kHz PCM to the target rate; mu-law encode for telephony."""
+        if not chunk:
+            return None
+        try:
+            audio = resample(
+                chunk,
+                self.target_sample_rate,
+                format="pcm",
+                original_sample_rate=self.native_sample_rate,
+            )
+        except Exception as e:
+            logger.error(f"Error resampling Kalpa audio: {e}")
+            return None
+        return pcm_to_ulaw(audio) if self.use_mulaw else audio
+
+    def _on_push(self, meta_info, text):
+        """Runs synchronously in push order (before the sender task): if a new turn starts
+        while the previous one is still buffered, drop the stale buffer so it can't prepend
+        onto this turn's text."""
+        seq = meta_info.get("sequence_id")
+        if self._buffer_seq is not None and self._buffer_seq != seq and self._text_buffer:
+            logger.info(
+                f"Dropping {len(self._text_buffer)} unflushed Kalpa chunk(s) from superseded seq={self._buffer_seq}"
+            )
+            self._text_buffer = []
+        self._buffer_seq = seq
+
+    # ------------------------------------------------------------------
+    # Voice resolution
+    # ------------------------------------------------------------------
+
+    async def _resolve_voice_id(self):
+        """Return the opaque voice id, resolving a display name via GET /v1/voices once.
+
+        Names match case-insensitively, on the full name ("Kiara (hindi)") or its base
+        before the qualifier ("Kiara") — so agent configs don't have to carry UUIDs.
+        """
+        if self.voice_id:
+            return self.voice_id
+
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        url = f"https://{self.kalpa_host}/v1/voices"
+        async with aiohttp.ClientSession() as session:
+            async with session.get(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(f"Kalpa GET /v1/voices failed: {resp.status} - {await resp.text()}")
+                body = await resp.json()
+        voices = body.get("data", []) if isinstance(body, dict) else body
+
+        wanted = self.voice.strip().lower()
+        matches = [v for v in voices if v.get("name", "").lower() == wanted]
+        if not matches:
+            matches = [v for v in voices if v.get("name", "").split(" (")[0].lower() == wanted]
+        if len(matches) == 1:
+            self.voice_id = matches[0]["id"]
+            logger.info(f"Resolved Kalpa voice {self.voice!r} -> {matches[0]['name']!r} ({self.voice_id})")
+            return self.voice_id
+
+        names = sorted(v.get("name", "") for v in voices)
+        if not matches:
+            raise ValueError(f"Unknown Kalpa voice {self.voice!r}. Available: {names}")
+        raise ValueError(f"Ambiguous Kalpa voice {self.voice!r} matches {[v['name'] for v in matches]}")
+
+    # ------------------------------------------------------------------
+    # Interruption
+    # ------------------------------------------------------------------
+
+    async def handle_interruption(self):
+        """Drop the buffered turn and cancel the in-flight response. Cancel is idempotent
+        server-side, so it is unconditionally safe to fire; the cancelled response still
+        terminates with its own responseDone (status "cancelled"), which frees the
+        in-flight slot without emitting an end-of-stream sentinel."""
+        self._text_buffer = []
+        self._buffer_seq = None
+        try:
+            ws = self.websocket
+            if ws is not None and ws.state is websockets.protocol.State.OPEN:
+                await ws.send(json.dumps({"type": "cancelResponse"}))
+                logger.info("Sent cancelResponse to Kalpa TTS WebSocket")
+            # The cancelled turn's end-of-stream is never forwarded, so the next turn must
+            # be re-detected as new for stale text_queue entries to be pruned.
+            self.current_turn_start_time = None
+        except Exception as e:
+            logger.error(f"Error handling Kalpa interruption: {e}")
+
+    # ------------------------------------------------------------------
+    # sender / receiver
+    # ------------------------------------------------------------------
+
+    async def sender(self, text, sequence_id, end_of_llm_stream=False):
+        try:
+            if self.conversation_ended:
+                return
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
+                return
+
+            await self._wait_for_ws()
+
+            if text:
+                self._text_buffer.append(text)
+
+            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn
+            # (see the module docstring for why fragments are never streamed server-side).
+            if not end_of_llm_stream:
+                return
+
+            # LLM chunks carry their own spacing, so they concatenate verbatim.
+            full_text = "".join(self._text_buffer).strip()
+            self._text_buffer = []
+            self._buffer_seq = None
+            self.last_text_sent = True
+
+            if not full_text:
+                return
+            if len(full_text) > MAX_TEXT_CHARS:
+                logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
+                full_text = full_text[:MAX_TEXT_CHARS]
+
+            # One response in flight per connection: wait for the previous turn's
+            # responseDone (a cancelled turn still gets one) before flushing.
+            try:
+                await asyncio.wait_for(self._response_idle.wait(), timeout=RESPONSE_IDLE_TIMEOUT)
+            except asyncio.TimeoutError:
+                logger.warning("Kalpa: previous response still in flight after 10s; flushing anyway")
+
+            # The waits above can span a barge-in that retires this sequence without
+            # cancelling the task; re-check before anything reaches the socket.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (inner): sequence_id {sequence_id} not current")
+                return
+
+            try:
+                self._response_idle.clear()
+                if self.ws_send_time is None:
+                    self.ws_send_time = time.perf_counter()
+                await self._send_json({"type": "sendText", "text": full_text, "flush": True})
+            except Exception as e:
+                logger.error(f"Error sending text to Kalpa: {e}")
+                self.connection_error = str(e)
+
+        except asyncio.CancelledError:
+            logger.info("Kalpa sender task was cancelled.")
+        except Exception as e:
+            logger.error(f"Unexpected error in Kalpa sender: {e}")
+
+    async def receiver(self):
+        not_connected_since = None
+        while True:
+            try:
+                if self.conversation_ended:
+                    return
+                if not self._is_ws_connected():
+                    if self.connection_error:
+                        return
+                    now = time.perf_counter()
+                    if not_connected_since is None:
+                        not_connected_since = now
+                    elif now - not_connected_since > 30:
+                        logger.error("Kalpa receiver: WebSocket never connected after 30s, giving up.")
+                        self.connection_error = self.connection_error or "WebSocket never connected"
+                        return
+                    logger.info("Kalpa WebSocket is not connected, skipping receive.")
+                    await asyncio.sleep(0.1)
+                    continue
+                else:
+                    not_connected_since = None
+
+                response = await self.websocket.recv()
+                data = self._loads_event(response)
+                if data is None:
+                    continue
+
+                event = data.get("type")
+                if event == "responseAudio":
+                    chunk = self._decode_audio(data.get("pcm_b64"))
+                    if chunk:
+                        yield chunk
+                elif event == "responseDone":
+                    self._response_idle.set()
+                    status = data.get("status")
+                    logger.info(f"Kalpa responseDone status={status} response_id={data.get('response_id')}")
+                    if status == "completed":
+                        yield b"\x00"
+                    # "cancelled" terminates a turn we interrupted; handle_interruption()
+                    # already abandoned it, so forwarding a sentinel would stamp
+                    # end-of-stream on a turn the pipeline dropped.
+                elif event == "error":
+                    err = data.get("error") or {}
+                    if data.get("fatal"):
+                        # The server closes the socket after a fatal error; ConnectionClosed
+                        # is what ends this loop, and auth failures won't fix themselves.
+                        logger.error(f"Kalpa fatal error: {err}")
+                        if err.get("type") == "authentication_error":
+                            self.connection_error = err.get("message") or "authentication error"
+                    else:
+                        # A non-fatal error is a rejected client frame. This integration only
+                        # sends whole-turn flushes, so the rejected turn will never produce
+                        # audio or a responseDone — terminate it and free the in-flight slot.
+                        logger.error(f"Kalpa TTS error: {err}")
+                        self._response_idle.set()
+                        yield b"\x00"
+                elif event == "sessionCreated":
+                    # Normally consumed inside establish_connection; tolerated here in case
+                    # a future server pushes an unsolicited session update.
+                    self.native_sample_rate = int(data.get("sample_rate") or self.native_sample_rate)
+                elif event == "responseCreated":
+                    logger.info(f"Kalpa responseCreated response_id={data.get('response_id')}")
+                else:
+                    logger.info(f"Ignoring Kalpa event: {data}")
+
+            except websockets.exceptions.ConnectionClosed:
+                logger.info("Kalpa WebSocket connection closed")
+                break
+            except Exception as e:
+                logger.error(f"Error occurred in Kalpa receiver - {e}")
+
+    def _decode_audio(self, pcm_b64):
+        if not pcm_b64:
+            return None
+        try:
+            return base64.b64decode(pcm_b64)
+        except Exception as e:
+            logger.error(f"Kalpa sent undecodable audio: {e}")
+            return None
+
+    @staticmethod
+    def _loads_event(data):
+        try:
+            parsed = json.loads(data)
+        except (TypeError, ValueError):
+            logger.error(f"Kalpa sent a non-JSON frame: {data!r}")
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    def _initialize_message(self):
+        message = {"type": "initializeConnection", "api_key": self.api_key}
+        if self.model:
+            message["model"] = self.model
+        if self.params:
+            message["params"] = self.params
+        return message
+
+    async def establish_connection(self):
+        """Connect, authenticate, and consume the init reply — so receiver() only ever sees
+        response frames. Returns the ready websocket, or None (monitor_connection retries;
+        deterministic rejections also set connection_error so it doesn't retry a bad key)."""
+        try:
+            start_time = time.perf_counter()
+            voice_id = await self._resolve_voice_id()
+            ws_url = f"wss://{self.kalpa_host}/v1/tts/{voice_id}/stream"
+            websocket_conn = await asyncio.wait_for(
+                websockets.connect(ws_url, ssl=get_ssl_context(ws_url)),
+                timeout=10.0,
+            )
+            try:
+                # The handshake is unauthenticated by design; auth rides the first frame.
+                await websocket_conn.send(json.dumps(self._initialize_message()))
+                reply = self._loads_event(await asyncio.wait_for(websocket_conn.recv(), timeout=10.0)) or {}
+            except Exception:
+                await websocket_conn.close()
+                raise
+
+            if reply.get("type") != "sessionCreated":
+                err = reply.get("error") or {}
+                message = err.get("message") or f"unexpected init reply: {reply}"
+                logger.error(f"Kalpa session rejected: {message}")
+                # A bad key, model, or voice won't fix itself on retry; an inference-side
+                # outage (e.g. voice seed temporarily unavailable) might.
+                if err.get("type") in ("authentication_error", "invalid_request", "not_found"):
+                    self.connection_error = message
+                await websocket_conn.close()
+                return None
+
+            self.native_sample_rate = int(reply.get("sample_rate") or self.native_sample_rate)
+            # A fresh connection has nothing in flight.
+            self._response_idle.set()
+            if not self.connection_time:
+                self.connection_time = round((time.perf_counter() - start_time) * 1000)
+            logger.info(
+                f"Connected to Kalpa TTS (model={reply.get('model')}, voice={reply.get('voice_id')}, "
+                f"{self.native_sample_rate} Hz)"
+            )
+            return websocket_conn
+        except asyncio.TimeoutError:
+            logger.error("Timeout while connecting to Kalpa TTS websocket")
+            return None
+        except ValueError as e:
+            # Voice resolution failed against the live catalog — retrying won't change it.
+            logger.error(str(e))
+            self.connection_error = str(e)
+            return None
+        except InvalidHandshake as e:
+            logger.error(f"Kalpa TTS handshake failed: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Failed to connect to Kalpa TTS: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # HTTP (one-shot renders: non-streaming loop, prewarm/handoff clips, caching)
+    # ------------------------------------------------------------------
+
+    async def _generate_http(self, text):
+        """POST /v1/tts/{voice_id}; the response JSON carries base64 16-bit PCM WAV."""
+        try:
+            voice_id = await self._resolve_voice_id()
+        except Exception as e:
+            logger.error(f"Kalpa voice resolution failed: {e}")
+            return None
+
+        payload = {"text": text}
+        if self.model:
+            payload["model"] = self.model
+        if self.params:
+            payload["params"] = self.params
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        url = f"https://{self.kalpa_host}/v1/tts/{voice_id}"
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, headers=headers, json=payload) as response:
+                request_id = response.headers.get("X-Request-ID")
+                if response.status != 200:
+                    logger.error(
+                        f"Kalpa TTS HTTP error: {response.status} request_id={request_id} - {await response.text()}"
+                    )
+                    return None
+                data = await response.json()
+        audio = (data.get("audio") or {}).get("data_b64")
+        if not audio:
+            logger.error(f"Kalpa TTS HTTP response carried no audio (request_id={request_id})")
+            return None
+        return self._decode_audio(audio)
+
+    async def synthesize(self, text):
+        """One-shot render used by prewarm/handoff paths. The API returns WAV, whose
+        self-describing header lets downstream mu-law conversion pick the right rate."""
+        return await self._generate_http(text)
+
+    async def synthesize_telephony_clip(self, text):
+        """Mu-law 8000 one-shot for handoff/prewarm clips, converted in-process so the
+        caller skips the pydub/ffmpeg decode. None on non-telephony configs."""
+        if not self.use_mulaw:
+            return None
+        audio = await self._generate_http(text)
+        if not audio:
+            return None
+        return self._process_http_audio(audio)
+
+    def _process_http_audio(self, audio):
+        """Convert the one-shot WAV to the format the non-streaming loop should emit."""
+        if not audio:
+            return audio
+        if self.use_mulaw:
+            return audio_to_mulaw8k(audio, rate_hint=self.native_sample_rate, format_hint="wav")
+        if self.target_sample_rate != self.native_sample_rate:
+            return resample(audio, self.target_sample_rate, format="wav")
+        return audio
+
+    def _get_http_audio_format(self):
+        return "mulaw" if self.use_mulaw else "wav"

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -313,6 +313,26 @@ class KalpaSynthesizer(StreamSynthesizer):
         self._turn_truncated = False
         self._turn_dead = False
 
+    async def _send_frame(self, payload):
+        """Send one frame. Unlike the shared _send_json, a failure here is not recorded as
+        connection_error: a socket dying mid-send is transient — the receiver settles or
+        replays the turn and monitor_connection redials — while connection_error is
+        reserved for fatal conditions that must stop the whole synthesizer."""
+        try:
+            await self.websocket.send(json.dumps(payload))
+        except Exception as e:
+            logger.error(f"Kalpa send failed ({payload.get('type')}): {e}")
+            raise
+
+    @staticmethod
+    def _truncate_at_word(text, limit):
+        """Cut at a word boundary so the caller doesn't hear a clipped syllable."""
+        if len(text) <= limit:
+            return text
+        logger.warning(f"Kalpa text exceeds {limit} chars; truncating at a word boundary")
+        cut = text.rfind(" ", 0, limit + 1)
+        return text[:cut] if cut > 0 else text[:limit]
+
     async def _close_ws(self, reason):
         """Deterministic reset: the receiver notices the closure and settles the lost turn,
         monitor_connection redials, and establish_connection reinitializes the state."""
@@ -361,6 +381,19 @@ class KalpaSynthesizer(StreamSynthesizer):
                 return False, False
             if not self.should_synthesize_response(sequence_id):
                 return False, False
+            if self._turn_dead and not self._response_idle.is_set():
+                # A superseded turn holds the slot but can never settle it (it will never
+                # flush); run the barge-in triage handle_interruption never got to run:
+                # cancel when its response is known — the done frees the slot in
+                # milliseconds — and reset the socket when none may ever exist.
+                self._abandoned_in_flight = True
+                if self._current_response_id is not None:
+                    self._ignored_response_ids.add(self._current_response_id)
+                    self._dirty_conn_gen = None  # the cancel wipes the buffered text too
+                    await self._send_frame({"type": "cancelResponse"})
+                else:
+                    await self._close_ws("superseded utterance holds the slot with no response")
+                    continue
             # A new utterance (or a replay after a reconnect) claims the connection's slot.
             slot = await self._wait_for_idle_slot(sequence_id)
             if slot == "retired" or not self.should_synthesize_response(sequence_id):
@@ -376,7 +409,7 @@ class KalpaSynthesizer(StreamSynthesizer):
                 # A superseded turn left un-flushed text in the server buffer; wipe it
                 # before this turn's first chunk or the utterances merge.
                 self._dirty_conn_gen = None
-                await self._send_json({"type": "cancelResponse"})
+                await self._send_frame({"type": "cancelResponse"})
             replay = bool(self._turn_chunks)
             self._turn_conn_gen = self._conn_gen
             self._response_idle.clear()
@@ -399,9 +432,7 @@ class KalpaSynthesizer(StreamSynthesizer):
             piece = (" " if self._turn_chars else "") + text
             budget = MAX_TEXT_CHARS - self._turn_chars
             if len(piece) > budget:
-                logger.warning(f"Kalpa utterance exceeds {MAX_TEXT_CHARS} chars; truncating")
-                cut = piece.rfind(" ", 0, budget + 1)
-                piece = piece[:cut] if cut > 0 else piece[:budget]
+                piece = self._truncate_at_word(piece, budget)
                 self._turn_truncated = True
             if piece:
                 self._turn_chunks.append(piece)
@@ -432,7 +463,7 @@ class KalpaSynthesizer(StreamSynthesizer):
                     wire_text = self._wire_text(text, replay)
                     if wire_text:
                         try:
-                            await self._send_json({"type": "sendText", "text": wire_text})
+                            await self._send_frame({"type": "sendText", "text": wire_text})
                         except Exception:
                             # The socket died mid-send; the chunk stays in _turn_chunks, so
                             # the next send (or this call's flush below) replays the turn
@@ -463,7 +494,7 @@ class KalpaSynthesizer(StreamSynthesizer):
             frame["text"] = "".join(self._turn_chunks)
         self.last_text_sent = True
         try:
-            await self._send_json(frame)
+            await self._send_frame(frame)
         except Exception:
             # Died at the flush: the receiver's settle path terminates the turn (the slot
             # stays claimed until then, so nothing else flushes into the gap).
@@ -742,7 +773,9 @@ class KalpaSynthesizer(StreamSynthesizer):
             logger.error(f"Kalpa voice resolution failed: {e}")
             return None
 
-        payload = {"text": text}
+        # Same cap as the streaming path: the API rejects longer utterances outright, and
+        # in the non-streaming loop that rejection would silently mute the whole turn.
+        payload = {"text": self._truncate_at_word(text, MAX_TEXT_CHARS)}
         if self.model:
             payload["model"] = self.model
         if self.params:

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -653,6 +653,13 @@ class KalpaSynthesizer(StreamSynthesizer):
                             self._response_idle.set()
                             owns_head = self._sentinel_owns_queue_head()
                             self._slot_seq = None
+                            if self._current_response_id is not None:
+                                # The failed response may still have frames on the wire:
+                                # ignore its late audio, and retire its id so a delayed
+                                # done cannot match as current after a newer turn claims
+                                # the slot — that would finish the newer turn early.
+                                self._ignored_response_ids.add(self._current_response_id)
+                                self._current_response_id = None
                             if self._turn_seq is not None:
                                 self._turn_dead = True  # drop the broken turn's stragglers
                             if not self._abandoned_in_flight and owns_head:

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -2,31 +2,19 @@
 Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.
 
 Kalpa's conversational speech models render named voices from GET /v1/voices
-(kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi — including code-switched
-Hinglish — with no language parameter; kalpa-tts-beta-v0.1 is English-only). Everything on
-the socket is JSON text frames: the client authenticates with an initializeConnection
-frame (the handshake itself is unauthenticated), the server confirms with sessionCreated,
-then each sendText frame appends text and flush=true renders the buffered utterance.
-Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM, and every
-flushed utterance terminates with exactly one responseDone (status "completed", or
-"cancelled" after a cancelResponse).
 
-Two transport behaviors shape this integration:
+Models:
+1. kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi, including code-switched
+Hinglish with no language parameter
+2. kalpa-tts-beta-v0.1 is English-only.
 
-  * One response generates at a time per connection. Current gateways queue one flush that
-    arrives mid-generation (older deployments rejected it outright), and this integration
-    leans on neither: the sender waits for the previous turn's responseDone (a cancelled
-    turn still gets one) before flushing, which serializes turns without ever risking the
-    one-slot queue's rejection and stays correct on older gateways.
-  * On current gateways a bare cancelResponse abandons everything undelivered server-side
-    — the in-flight generation, the queued flush, and buffered text; older deployments
-    only stopped the generation and kept the text buffer. Aggregating a whole assistant
-    turn client-side and sending it as a single text+flush frame keeps every turn atomic
-    on the wire — exactly one responseDone per turn — and never leaves an abandoned
-    turn's fragments in a server buffer on any gateway version.
-
-Kalpa output is a fixed 24 kHz, so like the Maya/Sarvam synthesizers we resample every
-chunk down to the target rate and, for telephony, mu-law encode it.
+Flow
+1. The client authenticates with an initializeConnection frame (the handshake itself is unauthenticated),
+2. The server confirms with sessionCreated
+3. Each sendText frame appends text and flush=true renders the buffered utterance.
+4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM.
+5. Every flushed utterance terminates with exactly one responseDone (status "completed", or "cancelled" after a cancelResponse).
+6. For telephony, mu-law encodes audio from 24KHz to 8KHz
 """
 
 import asyncio
@@ -276,11 +264,19 @@ class KalpaSynthesizer(StreamSynthesizer):
 
             await self._wait_for_ws()
 
+            # The wait suspends for real while the socket is reconnecting, and a barge-in can
+            # retire this sequence (and clear the shared buffer) in that gap — appending after
+            # it would leak this turn's fragment into the next turn's utterance.
+            if not self.should_synthesize_response(sequence_id):
+                logger.info(f"Not synthesizing (post-wait): sequence_id {sequence_id} not current")
+                return
+
             if text:
                 self._text_buffer.append(text)
 
-            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn
-            # (see the module docstring for why fragments are never streamed server-side).
+            # Keep buffering until the LLM turn ends: one atomic text+flush frame per turn, so
+            # an abandoned turn's fragments never sit in a server-side buffer and every turn
+            # settles with exactly one responseDone.
             if not end_of_llm_stream:
                 return
 
@@ -390,6 +386,12 @@ class KalpaSynthesizer(StreamSynthesizer):
 
             except websockets.exceptions.ConnectionClosed:
                 logger.info("Kalpa WebSocket connection closed")
+                # A response that dies with the socket will never get its responseDone: free
+                # the single-flight slot and terminate the turn so playback doesn't hang on
+                # it (monitor_connection re-establishes the socket for the next turn).
+                if not self._response_idle.is_set():
+                    self._response_idle.set()
+                    yield b"\x00"
                 break
             except Exception as e:
                 logger.error(f"Error occurred in Kalpa receiver - {e}")

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -149,9 +149,11 @@ class KalpaSynthesizer(StreamSynthesizer):
         # A superseded turn can leave un-flushed text in the server buffer (no interruption
         # ran); the generation it happened on gates a defensive wipe before the next turn.
         self._dirty_conn_gen = None
-        # Set while no utterance occupies the connection.
+        # Set while no utterance occupies the connection; _slot_seq names the sequence that
+        # claimed it (it outlives the turn state, which resets at the flush).
         self._response_idle = asyncio.Event()
         self._response_idle.set()
+        self._slot_seq = None
         # After a cancel, audio frames already on the wire keep arriving until the
         # response's own responseDone; ids in this set are dropped instead of played.
         self._ignored_response_ids = set()
@@ -378,6 +380,7 @@ class KalpaSynthesizer(StreamSynthesizer):
             replay = bool(self._turn_chunks)
             self._turn_conn_gen = self._conn_gen
             self._response_idle.clear()
+            self._slot_seq = sequence_id
             # Generation may start at any segment boundary from here on, so synth latency
             # is measured from the turn's first text frame.
             if self.ws_send_time is None:
@@ -467,6 +470,22 @@ class KalpaSynthesizer(StreamSynthesizer):
             pass
         self._reset_turn()
 
+    def _sentinel_owns_queue_head(self):
+        """A completion sentinel is positional: the shared stream generator stamps it onto
+        the next queued meta_info. If a newer turn's metadata is already queued (its pushes
+        enqueue synchronously while its sender parks on the slot), the settling turn's own
+        metas were consumed by its audio — emitting would mark the newer turn complete
+        before it renders, so the settling turn is dropped without a completion instead."""
+        if not self.text_queue:
+            return True
+        head_seq = self.text_queue[0].get("sequence_id")
+        if head_seq == self._slot_seq:
+            return True
+        logger.warning(
+            f"Suppressing Kalpa end-of-stream for lost seq={self._slot_seq}: queue head belongs to seq={head_seq}"
+        )
+        return False
+
     def _settle_lost_utterance(self):
         """The socket died. Free the connection slot and return how many end-of-stream
         sentinels settle the lost turn (0 or 1):
@@ -483,11 +502,11 @@ class KalpaSynthesizer(StreamSynthesizer):
             self._response_idle.set()
             if self._abandoned_in_flight or self._turn_dead:
                 lost = 0
-            elif self._turn_seq is None:
-                lost = 1
-            elif self._current_response_id is not None:
-                self._turn_dead = True
-                lost = 1
+            elif self._turn_seq is None or self._current_response_id is not None:
+                if self._turn_seq is not None:
+                    self._turn_dead = True
+                lost = 1 if self._sentinel_owns_queue_head() else 0
+        self._slot_seq = None
         self._abandoned_in_flight = False
         self._current_response_id = None
         self._ignored_response_ids.clear()
@@ -538,6 +557,8 @@ class KalpaSynthesizer(StreamSynthesizer):
                     status = data.get("status")
                     logger.info(f"Kalpa responseDone status={status} response_id={rid}")
                     self._response_idle.set()
+                    owns_head = self._sentinel_owns_queue_head()
+                    self._slot_seq = None
                     was_abandoned = self._abandoned_in_flight
                     self._abandoned_in_flight = False
                     if rid in self._ignored_response_ids or was_abandoned:
@@ -545,7 +566,7 @@ class KalpaSynthesizer(StreamSynthesizer):
                         # "completed" done (the cancel lost the race) must not stamp
                         # end-of-stream onto the next turn.
                         self._ignored_response_ids.discard(rid)
-                    elif status == "completed":
+                    elif status == "completed" and owns_head:
                         yield b"\x00"
                     # "cancelled" terminates a turn we interrupted; handle_interruption()
                     # already abandoned it, so forwarding a sentinel would stamp
@@ -566,9 +587,11 @@ class KalpaSynthesizer(StreamSynthesizer):
                         logger.error(f"Kalpa TTS error: {err}")
                         if not self._response_idle.is_set():
                             self._response_idle.set()
+                            owns_head = self._sentinel_owns_queue_head()
+                            self._slot_seq = None
                             if self._turn_seq is not None:
                                 self._turn_dead = True  # drop the broken turn's stragglers
-                            if not self._abandoned_in_flight:
+                            if not self._abandoned_in_flight and owns_head:
                                 yield b"\x00"
                             self._abandoned_in_flight = False
                 elif event == "sessionCreated":

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -593,10 +593,18 @@ class KalpaSynthesizer(StreamSynthesizer):
                         yield chunk
                 elif event == "responseDone":
                     rid = data.get("response_id")
-                    if rid == self._current_response_id:
-                        self._current_response_id = None
                     status = data.get("status")
                     logger.info(f"Kalpa responseDone status={status} response_id={rid}")
+                    if rid is None or rid != self._current_response_id:
+                        # created always precedes done on this ordered socket, so a done
+                        # that does not name the response being served is stale or foreign
+                        # (e.g. a late settle after an error already freed its turn) — it
+                        # must not free, or positionally complete, a slot a newer turn may
+                        # own. If it strands the connection, the idle timeout resets it.
+                        logger.warning(f"Ignoring Kalpa responseDone for unmatched response_id={rid}")
+                        self._ignored_response_ids.discard(rid)
+                        continue
+                    self._current_response_id = None
                     self._response_idle.set()
                     owns_head = self._sentinel_owns_queue_head()
                     self._slot_seq = None

--- a/bolna/synthesizer/kalpa_synthesizer.py
+++ b/bolna/synthesizer/kalpa_synthesizer.py
@@ -29,6 +29,7 @@ import base64
 import json
 import os
 import time
+from collections import deque
 
 import aiohttp
 import websockets
@@ -150,10 +151,15 @@ class KalpaSynthesizer(StreamSynthesizer):
         # A superseded turn can leave un-flushed text in the server buffer (no interruption
         # ran); the generation it happened on gates a defensive wipe before the next turn.
         self._dirty_conn_gen = None
-        # Bumped by handle_interruption() before anything else. Senders capture it at entry
-        # and retire at their next await boundary on a mismatch — including on task-manager
-        # paths that cancel first and only invalidate the sequence later.
+        # Bumped by handle_interruption() before anything else; senders retire at their
+        # next await boundary on a mismatch — including on task-manager paths that cancel
+        # first and only invalidate the sequence later. Each sender's epoch is captured at
+        # PUSH time (_on_push runs synchronously when its task is created, and pushes and
+        # senders are strictly FIFO, so the deque pairs them): a sender task created just
+        # before the barge-in but first scheduled after it must still count as
+        # pre-interruption work.
         self._interrupt_gen = 0
+        self._sender_epochs = deque()
         # THE SLOT: one utterance occupies the connection from its first sendText until its
         # settle. _slot_seq names the owning sequence; _slot_abandoned marks a barge-in on
         # it (its completion then settles silently). Freed ONLY by _settle_slot() (and the
@@ -221,10 +227,12 @@ class KalpaSynthesizer(StreamSynthesizer):
         return pcm_to_ulaw(audio) if self.use_mulaw else audio
 
     def _on_push(self, meta_info, text):
-        """Runs synchronously in push order (before the sender task): a new turn starting
-        while an older utterance is still open means that turn was retired without an
-        interruption. Mark it dead so its stragglers drop instead of appending to this
-        turn's utterance, and remember that its text may still sit in the server buffer."""
+        """Runs synchronously in push order (before the sender task): stamp the interrupt
+        epoch this push belongs to, and detect supersession — a new turn starting while an
+        older utterance is still open means that turn was retired without an interruption.
+        Mark it dead so its stragglers drop instead of appending to this turn's utterance,
+        and remember that its text may still sit in the server buffer."""
+        self._sender_epochs.append(self._interrupt_gen)
         seq = meta_info.get("sequence_id")
         if self._turn_seq is not None and self._turn_seq != seq and not self._turn_dead:
             logger.info(f"Marking un-flushed Kalpa utterance from superseded seq={self._turn_seq} dead")
@@ -479,10 +487,11 @@ class KalpaSynthesizer(StreamSynthesizer):
 
     async def sender(self, text, sequence_id, end_of_llm_stream=False):
         try:
-            # Captured before any await: an interruption bumps the epoch first, so a
-            # sender that started before the barge-in retires at its next await boundary
-            # even when the sequence is only invalidated later.
-            interrupt_gen = self._interrupt_gen
+            # The epoch was stamped at push time (see _on_push): an interruption bumps it
+            # first, so a sender pushed before the barge-in retires even when its task is
+            # first scheduled after the bump and the sequence is only invalidated later.
+            # (Direct calls without a push fall back to the live epoch.)
+            interrupt_gen = self._sender_epochs.popleft() if self._sender_epochs else self._interrupt_gen
             if self._retired(sequence_id, interrupt_gen):
                 logger.info(f"Not synthesizing: sequence_id {sequence_id} not current")
                 return

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -296,9 +296,10 @@ def test_stale_sequence_sends_nothing():
 
 
 def test_the_flush_waits_for_the_previous_responses_done():
-    """One response in flight per connection: flushing while the previous turn is still
-    generating is rejected by the server (and the turn lost), so the sender must park on
-    the idle event until responseDone frees the slot."""
+    """One response generates at a time per connection: older gateways rejected a flush
+    sent mid-generation (losing the turn) and current ones queue exactly one, so the
+    sender parks on the idle event until responseDone frees the slot — serializing turns
+    without relying on either behavior."""
     s = _synth()
     s._response_idle.clear()  # a previous flush is still generating
     order = []

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -1,6 +1,7 @@
-"""Kalpa TTS: whole-turn aggregation + single-flight flushing, the JSON/base64 wire
-protocol, 24 kHz -> telephony conversion, voice-name resolution, and the init handshake
-that establish_connection() must complete before the receiver ever sees the socket."""
+"""Kalpa TTS: streamed text with server-side segmentation, the single-utterance connection
+slot, the JSON/base64 wire protocol, 24 kHz -> telephony conversion, voice-name resolution,
+and the init handshake that establish_connection() must complete before the receiver ever
+sees the socket."""
 
 import asyncio
 import audioop
@@ -15,6 +16,7 @@ from bolna.helpers.utils import audio_to_mulaw8k
 from bolna.models import KalpaConfig, Synthesizer
 from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
 from bolna.synthesizer.kalpa_synthesizer import (
+    DEFAULT_CHUNK_LENGTH_SCHEDULE,
     KALPA_DEFAULT_MODEL,
     KALPA_NATIVE_SAMPLE_RATE,
     MAX_TEXT_CHARS,
@@ -44,6 +46,7 @@ def _synth(**kwargs):
     s.task_manager_instance.is_sequence_id_in_current_ids.return_value = True
     s.websocket = MagicMock()
     s.websocket.send = AsyncMock()
+    s.websocket.close = AsyncMock()
     s._wait_for_ws = AsyncMock()
     s._is_ws_connected = MagicMock(return_value=True)
     s.sent = []
@@ -51,15 +54,25 @@ def _synth(**kwargs):
     return s
 
 
-def _push(s, text, seq, eos=False):
-    """Mimic _push_stream's ordering: _on_push stamps buffer ownership, then the sender runs."""
+async def _push(s, text, seq, eos=False):
+    """Mimic _push_stream's ordering: _on_push stamps turn ownership, then the sender runs."""
     s._on_push({"sequence_id": seq}, text)
-    asyncio.run(s.sender(text, sequence_id=seq, end_of_llm_stream=eos))
+    await s.sender(text, sequence_id=seq, end_of_llm_stream=eos)
 
 
 def _pcm(seconds, rate=KALPA_NATIVE_SAMPLE_RATE):
     """A silent-but-nonzero 16-bit mono buffer of a known length."""
     return (b"\x10\x00") * int(seconds * rate)
+
+
+def _open_ws(s):
+    """A live-looking websocket for handle_interruption's direct sends."""
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    ws.close = AsyncMock()
+    s.websocket = ws
+    return ws
 
 
 class _FakeResp:
@@ -154,15 +167,23 @@ def test_the_config_always_carries_a_voice_name():
     assert cfg.provider_config.model == KALPA_DEFAULT_MODEL
 
 
+def test_top_k_is_not_part_of_the_public_interface():
+    # Kalpa's API runs the tuned internal sampling; top_k is not a public knob.
+    assert "top_k" not in KalpaConfig.model_fields
+    s = _synth(top_k=50)  # swallowed with the other unknown kwargs, never sent
+    assert "top_k" not in s.params
+
+
 @pytest.mark.parametrize(
     "bad",
     [
         {"temperature": 2.0},
         {"acoustic_temperature": -0.1},
-        {"top_k": 0},
         {"max_new_tokens": 4},
         {"max_new_tokens": 99999},
         {"audio_quality": "ultra"},
+        {"chunk_length_schedule": [30]},
+        {"chunk_length_schedule": [50] * 11},
     ],
 )
 def test_out_of_range_params_raise_at_construction_not_mid_call(bad):
@@ -189,17 +210,21 @@ def test_telephony_pins_8k_mulaw_and_web_keeps_the_configured_rate():
 # ----------------------------------------------------------------------
 
 
-def test_initialize_message_carries_auth_model_and_only_set_params():
-    s = _synth(temperature=0.8, top_k=50)
+def test_initialize_message_carries_auth_model_segmentation_and_only_set_params():
+    s = _synth(temperature=0.8)
     assert s._initialize_message() == {
         "type": "initializeConnection",
         "api_key": KEY,
         "model": KALPA_DEFAULT_MODEL,
-        "params": {"temperature": 0.8, "top_k": 50},
+        "generation_config": {"chunk_length_schedule": DEFAULT_CHUNK_LENGTH_SCHEDULE},
+        "params": {"temperature": 0.8},
     }
     # Kalpa's server defaults are the tuned production sampling; sending none keeps
     # the contract explicit.
     assert "params" not in _synth()._initialize_message()
+    # generation_config is never omitted: without it the connection falls back to
+    # generate-only-on-flush and first audio waits for the whole LLM turn.
+    assert "generation_config" in _synth()._initialize_message()
 
 
 # ----------------------------------------------------------------------
@@ -242,209 +267,243 @@ def test_a_catalog_error_raises_rather_than_guessing(monkeypatch):
 
 
 # ----------------------------------------------------------------------
-# sender: whole-turn aggregation + single-flight
+# sender: streamed text + the single-utterance slot
 # ----------------------------------------------------------------------
 
 
-def test_sender_aggregates_the_turn_and_flushes_once_on_eos():
-    """Chunks join with a single space: the streaming LLM wrappers split at buffer_size
-    with rsplit(" ", 1) and drop the boundary space — joining verbatim would glue words."""
+async def test_chunks_stream_as_they_arrive_and_the_flush_ends_the_turn():
+    """Text reaches the server the moment the LLM produces it — segmentation renders it
+    early — and chunks rejoin with the boundary space the LLM wrappers' rsplit consumed."""
     s = _synth()
-    _push(s, "Namaste!", 1)
-    _push(s, "Kaise hain aap?", 1)
-    assert s.sent == []  # nothing reaches the socket while the turn is still streaming
+    await _push(s, "Namaste!", 1)
+    assert s.sent == [{"type": "sendText", "text": "Namaste!"}]
+    assert not s._response_idle.is_set()  # the utterance claims the slot at its first chunk
 
-    _push(s, "", 1, eos=True)
-    assert s.sent == [{"type": "sendText", "text": "Namaste! Kaise hain aap?", "flush": True}]
+    await _push(s, "Kaise hain aap?", 1)
+    assert s.sent[-1] == {"type": "sendText", "text": " Kaise hain aap?"}
+
+    await _push(s, "", 1, eos=True)
+    assert s.sent[-1] == {"type": "sendText", "flush": True}
     assert s.last_text_sent is True
-    assert s._text_buffer == []
-    assert not s._response_idle.is_set()  # the flush occupies the single in-flight slot
+    assert s._turn_seq is None  # the turn is closed; the slot frees at its responseDone
+    assert not s._response_idle.is_set()
 
 
-def test_an_empty_turn_sends_nothing():
+async def test_an_empty_turn_sends_nothing():
     # The server rejects an empty flush outright, so it must never be sent.
     s = _synth()
-    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    await _push(s, "", 1, eos=True)
     assert s.sent == []
+    assert s._response_idle.is_set()  # nothing claimed the connection
 
 
-def test_an_overlong_turn_truncates_to_the_cap_at_a_word_boundary():
+async def test_an_overlong_turn_truncates_at_a_word_boundary_and_still_flushes():
     s = _synth()
-    _push(s, "hello " * (MAX_TEXT_CHARS // 6 + 50), 1, eos=True)
+    await _push(s, "hello " * (MAX_TEXT_CHARS // 6 + 50), 1, eos=True)
     sent = s.sent[0]["text"]
     assert len(sent) <= MAX_TEXT_CHARS
     assert sent.endswith("hello")  # never a clipped syllable
 
+    # Once the cap is hit, later chunks are dropped but the flush still lands.
     s = _synth()
-    _push(s, "a" * (MAX_TEXT_CHARS + 500), 1, eos=True)  # no whitespace: hard cap
-    assert len(s.sent[0]["text"]) == MAX_TEXT_CHARS
+    await _push(s, "a" * MAX_TEXT_CHARS, 1)
+    await _push(s, "overflow", 1)
+    await _push(s, "", 1, eos=True)
+    assert s.sent == [{"type": "sendText", "text": "a" * MAX_TEXT_CHARS}, {"type": "sendText", "flush": True}]
 
 
-def test_a_late_chunk_after_its_turns_flush_is_dropped():
-    """Ownership invariant: a stray chunk whose turn's buffer was already flushed or
-    dropped must not append and ride into the next turn's utterance."""
-    s = _synth()
-    _push(s, "chunk two", 1)
-    _push(s, "chunk three", 1, eos=True)  # the turn flushes without the straggler
-    asyncio.run(s.sender("chunk one", sequence_id=1, end_of_llm_stream=False))  # wakes late
-    assert s._text_buffer == []
-
-    s._response_idle.set()  # the flushed response completes
-    _push(s, "next turn", 2, eos=True)
-    assert s.sent[-1]["text"] == "next turn"
-
-
-def test_on_push_drops_a_superseded_turns_buffer():
-    s = _synth()
-    s._on_push({"sequence_id": 1}, "hi")
-    s._text_buffer = ["first turn, never flushed"]
-    s._on_push({"sequence_id": 2}, "second turn")  # a new turn arrives before eos
-    assert s._text_buffer == []
-    assert s._buffer_seq == 2
-
-
-def test_stale_sequence_sends_nothing():
+async def test_stale_sequence_sends_nothing():
     s = _synth()
     s.task_manager_instance.is_sequence_id_in_current_ids.return_value = False
-    asyncio.run(s.sender("dropped", sequence_id=7, end_of_llm_stream=True))
+    await s.sender("dropped", sequence_id=7, end_of_llm_stream=True)
     assert s.sent == []
 
 
-def test_the_flush_waits_for_the_previous_responses_done():
-    """One response generates at a time per connection: older gateways rejected a flush
-    sent mid-generation (losing the turn) and current ones queue exactly one, so the
-    sender parks on the idle event until responseDone frees the slot — serializing turns
-    without relying on either behavior."""
+async def test_ws_send_time_stamps_at_the_turns_first_chunk():
+    """With segmentation the server may start rendering at any sentence boundary, so synth
+    latency (TTFA) is measured from the turn's first text frame, not the flush."""
     s = _synth()
-    s._response_idle.clear()  # a previous flush is still generating
+    assert s.ws_send_time is None
+    await _push(s, "first chunk.", 1)
+    assert s.ws_send_time is not None
+
+
+async def test_a_new_turn_waits_for_the_previous_responses_done():
+    """One utterance occupies the connection at a time: the next turn's first chunk parks
+    on the idle event until responseDone frees the slot — serializing utterances without
+    relying on the server's one-slot flush queue."""
+    s = _synth()
+    s._response_idle.clear()  # a previous utterance is still settling
     s._on_push({"sequence_id": 2}, "next turn")
     order = []
 
     async def go():
-        async def flush():
-            await s.sender("next turn", sequence_id=2, end_of_llm_stream=True)
-            order.append("flushed")
+        await s.sender("next turn", sequence_id=2, end_of_llm_stream=True)
+        order.append("sent")
 
-        task = asyncio.create_task(flush())
-        await asyncio.sleep(0.05)
-        assert s.sent == []  # still parked
-        order.append("done arrived")
-        s._response_idle.set()  # receiver saw responseDone
-        await asyncio.wait_for(task, timeout=2)
-
-    asyncio.run(go())
-    assert order == ["done arrived", "flushed"]
-    assert s.sent == [{"type": "sendText", "text": "next turn", "flush": True}]
+    task = asyncio.create_task(go())
+    await asyncio.sleep(0.05)
+    assert s.sent == []  # still parked
+    order.append("done arrived")
+    s._response_idle.set()  # receiver saw responseDone
+    await asyncio.wait_for(task, timeout=2)
+    assert order == ["done arrived", "sent"]
+    assert s.sent == [{"type": "sendText", "text": "next turn"}, {"type": "sendText", "flush": True}]
 
 
-def test_a_barge_in_during_the_idle_wait_stops_the_sender():
+async def test_a_barge_in_during_the_idle_wait_stops_the_sender():
     """The idle wait can span a barge-in that retires this sequence without cancelling the
-    task; without the re-check the sender would flush a turn the pipeline already dropped."""
+    task; without the re-check the sender would stream a turn the pipeline already dropped."""
     s = _synth()
     s._response_idle.clear()
     s._on_push({"sequence_id": 1}, "text for an interrupted turn")
     retired = {"yet": False}
     s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
 
-    async def go():
-        async def flush():
-            await s.sender("text for an interrupted turn", sequence_id=1, end_of_llm_stream=True)
-
-        task = asyncio.create_task(flush())
-        await asyncio.sleep(0.05)
-        retired["yet"] = True  # the barge-in lands while the sender is parked
-        s._response_idle.set()
-        await asyncio.wait_for(task, timeout=2)
-
-    asyncio.run(go())
+    task = asyncio.create_task(s.sender("text for an interrupted turn", sequence_id=1, end_of_llm_stream=True))
+    await asyncio.sleep(0.05)
+    retired["yet"] = True  # the barge-in lands while the sender is parked
+    s._response_idle.set()
+    await asyncio.wait_for(task, timeout=2)
     assert s.sent == []
 
 
-def test_a_barge_in_during_the_ws_wait_stops_the_flush():
+async def test_a_barge_in_during_the_ws_wait_stops_the_turn():
     """_wait_for_ws() suspends for real while the socket reconnects; a barge-in in that gap
-    retires the sequence, and the captured turn must not flush when the wait resumes."""
+    retires the sequence, and the captured chunk must not reach the socket after it."""
     s = _synth()
     retired = {"yet": False}
     s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
 
     async def wait_then_barge_in():
-        retired["yet"] = True  # the barge-in lands while the flush is parked here
+        retired["yet"] = True  # the barge-in lands while the sender is parked here
 
-    s._wait_for_ws = AsyncMock(side_effect=wait_then_barge_in)
-    _push(s, "an interrupted turn", 1, eos=True)
+    s._wait_for_ws = wait_then_barge_in
+    await _push(s, "an interrupted turn", 1, eos=True)
     assert s.sent == []
-    assert s._text_buffer == []
+    assert s._turn_seq is None  # the utterance never opened
 
 
-def test_a_reconnect_gap_flushes_the_whole_turn_in_order():
-    """Chunks append before any await, in push order; only the EOS task waits on the
-    socket. A reconnect mid-turn must never reorder or drop earlier fragments."""
+async def test_senders_serialize_in_push_order_through_a_reconnect():
+    """Sender tasks acquire the send lock in push order, so a reconnect that parks the
+    turn's first chunk can neither reorder nor drop the fragments behind it."""
     s = _synth()
     gate = asyncio.Event()
+    s._is_ws_connected = MagicMock(side_effect=lambda: gate.is_set())
 
     async def parked_until_reconnect():
         await gate.wait()
 
     s._wait_for_ws = parked_until_reconnect
 
-    async def go():
-        tasks = []
-        for text, eos in (("first", False), ("middle", False), ("final", True)):
-            s._on_push({"sequence_id": 1}, text)
-            tasks.append(asyncio.create_task(s.sender(text, 1, end_of_llm_stream=eos)))
-        await asyncio.sleep(0.05)  # the EOS task is parked on the dead socket
-        assert s.sent == []
-        gate.set()  # reconnect completes
-        await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+    tasks = []
+    for text, eos in (("first", False), ("middle", False), ("final", True)):
+        s._on_push({"sequence_id": 1}, text)
+        tasks.append(asyncio.create_task(s.sender(text, 1, end_of_llm_stream=eos)))
+    await asyncio.sleep(0.05)  # the first sender is parked on the dead socket
+    assert s.sent == []
+    gate.set()  # reconnect completes
+    await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+    assert s.sent == [
+        {"type": "sendText", "text": "first"},
+        {"type": "sendText", "text": " middle"},
+        {"type": "sendText", "text": " final"},
+        {"type": "sendText", "flush": True},
+    ]
 
-    asyncio.run(go())
-    assert s.sent == [{"type": "sendText", "text": "first middle final", "flush": True}]
 
-
-def test_a_dead_socket_settles_the_in_flight_turn():
-    """A response that dies with the socket never gets its responseDone. The receiver must
-    free the single-flight slot and emit the end-of-stream sentinel so playback terminates
-    instead of waiting on a frame that will never arrive."""
+async def test_parked_turns_serialize_when_the_slot_frees():
+    """Event.set() wakes every parked sender; each must re-verify the slot so two turns
+    cannot ride one responseDone into overlapping utterances."""
     s = _synth()
-    s._response_idle.clear()  # a flush is in flight when the socket drops
+    s._response_idle.clear()  # a response is generating
 
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
+    s._on_push({"sequence_id": 2}, "turn two")
+    t2 = asyncio.create_task(s.sender("turn two", 2, end_of_llm_stream=True))
+    await asyncio.sleep(0.01)  # t2 parks on the idle wait (holding the send lock)
+    s._on_push({"sequence_id": 3}, "turn three")
+    t3 = asyncio.create_task(s.sender("turn three", 3, end_of_llm_stream=True))
+    await asyncio.sleep(0.01)  # t3 parks behind it on the lock
 
-    s.websocket.recv = recv
-    s.conversation_ended = False
+    s._response_idle.set()  # the in-flight response's done frees the slot once
+    await asyncio.sleep(0.05)
+    assert [p.get("text") for p in s.sent] == ["turn two", None]  # only turn two rode it
 
-    async def go():
-        return [item async for item in s.receiver()]
+    s._response_idle.set()  # turn two's done
+    await asyncio.wait_for(asyncio.gather(t2, t3), timeout=2)
+    assert [p.get("text") for p in s.sent] == ["turn two", None, "turn three", None]
 
-    out = asyncio.run(asyncio.wait_for(go(), timeout=5))
-    assert out == [b"\x00"]
+
+async def test_a_wedged_response_makes_the_sender_reset_the_socket(monkeypatch):
+    """Task-5 semantics: dones settle in milliseconds, so a 10s wait means the connection's
+    state is unknowable. The sender closes the socket — the receiver settles the lost turn,
+    monitor_connection redials — and the parked turn goes out on the fresh connection,
+    instead of being flushed into a session we no longer understand."""
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
+    s = _synth()
+    s._response_idle.clear()  # a previous response is wedged; its done never comes
+    closed = asyncio.Event()
+
+    async def close():
+        closed.set()
+
+    s.websocket.close = close
+
+    s._on_push({"sequence_id": 2}, "next turn")
+    task = asyncio.create_task(s.sender("next turn", 2, end_of_llm_stream=True))
+    await asyncio.wait_for(closed.wait(), timeout=2)
+    assert s.sent == []  # nothing was sent into the wedged session
+
+    # The closure settles the lost turn and the connection comes back:
+    assert s._settle_lost_utterance() == 1
+    await asyncio.wait_for(task, timeout=2)
+    assert s.sent == [{"type": "sendText", "text": "next turn"}, {"type": "sendText", "flush": True}]
+
+
+async def test_a_reconnect_mid_turn_replays_the_whole_turn():
+    """The server's buffer dies with the socket. No audio had started, so the sender
+    resends everything the turn already streamed on the fresh connection — no words lost,
+    none repeated."""
+    s = _synth()
+    await _push(s, "first words", 1)
+    await _push(s, "second words", 1)
+    assert s._settle_lost_utterance() == 0  # nothing played: the turn stays live, silently
     assert s._response_idle.is_set()
+    s._conn_gen += 1  # what establish_connection does on the redial
+
+    await _push(s, "final words", 1, eos=True)
+    assert s.sent[-2] == {"type": "sendText", "text": "first words second words final words"}
+    assert s.sent[-1] == {"type": "sendText", "flush": True}
 
 
-def test_a_dead_socket_with_nothing_in_flight_stays_silent():
-    # No sentinel when idle: a spurious one would pop the next turn's meta_info.
+async def test_a_socket_death_after_audio_started_ends_the_turn_instead_of_replaying():
+    """Segmentation had already rendered (and played) part of the open utterance; replaying
+    its text would repeat what the caller heard. The turn settles with a sentinel and its
+    stragglers are dropped."""
     s = _synth()
+    await _push(s, "some words that already rendered.", 1)
+    s._current_response_id = "r1"  # the server had started this utterance's response
+    assert s._settle_lost_utterance() == 1
+    s._conn_gen += 1
 
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
-
-    s.websocket.recv = recv
-    s.conversation_ended = False
-
-    async def go():
-        return [item async for item in s.receiver()]
-
-    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == []
+    await _push(s, "a straggler", 1)
+    await _push(s, "", 1, eos=True)
+    assert len(s.sent) == 1  # nothing after the death reached the wire
+    assert s._turn_seq is None  # the eos finally forgets the dead turn
 
 
-def test_sender_stamps_ws_send_time_at_the_flush():
-    # Generation only starts at the flush, so TTFB measured from here is true synth latency.
+async def test_a_superseded_turns_server_residue_is_wiped_before_the_next_turn():
+    """A turn retired without an interruption leaves its un-flushed text in the server
+    buffer; the next turn must wipe it (bare cancel) or the utterances would merge."""
     s = _synth()
-    _push(s, "first chunk", 1)
-    assert s.ws_send_time is None
-    _push(s, "last chunk", 1, eos=True)
-    assert s.ws_send_time is not None
+    await _push(s, "half a turn", 1)
+    s._on_push({"sequence_id": 2}, "next")  # superseded, no handle_interruption ran
+    assert s._turn_dead is True
+    s._response_idle.set()  # the old slot settles eventually
+
+    await s.sender("next", sequence_id=2, end_of_llm_stream=False)
+    assert s.sent[1] == {"type": "cancelResponse"}
+    assert s.sent[2] == {"type": "sendText", "text": "next"}
 
 
 # ----------------------------------------------------------------------
@@ -452,7 +511,7 @@ def test_sender_stamps_ws_send_time_at_the_flush():
 # ----------------------------------------------------------------------
 
 
-def _drain(s, frames):
+async def _drain(s, frames):
     """Feed `frames` through receiver() and collect what it yields.
 
     receiver() loops forever by design, so once the scripted frames run out we raise
@@ -475,17 +534,17 @@ def _drain(s, frames):
             out.append(item)
 
     try:
-        asyncio.run(asyncio.wait_for(go(), timeout=5))
+        await asyncio.wait_for(go(), timeout=5)
     except (asyncio.CancelledError, asyncio.TimeoutError):
         pass
     return out
 
 
-def test_receiver_decodes_audio_frames_and_maps_done_to_the_eos_sentinel():
+async def test_receiver_decodes_audio_frames_and_maps_done_to_the_eos_sentinel():
     s = _synth()
     s._response_idle.clear()
     pcm = _pcm(0.1)
-    out = _drain(
+    out = await _drain(
         s,
         [
             json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
@@ -494,15 +553,15 @@ def test_receiver_decodes_audio_frames_and_maps_done_to_the_eos_sentinel():
         ],
     )
     assert out == [pcm, b"\x00"]
-    assert s._response_idle.is_set()  # done freed the in-flight slot
+    assert s._response_idle.is_set()  # done freed the utterance slot
 
 
-def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
+async def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
     """A cancelled response terminates a turn handle_interruption() already abandoned;
     forwarding a sentinel would stamp end-of-stream onto the wrong turn's meta_info."""
     s = _synth()
     s._response_idle.clear()
-    out = _drain(
+    out = await _drain(
         s,
         [
             json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
@@ -513,13 +572,12 @@ def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
     assert s._response_idle.is_set()
 
 
-def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
-    """Non-fatal errors are rejected client frames. This integration only sends whole-turn
-    flushes, so a rejected turn will never produce audio or a responseDone — without the
-    sentinel the pipeline would wait on it forever."""
+async def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
+    """Non-fatal errors are rejected client frames: the utterance on the connection will
+    never finish normally, so it settles here — and its later fragments must not reopen it."""
     s = _synth()
-    s._response_idle.clear()
-    out = _drain(
+    await _push(s, "a turn the server rejected", 1)  # open utterance, slot claimed
+    out = await _drain(
         s,
         [
             json.dumps(
@@ -533,14 +591,15 @@ def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
     )
     assert out == [b"\x00"]
     assert s._response_idle.is_set()
+    assert s._turn_dead is True  # stragglers of the broken turn are dropped
     assert s.connection_error is None  # the socket stays usable
 
 
-def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
+async def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
     """A sentinel with nothing in flight would pop the next turn's meta_info from the
     text_queue and stamp end-of-stream onto a turn that never played."""
     s = _synth()  # _response_idle starts set
-    out = _drain(
+    out = await _drain(
         s,
         [json.dumps({"type": "error", "fatal": False, "error": {"type": "invalid_request", "message": "bad frame"}})],
     )
@@ -548,20 +607,17 @@ def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
     assert s._response_idle.is_set()
 
 
-def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
+async def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
     """After cancelResponse, frames already on the wire keep arriving until the response's
     own responseDone; played as-is they would open the next turn's reply."""
     s = _synth()
     s._response_idle.clear()
     s._current_response_id = "r1"  # responseCreated arrived before the barge-in
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock()
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())
+    _open_ws(s)
+    await s.handle_interruption()
     assert s._ignored_response_ids == {"r1"}
 
-    out = _drain(
+    out = await _drain(
         s,
         [
             json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(b"stale").decode()}),
@@ -577,18 +633,18 @@ def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
     assert s._ignored_response_ids == set()
 
 
-def test_a_barge_in_before_response_created_still_drops_that_responses_audio():
-    """The barge-in can land after the flush but before responseCreated delivers the id;
-    the late-arriving id must inherit the abandonment so its audio never plays."""
+async def test_a_barge_in_after_the_flush_but_before_response_created_still_drops_the_audio():
+    """The barge-in can land after the flush but before responseCreated delivers the id.
+    The flush committed the utterance, so its response (and done) are guaranteed — the
+    cancel rides on that, and the late-arriving id inherits the abandonment."""
     s = _synth()
-    s._response_idle.clear()  # a flush went out; responseCreated has not arrived yet
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock()
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())
+    await _push(s, "a flushed turn", 1, eos=True)  # turn closed, slot claimed, no id yet
+    ws = _open_ws(s)
+    await s.handle_interruption()
+    assert json.loads(ws.send.call_args[0][0]) == {"type": "cancelResponse"}
+    ws.close.assert_not_awaited()
 
-    out = _drain(
+    out = await _drain(
         s,
         [
             json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
@@ -601,16 +657,13 @@ def test_a_barge_in_before_response_created_still_drops_that_responses_audio():
     assert s._ignored_response_ids == set()
 
 
-def test_a_socket_death_after_an_early_barge_in_stays_silent():
+async def test_a_socket_death_after_an_early_barge_in_stays_silent():
     """Same window, but the socket dies before the abandoned response settles: the close
     handler must not emit a sentinel that would finalize the next turn's queued meta."""
     s = _synth()
-    s._response_idle.clear()  # a flush went out; responseCreated has not arrived yet
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock()
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())
+    await _push(s, "a flushed turn", 1, eos=True)
+    _open_ws(s)
+    await s.handle_interruption()
 
     async def recv():
         raise _ws.exceptions.ConnectionClosedOK(None, None)
@@ -618,72 +671,49 @@ def test_a_socket_death_after_an_early_barge_in_stays_silent():
     s.websocket.recv = recv
     s.conversation_ended = False
 
-    async def go():
-        return [item async for item in s.receiver()]
-
-    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == []
+    out = [item async for item in s.receiver()]
+    assert out == []
     assert s._response_idle.is_set()  # the slot is still freed for the next connection
 
 
-def test_a_timed_out_abandonment_does_not_poison_the_next_turn(monkeypatch):
-    """If the abandoned response's responseDone never arrives, the idle timeout lets the
-    next turn flush anyway; giving up must also retire the abandonment, or the next
-    turn's response is marked ignored at responseCreated and loses audio and sentinel."""
-    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
+async def test_a_dead_socket_settles_the_flushed_turn():
+    """A flushed utterance that dies with the socket never gets its responseDone. The
+    receiver must free the slot and emit the end-of-stream sentinel so playback terminates
+    instead of waiting on a frame that will never arrive."""
     s = _synth()
-    s._response_idle.clear()  # a flush is in flight; its responseDone will never come
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock()
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())  # abandoned before responseCreated named it
+    await _push(s, "a flushed turn", 1, eos=True)
 
-    _push(s, "next turn", 2, eos=True)  # parks on the idle wait, then flushes anyway
-    assert s.sent[-1] == {"type": "sendText", "text": "next turn", "flush": True}
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
 
-    out = _drain(
-        s,
-        [
-            json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000}),
-            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"live").decode()}),
-            json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "hi", "usage": {}}),
-        ],
-    )
-    assert out == [b"live", b"\x00"]
+    s.websocket.recv = recv
+    s.conversation_ended = False
 
-
-def test_a_late_done_for_a_retired_response_does_not_finish_the_active_turn(monkeypatch):
-    """After the idle timeout lets a newer turn flush past a wedged response, the old
-    response's late responseDone must neither free the newer flush's single-flight slot
-    nor emit a sentinel that finishes the newer turn's metadata before its audio."""
-    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
-    s = _synth()
-    _push(s, "turn one", 1, eos=True)  # in flight; its responseDone is delayed
-    _push(s, "turn two", 2, eos=True)  # parks on the idle wait, then flushes anyway
-    assert [p["text"] for p in s.sent] == ["turn one", "turn two"]
-
-    out = _drain(
-        s,
-        [json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}})],
-    )
-    assert out == []  # a late completion of a retired response is not the active turn's
-    assert not s._response_idle.is_set()  # turn two still owns the slot
-
-    out = _drain(
-        s,
-        [json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "", "usage": {}})],
-    )
+    out = [item async for item in s.receiver()]
     assert out == [b"\x00"]
     assert s._response_idle.is_set()
 
 
-def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
+async def test_a_dead_socket_with_nothing_in_flight_stays_silent():
+    # No sentinel when idle: a spurious one would pop the next turn's meta_info.
+    s = _synth()
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    out = [item async for item in s.receiver()]
+    assert out == []
+
+
+async def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
     """The receiver usually notices a dead socket at its connection poll, not inside
-    recv(); the in-flight turn must settle there too or its completion is lost and the
+    recv(); the flushed turn must settle there too or its completion is lost and the
     reconnect erases the evidence."""
     s = _synth()
-    s._response_idle.clear()
-    s._inflight_flushes = 1
+    await _push(s, "a flushed turn", 1, eos=True)
     s._is_ws_connected = MagicMock(return_value=False)
     s.conversation_ended = False
     out = []
@@ -693,87 +723,25 @@ def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
             out.append(item)
             s.connection_error = "socket died"  # ends the poll loop after the settle
 
-    asyncio.run(asyncio.wait_for(go(), timeout=5))
+    await asyncio.wait_for(go(), timeout=5)
     assert out == [b"\x00"]
     assert s._response_idle.is_set()
 
 
-def test_parked_senders_serialize_when_the_slot_frees():
-    """Event.set() wakes every parked sender; each must re-check the slot so two turns
-    cannot ride one responseDone into overlapping flushes (which would swallow the
-    older turn's completion sentinel)."""
-    s = _synth()
-    s._response_idle.clear()  # a response is generating
-
-    async def go():
-        s._on_push({"sequence_id": 2}, "turn two")
-        t2 = asyncio.create_task(s.sender("turn two", 2, end_of_llm_stream=True))
-        await asyncio.sleep(0.01)  # t2 captures its text and parks on the idle wait
-        s._on_push({"sequence_id": 3}, "turn three")
-        t3 = asyncio.create_task(s.sender("turn three", 3, end_of_llm_stream=True))
-        await asyncio.sleep(0.01)  # t3 parks behind it
-
-        s._response_idle.set()  # the in-flight response's done frees the slot once
-        await asyncio.sleep(0.05)
-        assert [p["text"] for p in s.sent] == ["turn two"]  # only one flush rode it
-
-        s._response_idle.set()  # turn two's done
-        await asyncio.wait_for(asyncio.gather(t2, t3), timeout=2)
-
-    asyncio.run(go())
-    assert [p["text"] for p in s.sent] == ["turn two", "turn three"]
-
-
-def test_interruption_bookkeeping_survives_a_failing_cancel_send():
-    """current_turn_start_time must reset even when the cancel send dies with the socket;
-    otherwise the next turn skips the stale-meta prune and its leading audio pops the
-    old turn's metas, which the pipeline then filters as a retired sequence."""
-    s = _synth()
-    s.current_turn_start_time = 123.0
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock(side_effect=RuntimeError("socket died mid-send"))
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())  # must not raise
-    assert s.current_turn_start_time is None
-
-
-def test_a_socket_death_with_overlapping_flushes_settles_each_turn(monkeypatch):
-    """When the idle timeout let a second turn flush past a wedged response, a close must
-    settle both outstanding turns in order — one positional sentinel would finish only
-    the older turn and leave the newer one queued without a completion signal."""
-    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
-    s = _synth()
-    _push(s, "turn one", 1, eos=True)  # in flight; its responseDone never comes
-    _push(s, "turn two", 2, eos=True)  # parks on the idle wait, then flushes anyway
-
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
-
-    s.websocket.recv = recv
-    s.conversation_ended = False
-
-    async def go():
-        return [item async for item in s.receiver()]
-
-    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == [b"\x00", b"\x00"]
-    assert s._response_idle.is_set()
-
-
-def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
+async def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
     # The server closes the socket after a fatal error; a bad key would just fail again,
     # so connection_error stops monitor_connection from burning its retries.
     s = _synth()
-    _drain(
+    await _drain(
         s,
         [json.dumps({"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "bad key"}})],
     )
     assert s.connection_error == "bad key"
 
 
-def test_receiver_survives_malformed_and_unknown_frames():
+async def test_receiver_survives_malformed_and_unknown_frames():
     s = _synth()
-    out = _drain(
+    out = await _drain(
         s,
         [
             "not json at all",
@@ -826,26 +794,53 @@ def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
 # ----------------------------------------------------------------------
 
 
-def test_interruption_cancels_and_clears_the_buffered_turn():
+async def test_interruption_cancels_the_rendering_utterance_and_clears_the_turn():
     s = _synth()
-    s._text_buffer = ["partial turn"]
+    await _push(s, "partial turn.", 1)
+    s._current_response_id = "r1"  # segmentation already started rendering it
     s.current_turn_start_time = 123.0
-    ws = MagicMock()
-    ws.state = _ws.protocol.State.OPEN
-    ws.send = AsyncMock()
-    s.websocket = ws
-    asyncio.run(s.handle_interruption())
-    assert s._text_buffer == []
+    ws = _open_ws(s)
+    await s.handle_interruption()
+    assert s._turn_seq is None  # nothing of the abandoned turn can reach the next one
     assert json.loads(ws.send.call_args[0][0]) == {"type": "cancelResponse"}
+    assert s._ignored_response_ids == {"r1"}
     # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
     # re-detected as new for stale text_queue entries to be pruned.
     assert s.current_turn_start_time is None
 
 
-def test_interruption_on_a_dead_socket_is_a_no_op():
+async def test_a_barge_in_on_an_unflushed_utterance_resets_the_socket():
+    """Text was streamed but never flushed and no response has been seen: the server may or
+    may not have started rendering, and a cancel that lands before any response exists
+    settles with no responseDone — the slot would hang. The close is the barge-in."""
+    s = _synth()
+    await _push(s, "streamed but never flushed", 1)
+    ws = _open_ws(s)
+    await s.handle_interruption()
+    ws.close.assert_awaited()
+    ws.send.assert_not_awaited()  # no cancel frame: the disconnect carries the barge-in
+    assert s._turn_seq is None
+    # the closure settles silently — the pipeline already dropped the turn:
+    assert s._settle_lost_utterance() == 0
+    assert s._response_idle.is_set()
+
+
+async def test_interruption_on_a_dead_socket_is_a_no_op():
     s = _synth()
     s.websocket = None
-    asyncio.run(s.handle_interruption())  # must not raise
+    await s.handle_interruption()  # must not raise
+
+
+async def test_interruption_bookkeeping_survives_a_failing_cancel_send():
+    """current_turn_start_time must reset even when the cancel send dies with the socket;
+    otherwise the next turn skips the stale-meta prune and its leading audio pops the
+    old turn's metas, which the pipeline then filters as a retired sequence."""
+    s = _synth()
+    s.current_turn_start_time = 123.0
+    ws = _open_ws(s)
+    ws.send = AsyncMock(side_effect=RuntimeError("socket died mid-send"))
+    await s.handle_interruption()  # must not raise
+    assert s.current_turn_start_time is None
 
 
 # ----------------------------------------------------------------------
@@ -868,7 +863,7 @@ def _fake_connect(monkeypatch, replies):
     return ws
 
 
-def test_establish_connection_authenticates_and_consumes_session_created(monkeypatch):
+async def test_establish_connection_authenticates_and_consumes_session_created(monkeypatch):
     """The init frame must be the first thing on the wire, and its reply must be consumed
     here — receiver() knows nothing about sessionCreated-or-error init semantics."""
     s = _synth(temperature=0.8)
@@ -889,40 +884,42 @@ def test_establish_connection_authenticates_and_consumes_session_created(monkeyp
     )
     s._response_idle.clear()  # a stale in-flight marker from a dead socket
 
-    result = asyncio.run(s.establish_connection())
+    result = await s.establish_connection()
     assert result is ws
     assert ws.sent[0]["type"] == "initializeConnection"
     assert ws.sent[0]["api_key"] == KEY
     assert ws.sent[0]["params"] == {"temperature": 0.8}
+    assert ws.sent[0]["generation_config"] == {"chunk_length_schedule": DEFAULT_CHUNK_LENGTH_SCHEDULE}
     assert s.native_sample_rate == 24000
     assert s._response_idle.is_set()  # a fresh connection has nothing in flight
+    assert s._conn_gen == 1  # senders see the new connection and replay open turns onto it
 
 
-def test_a_rejected_init_returns_none_and_pins_deterministic_failures(monkeypatch):
+async def test_a_rejected_init_returns_none_and_pins_deterministic_failures(monkeypatch):
     s = _synth()
     ws = _fake_connect(
         monkeypatch,
         [{"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "Invalid API key."}}],
     )
-    assert asyncio.run(s.establish_connection()) is None
+    assert await s.establish_connection() is None
     assert s.connection_error == "Invalid API key."  # monitor_connection must not retry a bad key
     ws.close.assert_awaited()
 
 
-def test_a_retryable_init_failure_returns_none_without_pinning(monkeypatch):
+async def test_a_retryable_init_failure_returns_none_without_pinning(monkeypatch):
     s = _synth()
     _fake_connect(
         monkeypatch,
         [{"type": "error", "fatal": True, "error": {"type": "inference_error", "message": "Seed audio unavailable."}}],
     )
-    assert asyncio.run(s.establish_connection()) is None
+    assert await s.establish_connection() is None
     assert s.connection_error is None  # transient: leave monitor_connection its retries
 
 
-def test_an_unresolvable_voice_fails_the_connection_permanently(monkeypatch):
+async def test_an_unresolvable_voice_fails_the_connection_permanently(monkeypatch):
     _patch_http(monkeypatch, CATALOG)
     s = _synth(voice_id=None, voice="Priya")
-    assert asyncio.run(s.establish_connection()) is None
+    assert await s.establish_connection() is None
     assert "Priya" in s.connection_error
 
 
@@ -998,5 +995,3 @@ def test_a_failed_one_shot_render_degrades_to_the_eos_sentinel():
     handler's b64encode, which then marks itself closed and mutes the whole session."""
     s = _synth()
     assert s._process_http_audio(None) == b"\x00"
-
-

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -50,7 +50,7 @@ def _synth(**kwargs):
     s._wait_for_ws = AsyncMock()
     s._is_ws_connected = MagicMock(return_value=True)
     s.sent = []
-    s._send_json = AsyncMock(side_effect=lambda p: s.sent.append(p))
+    s._send_frame = AsyncMock(side_effect=lambda p: s.sent.append(p))
     return s
 
 
@@ -131,7 +131,12 @@ def test_config_survives_the_model_and_reaches_the_synthesizer():
     model drops silently would leave the synthesizer on defaults."""
     cfg = Synthesizer(
         provider="kalpa",
-        provider_config={"voice_id": VOICE_ID, "model": "kalpa-tts-beta-v0.1", "temperature": 0.7},
+        provider_config={
+            "voice_id": VOICE_ID,
+            "model": "kalpa-tts-beta-v0.1",
+            "temperature": 0.7,
+            "chunk_length_schedule": [100, 200],
+        },
         stream=True,
     ).model_dump()
     cfg.pop("caching", None)
@@ -145,6 +150,7 @@ def test_config_survives_the_model_and_reaches_the_synthesizer():
     assert s.voice_id == VOICE_ID
     assert s.model == "kalpa-tts-beta-v0.1"
     assert s.params == {"temperature": 0.7}
+    assert s.chunk_length_schedule == [100, 200]
 
 
 # ----------------------------------------------------------------------
@@ -490,6 +496,73 @@ async def test_a_socket_death_after_audio_started_ends_the_turn_instead_of_repla
     await _push(s, "", 1, eos=True)
     assert len(s.sent) == 1  # nothing after the death reached the wire
     assert s._turn_seq is None  # the eos finally forgets the dead turn
+
+
+async def test_a_superseded_turn_with_a_live_response_is_cancelled_not_timed_out():
+    """A superseded open turn holds the slot but can never settle it (it will never flush).
+    With its response known, the claim path cancels it — the done frees the slot in
+    milliseconds — instead of eating the 10s idle timeout."""
+    s = _synth()
+    await _push(s, "half a turn", 1)
+    s._current_response_id = "r1"  # segmentation already started rendering it
+    s._on_push({"sequence_id": 2}, "next")  # superseded, no handle_interruption ran
+    task = asyncio.create_task(s.sender("next", sequence_id=2, end_of_llm_stream=False))
+    await asyncio.sleep(0.05)
+    assert {"type": "cancelResponse"} in s.sent
+    assert "r1" in s._ignored_response_ids  # its still-arriving audio must not play
+
+    # the cancelled done arrives and frees the slot:
+    s._response_idle.set()
+    s._abandoned_in_flight = False
+    s._current_response_id = None
+    await asyncio.wait_for(task, timeout=2)
+    assert s.sent[-1] == {"type": "sendText", "text": "next"}
+
+
+async def test_a_superseded_turn_with_no_response_resets_the_socket_immediately():
+    """Same supersession, but no response is known: a cancel could settle nothing, so the
+    claim path closes the socket right away rather than waiting out the idle timeout."""
+    s = _synth()
+    await _push(s, "half a turn", 1)
+    s._on_push({"sequence_id": 2}, "next")
+    closed = {"yet": False}
+
+    async def close():
+        closed["yet"] = True
+        # what the receiver's settle and monitor's redial do once the closure lands:
+        s._settle_lost_utterance()
+        s._conn_gen += 1
+
+    s.websocket.close = close
+    await s.sender("next", sequence_id=2, end_of_llm_stream=False)
+    assert closed["yet"] is True
+    assert s.sent[-1] == {"type": "sendText", "text": "next"}
+
+
+async def test_a_failed_send_stays_transient_and_the_turn_replays():
+    """The shared _send_json marks any failure as connection_error, which is fatal to the
+    generate loop; Kalpa sends its own frames, so a socket dying mid-send stays transient
+    and the turn replays on the next connection instead of ending the call."""
+    s = _synth()
+    s._send_frame = KalpaSynthesizer._send_frame.__get__(s)  # the real send path
+    sent = []
+    fail = {"next": True}
+
+    async def ws_send(raw):
+        if fail["next"]:
+            fail["next"] = False
+            raise RuntimeError("socket died mid-send")
+        sent.append(json.loads(raw))
+
+    s.websocket.send = ws_send
+    await _push(s, "first words.", 1)  # this send fails with the socket
+    assert s.connection_error is None  # transient: the shared loop must keep running
+    assert sent == []
+
+    assert s._settle_lost_utterance() == 0  # the receiver sees the death; nothing rendered
+    s._conn_gen += 1  # monitor_connection redials
+    await _push(s, "", 1, eos=True)
+    assert sent == [{"type": "sendText", "flush": True, "text": "first words."}]
 
 
 async def test_a_superseded_turns_server_residue_is_wiped_before_the_next_turn():
@@ -1081,6 +1154,27 @@ def test_http_error_and_empty_body_return_none(monkeypatch):
 
     _patch_http(monkeypatch, {"request_id": "r", "model": "m", "text": "hi", "usage": {}})
     assert asyncio.run(s.synthesize("hi")) is None
+
+
+def test_the_one_shot_render_truncates_at_the_cap_too(monkeypatch):
+    """The non-streaming loop sends the whole LLM response through this path; without the
+    same cap as streaming, an overlong turn is rejected by the API and silently muted."""
+    wav = _wav(0.1)
+    seen = {}
+
+    class _CapturingSession(_FakeSession):
+        def post(self, *a, **k):
+            seen["payload"] = k.get("json")
+            return _FakeResp(self._body, self._status)
+
+    monkeypatch.setattr(
+        "bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession",
+        lambda *a, **k: _CapturingSession(_tts_response(wav)),
+    )
+    s = _synth()
+    asyncio.run(s.synthesize("hello " * (MAX_TEXT_CHARS // 6 + 50)))
+    assert len(seen["payload"]["text"]) <= MAX_TEXT_CHARS
+    assert seen["payload"]["text"].endswith("hello")  # cut at a word boundary
 
 
 def test_a_failed_one_shot_render_degrades_to_the_eos_sentinel():

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -1,0 +1,687 @@
+"""Kalpa TTS: whole-turn aggregation + single-flight flushing, the JSON/base64 wire
+protocol, 24 kHz -> telephony conversion, voice-name resolution, and the init handshake
+that establish_connection() must complete before the receiver ever sees the socket."""
+
+import asyncio
+import audioop
+import base64
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.helpers.utils import audio_to_mulaw8k
+from bolna.models import KalpaConfig, Synthesizer
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
+from bolna.synthesizer.kalpa_synthesizer import (
+    KALPA_DEFAULT_MODEL,
+    KALPA_NATIVE_SAMPLE_RATE,
+    MAX_TEXT_CHARS,
+    KalpaSynthesizer,
+)
+
+KEY = "kalpa_sk_test_dummy"
+VOICE_ID = "5e0c5704-590f-483b-b291-00a2415cb67e"
+
+# GET /v1/voices wraps the catalog in {"data": [...]}, exactly as the live API does.
+CATALOG = {
+    "data": [
+        {"id": VOICE_ID, "name": "Kiara (hindi)", "gender": "feminine"},
+        {"id": "id-ruby", "name": "Ruby", "gender": "feminine"},
+        {"id": "id-wren", "name": "Wren (human-like)", "gender": "feminine"},
+        {"id": "id-arjun", "name": "Arjun (hindi)", "gender": "masculine"},
+    ]
+}
+
+
+def _synth(**kwargs):
+    """A real synthesizer with the websocket stubbed out — no env var, no network."""
+    kwargs.setdefault("voice_id", VOICE_ID)
+    kwargs.setdefault("stream", True)
+    kwargs.setdefault("use_mulaw", True)
+    s = KalpaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock(), **kwargs)
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = True
+    s.websocket = MagicMock()
+    s.websocket.send = AsyncMock()
+    s._wait_for_ws = AsyncMock()
+    s._is_ws_connected = MagicMock(return_value=True)
+    s.sent = []
+    s._send_json = AsyncMock(side_effect=lambda p: s.sent.append(p))
+    return s
+
+
+def _pcm(seconds, rate=KALPA_NATIVE_SAMPLE_RATE):
+    """A silent-but-nonzero 16-bit mono buffer of a known length."""
+    return (b"\x10\x00") * int(seconds * rate)
+
+
+class _FakeResp:
+    def __init__(self, body, status=200):
+        self._body = body
+        self.status = status
+        self.headers = {}
+
+    async def json(self):
+        return self._body
+
+    async def text(self):
+        return json.dumps(self._body)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    """Stands in for aiohttp.ClientSession; serves one canned response for get and post."""
+
+    def __init__(self, body, status=200):
+        self._body = body
+        self._status = status
+
+    def get(self, *a, **k):
+        return _FakeResp(self._body, self._status)
+
+    def post(self, *a, **k):
+        return _FakeResp(self._body, self._status)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _patch_http(monkeypatch, body, status=200):
+    monkeypatch.setattr(
+        "bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession",
+        lambda *a, **k: _FakeSession(body, status),
+    )
+
+
+# ----------------------------------------------------------------------
+# Wiring
+# ----------------------------------------------------------------------
+
+
+def test_provider_is_registered():
+    assert SUPPORTED_SYNTHESIZER_MODELS["kalpa"] is KalpaSynthesizer
+
+
+def test_synthesizer_model_builds_kalpa_config():
+    synth = Synthesizer(
+        provider="kalpa",
+        provider_config={"voice": "Kiara", "voice_id": VOICE_ID},
+        stream=True,
+    )
+    assert isinstance(synth.provider_config, KalpaConfig)
+    assert synth.provider_config.model == KALPA_DEFAULT_MODEL
+
+
+def test_config_survives_the_model_and_reaches_the_synthesizer():
+    """The dashboard round-trips provider_config through the pydantic model; a field the
+    model drops silently would leave the synthesizer on defaults."""
+    cfg = Synthesizer(
+        provider="kalpa",
+        provider_config={"voice_id": VOICE_ID, "model": "kalpa-tts-beta-v0.1", "temperature": 0.7},
+        stream=True,
+    ).model_dump()
+    cfg.pop("caching", None)
+    cfg.pop("provider")
+    provider_config = cfg.pop("provider_config")
+
+    s = SUPPORTED_SYNTHESIZER_MODELS["kalpa"](
+        **cfg, **provider_config, caching=True, synthesizer_key=KEY, task_manager_instance=MagicMock()
+    )
+    assert s.voice_id == VOICE_ID
+    assert s.model == "kalpa-tts-beta-v0.1"
+    assert s.params == {"temperature": 0.7}
+
+
+# ----------------------------------------------------------------------
+# Construction and validation
+# ----------------------------------------------------------------------
+
+
+def test_a_voice_or_voice_id_is_required():
+    with pytest.raises(ValueError):
+        KalpaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock())
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"temperature": 2.0},
+        {"acoustic_temperature": -0.1},
+        {"top_k": 0},
+        {"max_new_tokens": 4},
+        {"max_new_tokens": 99999},
+        {"audio_quality": "ultra"},
+    ],
+)
+def test_out_of_range_params_raise_at_construction_not_mid_call(bad):
+    # Kalpa rejects these too, but only once the session initializes on a live call.
+    with pytest.raises(ValueError):
+        _synth(**bad)
+
+
+def test_mulaw_is_off_unless_task_manager_asks_for_it():
+    s = KalpaSynthesizer(voice_id=VOICE_ID, stream=True, synthesizer_key=KEY, task_manager_instance=MagicMock())
+    assert s.use_mulaw is False
+    assert s._get_audio_format() == "pcm"
+
+
+def test_telephony_pins_8k_mulaw_and_web_keeps_the_configured_rate():
+    tel = _synth(use_mulaw=True)
+    assert (tel.target_sample_rate, tel._get_audio_format()) == (8000, "mulaw")
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert (web.target_sample_rate, web._get_audio_format()) == (24000, "pcm")
+
+
+# ----------------------------------------------------------------------
+# Init frame / payload
+# ----------------------------------------------------------------------
+
+
+def test_initialize_message_carries_auth_model_and_only_set_params():
+    s = _synth(temperature=0.8, top_k=50)
+    assert s._initialize_message() == {
+        "type": "initializeConnection",
+        "api_key": KEY,
+        "model": KALPA_DEFAULT_MODEL,
+        "params": {"temperature": 0.8, "top_k": 50},
+    }
+
+
+def test_initialize_message_omits_params_when_none_are_configured():
+    # Kalpa's server defaults are the tuned production sampling; sending an empty params
+    # object is harmless but sending none keeps the contract explicit.
+    assert "params" not in _synth()._initialize_message()
+
+
+# ----------------------------------------------------------------------
+# Voice resolution
+# ----------------------------------------------------------------------
+
+
+def test_a_configured_voice_id_is_used_without_touching_the_catalog(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("should not fetch /v1/voices when voice_id is set")
+
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession", boom)
+    s = _synth(voice_id=VOICE_ID)
+    assert asyncio.run(s._resolve_voice_id()) == VOICE_ID
+
+
+@pytest.mark.parametrize("name", ["Kiara (hindi)", "kiara (hindi)", "Kiara", "kiara", " KIARA "])
+def test_voice_names_resolve_case_insensitively_with_or_without_the_qualifier(monkeypatch, name):
+    """The catalog names carry qualifiers ("Kiara (hindi)") but an agent config saying
+    just "Kiara" should work — nobody should have to hunt down a UUID."""
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice=name)
+    assert asyncio.run(s._resolve_voice_id()) == VOICE_ID
+    assert s.voice_id == VOICE_ID  # cached: later reconnects skip the catalog fetch
+
+
+def test_an_unknown_voice_raises_with_the_available_names(monkeypatch):
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice="Priya")
+    with pytest.raises(ValueError) as exc:
+        asyncio.run(s._resolve_voice_id())
+    assert "Kiara (hindi)" in str(exc.value)
+
+
+def test_a_catalog_error_raises_rather_than_guessing(monkeypatch):
+    _patch_http(monkeypatch, {"error": "nope"}, status=500)
+    s = _synth(voice_id=None, voice="Kiara")
+    with pytest.raises(RuntimeError):
+        asyncio.run(s._resolve_voice_id())
+
+
+# ----------------------------------------------------------------------
+# sender: whole-turn aggregation + single-flight
+# ----------------------------------------------------------------------
+
+
+def test_sender_aggregates_the_turn_and_flushes_once_on_eos():
+    s = _synth()
+    asyncio.run(s.sender("Namaste! ", sequence_id=1, end_of_llm_stream=False))
+    asyncio.run(s.sender("Kaise hain aap?", sequence_id=1, end_of_llm_stream=False))
+    assert s.sent == []  # nothing reaches the socket while the turn is still streaming
+
+    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent == [{"type": "sendText", "text": "Namaste! Kaise hain aap?", "flush": True}]
+    assert s.last_text_sent is True
+    assert s._text_buffer == []
+    assert not s._response_idle.is_set()  # the flush occupies the single in-flight slot
+
+
+def test_an_empty_turn_sends_nothing():
+    # The server rejects an empty flush outright, so it must never be sent.
+    s = _synth()
+    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent == []
+
+
+def test_an_overlong_turn_is_truncated_to_the_server_cap():
+    s = _synth()
+    asyncio.run(s.sender("a" * (MAX_TEXT_CHARS + 500), sequence_id=1, end_of_llm_stream=True))
+    assert len(s.sent[0]["text"]) == MAX_TEXT_CHARS
+
+
+def test_chunks_concatenate_verbatim_because_the_llm_owns_spacing():
+    s = _synth()
+    asyncio.run(s.sender("Sure, I can", sequence_id=1))
+    asyncio.run(s.sender(" help with that.", sequence_id=1, end_of_llm_stream=True))
+    assert s.sent[0]["text"] == "Sure, I can help with that."
+
+
+def test_on_push_drops_a_superseded_turns_buffer():
+    s = _synth()
+    s._on_push({"sequence_id": 1}, "hi")
+    s._text_buffer = ["first turn, never flushed"]
+    s._on_push({"sequence_id": 2}, "second turn")  # a new turn arrives before eos
+    assert s._text_buffer == []
+    assert s._buffer_seq == 2
+
+
+def test_stale_sequence_sends_nothing():
+    s = _synth()
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = False
+    asyncio.run(s.sender("dropped", sequence_id=7, end_of_llm_stream=True))
+    assert s.sent == []
+
+
+def test_the_flush_waits_for_the_previous_responses_done():
+    """One response in flight per connection: flushing while the previous turn is still
+    generating is rejected by the server (and the turn lost), so the sender must park on
+    the idle event until responseDone frees the slot."""
+    s = _synth()
+    s._response_idle.clear()  # a previous flush is still generating
+    order = []
+
+    async def go():
+        async def flush():
+            await s.sender("next turn", sequence_id=2, end_of_llm_stream=True)
+            order.append("flushed")
+
+        task = asyncio.create_task(flush())
+        await asyncio.sleep(0.05)
+        assert s.sent == []  # still parked
+        order.append("done arrived")
+        s._response_idle.set()  # receiver saw responseDone
+        await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(go())
+    assert order == ["done arrived", "flushed"]
+    assert s.sent == [{"type": "sendText", "text": "next turn", "flush": True}]
+
+
+def test_a_barge_in_during_the_idle_wait_stops_the_sender():
+    """The idle wait can span a barge-in that retires this sequence without cancelling the
+    task; without the re-check the sender would flush a turn the pipeline already dropped."""
+    s = _synth()
+    s._response_idle.clear()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def go():
+        async def flush():
+            await s.sender("text for an interrupted turn", sequence_id=1, end_of_llm_stream=True)
+
+        task = asyncio.create_task(flush())
+        await asyncio.sleep(0.05)
+        retired["yet"] = True  # the barge-in lands while the sender is parked
+        s._response_idle.set()
+        await asyncio.wait_for(task, timeout=2)
+
+    asyncio.run(go())
+    assert s.sent == []
+
+
+def test_sender_stamps_ws_send_time_at_the_flush():
+    # Generation only starts at the flush, so TTFB measured from here is true synth latency.
+    s = _synth()
+    asyncio.run(s.sender("first chunk", sequence_id=1))
+    assert s.ws_send_time is None
+    asyncio.run(s.sender(" last chunk", sequence_id=1, end_of_llm_stream=True))
+    assert s.ws_send_time is not None
+
+
+# ----------------------------------------------------------------------
+# receiver
+# ----------------------------------------------------------------------
+
+
+def _drain(s, frames):
+    """Feed `frames` through receiver() and collect what it yields.
+
+    receiver() loops forever by design, so once the scripted frames run out we raise
+    CancelledError — it is a BaseException, so the receiver's broad `except Exception`
+    does not swallow it and the loop unwinds instead of spinning on a dead mock.
+    """
+    remaining = list(frames)
+    out = []
+
+    async def recv():
+        if not remaining:
+            raise asyncio.CancelledError
+        return remaining.pop(0)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        async for item in s.receiver():
+            out.append(item)
+
+    try:
+        asyncio.run(asyncio.wait_for(go(), timeout=5))
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+    return out
+
+
+def test_receiver_decodes_audio_frames_and_maps_done_to_the_eos_sentinel():
+    s = _synth()
+    s._response_idle.clear()
+    pcm = _pcm(0.1)
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(pcm).decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "hi", "usage": {}}),
+        ],
+    )
+    assert out == [pcm, b"\x00"]
+    assert s._response_idle.is_set()  # done freed the in-flight slot
+
+
+def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
+    """A cancelled response terminates a turn handle_interruption() already abandoned;
+    forwarding a sentinel would stamp end-of-stream onto the wrong turn's meta_info."""
+    s = _synth()
+    s._response_idle.clear()
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
+            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"go").decode()}),
+        ],
+    )
+    assert out == [b"go"]
+    assert s._response_idle.is_set()
+
+
+def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
+    """Non-fatal errors are rejected client frames. This integration only sends whole-turn
+    flushes, so a rejected turn will never produce audio or a responseDone — without the
+    sentinel the pipeline would wait on it forever."""
+    s = _synth()
+    s._response_idle.clear()
+    out = _drain(
+        s,
+        [
+            json.dumps(
+                {
+                    "type": "error",
+                    "fatal": False,
+                    "error": {"type": "invalid_request", "message": "utterance text exceeds the limit"},
+                }
+            )
+        ],
+    )
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+    assert s.connection_error is None  # the socket stays usable
+
+
+def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
+    # The server closes the socket after a fatal error; a bad key would just fail again,
+    # so connection_error stops monitor_connection from burning its retries.
+    s = _synth()
+    _drain(
+        s,
+        [json.dumps({"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "bad key"}})],
+    )
+    assert s.connection_error == "bad key"
+
+
+def test_an_unsolicited_session_created_updates_the_native_rate():
+    s = _synth()
+    _drain(s, [json.dumps({"type": "sessionCreated", "sample_rate": 48000})])
+    assert s.native_sample_rate == 48000
+
+
+def test_receiver_survives_malformed_and_unknown_frames():
+    s = _synth()
+    out = _drain(
+        s,
+        [
+            "not json at all",
+            json.dumps(["a", "list"]),
+            json.dumps({"type": "something_new"}),
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": "@@not-base64@@"}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == [b"\x00"]
+    assert s.connection_error is None
+
+
+# ----------------------------------------------------------------------
+# Audio conversion
+# ----------------------------------------------------------------------
+
+
+def test_telephony_chunks_are_resampled_to_8k_and_mulaw_encoded():
+    s = _synth(use_mulaw=True)
+    out = s._process_audio_chunk(_pcm(1.0))
+    # 24k 16-bit in -> 8k 8-bit out: one sixth of the bytes, and decodable as mu-law.
+    assert len(out) == 8000
+    assert len(audioop.ulaw2lin(out, 2)) == 16000
+
+
+def test_web_chunks_pass_through_untouched_at_the_native_rate():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    chunk = _pcm(0.5)
+    assert s._process_audio_chunk(chunk) == chunk  # no resample, no encode
+
+
+def test_the_session_rate_from_session_created_drives_the_resample():
+    s = _synth(use_mulaw=True)
+    s.native_sample_rate = 48000  # as a future sessionCreated might report
+    out = s._process_audio_chunk(_pcm(1.0, rate=48000))
+    assert len(out) == 8000
+
+
+def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
+    s = _synth()
+    assert s._process_audio_chunk(b"") is None
+    # An odd-length buffer can't be whole 16-bit samples; drop it instead of raising
+    # inside the audio path.
+    assert s._process_audio_chunk(b"\x01") is None
+
+
+# ----------------------------------------------------------------------
+# Interruption
+# ----------------------------------------------------------------------
+
+
+def test_interruption_cancels_and_clears_the_buffered_turn():
+    import websockets as _ws
+
+    s = _synth()
+    s._text_buffer = ["partial turn"]
+    s.current_turn_start_time = 123.0
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())
+    assert s._text_buffer == []
+    assert json.loads(ws.send.call_args[0][0]) == {"type": "cancelResponse"}
+    # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
+    # re-detected as new for stale text_queue entries to be pruned.
+    assert s.current_turn_start_time is None
+
+
+def test_interruption_on_a_dead_socket_is_a_no_op():
+    s = _synth()
+    s.websocket = None
+    asyncio.run(s.handle_interruption())  # must not raise
+
+
+# ----------------------------------------------------------------------
+# Connection
+# ----------------------------------------------------------------------
+
+
+def _fake_connect(monkeypatch, replies):
+    """Patch websockets.connect with a socket that records sends and scripts recvs."""
+    ws = MagicMock()
+    ws.sent = []
+    ws.send = AsyncMock(side_effect=lambda p: ws.sent.append(json.loads(p)))
+    ws.recv = AsyncMock(side_effect=[json.dumps(r) for r in replies])
+    ws.close = AsyncMock()
+
+    async def fake(*a, **k):
+        return ws
+
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.websockets.connect", fake)
+    return ws
+
+
+def test_establish_connection_authenticates_and_consumes_session_created(monkeypatch):
+    """The init frame must be the first thing on the wire, and its reply must be consumed
+    here — receiver() knows nothing about sessionCreated-or-error init semantics."""
+    s = _synth(temperature=0.8)
+    ws = _fake_connect(
+        monkeypatch,
+        [
+            {
+                "type": "sessionCreated",
+                "session_id": "sess_1",
+                "model": KALPA_DEFAULT_MODEL,
+                "voice_id": VOICE_ID,
+                "output_format": "pcm_s16le",
+                "sample_rate": 24000,
+                "channels": 1,
+                "audio_quality": "high",
+            }
+        ],
+    )
+    s._response_idle.clear()  # a stale in-flight marker from a dead socket
+
+    result = asyncio.run(s.establish_connection())
+    assert result is ws
+    assert ws.sent[0]["type"] == "initializeConnection"
+    assert ws.sent[0]["api_key"] == KEY
+    assert ws.sent[0]["params"] == {"temperature": 0.8}
+    assert s.native_sample_rate == 24000
+    assert s._response_idle.is_set()  # a fresh connection has nothing in flight
+
+
+def test_a_rejected_init_returns_none_and_pins_deterministic_failures(monkeypatch):
+    s = _synth()
+    ws = _fake_connect(
+        monkeypatch,
+        [{"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "Invalid API key."}}],
+    )
+    assert asyncio.run(s.establish_connection()) is None
+    assert s.connection_error == "Invalid API key."  # monitor_connection must not retry a bad key
+    ws.close.assert_awaited()
+
+
+def test_a_retryable_init_failure_returns_none_without_pinning(monkeypatch):
+    s = _synth()
+    _fake_connect(
+        monkeypatch,
+        [{"type": "error", "fatal": True, "error": {"type": "inference_error", "message": "Seed audio unavailable."}}],
+    )
+    assert asyncio.run(s.establish_connection()) is None
+    assert s.connection_error is None  # transient: leave monitor_connection its retries
+
+
+def test_an_unresolvable_voice_fails_the_connection_permanently(monkeypatch):
+    _patch_http(monkeypatch, CATALOG)
+    s = _synth(voice_id=None, voice="Priya")
+    assert asyncio.run(s.establish_connection()) is None
+    assert "Priya" in s.connection_error
+
+
+# ----------------------------------------------------------------------
+# One-shot HTTP (prewarm / handoff / non-streaming loop)
+# ----------------------------------------------------------------------
+
+
+def _wav(seconds=1.0):
+    from bolna.helpers.utils import pcm_to_wav_bytes
+
+    return pcm_to_wav_bytes(_pcm(seconds), sample_rate=KALPA_NATIVE_SAMPLE_RATE)
+
+
+def _tts_response(wav):
+    return {
+        "request_id": "req_1",
+        "model": KALPA_DEFAULT_MODEL,
+        "text": "hi",
+        "audio": {
+            "sample_rate": KALPA_NATIVE_SAMPLE_RATE,
+            "audio_quality": "high",
+            "format": "wav",
+            "data_b64": base64.b64encode(wav).decode(),
+        },
+        "usage": {"input_chars": 2, "output_audio_seconds": 1.0},
+    }
+
+
+def test_synthesize_returns_the_apis_wav_which_is_self_describing(monkeypatch):
+    """The handoff path calls audio_to_mulaw8k(rate_hint=getattr(synth, 'sampling_rate')).
+    Kalpa's REST body is already RIFF WAV, so the hint stops mattering."""
+    wav = _wav(1.0)
+    _patch_http(monkeypatch, _tts_response(wav))
+    s = _synth(use_mulaw=True)
+    out = asyncio.run(s.synthesize("hi"))
+    assert out == wav
+    assert out[:4] == b"RIFF"
+
+    # One second in must stay one second out (8000 mu-law bytes) even with a wrong hint.
+    clip = audio_to_mulaw8k(out, rate_hint=8000, format_hint="")
+    assert len(clip) == 8000
+
+
+def test_telephony_one_shot_returns_mulaw_and_skips_the_transcode(monkeypatch):
+    _patch_http(monkeypatch, _tts_response(_wav(1.0)))
+    s = _synth(use_mulaw=True)
+    clip = asyncio.run(s.synthesize_telephony_clip("hi"))
+    assert len(clip) == 8000  # 1s of mu-law @8k, no pydub/ffmpeg involved downstream
+
+
+def test_telephony_one_shot_defers_to_synthesize_on_non_telephony_configs():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    assert asyncio.run(s.synthesize_telephony_clip("hi")) is None
+
+
+def test_http_error_and_empty_body_return_none(monkeypatch):
+    s = _synth()
+    _patch_http(monkeypatch, {"error": {"type": "rate_limit_error", "message": "slow down"}}, status=429)
+    assert asyncio.run(s.synthesize("hi")) is None
+
+    _patch_http(monkeypatch, {"request_id": "r", "model": "m", "text": "hi", "usage": {}})
+    assert asyncio.run(s.synthesize("hi")) is None
+
+
+def test_http_conversion_matches_the_declared_http_format():
+    s = _synth(use_mulaw=True)
+    assert s._get_http_audio_format() == "mulaw"
+    assert len(s._process_http_audio(_wav(1.0))) == 8000
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert web._get_http_audio_format() == "wav"
+    wav = _wav(0.5)
+    assert web._process_http_audio(wav) == wav  # already at the target rate

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -343,6 +343,64 @@ def test_a_barge_in_during_the_idle_wait_stops_the_sender():
     assert s.sent == []
 
 
+def test_a_barge_in_during_the_ws_wait_never_buffers_stale_text():
+    """_wait_for_ws() suspends for real while the socket reconnects; a barge-in in that gap
+    retires the sequence and clears the shared buffer. The resumed sender must not append
+    its stale fragment into the next turn's buffer (it would flush as OLD-NEW text)."""
+    s = _synth()
+    retired = {"yet": False}
+    s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
+
+    async def wait_then_barge_in():
+        retired["yet"] = True  # the barge-in lands while the sender is parked here
+
+    s._wait_for_ws = AsyncMock(side_effect=wait_then_barge_in)
+    asyncio.run(s.sender("stale fragment", sequence_id=1, end_of_llm_stream=False))
+    assert s._text_buffer == []
+    assert s.sent == []
+
+
+def test_a_dead_socket_settles_the_in_flight_turn():
+    """A response that dies with the socket never gets its responseDone. The receiver must
+    free the single-flight slot and emit the end-of-stream sentinel so playback terminates
+    instead of waiting on a frame that will never arrive."""
+    import websockets as _ws
+
+    s = _synth()
+    s._response_idle.clear()  # a flush is in flight when the socket drops
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    out = asyncio.run(asyncio.wait_for(go(), timeout=5))
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+
+
+def test_a_dead_socket_with_nothing_in_flight_stays_silent():
+    # No sentinel when idle: a spurious one would pop the next turn's meta_info.
+    import websockets as _ws
+
+    s = _synth()
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == []
+
+
 def test_sender_stamps_ws_send_time_at_the_flush():
     # Generation only starts at the flush, so TTFB measured from here is true synth latency.
     s = _synth()

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -694,6 +694,24 @@ async def test_a_dead_socket_settles_the_flushed_turn():
     assert s._response_idle.is_set()
 
 
+async def test_a_lost_turns_sentinel_is_suppressed_when_a_newer_turn_is_queued():
+    """The settle sentinel is positional: the stream generator stamps it onto the next
+    queued meta_info. With the newer turn's metadata already queued (pushes enqueue while
+    the sender parks on the slot), emitting it would mark that turn complete before it
+    produces any audio — the lost turn drops its completion instead, and the slot still
+    frees so the newer turn proceeds."""
+    s = _synth()
+    await _push(s, "turn one", 1, eos=True)  # flushed; its responseDone never arrives
+    s.text_queue.append({"sequence_id": 2})  # turn two pushed, parked on the slot
+    assert s._settle_lost_utterance() == 0
+    assert s._response_idle.is_set()
+
+    s = _synth()
+    await _push(s, "turn one", 1, eos=True)
+    s.text_queue.append({"sequence_id": 1})  # its own unconsumed meta: attribution is right
+    assert s._settle_lost_utterance() == 1
+
+
 async def test_a_dead_socket_with_nothing_in_flight_stays_silent():
     # No sentinel when idle: a spurious one would pop the next turn's meta_info.
     s = _synth()

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -281,8 +281,8 @@ async def test_chunks_stream_as_they_arrive_and_the_flush_ends_the_turn():
     """Text reaches the server the moment the LLM produces it — segmentation renders it
     early — and chunks rejoin with the boundary space the LLM wrappers' rsplit consumed."""
     s = _synth()
-    await _push(s, "Namaste!", 1)
-    assert s.sent == [{"type": "sendText", "text": "Namaste!"}]
+    await _push(s, "Namaste ji!", 1)
+    assert s.sent == [{"type": "sendText", "text": "Namaste ji!"}]
     assert not s._response_idle.is_set()  # the utterance claims the slot at its first chunk
 
     await _push(s, "Kaise hain aap?", 1)
@@ -293,6 +293,47 @@ async def test_chunks_stream_as_they_arrive_and_the_flush_ends_the_turn():
     assert s.last_text_sent is True
     assert s._turn_seq is None  # the turn is closed; the slot frees at its responseDone
     assert not s._response_idle.is_set()
+
+
+async def test_an_unbroken_token_is_not_split_by_a_phantom_space():
+    """The wrappers' rsplit(" ", 1) consumed a boundary space only when the emitted chunk
+    still contains one; a space-less chunk was an unbreakable token (long URL, number) cut
+    mid-way at the buffer size, and the next chunk continues it directly — gluing a space
+    in would mispronounce it."""
+    s = _synth()
+    await _push(s, "Your code is", 1)
+    await _push(s, "123456789012345678", 1)  # space-less: cut mid-token by the buffer size
+    await _push(s, "9012 got it?", 1, eos=True)  # continues the token directly
+    assert s.sent == [
+        {"type": "sendText", "text": "Your code is"},
+        {"type": "sendText", "text": " 123456789012345678"},
+        {"type": "sendText", "text": "9012 got it?"},
+        {"type": "sendText", "flush": True},
+    ]
+
+
+async def test_a_failed_supersession_cancel_retries_instead_of_losing_the_chunk():
+    """The triage cancel can die with the socket; bailing out of the sender there would
+    lose the new turn's first chunk before anything retained it — a one-chunk turn would
+    go completely silent. The claim path parks on the redial and retries instead."""
+    s = _synth()
+    await _push(s, "half a turn", 1)
+    s._current_response_id = "r1"  # the dead turn's response is known
+    s._on_push({"sequence_id": 2}, "next")  # superseded, no handle_interruption ran
+    calls = {"n": 0}
+
+    async def flaky_send(payload):
+        calls["n"] += 1
+        if calls["n"] == 2:  # the triage cancelResponse dies with the socket
+            # what the receiver's settle and monitor's redial do once the death lands:
+            s._settle_lost_utterance()
+            s._conn_gen += 1
+            raise RuntimeError("socket died mid-send")
+        s.sent.append(payload)
+
+    s._send_frame = flaky_send
+    await s.sender("next", sequence_id=2, end_of_llm_stream=True)
+    assert s.sent[-2:] == [{"type": "sendText", "text": "next"}, {"type": "sendText", "flush": True}]
 
 
 async def test_an_empty_turn_sends_nothing():
@@ -403,7 +444,7 @@ async def test_senders_serialize_in_push_order_through_a_reconnect():
     s._wait_for_ws = parked_until_reconnect
 
     tasks = []
-    for text, eos in (("first", False), ("middle", False), ("final", True)):
+    for text, eos in (("first words", False), ("middle words", False), ("final words", True)):
         s._on_push({"sequence_id": 1}, text)
         tasks.append(asyncio.create_task(s.sender(text, 1, end_of_llm_stream=eos)))
     await asyncio.sleep(0.05)  # the first sender is parked on the dead socket
@@ -411,9 +452,9 @@ async def test_senders_serialize_in_push_order_through_a_reconnect():
     gate.set()  # reconnect completes
     await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
     assert s.sent == [
-        {"type": "sendText", "text": "first"},
-        {"type": "sendText", "text": " middle"},
-        {"type": "sendText", "text": " final"},
+        {"type": "sendText", "text": "first words"},
+        {"type": "sendText", "text": " middle words"},
+        {"type": "sendText", "text": " final words"},
         {"type": "sendText", "flush": True},
     ]
 

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -31,6 +31,7 @@ def _fresh_voice_cache():
     _VOICE_IDS.clear()
     yield
 
+
 KEY = "kalpa_sk_test_dummy"
 VOICE_ID = "5e0c5704-590f-483b-b291-00a2415cb67e"
 
@@ -995,7 +996,9 @@ async def test_frames_from_a_replaced_socket_are_ignored():
     s = _synth()
     old_ws = s.websocket
     new_ws = _cancelling_ws()
-    frames = [json.dumps({"type": "responseDone", "response_id": "r-old", "status": "completed", "text": "", "usage": {}})]
+    frames = [
+        json.dumps({"type": "responseDone", "response_id": "r-old", "status": "completed", "text": "", "usage": {}})
+    ]
 
     async def old_recv():
         # monitor_connection replaced the socket while this recv was parked; the newer
@@ -1059,9 +1062,13 @@ async def test_the_receiver_survives_a_reconnect_within_one_generate_call():
         if ev == "r2-created":
             return json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000})
         if ev == "r2-audio":
-            return json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"two").decode()})
+            return json.dumps(
+                {"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"two").decode()}
+            )
         if ev == "r2-done":
-            return json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "", "usage": {}})
+            return json.dumps(
+                {"type": "responseDone", "response_id": "r2", "status": "completed", "text": "", "usage": {}}
+            )
         raise asyncio.CancelledError
 
     s.websocket.recv = recv

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -1202,6 +1202,19 @@ async def test_an_interruption_retires_parked_senders_even_when_the_sequence_sta
     assert s.sent == []  # the epoch bump retired it before anything reached the socket
 
 
+async def test_a_sender_pushed_before_the_interruption_is_retired_even_if_it_starts_after():
+    """The epoch pairs with the PUSH, not the coroutine's first timeslice: a sender task
+    created just before the barge-in can be scheduled only after handle_interruption
+    already bumped the epoch, and must still count as pre-interruption work."""
+    s = _synth()
+    s._on_push({"sequence_id": 2}, "stale text")
+    task = asyncio.create_task(s.sender("stale text", sequence_id=2, end_of_llm_stream=True))
+    # the interruption wins the race to the first timeslice; the sequence stays valid
+    await s.handle_interruption()
+    await asyncio.wait_for(task, timeout=2)
+    assert s.sent == []
+
+
 async def test_interruption_on_a_dead_socket_is_a_no_op():
     s = _synth()
     s.websocket = None

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -710,6 +710,37 @@ async def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
     assert s.connection_error is None  # the socket stays usable
 
 
+async def test_a_failed_responses_late_done_cannot_finish_the_next_turn():
+    """The non-fatal error settles the failed response's turn; its id must not linger as
+    'current', or its delayed done would match after a newer turn claims the slot and
+    finish that turn before its audio — and its late audio frames would play into it."""
+    s = _synth()
+    await _push(s, "turn one.", 1)
+    out = await _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "error", "fatal": False, "error": {"type": "invalid_request", "message": "boom"}}),
+        ],
+    )
+    assert out == [b"\x00"]  # the failed turn settles
+    assert s._current_response_id is None
+
+    # the next turn claims the slot; r1's delayed frames arrive before its own created
+    s._on_push({"sequence_id": 2}, "turn two.")
+    await s.sender("turn two.", sequence_id=2, end_of_llm_stream=True)
+    assert not s._response_idle.is_set()
+    out = await _drain(
+        s,
+        [
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(b"stale").decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == []  # neither plays nor completes anything
+    assert not s._response_idle.is_set()  # turn two still owns the slot
+
+
 async def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
     """A sentinel with nothing in flight would pop the next turn's meta_info from the
     text_queue and stamp end-of-stream onto a turn that never played."""

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -726,6 +726,81 @@ async def test_a_dead_socket_with_nothing_in_flight_stays_silent():
     assert out == []
 
 
+async def _consume_all(s):
+    out = []
+    try:
+
+        async def go():
+            async for item in s.receiver():
+                out.append(item)
+
+        await asyncio.wait_for(go(), timeout=5)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+    return out
+
+
+def _cancelling_ws():
+    ws = MagicMock()
+
+    async def recv():
+        raise asyncio.CancelledError
+
+    ws.recv = recv
+    return ws
+
+
+async def test_frames_from_a_replaced_socket_are_ignored():
+    """A closed socket drains its buffered frames before raising ConnectionClosed, so after
+    a reset the receiver can still be reading the replaced socket while the new connection
+    already serves the next turn. The old response's late done must not free — let alone
+    complete — the newer turn's slot."""
+    s = _synth()
+    old_ws = s.websocket
+    new_ws = _cancelling_ws()
+    frames = [json.dumps({"type": "responseDone", "response_id": "r-old", "status": "completed", "text": "", "usage": {}})]
+
+    async def old_recv():
+        # monitor_connection replaced the socket while this recv was parked; the newer
+        # turn has already claimed the slot on the fresh connection
+        s.websocket = new_ws
+        s._response_idle.clear()
+        s._slot_seq = 2
+        if frames:
+            return frames.pop(0)
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    old_ws.recv = old_recv
+    s.conversation_ended = False
+
+    out = await _consume_all(s)
+    assert out == []  # the stale done neither played nor completed anything
+    assert not s._response_idle.is_set()  # the newer turn still owns the slot
+    assert s._slot_seq == 2
+
+
+async def test_a_replaced_sockets_death_does_not_settle_the_new_connection():
+    """The replaced socket's ConnectionClosed must not settle the live connection's state:
+    establish_connection already reset it, and the newer turn owns the slot."""
+    s = _synth()
+    old_ws = s.websocket
+    new_ws = _cancelling_ws()
+
+    async def old_recv():
+        s.websocket = new_ws
+        s._response_idle.clear()
+        s._slot_seq = 2
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    old_ws.recv = old_recv
+    s.conversation_ended = False
+
+    out = await _consume_all(s)
+    assert out == []
+    assert not s._response_idle.is_set()
+    assert s._slot_seq == 2
+
+
 async def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
     """The receiver usually notices a dead socket at its connection poll, not inside
     recv(); the flushed turn must settle there too or its completion is lost and the

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -637,6 +637,7 @@ async def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
     out = await _drain(
         s,
         [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
             json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
             json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"go").decode()}),
         ],
@@ -913,12 +914,29 @@ async def test_receiver_survives_malformed_and_unknown_frames():
             "not json at all",
             json.dumps(["a", "list"]),
             json.dumps({"type": "something_new"}),
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
             json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": "@@not-base64@@"}),
             json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
         ],
     )
     assert out == [b"\x00"]
     assert s.connection_error is None
+
+
+async def test_an_unmatched_done_does_not_free_the_active_slot():
+    """created always precedes done on the ordered socket, so a done that does not name
+    the response being served is stale or foreign (e.g. a late settle after an error
+    already freed its turn); freeing — and positionally completing — the slot on it would
+    finish a newer turn before its audio."""
+    s = _synth()
+    await _push(s, "streaming turn", 2)  # slot claimed; its responseCreated hasn't arrived
+    out = await _drain(
+        s,
+        [json.dumps({"type": "responseDone", "response_id": "r-old", "status": "completed", "text": "", "usage": {}})],
+    )
+    assert out == []
+    assert not s._response_idle.is_set()  # the active turn still owns the slot
+    assert s._slot_seq == 2
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -9,6 +9,7 @@ import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import websockets as _ws
 
 from bolna.helpers.utils import audio_to_mulaw8k
 from bolna.models import KalpaConfig, Synthesizer
@@ -48,6 +49,12 @@ def _synth(**kwargs):
     s.sent = []
     s._send_json = AsyncMock(side_effect=lambda p: s.sent.append(p))
     return s
+
+
+def _push(s, text, seq, eos=False):
+    """Mimic _push_stream's ordering: _on_push stamps buffer ownership, then the sender runs."""
+    s._on_push({"sequence_id": seq}, text)
+    asyncio.run(s.sender(text, sequence_id=seq, end_of_llm_stream=eos))
 
 
 def _pcm(seconds, rate=KALPA_NATIVE_SAMPLE_RATE):
@@ -106,20 +113,6 @@ def _patch_http(monkeypatch, body, status=200):
 # ----------------------------------------------------------------------
 
 
-def test_provider_is_registered():
-    assert SUPPORTED_SYNTHESIZER_MODELS["kalpa"] is KalpaSynthesizer
-
-
-def test_synthesizer_model_builds_kalpa_config():
-    synth = Synthesizer(
-        provider="kalpa",
-        provider_config={"voice": "Kiara", "voice_id": VOICE_ID},
-        stream=True,
-    )
-    assert isinstance(synth.provider_config, KalpaConfig)
-    assert synth.provider_config.model == KALPA_DEFAULT_MODEL
-
-
 def test_config_survives_the_model_and_reaches_the_synthesizer():
     """The dashboard round-trips provider_config through the pydantic model; a field the
     model drops silently would leave the synthesizer on defaults."""
@@ -132,6 +125,7 @@ def test_config_survives_the_model_and_reaches_the_synthesizer():
     cfg.pop("provider")
     provider_config = cfg.pop("provider_config")
 
+    assert SUPPORTED_SYNTHESIZER_MODELS["kalpa"] is KalpaSynthesizer
     s = SUPPORTED_SYNTHESIZER_MODELS["kalpa"](
         **cfg, **provider_config, caching=True, synthesizer_key=KEY, task_manager_instance=MagicMock()
     )
@@ -148,6 +142,16 @@ def test_config_survives_the_model_and_reaches_the_synthesizer():
 def test_a_voice_or_voice_id_is_required():
     with pytest.raises(ValueError):
         KalpaSynthesizer(synthesizer_key=KEY, task_manager_instance=MagicMock())
+
+
+def test_the_config_always_carries_a_voice_name():
+    """task_manager reads provider_config["voice"] unconditionally and calls .lower() on it
+    when backchanneling is on; a None voice crashes call setup before any audio."""
+    cfg = Synthesizer(provider="kalpa", provider_config={"voice_id": VOICE_ID}, stream=True)
+    assert isinstance(cfg.provider_config, KalpaConfig)
+    assert cfg.provider_config.voice == "Kiara"
+    assert cfg.provider_config.voice_id == VOICE_ID  # the id still wins at resolution time
+    assert cfg.provider_config.model == KALPA_DEFAULT_MODEL
 
 
 @pytest.mark.parametrize(
@@ -167,18 +171,17 @@ def test_out_of_range_params_raise_at_construction_not_mid_call(bad):
         _synth(**bad)
 
 
-def test_mulaw_is_off_unless_task_manager_asks_for_it():
-    s = KalpaSynthesizer(voice_id=VOICE_ID, stream=True, synthesizer_key=KEY, task_manager_instance=MagicMock())
-    assert s.use_mulaw is False
-    assert s._get_audio_format() == "pcm"
-
-
 def test_telephony_pins_8k_mulaw_and_web_keeps_the_configured_rate():
     tel = _synth(use_mulaw=True)
     assert (tel.target_sample_rate, tel._get_audio_format()) == (8000, "mulaw")
 
     web = _synth(use_mulaw=False, sampling_rate="24000")
     assert (web.target_sample_rate, web._get_audio_format()) == (24000, "pcm")
+
+    # Without the task_manager kwargs (dashboard/turn-based constructs with defaults),
+    # mulaw stays off and the rate is Kalpa's 24 kHz native — not telephone quality.
+    plain = KalpaSynthesizer(voice_id=VOICE_ID, stream=True, synthesizer_key=KEY, task_manager_instance=MagicMock())
+    assert (plain.use_mulaw, plain.target_sample_rate, plain._get_audio_format()) == (False, 24000, "pcm")
 
 
 # ----------------------------------------------------------------------
@@ -194,11 +197,8 @@ def test_initialize_message_carries_auth_model_and_only_set_params():
         "model": KALPA_DEFAULT_MODEL,
         "params": {"temperature": 0.8, "top_k": 50},
     }
-
-
-def test_initialize_message_omits_params_when_none_are_configured():
-    # Kalpa's server defaults are the tuned production sampling; sending an empty params
-    # object is harmless but sending none keeps the contract explicit.
+    # Kalpa's server defaults are the tuned production sampling; sending none keeps
+    # the contract explicit.
     assert "params" not in _synth()._initialize_message()
 
 
@@ -247,12 +247,14 @@ def test_a_catalog_error_raises_rather_than_guessing(monkeypatch):
 
 
 def test_sender_aggregates_the_turn_and_flushes_once_on_eos():
+    """Chunks join with a single space: the streaming LLM wrappers split at buffer_size
+    with rsplit(" ", 1) and drop the boundary space — joining verbatim would glue words."""
     s = _synth()
-    asyncio.run(s.sender("Namaste! ", sequence_id=1, end_of_llm_stream=False))
-    asyncio.run(s.sender("Kaise hain aap?", sequence_id=1, end_of_llm_stream=False))
+    _push(s, "Namaste!", 1)
+    _push(s, "Kaise hain aap?", 1)
     assert s.sent == []  # nothing reaches the socket while the turn is still streaming
 
-    asyncio.run(s.sender("", sequence_id=1, end_of_llm_stream=True))
+    _push(s, "", 1, eos=True)
     assert s.sent == [{"type": "sendText", "text": "Namaste! Kaise hain aap?", "flush": True}]
     assert s.last_text_sent is True
     assert s._text_buffer == []
@@ -266,17 +268,30 @@ def test_an_empty_turn_sends_nothing():
     assert s.sent == []
 
 
-def test_an_overlong_turn_is_truncated_to_the_server_cap():
+def test_an_overlong_turn_truncates_to_the_cap_at_a_word_boundary():
     s = _synth()
-    asyncio.run(s.sender("a" * (MAX_TEXT_CHARS + 500), sequence_id=1, end_of_llm_stream=True))
+    _push(s, "hello " * (MAX_TEXT_CHARS // 6 + 50), 1, eos=True)
+    sent = s.sent[0]["text"]
+    assert len(sent) <= MAX_TEXT_CHARS
+    assert sent.endswith("hello")  # never a clipped syllable
+
+    s = _synth()
+    _push(s, "a" * (MAX_TEXT_CHARS + 500), 1, eos=True)  # no whitespace: hard cap
     assert len(s.sent[0]["text"]) == MAX_TEXT_CHARS
 
 
-def test_chunks_concatenate_verbatim_because_the_llm_owns_spacing():
+def test_a_late_chunk_after_its_turns_flush_is_dropped():
+    """Ownership invariant: a stray chunk whose turn's buffer was already flushed or
+    dropped must not append and ride into the next turn's utterance."""
     s = _synth()
-    asyncio.run(s.sender("Sure, I can", sequence_id=1))
-    asyncio.run(s.sender(" help with that.", sequence_id=1, end_of_llm_stream=True))
-    assert s.sent[0]["text"] == "Sure, I can help with that."
+    _push(s, "chunk two", 1)
+    _push(s, "chunk three", 1, eos=True)  # the turn flushes without the straggler
+    asyncio.run(s.sender("chunk one", sequence_id=1, end_of_llm_stream=False))  # wakes late
+    assert s._text_buffer == []
+
+    s._response_idle.set()  # the flushed response completes
+    _push(s, "next turn", 2, eos=True)
+    assert s.sent[-1]["text"] == "next turn"
 
 
 def test_on_push_drops_a_superseded_turns_buffer():
@@ -302,6 +317,7 @@ def test_the_flush_waits_for_the_previous_responses_done():
     without relying on either behavior."""
     s = _synth()
     s._response_idle.clear()  # a previous flush is still generating
+    s._on_push({"sequence_id": 2}, "next turn")
     order = []
 
     async def go():
@@ -326,6 +342,7 @@ def test_a_barge_in_during_the_idle_wait_stops_the_sender():
     task; without the re-check the sender would flush a turn the pipeline already dropped."""
     s = _synth()
     s._response_idle.clear()
+    s._on_push({"sequence_id": 1}, "text for an interrupted turn")
     retired = {"yet": False}
     s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
 
@@ -343,29 +360,51 @@ def test_a_barge_in_during_the_idle_wait_stops_the_sender():
     assert s.sent == []
 
 
-def test_a_barge_in_during_the_ws_wait_never_buffers_stale_text():
+def test_a_barge_in_during_the_ws_wait_stops_the_flush():
     """_wait_for_ws() suspends for real while the socket reconnects; a barge-in in that gap
-    retires the sequence and clears the shared buffer. The resumed sender must not append
-    its stale fragment into the next turn's buffer (it would flush as OLD-NEW text)."""
+    retires the sequence, and the captured turn must not flush when the wait resumes."""
     s = _synth()
     retired = {"yet": False}
     s.task_manager_instance.is_sequence_id_in_current_ids.side_effect = lambda _: not retired["yet"]
 
     async def wait_then_barge_in():
-        retired["yet"] = True  # the barge-in lands while the sender is parked here
+        retired["yet"] = True  # the barge-in lands while the flush is parked here
 
     s._wait_for_ws = AsyncMock(side_effect=wait_then_barge_in)
-    asyncio.run(s.sender("stale fragment", sequence_id=1, end_of_llm_stream=False))
-    assert s._text_buffer == []
+    _push(s, "an interrupted turn", 1, eos=True)
     assert s.sent == []
+    assert s._text_buffer == []
+
+
+def test_a_reconnect_gap_flushes_the_whole_turn_in_order():
+    """Chunks append before any await, in push order; only the EOS task waits on the
+    socket. A reconnect mid-turn must never reorder or drop earlier fragments."""
+    s = _synth()
+    gate = asyncio.Event()
+
+    async def parked_until_reconnect():
+        await gate.wait()
+
+    s._wait_for_ws = parked_until_reconnect
+
+    async def go():
+        tasks = []
+        for text, eos in (("first", False), ("middle", False), ("final", True)):
+            s._on_push({"sequence_id": 1}, text)
+            tasks.append(asyncio.create_task(s.sender(text, 1, end_of_llm_stream=eos)))
+        await asyncio.sleep(0.05)  # the EOS task is parked on the dead socket
+        assert s.sent == []
+        gate.set()  # reconnect completes
+        await asyncio.wait_for(asyncio.gather(*tasks), timeout=2)
+
+    asyncio.run(go())
+    assert s.sent == [{"type": "sendText", "text": "first middle final", "flush": True}]
 
 
 def test_a_dead_socket_settles_the_in_flight_turn():
     """A response that dies with the socket never gets its responseDone. The receiver must
     free the single-flight slot and emit the end-of-stream sentinel so playback terminates
     instead of waiting on a frame that will never arrive."""
-    import websockets as _ws
-
     s = _synth()
     s._response_idle.clear()  # a flush is in flight when the socket drops
 
@@ -385,8 +424,6 @@ def test_a_dead_socket_settles_the_in_flight_turn():
 
 def test_a_dead_socket_with_nothing_in_flight_stays_silent():
     # No sentinel when idle: a spurious one would pop the next turn's meta_info.
-    import websockets as _ws
-
     s = _synth()
 
     async def recv():
@@ -404,9 +441,9 @@ def test_a_dead_socket_with_nothing_in_flight_stays_silent():
 def test_sender_stamps_ws_send_time_at_the_flush():
     # Generation only starts at the flush, so TTFB measured from here is true synth latency.
     s = _synth()
-    asyncio.run(s.sender("first chunk", sequence_id=1))
+    _push(s, "first chunk", 1)
     assert s.ws_send_time is None
-    asyncio.run(s.sender(" last chunk", sequence_id=1, end_of_llm_stream=True))
+    _push(s, "last chunk", 1, eos=True)
     assert s.ws_send_time is not None
 
 
@@ -499,6 +536,230 @@ def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
     assert s.connection_error is None  # the socket stays usable
 
 
+def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
+    """A sentinel with nothing in flight would pop the next turn's meta_info from the
+    text_queue and stamp end-of-stream onto a turn that never played."""
+    s = _synth()  # _response_idle starts set
+    out = _drain(
+        s,
+        [json.dumps({"type": "error", "fatal": False, "error": {"type": "invalid_request", "message": "bad frame"}})],
+    )
+    assert out == []
+    assert s._response_idle.is_set()
+
+
+def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
+    """After cancelResponse, frames already on the wire keep arriving until the response's
+    own responseDone; played as-is they would open the next turn's reply."""
+    s = _synth()
+    s._response_idle.clear()
+    s._current_response_id = "r1"  # responseCreated arrived before the barge-in
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())
+    assert s._ignored_response_ids == {"r1"}
+
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(b"stale").decode()}),
+            # "completed", not "cancelled": even when the cancel loses the race, the
+            # abandoned response must not stamp end-of-stream onto the next turn.
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+            json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000}),
+            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"fresh").decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "hi", "usage": {}}),
+        ],
+    )
+    assert out == [b"fresh", b"\x00"]
+    assert s._ignored_response_ids == set()
+
+
+def test_a_barge_in_before_response_created_still_drops_that_responses_audio():
+    """The barge-in can land after the flush but before responseCreated delivers the id;
+    the late-arriving id must inherit the abandonment so its audio never plays."""
+    s = _synth()
+    s._response_idle.clear()  # a flush went out; responseCreated has not arrived yet
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())
+
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "responseAudio", "response_id": "r1", "pcm_b64": base64.b64encode(b"stale").decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == []
+    assert s._response_idle.is_set()
+    assert s._ignored_response_ids == set()
+
+
+def test_a_socket_death_after_an_early_barge_in_stays_silent():
+    """Same window, but the socket dies before the abandoned response settles: the close
+    handler must not emit a sentinel that would finalize the next turn's queued meta."""
+    s = _synth()
+    s._response_idle.clear()  # a flush went out; responseCreated has not arrived yet
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == []
+    assert s._response_idle.is_set()  # the slot is still freed for the next connection
+
+
+def test_a_timed_out_abandonment_does_not_poison_the_next_turn(monkeypatch):
+    """If the abandoned response's responseDone never arrives, the idle timeout lets the
+    next turn flush anyway; giving up must also retire the abandonment, or the next
+    turn's response is marked ignored at responseCreated and loses audio and sentinel."""
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
+    s = _synth()
+    s._response_idle.clear()  # a flush is in flight; its responseDone will never come
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock()
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())  # abandoned before responseCreated named it
+
+    _push(s, "next turn", 2, eos=True)  # parks on the idle wait, then flushes anyway
+    assert s.sent[-1] == {"type": "sendText", "text": "next turn", "flush": True}
+
+    out = _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000}),
+            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"live").decode()}),
+            json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "hi", "usage": {}}),
+        ],
+    )
+    assert out == [b"live", b"\x00"]
+
+
+def test_a_late_done_for_a_retired_response_does_not_finish_the_active_turn(monkeypatch):
+    """After the idle timeout lets a newer turn flush past a wedged response, the old
+    response's late responseDone must neither free the newer flush's single-flight slot
+    nor emit a sentinel that finishes the newer turn's metadata before its audio."""
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
+    s = _synth()
+    _push(s, "turn one", 1, eos=True)  # in flight; its responseDone is delayed
+    _push(s, "turn two", 2, eos=True)  # parks on the idle wait, then flushes anyway
+    assert [p["text"] for p in s.sent] == ["turn one", "turn two"]
+
+    out = _drain(
+        s,
+        [json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}})],
+    )
+    assert out == []  # a late completion of a retired response is not the active turn's
+    assert not s._response_idle.is_set()  # turn two still owns the slot
+
+    out = _drain(
+        s,
+        [json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "", "usage": {}})],
+    )
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+
+
+def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
+    """The receiver usually notices a dead socket at its connection poll, not inside
+    recv(); the in-flight turn must settle there too or its completion is lost and the
+    reconnect erases the evidence."""
+    s = _synth()
+    s._response_idle.clear()
+    s._inflight_flushes = 1
+    s._is_ws_connected = MagicMock(return_value=False)
+    s.conversation_ended = False
+    out = []
+
+    async def go():
+        async for item in s.receiver():
+            out.append(item)
+            s.connection_error = "socket died"  # ends the poll loop after the settle
+
+    asyncio.run(asyncio.wait_for(go(), timeout=5))
+    assert out == [b"\x00"]
+    assert s._response_idle.is_set()
+
+
+def test_parked_senders_serialize_when_the_slot_frees():
+    """Event.set() wakes every parked sender; each must re-check the slot so two turns
+    cannot ride one responseDone into overlapping flushes (which would swallow the
+    older turn's completion sentinel)."""
+    s = _synth()
+    s._response_idle.clear()  # a response is generating
+
+    async def go():
+        s._on_push({"sequence_id": 2}, "turn two")
+        t2 = asyncio.create_task(s.sender("turn two", 2, end_of_llm_stream=True))
+        await asyncio.sleep(0.01)  # t2 captures its text and parks on the idle wait
+        s._on_push({"sequence_id": 3}, "turn three")
+        t3 = asyncio.create_task(s.sender("turn three", 3, end_of_llm_stream=True))
+        await asyncio.sleep(0.01)  # t3 parks behind it
+
+        s._response_idle.set()  # the in-flight response's done frees the slot once
+        await asyncio.sleep(0.05)
+        assert [p["text"] for p in s.sent] == ["turn two"]  # only one flush rode it
+
+        s._response_idle.set()  # turn two's done
+        await asyncio.wait_for(asyncio.gather(t2, t3), timeout=2)
+
+    asyncio.run(go())
+    assert [p["text"] for p in s.sent] == ["turn two", "turn three"]
+
+
+def test_interruption_bookkeeping_survives_a_failing_cancel_send():
+    """current_turn_start_time must reset even when the cancel send dies with the socket;
+    otherwise the next turn skips the stale-meta prune and its leading audio pops the
+    old turn's metas, which the pipeline then filters as a retired sequence."""
+    s = _synth()
+    s.current_turn_start_time = 123.0
+    ws = MagicMock()
+    ws.state = _ws.protocol.State.OPEN
+    ws.send = AsyncMock(side_effect=RuntimeError("socket died mid-send"))
+    s.websocket = ws
+    asyncio.run(s.handle_interruption())  # must not raise
+    assert s.current_turn_start_time is None
+
+
+def test_a_socket_death_with_overlapping_flushes_settles_each_turn(monkeypatch):
+    """When the idle timeout let a second turn flush past a wedged response, a close must
+    settle both outstanding turns in order — one positional sentinel would finish only
+    the older turn and leave the newer one queued without a completion signal."""
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.RESPONSE_IDLE_TIMEOUT", 0.05)
+    s = _synth()
+    _push(s, "turn one", 1, eos=True)  # in flight; its responseDone never comes
+    _push(s, "turn two", 2, eos=True)  # parks on the idle wait, then flushes anyway
+
+    async def recv():
+        raise _ws.exceptions.ConnectionClosedOK(None, None)
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+    async def go():
+        return [item async for item in s.receiver()]
+
+    assert asyncio.run(asyncio.wait_for(go(), timeout=5)) == [b"\x00", b"\x00"]
+    assert s._response_idle.is_set()
+
+
 def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
     # The server closes the socket after a fatal error; a bad key would just fail again,
     # so connection_error stops monitor_connection from burning its retries.
@@ -508,12 +769,6 @@ def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting():
         [json.dumps({"type": "error", "fatal": True, "error": {"type": "authentication_error", "message": "bad key"}})],
     )
     assert s.connection_error == "bad key"
-
-
-def test_an_unsolicited_session_created_updates_the_native_rate():
-    s = _synth()
-    _drain(s, [json.dumps({"type": "sessionCreated", "sample_rate": 48000})])
-    assert s.native_sample_rate == 48000
 
 
 def test_receiver_survives_malformed_and_unknown_frames():
@@ -572,8 +827,6 @@ def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
 
 
 def test_interruption_cancels_and_clears_the_buffered_turn():
-    import websockets as _ws
-
     s = _synth()
     s._text_buffer = ["partial turn"]
     s.current_turn_start_time = 123.0
@@ -713,12 +966,17 @@ def test_synthesize_returns_the_apis_wav_which_is_self_describing(monkeypatch):
     clip = audio_to_mulaw8k(out, rate_hint=8000, format_hint="")
     assert len(clip) == 8000
 
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert web._get_http_audio_format() == "wav"
+    assert web._process_http_audio(wav) == wav  # already at the target rate
+
 
 def test_telephony_one_shot_returns_mulaw_and_skips_the_transcode(monkeypatch):
     _patch_http(monkeypatch, _tts_response(_wav(1.0)))
     s = _synth(use_mulaw=True)
     clip = asyncio.run(s.synthesize_telephony_clip("hi"))
     assert len(clip) == 8000  # 1s of mu-law @8k, no pydub/ffmpeg involved downstream
+    assert s._get_http_audio_format() == "mulaw"
 
 
 def test_telephony_one_shot_defers_to_synthesize_on_non_telephony_configs():
@@ -735,12 +993,10 @@ def test_http_error_and_empty_body_return_none(monkeypatch):
     assert asyncio.run(s.synthesize("hi")) is None
 
 
-def test_http_conversion_matches_the_declared_http_format():
-    s = _synth(use_mulaw=True)
-    assert s._get_http_audio_format() == "mulaw"
-    assert len(s._process_http_audio(_wav(1.0))) == 8000
+def test_a_failed_one_shot_render_degrades_to_the_eos_sentinel():
+    """The non-streaming loop has no None guard: a None packet crashes the output
+    handler's b64encode, which then marks itself closed and mutes the whole session."""
+    s = _synth()
+    assert s._process_http_audio(None) == b"\x00"
 
-    web = _synth(use_mulaw=False, sampling_rate="24000")
-    assert web._get_http_audio_format() == "wav"
-    wav = _wav(0.5)
-    assert web._process_http_audio(wav) == wav  # already at the target rate
+

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -75,6 +75,22 @@ def _open_ws(s):
     return ws
 
 
+def _die_once(s):
+    """recv that raises ConnectionClosed once. The receiver keeps looping across the
+    closure (SynthesizerPool iterates generate() only once), so the script must end it
+    explicitly with CancelledError on the next read."""
+    calls = {"n": 0}
+
+    async def recv():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _ws.exceptions.ConnectionClosedOK(None, None)
+        raise asyncio.CancelledError
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+
+
 class _FakeResp:
     def __init__(self, body, status=200):
         self._body = body
@@ -318,7 +334,8 @@ async def test_a_failed_supersession_cancel_retries_instead_of_losing_the_chunk(
     go completely silent. The claim path parks on the redial and retries instead."""
     s = _synth()
     await _push(s, "half a turn", 1)
-    s._current_response_id = "r1"  # the dead turn's response is known
+    s._wire_rid = "r1"  # the dead turn's response is on the wire
+    s._wire_serves_slot = True
     s._on_push({"sequence_id": 2}, "next")  # superseded, no handle_interruption ran
     calls = {"n": 0}
 
@@ -529,7 +546,8 @@ async def test_a_socket_death_after_audio_started_ends_the_turn_instead_of_repla
     stragglers are dropped."""
     s = _synth()
     await _push(s, "some words that already rendered.", 1)
-    s._current_response_id = "r1"  # the server had started this utterance's response
+    s._wire_rid = "r1"  # the server had started this utterance's response
+    s._wire_serves_slot = True
     assert s._settle_lost_utterance() == 1
     s._conn_gen += 1
 
@@ -545,17 +563,18 @@ async def test_a_superseded_turn_with_a_live_response_is_cancelled_not_timed_out
     milliseconds — instead of eating the 10s idle timeout."""
     s = _synth()
     await _push(s, "half a turn", 1)
-    s._current_response_id = "r1"  # segmentation already started rendering it
+    s._wire_rid = "r1"  # segmentation already started rendering it
+    s._wire_serves_slot = True
     s._on_push({"sequence_id": 2}, "next")  # superseded, no handle_interruption ran
     task = asyncio.create_task(s.sender("next", sequence_id=2, end_of_llm_stream=False))
     await asyncio.sleep(0.05)
     assert {"type": "cancelResponse"} in s.sent
-    assert "r1" in s._ignored_response_ids  # its still-arriving audio must not play
+    assert s._slot_abandoned is True  # its still-arriving audio must not play
 
     # the cancelled done arrives and frees the slot:
-    s._response_idle.set()
-    s._abandoned_in_flight = False
-    s._current_response_id = None
+    s._settle_slot(emit=False)
+    s._wire_rid = None
+    s._wire_serves_slot = False
     await asyncio.wait_for(task, timeout=2)
     assert s.sent[-1] == {"type": "sendText", "text": "next"}
 
@@ -680,10 +699,9 @@ async def test_a_cancelled_done_frees_the_slot_without_a_sentinel():
         [
             json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
             json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
-            json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"go").decode()}),
         ],
     )
-    assert out == [b"go"]
+    assert out == []
     assert s._response_idle.is_set()
 
 
@@ -710,21 +728,28 @@ async def test_a_non_fatal_error_terminates_the_turn_and_frees_the_slot():
     assert s.connection_error is None  # the socket stays usable
 
 
-async def test_a_failed_responses_late_done_cannot_finish_the_next_turn():
-    """The non-fatal error settles the failed response's turn; its id must not linger as
-    'current', or its delayed done would match after a newer turn claims the slot and
-    finish that turn before its audio — and its late audio frames would play into it."""
+async def test_a_response_scoped_error_kills_only_that_response():
+    """An error naming the open wire response terminates its turn (sentinel, slot freed,
+    stragglers dropped); its delayed done and audio afterwards touch nothing."""
     s = _synth()
     await _push(s, "turn one.", 1)
     out = await _drain(
         s,
         [
             json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
-            json.dumps({"type": "error", "fatal": False, "error": {"type": "invalid_request", "message": "boom"}}),
+            json.dumps(
+                {
+                    "type": "error",
+                    "fatal": False,
+                    "response_id": "r1",
+                    "error": {"type": "inference_error", "message": "boom"},
+                }
+            ),
         ],
     )
     assert out == [b"\x00"]  # the failed turn settles
-    assert s._current_response_id is None
+    assert s._response_idle.is_set()
+    assert s._turn_dead is True
 
     # the next turn claims the slot; r1's delayed frames arrive before its own created
     s._on_push({"sequence_id": 2}, "turn two.")
@@ -739,6 +764,57 @@ async def test_a_failed_responses_late_done_cannot_finish_the_next_turn():
     )
     assert out == []  # neither plays nor completes anything
     assert not s._response_idle.is_set()  # turn two still owns the slot
+
+
+async def test_a_delayed_error_for_a_settled_response_touches_nothing():
+    """A response-scoped error arriving after that response already settled must not free
+    — or positionally complete — a slot a newer turn owns."""
+    s = _synth()
+    await _push(s, "turn one.", 1, eos=True)
+    out = await _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == [b"\x00"]  # turn one settled normally
+
+    s._on_push({"sequence_id": 2}, "turn two.")
+    await s.sender("turn two.", sequence_id=2, end_of_llm_stream=True)
+    assert not s._response_idle.is_set()
+    out = await _drain(
+        s,
+        [
+            json.dumps(
+                {
+                    "type": "error",
+                    "fatal": False,
+                    "response_id": "r1",
+                    "error": {"type": "inference_error", "message": "late boom"},
+                }
+            )
+        ],
+    )
+    assert out == []
+    assert not s._response_idle.is_set()  # turn two still owns the slot
+    assert s._slot_seq == 2
+
+
+async def test_a_connection_scoped_error_while_a_response_renders_just_logs():
+    """An error with no response_id while a response is open on the wire (e.g. a rejected
+    cancelResponse) must not settle anything: the response's own done still arrives."""
+    s = _synth()
+    await _push(s, "turn one.", 1, eos=True)
+    out = await _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "error", "fatal": False, "error": {"type": "invalid_request", "message": "bad frame"}}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == [b"\x00"]  # exactly one completion, from the done — not the error
 
 
 async def test_an_idle_error_frame_logs_without_terminating_the_next_turn():
@@ -757,11 +833,12 @@ async def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
     """After cancelResponse, frames already on the wire keep arriving until the response's
     own responseDone; played as-is they would open the next turn's reply."""
     s = _synth()
-    s._response_idle.clear()
-    s._current_response_id = "r1"  # responseCreated arrived before the barge-in
+    await _push(s, "the interrupted turn", 1, eos=True)
+    out = await _drain(s, [json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000})])
+    assert out == []
     _open_ws(s)
     await s.handle_interruption()
-    assert s._ignored_response_ids == {"r1"}
+    assert s._slot_abandoned is True
 
     out = await _drain(
         s,
@@ -770,13 +847,23 @@ async def test_audio_from_a_cancelled_response_is_dropped_until_its_done():
             # "completed", not "cancelled": even when the cancel loses the race, the
             # abandoned response must not stamp end-of-stream onto the next turn.
             json.dumps({"type": "responseDone", "response_id": "r1", "status": "completed", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == []  # nothing of the abandoned turn plays or completes
+    assert s._response_idle.is_set()
+
+    # the next turn claims the slot and renders normally
+    s._on_push({"sequence_id": 2}, "next turn")
+    await s.sender("next turn", sequence_id=2, end_of_llm_stream=True)
+    out = await _drain(
+        s,
+        [
             json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000}),
             json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"fresh").decode()}),
             json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "hi", "usage": {}}),
         ],
     )
     assert out == [b"fresh", b"\x00"]
-    assert s._ignored_response_ids == set()
 
 
 async def test_a_barge_in_after_the_flush_but_before_response_created_still_drops_the_audio():
@@ -800,7 +887,7 @@ async def test_a_barge_in_after_the_flush_but_before_response_created_still_drop
     )
     assert out == []
     assert s._response_idle.is_set()
-    assert s._ignored_response_ids == set()
+    assert s._slot_abandoned is False  # the settle retired the abandonment
 
 
 async def test_a_socket_death_after_an_early_barge_in_stays_silent():
@@ -811,13 +898,8 @@ async def test_a_socket_death_after_an_early_barge_in_stays_silent():
     _open_ws(s)
     await s.handle_interruption()
 
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
-
-    s.websocket.recv = recv
-    s.conversation_ended = False
-
-    out = [item async for item in s.receiver()]
+    _die_once(s)
+    out = await _consume_all(s)
     assert out == []
     assert s._response_idle.is_set()  # the slot is still freed for the next connection
 
@@ -829,13 +911,8 @@ async def test_a_dead_socket_settles_the_flushed_turn():
     s = _synth()
     await _push(s, "a flushed turn", 1, eos=True)
 
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
-
-    s.websocket.recv = recv
-    s.conversation_ended = False
-
-    out = [item async for item in s.receiver()]
+    _die_once(s)
+    out = await _consume_all(s)
     assert out == [b"\x00"]
     assert s._response_idle.is_set()
 
@@ -861,15 +938,8 @@ async def test_a_lost_turns_sentinel_is_suppressed_when_a_newer_turn_is_queued()
 async def test_a_dead_socket_with_nothing_in_flight_stays_silent():
     # No sentinel when idle: a spurious one would pop the next turn's meta_info.
     s = _synth()
-
-    async def recv():
-        raise _ws.exceptions.ConnectionClosedOK(None, None)
-
-    s.websocket.recv = recv
-    s.conversation_ended = False
-
-    out = [item async for item in s.receiver()]
-    assert out == []
+    _die_once(s)
+    assert await _consume_all(s) == []
 
 
 async def _consume_all(s):
@@ -947,6 +1017,38 @@ async def test_a_replaced_sockets_death_does_not_settle_the_new_connection():
     assert s._slot_seq == 2
 
 
+async def test_the_receiver_survives_a_reconnect_within_one_generate_call():
+    """SynthesizerPool iterates generate() exactly once, so the receiver must keep looping
+    across a transient closure: settle the lost turn, then serve the next turn on the
+    reconnected socket — all inside the same generator run."""
+    s = _synth()
+    await _push(s, "turn one", 1, eos=True)  # flushed; the socket dies before its done
+    events = ["CLOSE", "RECLAIM", "r2-created", "r2-audio", "r2-done", "END"]
+
+    async def recv():
+        ev = events.pop(0)
+        if ev == "CLOSE":
+            raise _ws.exceptions.ConnectionClosedOK(None, None)
+        if ev == "RECLAIM":
+            # monitor_connection redialed and the next turn claimed the fresh connection
+            s._conn_gen += 1
+            s._response_idle.clear()
+            s._slot_seq = 2
+            return json.dumps({"type": "sessionCreated", "sample_rate": 24000})
+        if ev == "r2-created":
+            return json.dumps({"type": "responseCreated", "response_id": "r2", "sample_rate": 24000})
+        if ev == "r2-audio":
+            return json.dumps({"type": "responseAudio", "response_id": "r2", "pcm_b64": base64.b64encode(b"two").decode()})
+        if ev == "r2-done":
+            return json.dumps({"type": "responseDone", "response_id": "r2", "status": "completed", "text": "", "usage": {}})
+        raise asyncio.CancelledError
+
+    s.websocket.recv = recv
+    s.conversation_ended = False
+    out = await _consume_all(s)
+    assert out == [b"\x00", b"two", b"\x00"]  # turn one settles, turn two renders — one generate()
+
+
 async def test_a_socket_death_seen_by_the_poll_path_still_settles_the_turn():
     """The receiver usually notices a dead socket at its connection poll, not inside
     recv(); the flushed turn must settle there too or its completion is lost and the
@@ -980,6 +1082,7 @@ async def test_a_fatal_auth_error_kills_the_synthesizer_instead_of_reconnecting(
 
 async def test_receiver_survives_malformed_and_unknown_frames():
     s = _synth()
+    await _push(s, "a real turn", 1, eos=True)  # the garbage arrives around a live turn
     out = await _drain(
         s,
         [
@@ -1053,13 +1156,14 @@ def test_empty_and_undecodable_chunks_are_dropped_rather_than_yielded():
 async def test_interruption_cancels_the_rendering_utterance_and_clears_the_turn():
     s = _synth()
     await _push(s, "partial turn.", 1)
-    s._current_response_id = "r1"  # segmentation already started rendering it
+    s._wire_rid = "r1"  # segmentation already started rendering it
+    s._wire_serves_slot = True
     s.current_turn_start_time = 123.0
     ws = _open_ws(s)
     await s.handle_interruption()
     assert s._turn_seq is None  # nothing of the abandoned turn can reach the next one
     assert json.loads(ws.send.call_args[0][0]) == {"type": "cancelResponse"}
-    assert s._ignored_response_ids == {"r1"}
+    assert s._slot_abandoned is True  # its still-arriving audio is dropped until the done
     # The cancelled turn's end-of-stream is never forwarded, so the next turn must be
     # re-detected as new for stale text_queue entries to be pruned.
     assert s.current_turn_start_time is None
@@ -1079,6 +1183,23 @@ async def test_a_barge_in_on_an_unflushed_utterance_resets_the_socket():
     # the closure settles silently — the pipeline already dropped the turn:
     assert s._settle_lost_utterance() == 0
     assert s._response_idle.is_set()
+
+
+async def test_an_interruption_retires_parked_senders_even_when_the_sequence_stays_valid():
+    """Some task-manager paths (hangup, overlap, language switch) interrupt first and only
+    invalidate the sequence later. The epoch bump in handle_interruption must retire a
+    parked sender on its own — otherwise it wakes when the cancelled response settles and
+    sends the interrupted text after the cancel, contaminating the next utterance."""
+    s = _synth()
+    s._response_idle.clear()  # a response is rendering; the sender parks on the slot
+    s._on_push({"sequence_id": 2}, "old turn text")
+    task = asyncio.create_task(s.sender("old turn text", sequence_id=2, end_of_llm_stream=True))
+    await asyncio.sleep(0.05)
+
+    await s.handle_interruption()  # note: the sequence is NOT invalidated
+    s._response_idle.set()  # the cancelled response settles; the parked sender wakes
+    await asyncio.wait_for(task, timeout=2)
+    assert s.sent == []  # the epoch bump retired it before anything reached the socket
 
 
 async def test_interruption_on_a_dead_socket_is_a_no_op():

--- a/tests/test_kalpa_synthesizer.py
+++ b/tests/test_kalpa_synthesizer.py
@@ -20,8 +20,16 @@ from bolna.synthesizer.kalpa_synthesizer import (
     KALPA_DEFAULT_MODEL,
     KALPA_NATIVE_SAMPLE_RATE,
     MAX_TEXT_CHARS,
+    _VOICE_IDS,
     KalpaSynthesizer,
 )
+
+
+@pytest.fixture(autouse=True)
+def _fresh_voice_cache():
+    """The name->id cache is process-wide by design; tests must not see each other's."""
+    _VOICE_IDS.clear()
+    yield
 
 KEY = "kalpa_sk_test_dummy"
 VOICE_ID = "5e0c5704-590f-483b-b291-00a2415cb67e"
@@ -286,6 +294,19 @@ def test_a_catalog_error_raises_rather_than_guessing(monkeypatch):
     s = _synth(voice_id=None, voice="Kiara")
     with pytest.raises(RuntimeError):
         asyncio.run(s._resolve_voice_id())
+
+
+def test_voice_resolution_is_cached_across_instances(monkeypatch):
+    """The task manager builds a fresh synthesizer per call; without a process-wide cache
+    every call pays the GET /v1/voices round trip on its connect path."""
+    _patch_http(monkeypatch, CATALOG)
+    assert asyncio.run(_synth(voice_id=None, voice="Kiara")._resolve_voice_id()) == VOICE_ID
+
+    def boom(*a, **k):
+        raise AssertionError("a later call must not fetch /v1/voices again")
+
+    monkeypatch.setattr("bolna.synthesizer.kalpa_synthesizer.aiohttp.ClientSession", boom)
+    assert asyncio.run(_synth(voice_id=None, voice=" KIARA ")._resolve_voice_id()) == VOICE_ID
 
 
 # ----------------------------------------------------------------------
@@ -579,23 +600,23 @@ async def test_a_superseded_turn_with_a_live_response_is_cancelled_not_timed_out
     assert s.sent[-1] == {"type": "sendText", "text": "next"}
 
 
-async def test_a_superseded_turn_with_no_response_resets_the_socket_immediately():
-    """Same supersession, but no response is known: a cancel could settle nothing, so the
-    claim path closes the socket right away rather than waiting out the idle timeout."""
+async def test_a_superseded_turn_with_no_response_flushes_then_cancels():
+    """Same supersession, but no response is known: a bare cancel could settle nothing, so
+    the claim path flushes first — committing the utterance so the cancel's done is
+    guaranteed — instead of resetting the socket and paying the reconnect."""
     s = _synth()
     await _push(s, "half a turn", 1)
     s._on_push({"sequence_id": 2}, "next")
-    closed = {"yet": False}
+    task = asyncio.create_task(s.sender("next", sequence_id=2, end_of_llm_stream=False))
+    await asyncio.sleep(0.05)
+    s.websocket.close.assert_not_awaited()
+    assert s.sent[-2:] == [{"type": "sendText", "flush": True}, {"type": "cancelResponse"}]
+    assert s._slot_abandoned is True
 
-    async def close():
-        closed["yet"] = True
-        # what the receiver's settle and monitor's redial do once the closure lands:
-        s._settle_lost_utterance()
-        s._conn_gen += 1
-
-    s.websocket.close = close
-    await s.sender("next", sequence_id=2, end_of_llm_stream=False)
-    assert closed["yet"] is True
+    # the cancelled done arrives and frees the slot; the new turn proceeds on the same
+    # connection:
+    s._settle_slot(emit=False)
+    await asyncio.wait_for(task, timeout=2)
     assert s.sent[-1] == {"type": "sendText", "text": "next"}
 
 
@@ -1169,19 +1190,31 @@ async def test_interruption_cancels_the_rendering_utterance_and_clears_the_turn(
     assert s.current_turn_start_time is None
 
 
-async def test_a_barge_in_on_an_unflushed_utterance_resets_the_socket():
-    """Text was streamed but never flushed and no response has been seen: the server may or
-    may not have started rendering, and a cancel that lands before any response exists
-    settles with no responseDone — the slot would hang. The close is the barge-in."""
+async def test_a_barge_in_on_an_unflushed_utterance_flushes_then_cancels():
+    """Text was streamed but never flushed and no response has been seen: a bare cancel
+    could settle with no responseDone (the server may not have started rendering), and a
+    socket reset would cost the next turn the full reconnect. The flush commits the
+    utterance — a response and its done are then guaranteed — so the cancel settles the
+    slot in milliseconds on the same connection."""
     s = _synth()
     await _push(s, "streamed but never flushed", 1)
     ws = _open_ws(s)
     await s.handle_interruption()
-    ws.close.assert_awaited()
-    ws.send.assert_not_awaited()  # no cancel frame: the disconnect carries the barge-in
+    ws.close.assert_not_awaited()  # the reconnect cost was the bug
+    frames = [json.loads(c.args[0]) for c in ws.send.await_args_list]
+    assert frames == [{"type": "sendText", "flush": True}, {"type": "cancelResponse"}]
     assert s._turn_seq is None
-    # the closure settles silently — the pipeline already dropped the turn:
-    assert s._settle_lost_utterance() == 0
+    assert s._slot_abandoned is True  # the committed response's audio must never play
+
+    # the guaranteed done settles the slot silently, without a socket reset:
+    out = await _drain(
+        s,
+        [
+            json.dumps({"type": "responseCreated", "response_id": "r1", "sample_rate": 24000}),
+            json.dumps({"type": "responseDone", "response_id": "r1", "status": "cancelled", "text": "", "usage": {}}),
+        ],
+    )
+    assert out == []
     assert s._response_idle.is_set()
 
 

--- a/tests/test_llm_output_empty_eos.py
+++ b/tests/test_llm_output_empty_eos.py
@@ -1,0 +1,52 @@
+"""_handle_llm_output must forward the LLM turn's final buffer even when it is empty:
+end_of_llm_stream rides on it, and a streaming synthesizer that never sees the marker never
+flushes the turn — the response is silently lost. A turn that never produced text must stay
+silent as before (no phantom packet for the synthesizer to mis-track)."""
+
+import asyncio
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+class _Stub:
+    """Just the attributes the synthesizer branch of _handle_llm_output touches."""
+
+
+def _handler(turn_streamed_text):
+    stub = _Stub()
+    stub.stream = True
+    # Cleared while a turn's audio is in flight — i.e. once a chunk reached the synthesizer.
+    stub._turn_audio_flushed = asyncio.Event()
+    if not turn_streamed_text:
+        stub._turn_audio_flushed.set()
+    stub.synthesizer_tasks = []
+    stub.forwarded = []
+
+    async def _synthesize(packet):
+        stub.forwarded.append(packet)
+
+    stub._synthesize = _synthesize
+    return stub
+
+
+async def test_an_empty_final_buffer_still_carries_end_of_llm_stream():
+    stub = _handler(turn_streamed_text=True)
+    meta = {"request_id": "r", "sequence_id": 4, "end_of_llm_stream": True}
+    await TaskManager._handle_llm_output(stub, "synthesizer", "", False, meta)
+    await asyncio.gather(*stub.synthesizer_tasks)
+    assert [p["data"] for p in stub.forwarded] == [""]
+    assert stub.forwarded[0]["meta_info"]["end_of_llm_stream"] is True
+
+
+async def test_a_fully_empty_turn_stays_silent():
+    stub = _handler(turn_streamed_text=False)
+    meta = {"request_id": "r", "sequence_id": 4, "end_of_llm_stream": True}
+    await TaskManager._handle_llm_output(stub, "synthesizer", "  ", False, meta)
+    assert stub.synthesizer_tasks == []
+
+
+async def test_a_mid_turn_empty_buffer_is_still_dropped():
+    stub = _handler(turn_streamed_text=True)
+    meta = {"request_id": "r", "sequence_id": 4}
+    await TaskManager._handle_llm_output(stub, "synthesizer", "", False, meta)
+    assert stub.synthesizer_tasks == []


### PR DESCRIPTION
Kalpa Labs TTS: streaming WSS /v1/tts/{voice_id}/stream, one-shot POST /v1/tts/{voice_id}.

Kalpa's conversational speech models render named voices from GET /v1/voices

Models:
1. kalpa-tts-multilingual-beta-v0.1 speaks English and Hindi, including code-switched Hinglish with no language parameter
2. kalpa-tts-beta-v0.1 is English-only.

Flow
1. The client authenticates with an initializeConnection frame (the handshake itself is unauthenticated),
2. The server confirms with sessionCreated
3. Each sendText frame appends text and flush=true renders the buffered utterance.
4. Audio arrives as responseAudio frames carrying base64 raw 24 kHz mono s16le PCM.
5. Every flushed utterance terminates with exactly one responseDone (status "completed", or "cancelled" after a cancelResponse).
6. For telephony, mu-law encodes audio from 24KHz to 8KHz

## Config

```json
{
  "provider": "kalpa",
  "provider_config": {
    "voice": "Kiara",
    "model": "kalpa-tts-multilingual-beta-v0.1"
  },
  "stream": true
}
```

Voices resolve by display name against GET /v1/voices ("Kiara" → catalog UUID, cached), or pass `voice_id` directly. Optional sampling controls: `temperature`, `top_k`, `acoustic_temperature`, `max_new_tokens`, `audio_quality` — omitted by default so Kalpa's tuned production sampling applies. Env: `KALPA_API_KEY` (or `synthesizer_key`), `KALPA_API_HOST` to override the host.