### PR TITLE
fix: mix call recordings with pydub instead of undeclared torch/torchaudio

### DIFF
--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -798,69 +798,62 @@ async def write_request_logs(message, run_id):
 
 
 async def save_audio_file_to_s3(conversation_recording, sampling_rate=24000, assistant_id=None, run_id=None):
-    last_frame_end_time = conversation_recording["output"][0]["start_time"]
     logger.info(f"LENGTH OF OUTPUT AUDIO {len(conversation_recording['output'])}")
-    initial_gap = (last_frame_end_time - conversation_recording["metadata"]["started"]) * 1000
-    logger.info(f"Initial gap {initial_gap}")
-    combined_audio = AudioSegment.silent(duration=initial_gap, frame_rate=sampling_rate)
-    for i, frame in enumerate(conversation_recording["output"]):
-        frame_start_time = frame["start_time"]
-        logger.info(
-            f"Processing frame {i}, fram start time = {last_frame_end_time}, frame start time= {frame_start_time}"
-        )
-        if last_frame_end_time < frame_start_time:
-            gap_duration_samples = frame_start_time - last_frame_end_time
-            silence = AudioSegment.silent(duration=gap_duration_samples * 1000, frame_rate=sampling_rate)
-            combined_audio += silence
-        last_frame_end_time = frame_start_time + frame["duration"]
-        frame_as = AudioSegment.from_file(io.BytesIO(frame["data"]), format="wav")
-        combined_audio += frame_as
 
-    webm_segment = AudioSegment.from_file(io.BytesIO(conversation_recording["input"]["data"]))
-    wav_bytes = io.BytesIO()
-    webm_segment.export(wav_bytes, format="wav")
-    wav_bytes.seek(0)  # Reset the pointer to the start
-    waveform, sample_rate = torchaudio.load(wav_bytes)
-    resampler = torchaudio.transforms.Resample(orig_freq=sample_rate, new_freq=sampling_rate)
-    downsampled_waveform = resampler(waveform)
-    torchaudio_wavio = io.BytesIO()
-    torchaudio.save(torchaudio_wavio, downsampled_waveform, sampling_rate, format="wav")
-    audio_segment_bytes = io.BytesIO()
-    combined_audio.export(audio_segment_bytes, format="wav")
-    audio_segment_bytes.seek(0)
-    waveform_audio_segment, sample_rate = torchaudio.load(audio_segment_bytes)
+    # Bot (agent) channel: stitch the recorded output frames back together, restoring the
+    # silence between them so the timeline matches the real call.
+    output_frames = conversation_recording["output"]
+    if output_frames:
+        last_frame_end_time = output_frames[0]["start_time"]
+        initial_gap = max((last_frame_end_time - conversation_recording["metadata"]["started"]) * 1000, 0)
+        logger.info(f"Initial gap {initial_gap}")
+        combined_audio = AudioSegment.silent(duration=initial_gap, frame_rate=sampling_rate)
+        for i, frame in enumerate(output_frames):
+            frame_start_time = frame["start_time"]
+            logger.info(
+                f"Processing frame {i}, fram start time = {last_frame_end_time}, frame start time= {frame_start_time}"
+            )
+            if last_frame_end_time < frame_start_time:
+                gap_duration_samples = frame_start_time - last_frame_end_time
+                silence = AudioSegment.silent(duration=gap_duration_samples * 1000, frame_rate=sampling_rate)
+                combined_audio += silence
+            last_frame_end_time = frame_start_time + frame["duration"]
+            frame_as = AudioSegment.from_file(io.BytesIO(frame["data"]), format="wav")
+            combined_audio += frame_as
+    else:
+        # No agent audio was recorded; keep an empty bot channel so the mix still succeeds.
+        combined_audio = AudioSegment.silent(duration=0, frame_rate=sampling_rate)
 
