### PR TITLE
feat: register synthesizer configs once and end the turn on a failed one-shot render

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.221"
+__version__ = "0.10.222"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -131,7 +131,7 @@ class AzureConfig(BaseModel):
 
 
 # The config class each provider's provider_config is validated against. Adding a provider means
-# one entry here, and downstream services read this map rather than keeping their own copy.
+# one entry here.
 SYNTHESIZER_CONFIG_MODELS = {
     SynthesizerProvider.POLLY.value: PollyConfig,
     SynthesizerProvider.ELEVENLABS.value: ElevenLabsConfig,
@@ -192,7 +192,7 @@ class Synthesizer(BaseModel):
         if not isinstance(config, dict):
             return values
 
-        if provider == "elevenlabs" and (not config.get("voice") or not config.get("voice_id")):
+        if provider == SynthesizerProvider.ELEVENLABS.value and (not config.get("voice") or not config.get("voice_id")):
             raise ValueError("ElevenLabs config requires both 'voice' and 'voice_id'.")
 
         config_model = SYNTHESIZER_CONFIG_MODELS.get(provider)

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -177,20 +177,8 @@ class Transcriber(BaseModel):
 
 class Synthesizer(BaseModel):
     provider: str
-    provider_config: Union[
-        PollyConfig,
-        ElevenLabsConfig,
-        AzureConfig,
-        RimeConfig,
-        SmallestConfig,
-        SarvamConfig,
-        PixaConfig,
-        CartesiaConfig,
-        DeepgramConfig,
-        OpenAIConfig,
-        MayaConfig,
-        KalpaConfig,
-    ] = Field(union_mode="smart")
+    # Derived from the registry so a provider registered there is always accepted here.
+    provider_config: Union[tuple(SYNTHESIZER_CONFIG_MODELS.values())] = Field(union_mode="smart")
     stream: bool = False
     buffer_size: Optional[int] = 40  # 40 characters in a buffer
     audio_format: Optional[str] = "pcm"
@@ -205,7 +193,7 @@ class Synthesizer(BaseModel):
             return values
 
         if provider == "elevenlabs" and (not config.get("voice") or not config.get("voice_id")):
-            raise ValueError("ElevenLabs config requires 'voice' or 'voice_id'.")
+            raise ValueError("ElevenLabs config requires both 'voice' and 'voice_id'.")
 
         config_model = SYNTHESIZER_CONFIG_MODELS.get(provider)
         if config_model:

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -71,41 +71,32 @@ class DeepgramConfig(BaseModel):
     model: str
 
 
-class CartesiaConfig(BaseModel):
-    voice_id: str
+class StandardVoiceConfig(BaseModel):
+    """The four fields every voice provider needs; extend it with provider-specific knobs."""
+
     voice: str
+    voice_id: str
     model: str
     language: str
+
+
+class CartesiaConfig(StandardVoiceConfig):
     speed: Optional[float] = 1.0
 
 
-class RimeConfig(BaseModel):
-    voice_id: str
-    language: str
-    voice: str
-    model: str
+class RimeConfig(StandardVoiceConfig):
+    pass
 
 
-class SmallestConfig(BaseModel):
-    voice_id: str
-    language: str
-    voice: str
-    model: str
+class SmallestConfig(StandardVoiceConfig):
+    pass
 
 
-class SarvamConfig(BaseModel):
-    voice_id: str
-    language: str
-    voice: str
-    model: str
+class SarvamConfig(StandardVoiceConfig):
     speed: Optional[float] = 1.0
 
 
-class PixaConfig(BaseModel):
-    voice_id: str
-    voice: str
-    model: str
-    language: str
+class PixaConfig(StandardVoiceConfig):
     top_p: Optional[float] = 0.95
     repetition_penalty: Optional[float] = 1.3
 
@@ -137,6 +128,24 @@ class AzureConfig(BaseModel):
     model: str
     language: str
     speed: Optional[float] = 1.0
+
+
+# The config class each provider's provider_config is validated against. Adding a provider means
+# one entry here, and downstream services read this map rather than keeping their own copy.
+SYNTHESIZER_CONFIG_MODELS = {
+    SynthesizerProvider.POLLY.value: PollyConfig,
+    SynthesizerProvider.ELEVENLABS.value: ElevenLabsConfig,
+    SynthesizerProvider.OPENAI.value: OpenAIConfig,
+    SynthesizerProvider.DEEPGRAM.value: DeepgramConfig,
+    SynthesizerProvider.AZURETTS.value: AzureConfig,
+    SynthesizerProvider.CARTESIA.value: CartesiaConfig,
+    SynthesizerProvider.SMALLEST.value: SmallestConfig,
+    SynthesizerProvider.SARVAM.value: SarvamConfig,
+    SynthesizerProvider.RIME.value: RimeConfig,
+    SynthesizerProvider.PIXA.value: PixaConfig,
+    SynthesizerProvider.MAYA.value: MayaConfig,
+    SynthesizerProvider.KALPA.value: KalpaConfig,
+}
 
 
 class Transcriber(BaseModel):
@@ -192,44 +201,15 @@ class Synthesizer(BaseModel):
         provider = values.get("provider")
         config = values.get("provider_config", {})
 
-        if provider == "elevenlabs":
-            if not config.get("voice") or not config.get("voice_id"):
-                raise ValueError("ElevenLabs config requires 'voice' or 'voice_id'.")
-            if isinstance(config, dict):
-                values["provider_config"] = ElevenLabsConfig(**config)
-        elif provider == "pixa":
-            if isinstance(config, dict):
-                values["provider_config"] = PixaConfig(**config)
-        elif provider == "cartesia":
-            if isinstance(config, dict):
-                values["provider_config"] = CartesiaConfig(**config)
-        elif provider == "polly":
-            if isinstance(config, dict):
-                values["provider_config"] = PollyConfig(**config)
-        elif provider == "azuretts":
-            if isinstance(config, dict):
-                values["provider_config"] = AzureConfig(**config)
-        elif provider == "deepgram":
-            if isinstance(config, dict):
-                values["provider_config"] = DeepgramConfig(**config)
-        elif provider == "openai":
-            if isinstance(config, dict):
-                values["provider_config"] = OpenAIConfig(**config)
-        elif provider == "smallest":
-            if isinstance(config, dict):
-                values["provider_config"] = SmallestConfig(**config)
-        elif provider == "sarvam":
-            if isinstance(config, dict):
-                values["provider_config"] = SarvamConfig(**config)
-        elif provider == "rime":
-            if isinstance(config, dict):
-                values["provider_config"] = RimeConfig(**config)
-        elif provider == "maya":
-            if isinstance(config, dict):
-                values["provider_config"] = MayaConfig(**config)
-        elif provider == "kalpa":
-            if isinstance(config, dict):
-                values["provider_config"] = KalpaConfig(**config)
+        if not isinstance(config, dict):
+            return values
+
+        if provider == "elevenlabs" and (not config.get("voice") or not config.get("voice_id")):
+            raise ValueError("ElevenLabs config requires 'voice' or 'voice_id'.")
+
+        config_model = SYNTHESIZER_CONFIG_MODELS.get(provider)
+        if config_model:
+            values["provider_config"] = config_model(**config)
 
         return values
 

--- a/bolna/synthesizer/README.md
+++ b/bolna/synthesizer/README.md
@@ -1,0 +1,46 @@
+# Adding a TTS provider
+
+Four registrations, one synthesizer class, one smoke run.
+
+## Register
+
+1. `bolna/enums.py`: add the slug to `SynthesizerProvider`.
+2. `bolna/models.py`: add a config class, add it to `Synthesizer.provider_config`'s union, and add one
+   entry to `SYNTHESIZER_CONFIG_MODELS`. Extend `StandardVoiceConfig` unless the provider genuinely
+   needs a different shape: a config of `voice`, `voice_id`, `model` and `language` needs no
+   per-provider code downstream to build agent configs for it.
+3. `bolna/synthesizer/<name>_synthesizer.py`: the class. Subclass `StreamSynthesizer` for a websocket
+   provider, `BaseSynthesizer` for an HTTP-only one.
+4. `bolna/synthesizer/__init__.py` and `bolna/providers.py`: export it and register it in
+   `SUPPORTED_SYNTHESIZER_MODELS`.
+
+## The contract
+
+`StreamSynthesizer` owns push routing, latency bookkeeping, reconnects and cleanup. A subclass
+supplies `establish_connection`, `sender`, `receiver`, and usually `_process_audio_chunk`.
+
+- **One end-of-stream sentinel per turn.** `receiver()` yields `b"\x00"` exactly once, when the
+  provider reports the utterance complete. A second one stamps end-of-stream onto the next turn; a
+  missing one leaves the turn hanging until the pipeline's timeout.
+- **A cancelled turn gets no sentinel.** `handle_interruption()` has already abandoned it, so its
+  terminator must not be forwarded.
+- **Drop in-flight audio after a barge-in.** Frames generated before the provider processed the
+  cancel keep arriving. Anything still forwarded is popped against the next turn's metadata and
+  plays as the start of the new reply, so track the provider's response or context id and discard
+  by it.
+- **The turn's final LLM chunk is often empty.** `end_of_llm_stream` rides on it, so flush on the
+  flag rather than on having text.
+- **`synthesize()` returns a self-describing container.** Callers convert it for telephony with a
+  rate hint guessed from the synthesizer, which headerless PCM gets wrong.
+- **A failed one-shot render returns `None`.** The shared HTTP loop turns that into an end-of-turn;
+  never yield a `None` audio packet.
+- **`voice` is never `None`.** The platform reads it at call setup.
+
+## Verify
+
+```bash
+<PROVIDER>_API_KEY=... python3 tests/manual/tts_smoke.py --provider <slug> --voice <name>
+```
+
+Runs a streamed turn, a turn whose final chunk is empty, a barge-in, back-to-back turns and both
+one-shot paths against the live API. Every check should pass before the PR goes up.

--- a/bolna/synthesizer/README.md
+++ b/bolna/synthesizer/README.md
@@ -5,8 +5,8 @@ Four registrations, one synthesizer class, one smoke run.
 ## Register
 
 1. `bolna/enums.py`: add the slug to `SynthesizerProvider`.
-2. `bolna/models.py`: add a config class, add it to `Synthesizer.provider_config`'s union, and add one
-   entry to `SYNTHESIZER_CONFIG_MODELS`. Extend `StandardVoiceConfig` unless the provider genuinely
+2. `bolna/models.py`: add a config class and one entry to `SYNTHESIZER_CONFIG_MODELS`; the
+   `provider_config` union derives from it. Extend `StandardVoiceConfig` unless the provider genuinely
    needs a different shape: a config of `voice`, `voice_id`, `model` and `language` needs no
    per-provider code downstream to build agent configs for it.
 3. `bolna/synthesizer/<name>_synthesizer.py`: the class. Subclass `StreamSynthesizer` for a websocket

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -147,6 +147,9 @@ class BaseSynthesizer:
 
             audio = await self._fetch_http_audio(text, meta_info)
             audio = self._process_http_audio(audio)
+            # A failed render still terminates the turn: a None packet crashes the output handler.
+            if not audio:
+                audio = b"\x00"
 
             self._stamp_first_chunk(meta_info)
             self._stamp_end_of_stream(meta_info)
@@ -171,7 +174,9 @@ class BaseSynthesizer:
                 meta_info["is_cached"] = False
             self.synthesized_characters += len(text)
             audio = await self._generate_http(text)
-            self.cache.set(text, audio)
+            if audio:
+                # Caching a failed render would repeat it for every later turn with this text.
+                self.cache.set(text, audio)
             return audio
         else:
             if meta_info is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.221"
+version = "0.10.222"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/manual/tts_smoke.py
+++ b/tests/manual/tts_smoke.py
@@ -1,0 +1,276 @@
+"""Drive a TTS provider through the synthesizer contract against its live API.
+
+Checks the behaviours a synthesizer is easy to get wrong: one end-of-stream sentinel per turn,
+a turn whose final LLM chunk is empty still flushing, no audio surviving a barge-in, and the
+one-shot HTTP renders the welcome/handoff paths depend on.
+
+Usage:
+    KALPA_API_KEY=... python3 tests/manual/tts_smoke.py --provider kalpa --voice Kiara
+    ELEVENLABS_API_KEY=... python3 tests/manual/tts_smoke.py --provider elevenlabs \
+        --voice George --voice-id JBFqnCBsd6RMkjVDRZzb --model eleven_turbo_v2_5
+    ... --config '{"chunk_length_schedule": [50, 80]}' --web --keep-audio out/
+"""
+
+import argparse
+import asyncio
+import audioop
+import json
+import os
+import sys
+import time
+import wave
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS  # noqa: E402
+
+# Long enough that generation is still running when the barge-in lands.
+LONG_TEXT = (
+    "Let me walk you through the whole process, starting with account verification, then the "
+    "billing history, then the plan options, and finally the confirmation email you will receive."
+)
+# Split the way the streaming LLM wrappers do: rsplit(" ", 1) consumes the boundary space, so a
+# synthesizer that concatenates verbatim glues the words together.
+TURN_CHUNKS = ["Thanks for calling. I have pulled up your account and I can", "see the last payment cleared."]
+
+
+class _Pipeline:
+    """Stands in for the task manager: owns which sequence is live, nothing else."""
+
+    def __init__(self):
+        self.live = set()
+        self.conversation_start_init_ts = time.time() * 1000
+
+    def is_sequence_id_in_current_ids(self, sequence_id):
+        return sequence_id in self.live
+
+
+class Smoke:
+    def __init__(self, synth, pipeline, keep_audio=None):
+        self.synth = synth
+        self.pipeline = pipeline
+        self.keep_audio = Path(keep_audio) if keep_audio else None
+        self.packets = []
+        self.results = []
+        self._tasks = []
+
+    async def start(self):
+        if self.synth.stream:
+            self._tasks.append(asyncio.create_task(self.synth.monitor_connection()))
+            deadline = time.perf_counter() + 30
+            while not self.synth._is_ws_connected():
+                if self.synth.connection_error:
+                    raise RuntimeError(f"connection rejected: {self.synth.connection_error}")
+                if time.perf_counter() > deadline:
+                    raise RuntimeError("synthesizer never connected")
+                await asyncio.sleep(0.05)
+        self._tasks.append(asyncio.create_task(self._consume()))
+
+    async def _consume(self):
+        async for packet in self.synth.generate():
+            self.packets.append((time.perf_counter(), packet))
+
+    async def stop(self):
+        await self.synth.cleanup()
+        for task in self._tasks:
+            task.cancel()
+
+    def record(self, name, ok, detail):
+        self.results.append((name, ok, detail))
+        print(f"{'PASS' if ok else 'FAIL'}  {name:<34} {detail}")
+
+    @staticmethod
+    def _message(text, sequence_id, end_of_llm_stream):
+        return {
+            "data": text,
+            "meta_info": {
+                "sequence_id": sequence_id,
+                "turn_id": sequence_id,
+                "end_of_llm_stream": end_of_llm_stream,
+                "tts_start_ms": 0,
+                "message_category": None,
+                "request_id": "tts-smoke",
+            },
+        }
+
+    async def turn(self, sequence_id, chunks, gap=0.15, timeout=45):
+        """Push a turn the way the pipeline does and wait for its end-of-stream sentinel."""
+        self.pipeline.live.add(sequence_id)
+        first_index = len(self.packets)
+        started = time.perf_counter()
+        for chunk in chunks:
+            await self.synth.push(self._message(chunk, sequence_id, False))
+            await asyncio.sleep(gap)
+        flushed = time.perf_counter()
+        await self.synth.push(self._message("", sequence_id, True))
+
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline:
+            if any(p["meta_info"].get("end_of_synthesizer_stream") for _, p in self._mine(first_index, sequence_id)):
+                break
+            await asyncio.sleep(0.02)
+
+        mine = self._mine(first_index, sequence_id)
+        audio = [(t, p) for t, p in mine if p["data"] != b"\x00"]
+        return {
+            "sequence_id": sequence_id,
+            "settled": any(p["meta_info"].get("end_of_synthesizer_stream") for _, p in mine),
+            "packets": len(audio),
+            "seconds": round(sum(self._seconds(p) for _, p in audio), 2),
+            "ttfb_ms": round((audio[0][0] - started) * 1000) if audio else None,
+            "before_flush_ms": round((flushed - audio[0][0]) * 1000) if audio else None,
+            "audio": b"".join(p["data"] for _, p in audio),
+            "format": mine[0][1]["meta_info"].get("format") if mine else None,
+        }
+
+    def _mine(self, first_index, sequence_id):
+        return [(t, p) for t, p in self.packets[first_index:] if p["meta_info"].get("sequence_id") == sequence_id]
+
+    def _rate(self):
+        # Providers carry this as either an int or a string, depending on how the config declares it.
+        return int(self.synth.sampling_rate or 8000)
+
+    def _seconds(self, packet):
+        width = 1 if packet["meta_info"].get("format") == "mulaw" else 2
+        return len(packet["data"]) / (self._rate() * width)
+
+    def save(self, name, turn):
+        if not self.keep_audio or not turn["audio"]:
+            return
+        self.keep_audio.mkdir(parents=True, exist_ok=True)
+        pcm = audioop.ulaw2lin(turn["audio"], 2) if turn["format"] == "mulaw" else turn["audio"]
+        with wave.open(str(self.keep_audio / f"{name}.wav"), "wb") as out:
+            out.setnchannels(1)
+            out.setsampwidth(2)
+            out.setframerate(self._rate())
+            out.writeframes(pcm)
+
+    async def check_streaming_turn(self):
+        turn = await self.turn(1, TURN_CHUNKS)
+        self.save("streamed_turn", turn)
+        detail = f"{turn['seconds']}s in {turn['packets']} packets, ttfb {turn['ttfb_ms']}ms"
+        if turn["before_flush_ms"] and turn["before_flush_ms"] > 0:
+            detail += f", first audio {turn['before_flush_ms']}ms before the flush"
+        self.record("streamed turn settles", turn["settled"] and turn["packets"] > 0, detail)
+
+    async def check_empty_final_chunk(self):
+        """The turn's last LLM buffer is often empty; end_of_llm_stream rides on it."""
+        turn = await self.turn(2, ["One moment please."])
+        self.save("empty_final_chunk", turn)
+        self.record(
+            "empty final chunk flushes",
+            turn["settled"] and turn["packets"] > 0,
+            f"{turn['seconds']}s, settled={turn['settled']}",
+        )
+
+    async def check_barge_in(self):
+        self.pipeline.live.add(3)
+        first_index = len(self.packets)
+        await self.synth.push(self._message(LONG_TEXT, 3, False))
+        await self.synth.push(self._message("", 3, True))
+
+        deadline = time.perf_counter() + 25
+        while time.perf_counter() < deadline and not self._mine(first_index, 3):
+            await asyncio.sleep(0.02)
+        await asyncio.sleep(0.3)
+
+        self.pipeline.live.discard(3)
+        interrupted_at = time.perf_counter()
+        await self.synth.handle_interruption()
+        await asyncio.sleep(2.0)
+
+        leaked = [t for t, p in self.packets if t > interrupted_at and p["data"] != b"\x00"]
+        self.record("barge-in drops in-flight audio", not leaked, f"{len(leaked)} audio packets after the cancel")
+
+        recovery = await self.turn(4, ["Sure, no problem."])
+        self.save("after_barge_in", recovery)
+        self.record(
+            "turn after barge-in is clean",
+            recovery["settled"] and recovery["packets"] > 0,
+            f"{recovery['seconds']}s, ttfb {recovery['ttfb_ms']}ms",
+        )
+
+    async def check_back_to_back(self):
+        first = await self.turn(5, ["First short reply, done."])
+        second = await self.turn(6, ["Second short reply, done."])
+        self.record(
+            "back-to-back turns settle",
+            first["settled"] and second["settled"],
+            f"ttfb {first['ttfb_ms']}ms then {second['ttfb_ms']}ms",
+        )
+
+    async def check_one_shot(self):
+        audio = await self.synth.synthesize("Please hold while I transfer your call.")
+        self.record("synthesize() returns audio", bool(audio), f"{len(audio or b'')} bytes")
+
+        clip = await self.synth.synthesize_telephony_clip("Please hold while I transfer your call.")
+        if clip is None:
+            self.record("telephony one-shot", True, "not offered; caller falls back to synthesize()")
+        else:
+            self.record("telephony one-shot", bool(clip), f"{round(len(clip) / 8000, 2)}s of mu-law")
+
+
+def build_synthesizer(args):
+    provider_config = json.loads(args.config) if args.config else {}
+    for field, value in (
+        ("voice", args.voice),
+        ("voice_id", args.voice_id),
+        ("model", args.model),
+        ("language", args.language),
+    ):
+        if value is not None:
+            provider_config[field] = value
+
+    key = args.key or os.getenv(f"{args.provider.upper()}_API_KEY")
+    if not key:
+        sys.exit(f"no API key: pass --key or set {args.provider.upper()}_API_KEY")
+
+    pipeline = _Pipeline()
+    synth = SUPPORTED_SYNTHESIZER_MODELS[args.provider](
+        **provider_config,
+        stream=not args.no_stream,
+        use_mulaw=not args.web,
+        synthesizer_key=key,
+        task_manager_instance=pipeline,
+    )
+    return synth, pipeline
+
+
+async def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--provider", required=True, choices=sorted(SUPPORTED_SYNTHESIZER_MODELS))
+    parser.add_argument("--voice")
+    parser.add_argument("--voice-id")
+    parser.add_argument("--model")
+    parser.add_argument("--language")
+    parser.add_argument("--config", help="extra provider_config fields as JSON")
+    parser.add_argument("--key", help="defaults to <PROVIDER>_API_KEY")
+    parser.add_argument("--web", action="store_true", help="render PCM for web instead of telephony mu-law")
+    parser.add_argument("--no-stream", action="store_true", help="exercise the one-shot HTTP path only")
+    parser.add_argument("--keep-audio", help="directory to write each turn's WAV into")
+    args = parser.parse_args()
+
+    synth, pipeline = build_synthesizer(args)
+    smoke = Smoke(synth, pipeline, args.keep_audio)
+    print(f"provider={args.provider} stream={synth.stream} mulaw={getattr(synth, 'use_mulaw', False)}")
+
+    await smoke.start()
+    try:
+        if synth.stream:
+            print(f"connected in {synth.connection_time}ms")
+            await smoke.check_streaming_turn()
+            await smoke.check_empty_final_chunk()
+            await smoke.check_barge_in()
+            await smoke.check_back_to_back()
+        await smoke.check_one_shot()
+    finally:
+        await smoke.stop()
+
+    failed = [name for name, ok, _ in smoke.results if not ok]
+    print(f"\n{len(smoke.results) - len(failed)}/{len(smoke.results)} checks passed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/tests/test_synthesizer_config_registry.py
+++ b/tests/test_synthesizer_config_registry.py
@@ -1,0 +1,98 @@
+"""One config class per synthesizer provider, resolved through SYNTHESIZER_CONFIG_MODELS."""
+
+import pytest
+
+from bolna.enums import SynthesizerProvider
+from bolna.models import (
+    SYNTHESIZER_CONFIG_MODELS,
+    CartesiaConfig,
+    ElevenLabsConfig,
+    PixaConfig,
+    RimeConfig,
+    SarvamConfig,
+    SmallestConfig,
+    StandardVoiceConfig,
+    Synthesizer,
+)
+
+# provider -> {field: is_required}. Stored agent snapshots are validated against these classes,
+# so a field silently appearing, vanishing, or changing requiredness breaks existing agents.
+EXPECTED_FIELDS = {
+    "polly": {"voice": True, "engine": True, "language": True},
+    "elevenlabs": {
+        "voice": True,
+        "voice_id": True,
+        "model": True,
+        "temperature": False,
+        "similarity_boost": False,
+        "speed": False,
+        "style": False,
+    },
+    "openai": {"voice": True, "model": True},
+    "deepgram": {"voice_id": True, "voice": True, "model": True},
+    "azuretts": {"voice": True, "model": True, "language": True, "speed": False},
+    "cartesia": {"voice": True, "voice_id": True, "model": True, "language": True, "speed": False},
+    "smallest": {"voice": True, "voice_id": True, "model": True, "language": True},
+    "sarvam": {"voice": True, "voice_id": True, "model": True, "language": True, "speed": False},
+    "rime": {"voice": True, "voice_id": True, "model": True, "language": True},
+    "pixa": {
+        "voice": True,
+        "voice_id": True,
+        "model": True,
+        "language": True,
+        "top_p": False,
+        "repetition_penalty": False,
+    },
+    "maya": {"voice_id": True, "voice": True, "model": True, "language": False},
+    "kalpa": {
+        "voice": False,
+        "voice_id": False,
+        "model": False,
+        "temperature": False,
+        "acoustic_temperature": False,
+        "max_new_tokens": False,
+        "audio_quality": False,
+        "chunk_length_schedule": False,
+    },
+}
+
+
+# Every required field on every config is a plain string, so one filler serves them all.
+def _minimal_config(provider):
+    return {field: "x" for field, required in EXPECTED_FIELDS[provider].items() if required}
+
+
+def test_every_provider_resolves_to_a_config_model():
+    assert set(SYNTHESIZER_CONFIG_MODELS) == set(SynthesizerProvider.all_values())
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_FIELDS))
+def test_config_shapes_are_stable(provider):
+    fields = SYNTHESIZER_CONFIG_MODELS[provider].model_fields
+    assert {name: f.is_required() for name, f in fields.items()} == EXPECTED_FIELDS[provider]
+
+
+@pytest.mark.parametrize("config_model", [CartesiaConfig, RimeConfig, SmallestConfig, SarvamConfig, PixaConfig])
+def test_standard_shape_providers_extend_the_base(config_model):
+    assert issubclass(config_model, StandardVoiceConfig)
+
+
+@pytest.mark.parametrize("provider", sorted(EXPECTED_FIELDS))
+def test_preprocess_builds_the_registered_config(provider):
+    synth = Synthesizer(provider=provider, provider_config=_minimal_config(provider))
+    assert type(synth.provider_config) is SYNTHESIZER_CONFIG_MODELS[provider]
+
+
+def test_an_already_built_config_is_left_alone():
+    config = ElevenLabsConfig(voice="George", voice_id="JBFqnCBsd6RMkjVDRZzb", model="eleven_turbo_v2_5")
+    assert Synthesizer(provider="elevenlabs", provider_config=config).provider_config is config
+
+
+def test_elevenlabs_still_requires_both_voice_and_voice_id():
+    with pytest.raises(ValueError):
+        Synthesizer(provider="elevenlabs", provider_config={"voice": "George", "model": "eleven_turbo_v2_5"})
+
+
+def test_an_unknown_provider_is_rejected():
+    with pytest.raises(ValueError):
+        Synthesizer(provider="nope", provider_config={"voice": "x"})

