### PR TITLE
fix(trace): stamp graph routing rows at hop start and surface LLM/routing latency

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.217"
+__version__ = "0.10.218"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.212"
+__version__ = "0.10.213"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3510,6 +3510,8 @@ class TaskManager(BaseManager):
         reasoning_content=None,
         log_message=None,
         overflowed=False,
+        ts=None,
+        llm_latency=None,
     ):
         self.llm_response_generated = True
         # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn,
@@ -3533,6 +3535,8 @@ class TaskManager(BaseManager):
             reasoning_tokens=reasoning_tokens,
             cached_tokens=cached_tokens,
             reasoning_content=reasoning_content,
+            ts=ts,
+            latency=llm_latency,
         )
         turn_id = meta_info.get("turn_id")
         response_uid = meta_info.get("response_uid")
@@ -3571,6 +3575,11 @@ class TaskManager(BaseManager):
         )
         actual_overflowed = False
         actual_reasoning_content = None
+        # Stamped per chunk: after the loop these hold when the LLM actually finished and how
+        # fast it started. __store_into_history runs much later (once every chunk has been
+        # pushed to TTS), so the response trace row must be stamped from here, not from there.
+        llm_stream_end_ts = None
+        llm_first_token_latency = None
         synthesize = True
         if should_bypass_synth:
             synthesize = False
@@ -3603,6 +3612,12 @@ class TaskManager(BaseManager):
                 if isinstance(llm_message, dict) and "routing_info" in llm_message:
                     routing_info = llm_message["routing_info"]
 
+                    # Both rows are written here, after the hop already finished — stamp the
+                    # request row at the hop's start so the trace stays chronological.
+                    routing_started_at = routing_info.get("routing_started_at")
+                    routing_latency_ms = routing_info.get("routing_latency_ms")
+                    routing_latency = round(routing_latency_ms / 1000, 6) if routing_latency_ms is not None else None
+
                     # Log routing request with tools
                     routing_messages = routing_info.get("routing_messages")
                     routing_tools = routing_info.get("routing_tools", [])
@@ -3626,6 +3641,7 @@ class TaskManager(BaseManager):
                             component=LogComponent.GRAPH_ROUTING,
                             direction=LogDirection.REQUEST,
                             run_id=self.run_id,
+                            ts=routing_started_at,
                         )
                     elif routing_info.get("routing_type") == "deterministic":
                         expression_trace = (
@@ -3638,6 +3654,7 @@ class TaskManager(BaseManager):
                             component=LogComponent.GRAPH_ROUTING,
                             direction=LogDirection.REQUEST,
                             run_id=self.run_id,
+                            ts=routing_started_at,
                         )
 
                     # Build routing response data
@@ -3715,6 +3732,7 @@ class TaskManager(BaseManager):
                         output_tokens=routing_usage.get("output_tokens"),
                         reasoning_tokens=routing_usage.get("reasoning_tokens"),
                         cached_tokens=routing_usage.get("cached_tokens"),
+                        latency=routing_latency,
                     )
 
                     is_silence_trigger = routing_info.get("is_silence_trigger", False)
@@ -3764,6 +3782,9 @@ class TaskManager(BaseManager):
                 data = llm_message.data
                 end_of_llm_stream = llm_message.end_of_stream
                 latency = llm_message.latency
+                llm_stream_end_ts = time.time()
+                if latency and latency.first_token_latency_ms is not None and llm_first_token_latency is None:
+                    llm_first_token_latency = round(latency.first_token_latency_ms / 1000, 6)
                 trigger_function_call = llm_message.is_function_call
                 function_tool = llm_message.function_name
                 function_tool_message = llm_message.function_message
@@ -3820,6 +3841,8 @@ class TaskManager(BaseManager):
                             cached_tokens=actual_cached_tokens,
                             reasoning_content=actual_reasoning_content,
                             overflowed=actual_overflowed,
+                            ts=llm_stream_end_ts,
+                            llm_latency=llm_first_token_latency,
                         )
                     try:
                         await self.__execute_function_call(next_step=next_step, **data.model_dump())
@@ -3922,6 +3945,8 @@ class TaskManager(BaseManager):
                 reasoning_content=actual_reasoning_content,
                 log_message=empty_turn_detail,
                 overflowed=actual_overflowed,
+                ts=llm_stream_end_ts,
+                llm_latency=llm_first_token_latency,
             )
         elif not self.stream:
             llm_response = llm_response.strip()
