### PR TITLE
feat: SSRF-guard custom LLM base_url before outbound requests

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.211"
+__version__ = "0.10.212"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -11,6 +11,7 @@ from bolna.models import *
 from bolna.agent_types.base_agent import BaseAgent
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.rag_service_client import RAGServiceClientSingleton
+from bolna.helpers.function_calling_helpers import guard_llm_base_url
 from bolna.helpers.utils import (
     now_ms,
     format_messages,
@@ -77,6 +78,7 @@ class GraphAgent(BaseAgent):
         # Get credentials from config (injected by task_manager) or fall back to env vars
         self.llm_key = self.config.get("llm_key") or os.getenv("OPENAI_API_KEY")
         self.base_url = self.config.get("base_url")
+        self._base_url_validated = False
 
         # Initialize OpenAI client with credentials (supports EU routing)
         if self.base_url:
@@ -1317,6 +1319,12 @@ class GraphAgent(BaseAgent):
         detected_language = meta_info.get("detected_language")  # None if not yet detected
         if detected_language:
             self.context_data["detected_language"] = detected_language
+
+        # Before the first outbound hop (routing runs before the node LLM), so a blocked
+        # endpoint ends the call cleanly here rather than being swallowed and spoken below.
+        if self.base_url and not self._base_url_validated:
+            await guard_llm_base_url(self.base_url)
+            self._base_url_validated = True
 
         try:
             # Event-triggered generation: process_event() already handled routing

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -1320,8 +1320,7 @@ class GraphAgent(BaseAgent):
         if detected_language:
             self.context_data["detected_language"] = detected_language
 
-        # Before the first outbound hop (routing runs before the node LLM), so a blocked
-        # endpoint ends the call cleanly here rather than being swallowed and spoken below.
+        # Ahead of the try so a blocked endpoint ends the call instead of being spoken.
         if self.base_url and not self._base_url_validated:
             await guard_llm_base_url(self.base_url)
             self._base_url_validated = True

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -82,8 +82,7 @@ class GraphAgent(BaseAgent):
 
         # Initialize OpenAI client with credentials (supports EU routing)
         if self.base_url:
-            # A supplied client keeps httpx's follow_redirects=False, so a customer endpoint
-            # cannot redirect the routing hop to an internal address.
+            # Supplying the client keeps follow_redirects off, so the endpoint cannot redirect us inward.
             self.openai = OpenAI(
                 api_key=self.llm_key,
                 base_url=self.base_url,

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -82,7 +82,13 @@ class GraphAgent(BaseAgent):
 
         # Initialize OpenAI client with credentials (supports EU routing)
         if self.base_url:
-            self.openai = OpenAI(api_key=self.llm_key, base_url=self.base_url)
+            # A supplied client keeps httpx's follow_redirects=False, so a customer endpoint
+            # cannot redirect the routing hop to an internal address.
+            self.openai = OpenAI(
+                api_key=self.llm_key,
+                base_url=self.base_url,
+                http_client=get_shared_sync_http_client(base_url=self.base_url, http2=False),
+            )
             logger.info(f"OpenAI client initialized with custom base_url: {self.base_url}")
         else:
             self.openai = OpenAI(api_key=self.llm_key)
@@ -1321,7 +1327,8 @@ class GraphAgent(BaseAgent):
             self.context_data["detected_language"] = detected_language
 
         # Ahead of the try so a blocked endpoint ends the call instead of being spoken.
-        if self.base_url and not self._base_url_validated:
+        is_custom = (self.config.get("provider") or self.config.get("llm_provider")) == "custom"
+        if is_custom and self.base_url and not self._base_url_validated:
             await guard_llm_base_url(self.base_url)
             self._base_url_validated = True
 

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -82,12 +82,12 @@ class GraphAgent(BaseAgent):
 
         # Initialize OpenAI client with credentials (supports EU routing)
         if self.base_url:
-            # Supplying the client keeps follow_redirects off, so the endpoint cannot redirect us inward.
-            self.openai = OpenAI(
-                api_key=self.llm_key,
-                base_url=self.base_url,
-                http_client=get_shared_sync_http_client(base_url=self.base_url, http2=False),
-            )
+            client_kwargs = {"api_key": self.llm_key, "base_url": self.base_url}
+            if (self.config.get("provider") or self.config.get("llm_provider")) == "custom":
+                # Supplying the client keeps follow_redirects off, so a customer endpoint
+                # cannot redirect this hop inward.
+                client_kwargs["http_client"] = get_shared_sync_http_client(base_url=self.base_url, http2=False)
+            self.openai = OpenAI(**client_kwargs)
             logger.info(f"OpenAI client initialized with custom base_url: {self.base_url}")
         else:
             self.openai = OpenAI(api_key=self.llm_key)

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -8,6 +8,7 @@ from bolna.models import *
 from bolna.agent_types.base_agent import BaseAgent
 from bolna.helpers.logger_config import configure_logger
 from bolna.helpers.rag_service_client import RAGServiceClientSingleton
+from bolna.helpers.function_calling_helpers import guard_llm_base_url
 from bolna.helpers.utils import now_ms, format_messages
 from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
@@ -33,6 +34,7 @@ class KnowledgeBaseAgent(BaseAgent):
         self.agent_information = self.config.get("agent_information", "Knowledge-based AI assistant")
         self.context_data = self.config.get("context_data", {})
         self.llm_model = self.config.get("model", "gpt-4o")
+        self._base_url_validated = False
 
         # Main LLM for conversation
         self.llm = self._initialize_llm()
@@ -311,6 +313,14 @@ Use this information naturally when it helps answer the user's questions. Don't 
         meta_info["llm_metadata"] = meta_info.get("llm_metadata", {})
         meta_info["llm_metadata"]["rag_info"] = {}
         meta_info["llm_metadata"]["rag_info"]["all_sources"] = self.rag_config.get("used_sources", [])
+
+        # Before the first outbound hop, so a blocked custom endpoint ends the call cleanly
+        # here rather than being swallowed and spoken by the except below.
+        base_url = self.config.get("base_url")
+        if base_url and not self._base_url_validated:
+            await guard_llm_base_url(base_url)
+            self._base_url_validated = True
+
         try:
             messages_with_context, metadata = await self._add_rag_context(message)
 

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -315,7 +315,7 @@ Use this information naturally when it helps answer the user's questions. Don't 
         meta_info["llm_metadata"]["rag_info"]["all_sources"] = self.rag_config.get("used_sources", [])
 
         # Ahead of the try so a blocked endpoint ends the call instead of being spoken.
-        base_url = self.config.get("base_url")
+        base_url = self.config.get("base_url") if (self.config.get("provider") or self.config.get("llm_provider")) == "custom" else None
         if base_url and not self._base_url_validated:
             await guard_llm_base_url(base_url)
             self._base_url_validated = True

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -314,8 +314,7 @@ Use this information naturally when it helps answer the user's questions. Don't 
         meta_info["llm_metadata"]["rag_info"] = {}
         meta_info["llm_metadata"]["rag_info"]["all_sources"] = self.rag_config.get("used_sources", [])
 
-        # Before the first outbound hop, so a blocked custom endpoint ends the call cleanly
-        # here rather than being swallowed and spoken by the except below.
+        # Ahead of the try so a blocked endpoint ends the call instead of being spoken.
         base_url = self.config.get("base_url")
         if base_url and not self._base_url_validated:
             await guard_llm_base_url(base_url)

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -315,7 +315,8 @@ Use this information naturally when it helps answer the user's questions. Don't 
         meta_info["llm_metadata"]["rag_info"]["all_sources"] = self.rag_config.get("used_sources", [])
 
         # Ahead of the try so a blocked endpoint ends the call instead of being spoken.
-        base_url = self.config.get("base_url") if (self.config.get("provider") or self.config.get("llm_provider")) == "custom" else None
+        provider = self.config.get("provider") or self.config.get("llm_provider")
+        base_url = self.config.get("base_url") if provider == "custom" else None
         if base_url and not self._base_url_validated:
             await guard_llm_base_url(base_url)
             self._base_url_validated = True

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -97,11 +97,7 @@ async def validate_outbound_url(url):
 
 
 async def guard_llm_base_url(base_url):
-    """Validate a customer-supplied LLM base_url before any outbound call.
-
-    Raises SSRFError with the resolved address scrubbed, so a swallowed error never voices
-    or logs an internal IP to the caller. The detailed reason is logged here instead.
-    """
+    """Validate a customer-supplied LLM base_url, raising with the resolved address scrubbed."""
     if not base_url:
         return
     try:

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -96,6 +96,21 @@ async def validate_outbound_url(url):
             raise SSRFError(f"Blocked request to non-public address {addr} (resolved from {host})")
 
 
+async def guard_llm_base_url(base_url):
+    """Validate a customer-supplied LLM base_url before any outbound call.
+
+    Raises SSRFError with the resolved address scrubbed, so a swallowed error never voices
+    or logs an internal IP to the caller. The detailed reason is logged here instead.
+    """
+    if not base_url:
+        return
+    try:
+        await validate_outbound_url(base_url)
+    except SSRFError as e:
+        logger.warning(f"Blocked custom LLM base_url: {e}")
+        raise SSRFError("Blocked outbound request to a non-public LLM endpoint") from None
+
+
 def _contains_var_markers(obj):
     """
     Check if object contains any {"$var": ...} markers.

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -192,8 +192,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.async_client = AsyncOpenAI(api_key=llm_key, http_client=http_client)
             api_key = llm_key
         self.llm_host = urlparse(base_url).netloc if base_url else None
-        # Only a customer endpoint is guarded; platform ones (Azure, EU OpenAI, OpenRouter) are
-        # ours and must keep the SDK's connection retries in front of a transient DNS failure.
+        # Only a customer endpoint is guarded; platform ones keep the SDK's connection retries.
         self._base_url = base_url if kwargs.get("provider", "openai") == "custom" else None
         self._base_url_validated = False
         self.assistant_id = kwargs.get("assistant_id", None)

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -203,9 +203,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
             # logger.info(f'thread id : {self.thread_id}')
         self.run_id = kwargs.get("run_id", None)
 
-        self._init_responses_api(
-            kwargs.get("use_responses_api", False), compact_threshold=kwargs.get("compact_threshold")
-        )
+        # Self-hosted endpoints speak chat completions only; Responses-API chaining is OpenAI-specific.
+        use_responses_api = kwargs.get("use_responses_api", False) and kwargs.get("provider", "openai") != "custom"
+        self._init_responses_api(use_responses_api, compact_threshold=kwargs.get("compact_threshold"))
 
         self._ws_transport = None
         if self.use_responses_api and kwargs.get("provider", "openai") != "custom" and not base_url:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -192,7 +192,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.async_client = AsyncOpenAI(api_key=llm_key, http_client=http_client)
             api_key = llm_key
         self.llm_host = urlparse(base_url).netloc if base_url else None
-        self._base_url = base_url
+        # Only a customer endpoint is guarded; platform ones (Azure, EU OpenAI, OpenRouter) are
+        # ours and must keep the SDK's connection retries in front of a transient DNS failure.
+        self._base_url = base_url if kwargs.get("provider", "openai") == "custom" else None
         self._base_url_validated = False
         self.assistant_id = kwargs.get("assistant_id", None)
         if self.assistant_id:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -133,6 +133,9 @@ class OpenAIWSConnection:
 
 
 class OpenAiLLM(OpenAICompatibleLLM):
+    _base_url = None
+    _base_url_validated = False
+
     def __init__(
         self,
         max_tokens=100,

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -25,6 +25,7 @@ from bolna.constants import DEFAULT_LANGUAGE_CODE, GPT5_MODEL_PREFIX, default_re
 from bolna.enums import ResponseStreamEvent, ResponseItemType, Verbosity
 from bolna.helpers.ssl_context import get_ssl_context
 from bolna.helpers.utils import compute_function_pre_call_message, now_ms
+from bolna.helpers.function_calling_helpers import guard_llm_base_url
 from .openai_base import OpenAICompatibleLLM
 from .message_models import strip_internal_keys
 from .tool_call_accumulator import ToolCallAccumulator
@@ -188,6 +189,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 self.async_client = AsyncOpenAI(api_key=llm_key, http_client=http_client)
             api_key = llm_key
         self.llm_host = urlparse(base_url).netloc if base_url else None
+        self._base_url = base_url
+        self._base_url_validated = False
         self.assistant_id = kwargs.get("assistant_id", None)
         if self.assistant_id:
             logger.info(f"Initializing OpenAI assistant with assistant id {self.assistant_id}")
@@ -209,9 +212,17 @@ class OpenAiLLM(OpenAICompatibleLLM):
             self._ws_transport = OpenAIWSConnection(api_key=api_key)
             self._ws_transport.start_connect()
 
+    async def _ensure_base_url_allowed(self):
+        """SSRF-guard a customer-supplied base_url once before the first outbound request."""
+        if self._base_url_validated:
+            return
+        await guard_llm_base_url(self._base_url)
+        self._base_url_validated = True
+
     async def generate_stream(
         self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
+        await self._ensure_base_url_allowed()
         if self.use_responses_api:
             if self._ws_transport:
                 async for chunk in self._generate_stream_ws_responses(
@@ -441,6 +452,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.started_streaming = False
 
     async def generate(self, messages, request_json=False, ret_metadata=False, meta_info=None):
+        await self._ensure_base_url_allowed()
         if self.use_responses_api:
             return await self._generate_responses(messages, request_json, ret_metadata, meta_info)
         return await self._generate_chat(messages, request_json, ret_metadata)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.211"
+version = "0.10.212"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Makes the `custom` (self-hosted, OpenAI-compatible) LLM provider safe to expose to customers.

**SSRF-guards the customer-supplied `base_url`** before any outbound request, reusing the existing `validate_outbound_url` check. It covers all three places a custom endpoint is dialled: the conversation LLM, the graph-agent routing hop, and the knowledge-base agent. The guard runs once per instance and is a no-op when no `base_url` is set, so default OpenAI traffic is unaffected. A blocked endpoint raises with the resolved address scrubbed, so an internal IP is never spoken to the caller or echoed into the LLM context, and the call ends instead of looping.

**Forces chat completions when `provider == "custom"`.** The Responses API and its `previous_response_id` chaining are OpenAI-specific: a self-hosted endpoint serves the first turn, then 404s on the chained follow-up and the call drops. Real OpenAI and Azure agents keep the Responses API.