--- a/tests/test_synthesizer_http_failure.py
+++ b/tests/test_synthesizer_http_failure.py
@@ -1,0 +1,49 @@
+"""A one-shot render that fails must end the turn, not hand the output handler a None packet."""
+
+from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
+from bolna.synthesizer.base_synthesizer import BaseSynthesizer
+
+
+class _AlwaysCurrent:
+    def is_sequence_id_in_current_ids(self, sequence_id):
+        return True
+
+
+class _HttpSynth(BaseSynthesizer):
+    """Renders through the shared HTTP loop; the provider call is scripted per test."""
+
+    def __init__(self, audio):
+        super().__init__(task_manager_instance=_AlwaysCurrent(), stream=False)
+        self._audio = audio
+        self.calls = 0
+        self.caching = True
+        self.cache = InmemoryScalarCache()
+
+    async def _generate_http(self, text):
+        self.calls += 1
+        return self._audio
+
+
+async def _first_packet(synth, text="hello"):
+    await synth.push({"data": text, "meta_info": {"sequence_id": 1, "end_of_llm_stream": True}})
+    return await synth._generate_http_loop().__anext__()
+
+
+async def test_a_failed_render_yields_the_end_of_stream_sentinel():
+    synth = _HttpSynth(None)
+    packet = await _first_packet(synth)
+    assert packet["data"] == b"\x00"
+    assert packet["meta_info"]["end_of_synthesizer_stream"] is True
+
+
+async def test_a_failed_render_is_not_cached():
+    synth = _HttpSynth(None)
+    await _first_packet(synth)
+    assert synth.cache.get("hello") is None
+
+
+async def test_a_successful_render_is_passed_through_and_cached():
+    synth = _HttpSynth(b"audio-bytes")
+    packet = await _first_packet(synth)
+    assert packet["data"] == b"audio-bytes"
+    assert synth.cache.get("hello") == b"audio-bytes"


