### PR TITLE
fix: refresh s2s caller liveness on a provider speech start

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.214"
+__version__ = "0.10.215"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7887,6 +7887,9 @@ class TaskManager(BaseManager):
                 # the provider's VAD has already stopped generating, so nothing decided here
                 # can give the agent the floor back. Barge-in sensitivity is tuned provider-side.
                 self.interruption_manager.on_user_speech_started()
+                # A speech start is proof the caller is talking, so it must refresh liveness
+                # even when this turn is not a barge-in.
+                self.time_since_last_spoken_human_word = time.time()
                 if self._s2s_agent_has_floor():
                     logger.info("S2S: caller barged in, dropping queued audio")
                     self.interruption_manager.on_interruption_triggered()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.214"
+version = "0.10.215"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
On a speech-to-speech agent, the provider's speech-start event only updated the interruption accounting. It did not refresh `time_since_last_spoken_human_word`, which the caller-liveness timers read. A caller who was actively talking but not barging in could therefore be treated as silent, triggering the "are you still there" prompt or an inactivity hangup mid-conversation.

A speech start is proof the caller is talking, so it now refreshes the liveness timestamp whether or not the turn is a barge-in.