### PR TITLE
feat: OpenAI Realtime output speed + s2s caller-liveness refresh

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.216"
+__version__ = "0.10.217"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7887,6 +7887,8 @@ class TaskManager(BaseManager):
                 # the provider's VAD has already stopped generating, so nothing decided here
                 # can give the agent the floor back. Barge-in sensitivity is tuned provider-side.
                 self.interruption_manager.on_user_speech_started()
+                # A speech start refreshes liveness, barge-in or not.
+                self.time_since_last_spoken_human_word = time.time()
                 if self._s2s_agent_has_floor():
                     logger.info("S2S: caller barged in, dropping queued audio")
                     self.interruption_manager.on_interruption_triggered()

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -614,6 +614,8 @@ class ToolModel(BaseModel):
 class OpenAIRealtimeConfig(BaseModel):
     model: str = "gpt-realtime-2.1"
     voice: str = "marin"
+    # Playback rate (0.25 to 1.5), not how the reply is worded.
+    speed: Optional[float] = 1.0
     # semantic_vad scores whether the caller has actually finished from what they said, so
     # it waits longer on a trailing "ummm" than on a finished sentence. That is the job the
     # llm pipeline does with a word count and a phrase list, done by a model instead.

--- a/bolna/s2s/openai_realtime_s2s.py
+++ b/bolna/s2s/openai_realtime_s2s.py
@@ -63,6 +63,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         max_output_tokens: Optional[int] = None,
         transcription_model: str = "gpt-4o-mini-transcribe",
         language: Optional[str] = None,
+        speed: float = 1.0,
         **kwargs,
     ):
         super().__init__(
@@ -82,6 +83,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
         self.max_output_tokens = max_output_tokens
         self.transcription_model = transcription_model
         self.language = language
+        self.speed = speed
 
         self._ws = None
         self._closed = False
@@ -177,6 +179,7 @@ class OpenAIRealtimeS2S(BaseS2SProvider):
                 "output": {
                     "format": {"type": "audio/pcm", "rate": self.output_sample_rate},
                     "voice": self.voice,
+                    "speed": self.speed,
                 },
             },
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.216"
+version = "0.10.217"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Two small speech-to-speech changes.

**Output speed (feat).** OpenAI Realtime exposes `audio.output.speed` (0.25 to 1.5, default 1.0) to change the playback rate of the model's speech between turns. `OpenAIRealtimeConfig` had no such field, so a `speed` set on an s2s agent was dropped and never reached the provider. Adds `speed` to the config and sends it under `audio.output.speed`. Default 1.0 keeps existing agents unchanged; Gemini Live has no equivalent, so it is OpenAI-only.

**Caller-liveness refresh (fix).** A provider speech-start event only updated the interruption accounting, not `time_since_last_spoken_human_word`, which the caller-liveness timers read. A caller who was actively talking but not barging in could be treated as silent, triggering the "still there?" prompt or an inactivity hangup mid-conversation. It now refreshes the liveness timestamp on any speech start.