### PR TITLE
fix: stop misclassifying live human replies as voicemail (BOLNA-2487)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.214"
+__version__ = "0.10.215"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/prompts.py
+++ b/bolna/prompts.py
@@ -49,27 +49,244 @@ If none of these apply, the conversation is not complete.
 """
 
 VOICEMAIL_DETECTION_PROMPT = """
-You are an AI assistant that determines if a phone call has reached a voicemail system instead of a real person.
-You will receive a conversation transcript. Analyse ONLY the lines prefixed with "user:" - ignore all lines prefixed with "assistant:". If ANY single "user:" line contains voicemail signals, respond "Yes" immediately.
-Partial, cut-off, or mid-sentence fragments still count: if a "user:" line contains any recognisable part of a voicemail phrase below: its beginning, middle, or end then, respond "Yes", as long as the fragment clearly belongs to a voicemail message and not a normal human greeting.
+You are an AI assistant that determines whether a phone call has reached an automated voicemail system or a real, live person.
 
-Also match approximately, not just exactly: if a "user:" line is close to any voicemail phrase below in wording or meaning, even with transcription errors, missing words, or slightly different phrasing, treat it as a voicemail signal and respond "Yes". It does not need to match word-for-word, as long as it clearly resembles a voicemail message and not a normal human greeting.
+You will receive a message in the form "User message: <transcript>", containing the call transcript captured so far. This check is re-run periodically as more of the call comes in, so what you receive may be only a partial or growing chunk of the full call - always judge based on everything included in the message you've been given, not only its most recent part.
 
-Signs of voicemail include:
-Standard voicemail greetings
-(e.g., "You have reached...", "Please leave a message after the beep", "The person you are trying to reach..." (with or without "is unavailable", "is not available", or "at the tone"), "I am not available right now")
+If the transcript includes anything said by our own calling agent, disregard those parts entirely. You are judging only what was said by the party that answered the call (the recipient): the person, or automated system, on the other end of the line.
 
-Call forwarding and carrier messages
-(e.g., "Your call has been forwarded to an automated voice message system", "Your call has been forwarded to voicemail", "The person you are trying to reach is not available at the tone")
-Recording instructions
-(e.g., "At the tone, please record your message", "Please record your message", "When you have finished recording you may hang up", "Press pound when you are done", "After recording you may hang up")
+Break the recipient's side of the transcript into its individual utterances and evaluate each one against the test below. If ANY single utterance clearly qualifies as voicemail under this test, respond "Yes" immediately, even if other utterances in the same message read as a live reply.
 
-Automated IVR / system prompts (e.g., "Press 1 to leave a message", "Press 2 to...", "Your estimated wait time is...", "All agents are currently busy")
-Pre-recorded personal greetings
-(e.g., "Hi you've reached [Name], I can't take your call right now", "Sorry I missed you, leave me a message", "I'll call you back, please leave your name and number")
-If the user: line contains ANY of the above signals, respond with: {"is_voicemail": "Yes"}
-If the user: line clearly shows a real person speaking (e.g., "Hello?", "Haan", "Haan bolo", "Bol", "Who is this?", any natural two-way greeting), respond with: {"is_voicemail": "No"}
+CORE TEST: scripted announcement vs. interactive reply
 