### PR DESCRIPTION
Adding a TTS provider means editing the same list in several places, and the platform keeps its own copies of two of them. This collapses the per-provider branching here and writes down the contract a synthesizer has to meet.

**Config registry.** `SYNTHESIZER_CONFIG_MODELS` maps each provider slug to its config class, and `Synthesizer.preprocess` looks up instead of running a branch per provider. Downstream services can import the map rather than maintaining a second copy that drifts.

**`StandardVoiceConfig`.** Cartesia, Rime, Smallest, Sarvam and Pixa already declared the same four fields; they now extend a shared base and keep only their own knobs. `tests/test_synthesizer_config_registry.py` pins every provider's exact field set and requiredness, so the refactor cannot change how a stored agent config validates.

**Failed one-shot renders.** `_generate_http_loop` yielded whatever `_process_http_audio` returned, so a provider whose HTTP render failed handed the output handler a `None` packet, which raises inside its base64 encode and mutes the rest of the call. The loop now ends the turn with the end-of-stream sentinel, and a failed render is no longer written to the cache, where it would repeat for every later turn with the same text.

**Smoke harness.** `tests/manual/tts_smoke.py --provider <slug>` drives any provider through push, generate and handle_interruption against its live API, checking a streamed turn, a turn whose final LLM chunk is empty, a barge-in, back-to-back turns, and both one-shot paths. 7/7 against Kalpa, ElevenLabs and Cartesia.

**Contributor guide.** `bolna/synthesizer/README.md` lists the four registrations and the contract: one sentinel per turn, no sentinel for a cancelled turn, drop in-flight audio after a barge-in, and flush on `end_of_llm_stream` rather than on having text.

One behaviour change worth flagging: a `provider_config` that arrives as a config instance rather than a dict now passes through instead of raising `AttributeError` inside the ElevenLabs check.

Not in this PR: `use_mulaw` is read from kwargs by some synthesizers, hardcoded by Pixa and Rime, and ignored by Sarvam, Smallest, Azure, Polly and OpenAI. Worth unifying separately.
