### PR TITLE
Add Gandr TTS synthesizer

### DIFF
--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -64,6 +64,7 @@ class SynthesizerProvider(str, Enum):
     MAYA = "maya"
     KALPA = "kalpa"
     GEMINI = "gemini"
+    GANDR = "gandr"
 
     @classmethod
     def all_values(cls):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -135,6 +135,11 @@ class GeminiConfig(StandardVoiceConfig):
     style: Optional[str] = None
 
 
+class GandrConfig(BaseModel):
+    voice: str
+    model: Optional[str] = "tts-1"
+
+
 # The config class each provider's provider_config is validated against. Adding a provider means
 # one entry here.
 SYNTHESIZER_CONFIG_MODELS = {
@@ -151,6 +156,7 @@ SYNTHESIZER_CONFIG_MODELS = {
     SynthesizerProvider.MAYA.value: MayaConfig,
     SynthesizerProvider.KALPA.value: KalpaConfig,
     SynthesizerProvider.GEMINI.value: GeminiConfig,
+    SynthesizerProvider.GANDR.value: GandrConfig,
 }
 
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -13,6 +13,7 @@ from .synthesizer import (
     MayaSynthesizer,
     KalpaSynthesizer,
     GeminiSynthesizer,
+    GandrSynthesizer,
 )
 from .transcriber import (
     DeepgramTranscriber,
@@ -73,6 +74,7 @@ SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.MAYA.value: MayaSynthesizer,
     SynthesizerProvider.KALPA.value: KalpaSynthesizer,
     SynthesizerProvider.GEMINI.value: GeminiSynthesizer,
+    SynthesizerProvider.GANDR.value: GandrSynthesizer,
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -13,4 +13,5 @@ from .pixa_synthesizer import PixaSynthesizer
 from .maya_synthesizer import MayaSynthesizer
 from .kalpa_synthesizer import KalpaSynthesizer
 from .gemini_synthesizer import GeminiSynthesizer
+from .gandr_synthesizer import GandrSynthesizer
 from .synthesizer_pool import SynthesizerPool

--- a/bolna/synthesizer/gandr_synthesizer.py
+++ b/bolna/synthesizer/gandr_synthesizer.py
@@ -1,0 +1,66 @@
+import io
+import os
+
+from dotenv import load_dotenv
+from openai import AsyncOpenAI
+
+from .base_synthesizer import BaseSynthesizer
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.utils import convert_audio_to_wav, resample
+
+logger = configure_logger(__name__)
+load_dotenv()
+
+GANDR_TTS_BASE_URL = os.getenv("GANDR_TTS_BASE_URL", "https://tts.gandr.ai/v1")
+
+
+class GandrSynthesizer(BaseSynthesizer):
+    """Gandr TTS (https://gandr.ai). The API is OpenAI compatible (POST /v1/audio/speech,
+    Bearer key), so this mirrors OPENAISynthesizer with the Gandr endpoint, key and
+    voices (gandr-mia, gandr-ava, gandr-jenny, gandr-dane, gandr-leo, gandr-lewis)."""
+
+    def __init__(
+        self, voice="gandr-mia", audio_format="mp3", model="tts-1", stream=False, sampling_rate=8000, buffer_size=400, **kwargs
+    ):
+        super().__init__(kwargs.get("task_manager_instance"), stream, buffer_size)
+        self.voice = voice
+        self.model = model
+        self.sample_rate = int(sampling_rate) if isinstance(sampling_rate, str) else sampling_rate
+        self.stream = False
+        api_key = kwargs.get("synthesizer_key", os.getenv("GANDR_API_KEY"))
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=GANDR_TTS_BASE_URL)
+
+    def supports_websocket(self):
+        return True
+
+    # ------------------------------------------------------------------
+    # BaseSynthesizer hooks
+    # ------------------------------------------------------------------
+
+    def _process_http_audio(self, audio):
+        # Gandr returns mp3 by default; convert and resample to the target rate
+        return resample(convert_audio_to_wav(audio, "mp3"), self.sample_rate, format="wav")
+
+    async def _generate_http(self, text):
+        spoken_response = await self.async_client.audio.speech.create(
+            model=self.model,
+            voice=self.voice,
+            response_format="mp3",
+            input=text,
+        )
+        buffer = io.BytesIO()
+        for chunk in spoken_response.iter_bytes(chunk_size=4096):
+            buffer.write(chunk)
+        buffer.seek(0)
+        return buffer.getvalue()
+
+    async def synthesize(self, text):
+        return await self._generate_http(text)
+
+    # ------------------------------------------------------------------
+    # generate / push use the base _generate_http_loop
+    # ------------------------------------------------------------------
+
+    async def generate(self):
+        async for packet in self._generate_http_loop():
+            yield packet


### PR DESCRIPTION
Adds Gandr (https://gandr.ai) as a synthesizer provider.

Gandr serves an OpenAI compatible speech API (POST https://tts.gandr.ai/v1/audio/speech, Bearer key), so the synthesizer mirrors OPENAISynthesizer and reuses the AsyncOpenAI client with a base_url override plus the base _generate_http_loop. No new dependencies.

Changes:
- bolna/synthesizer/gandr_synthesizer.py: GandrSynthesizer (HTTP, mp3, converted and resampled to the configured sampling_rate)
- bolna/enums.py: SynthesizerProvider.GANDR = "gandr"
- bolna/synthesizer/__init__.py and bolna/providers.py: export and register under "gandr"
- bolna/models.py: GandrConfig wired into the Synthesizer union and preprocess, same pattern as the other providers

Usage:

    "synthesizer": {
      "provider": "gandr",
      "provider_config": {"voice": "gandr-mia", "model": "tts-1"},
      "stream": false,
      "buffer_size": 100
    }

Auth is GANDR_API_KEY (or synthesizer_key), keys at https://gandr.ai; the free tier is 50,000 tokens. Voices: gandr-mia, gandr-ava, gandr-jenny, gandr-dane, gandr-leo, gandr-lewis. 23 languages, every render watermarked. First audio byte in 146 ms over the open internet, 116 ms p50 first audio, server side warm.

Disclosure: I work on Gandr.