+For each utterance from the recipient, first decide which of these two things it is:
+
+1. A SCRIPTED, ONE-WAY ANNOUNCEMENT
+
+This is the kind of pre-recorded or automated message that a voicemail system, IVR, or carrier plays.
+
+It does not react to anything specific about this call. It is addressed generically to the caller and would sound the same regardless of who called or what was said.
+
+This can be written in either FIRST PERSON or THIRD PERSON.
+
+FIRST-PERSON voicemail examples include:
+- "I am not available right now. Please leave a message after the beep."
+- "I'm unable to take your call at the moment."
+- "Hi, you've reached John. I can't take your call right now."
+- "I'm currently unavailable. Please leave your name and number."
+- "I can't come to the phone right now. Please leave a message."
+- "I'll call you back as soon as possible. Please leave a message after the tone."
+
+THIRD-PERSON or SYSTEM voicemail examples include:
+- "The person you are trying to reach is not available at the moment."
+- "The person you are trying to reach is unavailable."
+- "Your call has been forwarded to voicemail."
+- "The subscriber you are trying to reach is unavailable."
+
+The important distinction is NOT whether the utterance uses "I", "he", "she", or "you".
+
+The important distinction is whether the utterance is a SCRIPTED, ONE-WAY ANNOUNCEMENT or an INTERACTIVE HUMAN RESPONSE.
+
+2. An INTERACTIVE REPLY FROM A LIVE PERSON
+
+This can be extremely short.
+
+A live person may speak in first person, third person, or on behalf of someone else.
+
+A live person may:
+- answer a question,
+- acknowledge the caller,
+- explain their current situation,
+- say they are unavailable,
+- say someone else is unavailable,
+- ask a question,
+- offer help,
+- react to something the caller said,
+- ask the caller to wait,
+- or otherwise participate naturally in the conversation.
+
+FIRST-PERSON LIVE-PERSON EXAMPLES:
+- "I'm not available right now."
+- "I'm in a meeting right now."
+- "I can't talk right now."
+- "I'm outside, can you call me later?"
+- "I'm busy at the moment."
+- "I don't have time right now."
+- "I can talk for a minute."
+- "I'll call you back later."
+- "I'm not sure what you're talking about."
+- "Yes, I'm here."
+- "I'm listening."
+- "Hold on one second."
+
+These are NOT automatically voicemail merely because they contain phrases such as "I'm not available", "I can't talk", "I'll call you back", or "I'm busy".
+
+If the statement is a natural response from a live person in the conversation, classify it as "No".
+
+THIRD-PERSON LIVE-PERSON EXAMPLES:
+- "Yes, but he is not available at the moment."
+- "He's in a meeting right now."
+- "She isn't here right now."
+- "The GM is not available at the moment."
+- "He'll call you back."
+- "She's busy right now, can I help you?"
+- "He is not available, would you like to leave a message?"
+- "Voh abhi available nahi hai."
+- "Woh meeting mein hai, kya message de doon?"
+
+A live person speaking on behalf of someone else - including a receptionist, colleague, assistant, spouse, family member, or any other third party - is still an interactive reply.
+
+These must be classified "No" when they read as natural responses in the conversation.
+
+FIRST-PERSON vs THIRD-PERSON IS NOT THE DECIDING FACTOR.
+
+For example:
+
+"I am not available right now. Please leave a message after the beep."
+→ Yes, because it is a scripted voicemail greeting.
+
+"I am not available right now, can you call me after 5?"
+→ No, because it is a natural interactive response.
+
+"He is not available at the moment."
+→ No when spoken by a live person responding to the caller.
+
+"The person you are trying to reach is not available at the moment."
+→ Yes when it is a generic automated announcement.
+
+Only classify an utterance as voicemail if it is a scripted, one-way announcement.
+
+Never classify an utterance as voicemail merely because it contains words or phrases that resemble a voicemail script.
+
+The words "not available", "unavailable", "can't talk", "can't take the call", "busy", "call me back", "leave a message", or similar phrases are NOT sufficient by themselves to classify something as voicemail.
+
+When deciding, evaluate the utterance as a whole and determine whether it sounds like:
+A) a fixed message being played to the caller, or
+B) a person naturally responding to the caller.
+
+When in doubt between the two, treat signs of responsiveness, conversational context, or natural human interaction as evidence of a live person and classify "No".
+
+PARTIAL OR CUT-OFF FRAGMENTS:
+
+A fragment counts as voicemail if what is audible clearly belongs to a scripted, one-way announcement.
+
+Do not classify a fragment as voicemail merely because it contains a voicemail-like phrase.
+
+Use the nature of the cutoff as evidence.
+
+For example:
+- "...not available at the—"
+- "...leave a message after the ton—"
+- "...when you have finished recording—"
+
+These may be fragments of scripted voicemail announcements.
+
+However:
+- "I'm not available right—"
+- "He's not available at the—"
+- "I can't talk right—"
+
+should NOT automatically be treated as voicemail merely because they are incomplete. They may simply be a live person's sentence being cut off by transcription or timing.
+
+A bare word or phrase match is never enough by itself.
+
+Use an abrupt, mid-word or mid-phrase cutoff as the primary signal that a fragment belongs to a scripted announcement, with phrase matching only as supporting evidence.
+
+PHRASE CATEGORIES - SUPPORTING EVIDENCE ONLY:
+
+Typical scripted-announcement phrasing:
+
+Standard voicemail greetings:
+- "You have reached..."
+- "Please leave a message after the beep"
+- "The person you are trying to reach is unavailable"
+- "The person you are trying to reach is not available at the tone"
+- "I am not available right now" (when clearly part of a fixed recorded greeting)
+- "I'm unable to take your call right now" (when clearly part of a fixed recorded greeting)
+
+Call forwarding / carrier messages:
+- "Your call has been forwarded to an automated voice message system"
+- "Your call has been forwarded to voicemail"
+- "The person you are trying to reach is not available at the tone"
+- "aapka call automatically ek voice message system par forward kar diya gaya hai"
+
+Recording instructions:
+- "At the tone, please record your message"
+- "Please record your message"
+- "When you have finished recording you may hang up"
+- "Press pound when you are done"
+- "After recording you may hang up"
+- "sandesh chhodein beep ke baad"
+
+Automated IVR / system prompts:
+- "Press 1 to leave a message"
+- "Press 2 to..."
+- "Your estimated wait time is..."
+- "All agents are currently busy"
+
+Pre-recorded personal greetings:
+- "Hi you've reached [Name], I can't take your call right now"
+- "Sorry I missed you, leave me a message"
+- "I'll call you back, please leave your name and number"
+
+These phrase categories are SUPPORTING EVIDENCE ONLY.
+
+Never treat a phrase match as a standalone trigger.
+
+TYPICAL INTERACTIVE-REPLY SIGNALS - RESPOND "No":
+
+- "Hello?"
+- "Haan"
+- "Haan bolo"
+- "Bol"
+- "Who is this?"
+- "Yes?"
+- "Yes, speaking."
+- "How can I help you?"
+- "I'm not available right now."
+- "I'm in a meeting."
+- "I can't talk right now."
+- "I'll call you back."
+- "He's not available."
+- "She's in a meeting."
+- "He'll call you back."
+- "Can I take a message?"
+- "Who's calling?"
+- "Hold on."
+- "One second."
+- "Voh abhi available nahi hai."
+- Any acknowledgement, clarifying question, contextual reaction, or natural response to what was just said.
+
+DECISION PROCEDURE:
+
+For each utterance from the recipient:
+
+1. Does it answer, react to, or otherwise respond to something in this specific call, however briefly, and read as a complete, natural reply?
+
+If YES:
+It is a live person responding.
+Classify "No", regardless of wording overlap with voicemail phrases.
+
+2. If it does not respond to anything and instead reads as a generic, self-contained, scripted announcement or an abrupt fragment of one:
+
+Compare it against the scripted phrase categories as supporting evidence.
+
+If it clearly represents a fixed automated/recorded announcement:
+Classify "Yes".
+
+3. If the utterance contains first-person language such as "I am not available", "I can't talk", "I'll call you back", etc.:
+
+DO NOT classify it as voicemail based on first-person language alone.
+
+Determine whether it sounds like:
+- a fixed, pre-recorded greeting/message → "Yes"
+OR
+- a natural response from a live person → "No"
+
+4. If neither test clearly applies:
+Default to "No".
+
+Do not classify an utterance as voicemail unless it genuinely reads as a scripted, non-responsive announcement.
 
 Respond only in this JSON format:
 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.214"
+version = "0.10.215"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
VOICEMAIL_DETECTION_PROMPT now judges each utterance as a scripted one-way announcement vs. an interactive reply from a live person, instead of fuzzy-matching against a voicemail phrase list. Fixes two confirmed false positives that hung up on real callers:

- third-party unavailability ("he is not available at the moment", "the GM is not available at the moment")
- first-person live decline ("hi i'm not available right now")

Also corrects the prompt's stale "user:"/"assistant:" line-prefix framing to match how it's actually invoked (a single "User message: <transcript>" chunk, re-checked periodically).
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/6660ef6e-60ab-4b1d-a787-a487db203a9e" />
<img width="1710" height="1107" alt="image" src="https://github.com/user-attachments/assets/147e46c9-69ed-4cef-a31b-db08ecbd38f6" />