@@ -3942,6 +3967,8 @@ class TaskManager(BaseManager):
                 reasoning_tokens=actual_reasoning_tokens,
                 cached_tokens=actual_cached_tokens,
                 reasoning_content=actual_reasoning_content,
+                ts=llm_stream_end_ts,
+                latency=llm_first_token_latency,
             )
 
         # Stamp full response text on the last LLM turn entry (new field, no existing fields changed)

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -614,6 +614,7 @@ class GraphAgent(BaseAgent):
         *,
         routing_type: str,
         latency_ms: float,
+        started_at: float,
         reasoning: Optional[str],
         confidence: Optional[float],
         is_silence_trigger: bool = False,
@@ -634,6 +635,8 @@ class GraphAgent(BaseAgent):
             "routing_model": self.routing_model if made_llm_call else None,
             "routing_provider": self.routing_provider if made_llm_call else None,
             "routing_latency_ms": round(latency_ms, 1),
+            # Wall clock at hop start — the trace row is written after the hop finished.
+            "routing_started_at": started_at,
             "extracted_params": extracted_params or {},
             "node_history": list(self.node_history),
             "routing_messages": routing_messages,
@@ -664,6 +667,7 @@ class GraphAgent(BaseAgent):
             visited.add(self.current_node_id)
 
             hop_start = time.perf_counter()
+            hop_started_at = time.time()
             self._enrich_routing_context(history)
             router_node = self.get_node_by_id(self.current_node_id)
             previous_node = self.current_node_id
@@ -702,6 +706,7 @@ class GraphAgent(BaseAgent):
                             previous_node,
                             routing_type="llm",
                             latency_ms=latency_ms,
+                            started_at=hop_started_at,
                             reasoning=reasoning,
                             confidence=confidence,
                             is_silence_trigger=is_silence_trigger,
@@ -737,6 +742,7 @@ class GraphAgent(BaseAgent):
                     previous_node,
                     routing_type="deterministic",
                     latency_ms=latency_ms,
+                    started_at=hop_started_at,
                     reasoning=f"{_ROUTER_REASONING_PREFIX}{condition}",
                     confidence=1.0,
                     is_silence_trigger=is_silence_trigger,
@@ -778,6 +784,7 @@ class GraphAgent(BaseAgent):
             "routing_model": None,
             "routing_provider": None,
             "routing_latency_ms": None,
+            "routing_started_at": time.time(),
             "extracted_params": {},
             "node_history": list(self.node_history),
             "routing_messages": None,
@@ -1348,6 +1355,7 @@ class GraphAgent(BaseAgent):
                         "routing_model": None,
                         "routing_provider": None,
                         "routing_latency_ms": 0,
+                        "routing_started_at": time.time(),
                         "extracted_params": {},
                         "node_history": list(self.node_history),
                         "routing_messages": None,
@@ -1415,6 +1423,7 @@ class GraphAgent(BaseAgent):
                 yield {"routing_info": self._hold_routing_info(is_silence_trigger)}
             else:
                 previous_node = self.current_node_id