-    if waveform_audio_segment.shape[0] > 1:
-        waveform_audio_segment = waveform_audio_segment[:1, :]
+    # User (caller) channel: decode whatever container the input arrived in and normalise it
+    # to the recording's mono 16-bit sampling_rate. pydub + scipy already ship as dependencies,
+    # so the mix is done here instead of pulling in torch/torchaudio (which were never declared
+    # and made this function raise NameError on every recorded call).
+    input_bytes = conversation_recording["input"]["data"]
+    user_channel = decode_audio_segment(input_bytes)
+    if user_channel is None:
+        # A compressed container (e.g. a browser's webm/opus) needs ffmpeg, which the
+        # deployment image ships; WAV/PCM are decoded natively above without it.
+        user_channel = AudioSegment.from_file(io.BytesIO(input_bytes))
+    user_channel = user_channel.set_frame_rate(sampling_rate).set_channels(1).set_sample_width(2)
+    bot_channel = combined_audio.set_frame_rate(sampling_rate).set_channels(1).set_sample_width(2)
 
-    # Adjust shapes to be [1, N] if not already
-    downsampled_waveform = (
-        downsampled_waveform.unsqueeze(0) if downsampled_waveform.dim() == 1 else downsampled_waveform
-    )
-    waveform_audio_segment = (
-        waveform_audio_segment.unsqueeze(0) if waveform_audio_segment.dim() == 1 else waveform_audio_segment
-    )
+    # Pad the shorter channel with trailing silence so both span the full call length before
+    # they are interleaved into a stereo file (left = caller, right = agent).
+    max_duration_ms = max(len(user_channel), len(bot_channel))
+    if len(user_channel) < max_duration_ms:
+        user_channel += AudioSegment.silent(duration=max_duration_ms - len(user_channel), frame_rate=sampling_rate)
+    if len(bot_channel) < max_duration_ms:
+        bot_channel += AudioSegment.silent(duration=max_duration_ms - len(bot_channel), frame_rate=sampling_rate)
 
-    # Ensure both waveforms have the same length
-    max_length = max(downsampled_waveform.size(1), waveform_audio_segment.size(1))
-    downsampled_waveform_padded = torch.nn.functional.pad(
-        downsampled_waveform, (0, max_length - downsampled_waveform.size(1))
-    )
-    waveform_audio_segment_padded = torch.nn.functional.pad(
-        waveform_audio_segment, (0, max_length - waveform_audio_segment.size(1))
-    )
-    stereo_waveform = torch.cat((downsampled_waveform_padded, waveform_audio_segment_padded), 0)
-
-    # Verify the stereo waveform shape is [2, M]
-    assert stereo_waveform.shape[0] == 2, "Stereo waveform should have 2 channels."
-    key = f"{assistant_id + run_id}.wav"
+    stereo_audio = AudioSegment.from_mono_audiosegments(user_channel, bot_channel)
 
     audio_buffer = io.BytesIO()
-    torchaudio.save(audio_buffer, stereo_waveform, 24000, format="wav")
-    audio_buffer.seek(0)
+    stereo_audio.export(audio_buffer, format="wav")
+    audio_data = audio_buffer.getvalue()
 
+    key = f"{assistant_id + run_id}.wav"
     logger.info(f"Storing in {RECORDING_BUCKET_URL}{key}")
-    await store_file(bucket_name=RECORDING_BUCKET_NAME, file_key=key, file_data=audio_buffer, content_type="wav")
+    await store_file(bucket_name=RECORDING_BUCKET_NAME, file_key=key, file_data=audio_data, content_type="wav")
 
     return f"{RECORDING_BUCKET_URL}{key}"
 

