### PR TITLE
fix: azure tts double-suffixed voice name and silent cancellation hang

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.210"
+__version__ = "0.10.211"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/azure_synthesizer.py
+++ b/bolna/synthesizer/azure_synthesizer.py
@@ -32,7 +32,8 @@ class AzureSynthesizer(BaseSynthesizer):
         super().__init__(kwargs.get("task_manager_instance"), stream, buffer_size)
         self.model = model
         self.language = language
-        self.voice = f"{language}-{voice}{model}"
+        suffixed = voice if voice.lower().endswith(model.lower()) else f"{voice}{model}"
+        self.voice = f"{language}-{suffixed}"
         logger.info(f"{self.voice} initialized")
         self.sample_rate = str(sampling_rate)
         self.stream = stream
@@ -187,10 +188,13 @@ class AzureSynthesizer(BaseSynthesizer):
                         logger.error(f"Error in synthesizing handler: {e}")
 
                 def on_completed(evt):
-                    if evt.result.reason == speechsdk.ResultReason.Canceled:
-                        cancellation = evt.result.cancellation_details
-                        if cancellation.reason == speechsdk.CancellationReason.Error:
-                            self._log_cancellation_error(cancellation)
+                    asyncio.run_coroutine_threadsafe(_set_done(), self.loop)
+
+                def on_canceled(evt):
+                    cancellation = evt.result.cancellation_details
+                    logger.error(f"Azure TTS canceled: {cancellation.reason} - voice {self.voice}")
+                    if cancellation.reason == speechsdk.CancellationReason.Error:
+                        self._log_cancellation_error(cancellation)
                     asyncio.run_coroutine_threadsafe(_set_done(), self.loop)
 
                 async def _set_done():
@@ -198,6 +202,7 @@ class AzureSynthesizer(BaseSynthesizer):
 
                 synthesizer.synthesizing.connect(on_synthesizing)
                 synthesizer.synthesis_completed.connect(on_completed)
+                synthesizer.synthesis_canceled.connect(on_canceled)
 
                 ssml = self._build_ssml(text)
                 start_time = time.perf_counter()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.210"
+version = "0.10.211"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

An Azure TTS agent was completely mute for an entire call. Two compounding bugs in `AzureSynthesizer`:

1. **Double-suffixed voice name.** `__init__` builds `self.voice = f"{language}-{voice}{model}"` with `model` defaulting to `neural`. When the configured voice already carries the `Neural` suffix (e.g. `NilarNeural`), the result is `my-MM-NilarNeuralneural`, which is not a real Azure voice. Azure rejects it with a cancellation.

2. **Streaming path never handles cancellation.** `generate()` connects only `synthesizing` and `synthesis_completed`. Azure signals a rejected voice via the `synthesis_canceled` event, which was not connected, so `done_event` was never set. The synthesis loop spun yielding no audio, logged nothing, and raised nothing — a totally silent agent with no error trail. (The `Canceled` branch inside `on_completed` was dead code: `synthesis_completed` never carries a Canceled reason.)

## Fix

1. Only append the model suffix when the configured voice does not already end in it, so `NilarNeural` resolves to `my-MM-NilarNeural`. Bare voices (`Nilar`) keep their existing behavior.
2. Connect `synthesis_canceled` so a rejected voice or any TTS error sets `done_event`, logs the cancellation reason via the existing `_log_cancellation_error`, and ends the turn instead of hanging silently.