+                routing_started_at = time.time()
                 (
                     next_node_id,
                     extracted_params,
@@ -1446,6 +1455,7 @@ class GraphAgent(BaseAgent):
                         "routing_model": self.routing_model,
                         "routing_provider": getattr(self, "routing_provider", None),
                         "routing_latency_ms": round(routing_latency_ms, 1),
+                        "routing_started_at": routing_started_at,
                         "routing_reasoning_effort": getattr(self, "_routing_reasoning_effort_used", None),
                         "extracted_params": extracted_params or {},
                         "node_history": list(self.node_history),

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -807,12 +807,16 @@ def convert_to_request_log(
     reasoning_tokens=None,
     cached_tokens=None,
     reasoning_content=None,
+    ts=None,
+    latency=None,
 ):
     log = dict()
     log["direction"] = direction.value if isinstance(direction, Enum) else direction
     log["data"] = message
     log["leg_id"] = meta_info["request_id"] if "request_id" in meta_info else "-"
-    log["time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")
+    # ts (epoch seconds) stamps the row when the event happened rather than when it is logged —
+    # callers that log after the fact (LLM response, graph routing request) must pass it.
+    log["time"] = (datetime.fromtimestamp(ts) if ts else datetime.now()).strftime("%Y-%m-%d %H:%M:%S.%f")
     log["component"] = component.value if isinstance(component, Enum) else component
     log["sequence_id"] = meta_info.get("sequence_id", None)
     log["model"] = model
@@ -902,6 +906,9 @@ def convert_to_request_log(
                     else UsageSource.ESTIMATED.value
                 )
                 log["llm_metadata"] = llm_metadata
+    # Explicit latency (seconds) wins over the meta_info lookups above.
+    if latency is not None:
+        log["latency"] = latency
     log["engine"] = engine
     asyncio.create_task(write_request_logs(log, run_id))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.217"
+version = "0.10.218"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.212"
+version = "0.10.213"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_trace_log_timestamps.py
+++ b/tests/test_trace_log_timestamps.py
@@ -1,0 +1,122 @@
+"""Trace rows must be stamped when the event happened, not when the row is written.
+
+Two rows are written after the fact: the LLM response (logged only once every chunk has
+been pushed to TTS) and the graph_routing request (logged only after the hop resolved).
+Without an explicit `ts` they land late enough that synthesizer rows sort in front of the
+LLM response, which is what makes a graph-agent trace read as non-sequential.
+"""
+
+import asyncio
+from datetime import datetime
+
+import pytest
+
+import bolna.helpers.utils as utils
+from bolna.enums import LogComponent, LogDirection
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    """Capture the log dicts convert_to_request_log would have written."""
+    rows = []
+
+    async def fake_write(log, run_id):
+        rows.append(log)
+
+    monkeypatch.setattr(utils, "write_request_logs", fake_write)
+    return rows
+
+
+async def _drain():
+    # convert_to_request_log dispatches via create_task
+    await asyncio.sleep(0)
+
+
+async def test_explicit_ts_is_used_for_the_row_time(captured):
+    event_ts = datetime(2026, 8, 19, 13, 56, 45, 689336).timestamp()
+    utils.convert_to_request_log(
+        "response text",
+        {"request_id": "leg", "sequence_id": 2},
+        "gpt-4.1-mini",
+        LogComponent.LLM,
+        direction=LogDirection.RESPONSE,
+        ts=event_ts,
+    )
+    await _drain()
+
+    assert captured[0]["time"] == "2026-08-19 13:56:45.689336"
+
+
+async def test_omitting_ts_falls_back_to_now(captured):
+    before = datetime.now()
+    utils.convert_to_request_log(
+        "response text",
+        {"request_id": "leg", "sequence_id": 2},
+        "gpt-4.1-mini",
+        LogComponent.LLM,
+        direction=LogDirection.RESPONSE,
+    )
+    await _drain()
+
+    stamped = datetime.strptime(captured[0]["time"], "%Y-%m-%d %H:%M:%S.%f")
+    assert before <= stamped <= datetime.now()
+
+
+async def test_explicit_latency_wins_over_meta_info(captured):
+    # meta_info["llm_latency"] is never set anywhere in bolna, so the column stayed empty
+    # on every LLM row until callers could pass the value directly.
+    utils.convert_to_request_log(
+        "response text",
+        {"request_id": "leg", "sequence_id": 2, "llm_latency": 9.9},
+        "gpt-4.1-mini",
+        LogComponent.LLM,
+        direction=LogDirection.RESPONSE,
+        latency=0.833,
+    )
+    await _drain()
+
+    assert captured[0]["latency"] == 0.833
+
+
+async def test_zero_latency_is_kept_not_dropped(captured):
+    # A deterministic routing hop really does take ~0s; it must not read as "no data".
+    utils.convert_to_request_log(
+        "Node: a -> b",
+        {"request_id": "leg", "sequence_id": 1},
+        "deterministic",
+        LogComponent.GRAPH_ROUTING,
+        direction=LogDirection.RESPONSE,
+        latency=0.0,
+    )
+    await _drain()
+
+    assert captured[0]["latency"] == 0.0
+
+
+async def test_routing_request_row_precedes_its_response_row(captured):
+    """The regression: both graph_routing rows are emitted after the hop finished, so the
+    request row must be stamped from routing_started_at or it sorts on top of the response."""
+    hop_started_at = datetime(2026, 8, 19, 13, 56, 44, 992414).timestamp()
+    meta_info = {"request_id": "leg", "sequence_id": 2}
+
+    utils.convert_to_request_log(
+        "routing prompt",
+        meta_info,
+        "gpt-4.1-mini",
+        LogComponent.GRAPH_ROUTING,
+        direction=LogDirection.REQUEST,
+        ts=hop_started_at,
+    )
+    utils.convert_to_request_log(
+        "Node: a -> b",
+        meta_info,
+        "gpt-4.1-mini",
+        LogComponent.GRAPH_ROUTING,
+        direction=LogDirection.RESPONSE,
+        latency=0.6918,
+    )
+    await _drain()
+
+    request_row, response_row = captured
+    assert request_row["time"] < response_row["time"]
+    assert response_row["latency"] == 0.6918


### PR DESCRIPTION
## Problem

Reported by Spinny on exec `677cfe93-8db4-40c9-af09-ab0b53303f88` (graph agent, 4 turns):
"the LLM response was logged long after the LLM request", and "graph-agent trace data is
often not sequential".

Confirmed against the actual trace CSV. Two distinct defects:

**1. `graph_routing` request rows are stamped at hop *completion*, not hop start.**
Both the REQUEST and RESPONSE rows are emitted from the same `yield {"routing_info": …}`
handler in `__do_llm_generation`, which the graph agent only reaches after
`decide_next_node_with_functions()` has already returned. So the request row is displaced
forward by the full routing latency, every hop reads as **0 ms**, and the real cost shows
up as an unexplained gap after the transcriber row:

| seq | ASR final → routing request | `routing_latency_ms` in that row's metadata |
|---|---|---|
| 2 | 696 ms | 691.8 ms |
| 3 | 897 ms | 895.8 ms |
| 4 | 785 ms | 783.7 ms |

**2. The `Latency` column is empty on every `llm` and `graph_routing` row.**
`convert_to_request_log` reads `meta_info["llm_latency"]` — nothing in bolna ever sets that
key (only `_stamp_llm_latency_dict`, which feeds the separate `llm_latencies` progression
struct). `routing_latency_ms` existed only buried in the Metadata JSON. With no latency
field, the only readable number is the request→response timestamp gap — which for a
streamed turn spans the **whole stream**, not the latency. On seq 3 that gap is 1834 ms
while time-to-first-token was 833 ms, and two complete synthesizer request→response pairs
sit inside the window. Correct streaming behaviour, unreadable presentation.

Note: the `llm` response row itself was *not* late. `_handle_llm_output` only
`asyncio.create_task`s the synth and never awaits TTS, so the row was already within ~1 ms
of end-of-stream.

## Changes

- `helpers/utils.py::convert_to_request_log` — optional `ts` (epoch seconds) and `latency`
  (seconds). `ts` stamps `log["time"]` at the moment the event happened rather than the
  moment the row is written; `latency` overrides the `meta_info` lookups. Both default to
  `None`, so all existing call sites are unchanged.
- `agent_types/graph_agent.py` — every `routing_info` now carries `routing_started_at`
  (wall clock at hop start): `_router_hop_info` (new `started_at` kwarg; both
  `_resolve_router_chain` sites pass `hop_started_at`, captured next to the existing
  `hop_start` perf_counter), `_hold_routing_info`, the event-triggered hop, and the main
  hop in `generate()` (stamped before `decide_next_node_with_functions`).
- `agent_manager/task_manager.py` — `graph_routing` REQUEST stamped `ts=routing_started_at`;
  RESPONSE carries `latency=routing_latency_ms/1000`.
- `agent_manager/task_manager.py::__do_llm_generation` — tracks `llm_stream_end_ts` and
  `llm_first_token_latency` (from the chunk's `LatencyData.first_token_latency_ms`,
  converted to seconds to match every other component's `Latency`), threaded through
  `__store_into_history` via new `ts`/`llm_latency` kwargs. The `ts` is a correctness guard
  against future work landing between loop exit and the log call; the `latency` is the fix.

## Verification

Replaying the fix's semantics over the real trace: routing hops go from 0.0/0.1/0.1 ms to
691.8/895.8/783.7 ms, and the seq-3 routing request row moves from +896 ms after the ASR
final to **+1 ms**.

New `tests/test_trace_log_timestamps.py` (5 cases): explicit `ts` honoured, omitted `ts`
falls back to `now()`, explicit latency beats `meta_info`, `latency=0.0` survives (a
deterministic hop really is ~0 s), and a routing request stamped from `routing_started_at`
sorts before its response.

`1181 passed, 1 skipped`. ruff check + format clean.