--- a/tests/test_save_audio_recording.py
+++ b/tests/test_save_audio_recording.py
@@ -1,0 +1,78 @@
+"""Mixing a recorded call into a stereo WAV must not depend on torch/torchaudio.
+
+save_audio_file_to_s3 used to reference torch/torchaudio, which are not declared
+dependencies and are never imported, so every call with recording enabled raised
+NameError. These tests exercise the mix end to end with pydub only.
+"""
+
+import io
+import wave
+
+import pytest
+
+import bolna.helpers.utils as utils
+from bolna.helpers.utils import save_audio_file_to_s3
+
+
+def _wav_bytes(duration_ms, sample_rate=24000, freq_byte=b"\x10\x00"):
+    """A tiny mono 16-bit WAV of the requested duration."""
+    n_frames = int(sample_rate * duration_ms / 1000)
+    buf = io.BytesIO()
+    with wave.open(buf, "wb") as w:
+        w.setnchannels(1)
+        w.setsampwidth(2)
+        w.setframerate(sample_rate)
+        w.writeframes(freq_byte * n_frames)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def captured_upload(monkeypatch):
+    """Capture what save_audio_file_to_s3 hands to store_file instead of hitting S3."""
+    captured = {}
+
+    async def fake_store_file(bucket_name=None, file_key=None, file_data=None, content_type=None, **kwargs):
+        captured["file_key"] = file_key
+        captured["file_data"] = file_data
+        captured["content_type"] = content_type
+
+    monkeypatch.setattr(utils, "store_file", fake_store_file)
+    monkeypatch.setattr(utils, "RECORDING_BUCKET_URL", "https://recordings.example/")
+    return captured
+
+
+async def test_recording_is_mixed_into_a_stereo_wav(captured_upload):
+    recording = {
+        "metadata": {"started": 0},
+        "input": {"data": _wav_bytes(500)},
+        "output": [
+            {"data": _wav_bytes(200), "start_time": 0.0, "duration": 0.2},
+            {"data": _wav_bytes(200), "start_time": 0.5, "duration": 0.2},
+        ],
+    }
+
+    url = await save_audio_file_to_s3(recording, sampling_rate=24000, assistant_id="agent", run_id="run")
+
+    assert url == "https://recordings.example/agentrun.wav"
+    assert captured_upload["content_type"] == "wav"
+
+    with wave.open(io.BytesIO(captured_upload["file_data"]), "rb") as w:
+        # Caller on one channel, agent on the other.
+        assert w.getnchannels() == 2
+        assert w.getframerate() == 24000
+        assert w.getnframes() > 0
+
+
+async def test_recording_survives_when_no_agent_audio_was_captured(captured_upload):
+    """An empty output list must not IndexError; the caller channel is still saved."""
+    recording = {
+        "metadata": {"started": 0},
+        "input": {"data": _wav_bytes(300)},
+        "output": [],
+    }
+
+    url = await save_audio_file_to_s3(recording, sampling_rate=24000, assistant_id="a", run_id="r")
+
+    assert url.endswith("ar.wav")
+    with wave.open(io.BytesIO(captured_upload["file_data"]), "rb") as w:
+        assert w.getnchannels() == 2


### PR DESCRIPTION
Fixes #1000

### Problem

`save_audio_file_to_s3` (`bolna/helpers/utils.py`) resamples the caller audio and interleaves it with the agent audio into a stereo file using `torchaudio.load/save`, `torchaudio.transforms.Resample`, `torch.nn.functional.pad` and `torch.cat`. Neither `torch` nor `torchaudio` is imported in the module or listed in `requirements.txt`, so the function raises `NameError` the moment it runs — which is every call made with recording enabled (`should_record`), on the teardown path in `TaskManager`.

`ruff check --select F821 bolna/helpers/utils.py` reports all 8 references as undefined names.

It also indexes `conversation_recording["output"][0]` up front, which `IndexError`s when no agent audio was captured.

### Fix

Rebuild the stereo mix using the audio stack that's already a dependency (pydub + numpy/scipy):

- normalise both channels to the recording sample rate,
- pad the shorter channel with trailing silence,
- interleave caller (left) and agent (right) via `AudioSegment.from_mono_audiosegments`.

WAV/PCM input is decoded natively via the existing `decode_audio_segment` helper (no ffmpeg); a compressed container (e.g. a browser's webm) still falls back to ffmpeg exactly as before. The empty-output case is now guarded.

No new dependencies, and `torch`/`torchaudio` are gone.

### Tests

Added `tests/test_save_audio_recording.py`:
- the recording is mixed into a valid 2-channel WAV at the requested sample rate,
- an empty output-frame list no longer errors and still writes the caller channel.

Full suite: `1365 passed, 1 skipped` locally (Python 3.10, matching CI).