### PR TITLE
fix: attach turn/response ids to web-call audio marks

### DIFF
--- a/bolna/output_handlers/default.py
+++ b/bolna/output_handlers/default.py
@@ -145,6 +145,12 @@ class DefaultOutputHandler:
                         "is_final_chunk": meta_info.get("end_of_llm_stream", False)
                         and meta_info.get("end_of_synthesizer_stream", False),
                         "sequence_id": meta_info["sequence_id"],
+                        # Carry the turn/response identifiers (as the telephony handler does) so the
+                        # input handler's ack path can attribute heard text to the right turn and
+                        # sync_history can trim the interrupted response instead of the whole turn.
+                        "turn_id": meta_info.get("turn_id"),
+                        "response_uid": meta_info.get("response_uid"),
+                        "response_group_uid": meta_info.get("response_group_uid"),
                         "sent_ts": time.time(),
                         # Feeds the completion watchdog's playout estimate, as on telephony.
                         "duration": self._playout_duration(packet["data"], meta_info.get("format", "pcm")),

--- a/tests/test_webcall_mark_turn_response_ids.py
+++ b/tests/test_webcall_mark_turn_response_ids.py
@@ -1,0 +1,68 @@
+"""Web-call audio marks must carry turn/response identifiers.
+
+On telephony, each post-mark records turn_id/response_uid/response_group_uid, and both
+the input handler's ack path (record_heard_text / response_heard_by_turn) and TaskManager's
+sync_history rely on them to trim an interrupted response to what the caller actually heard.
+The web (default) output handler used to omit these, so on a barge-in during a web call the
+whole turn was trimmed blindly and heard-text-by-turn was never populated.
+"""
+
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+from bolna.output_handlers.default import DefaultOutputHandler
+
+
+class FakeWebSocket:
+    def __init__(self):
+        self.text_messages = []
+        self.json_messages = []
+
+    async def send_text(self, message):
+        self.text_messages.append(message)
+
+    async def send_json(self, message):
+        self.json_messages.append(message)
+
+
+def _audio_packet():
+    return {
+        "data": b"\x01\x02\x03\x04\x05\x06\x07\x08",
+        "meta_info": {
+            "type": "audio",
+            "format": "pcm",
+            "sequence_id": 1,
+            "turn_id": 7,
+            "response_uid": "resp-1",
+            "response_group_uid": "group-1",
+            "text_synthesized": "hello there",
+            "message_category": "",
+        },
+    }
+
+
+async def test_web_post_mark_carries_turn_and_response_ids():
+    mark_store = MarkEventMetaData()
+    handler = DefaultOutputHandler(io_provider="default", websocket=FakeWebSocket(), mark_event_meta_data=mark_store)
+
+    await handler.handle(_audio_packet())
+
+    # The post-mark (content audio) is the one kept in _mark_history; the pre-mark is excluded.
+    post_marks = list(mark_store._mark_history.values())
+    assert len(post_marks) == 1
+    post_mark = post_marks[0]
+    assert post_mark["turn_id"] == 7
+    assert post_mark["response_uid"] == "resp-1"
+    assert post_mark["response_group_uid"] == "group-1"
+
+
+async def test_heard_text_is_attributed_to_the_turn_on_web_calls():
+    """With the ids present, an incoming ack credits heard text to the right turn/response."""
+    mark_store = MarkEventMetaData()
+    handler = DefaultOutputHandler(io_provider="default", websocket=FakeWebSocket(), mark_event_meta_data=mark_store)
+
+    await handler.handle(_audio_packet())
+    post_mark = list(mark_store._mark_history.values())[0]
+
+    mark_store.record_heard_text(post_mark, post_mark["text_synthesized"])
+
+    assert mark_store.get_heard_text_for_turn(7) == "hello there"
+    assert mark_store.get_heard_text_for_response("resp-1") == "hello there"


### PR DESCRIPTION
Fixes #1001

### Problem

The telephony output handler stamps every post-mark with `turn_id`, `response_uid` and `response_group_uid` (`bolna/output_handlers/telephony.py`). The web-call handler `DefaultOutputHandler.handle` (`bolna/output_handlers/default.py`) builds the equivalent mark but omits those three ids.

Downstream those ids are read back off the mark:

- `input_handlers/default.py::process_mark_message` → `record_heard_text(...)`, `response_heard_by_turn`, `last_heard_turn_id`, `response_heard_by_response` — all keyed by the mark's `turn_id`/`response_uid`.
- `agent_manager/task_manager.py::sync_history` → `_get_latest_turn_id_from_marks` / `_get_latest_response_uid_from_marks` plus the per-turn heard text, used to trim an interrupted response to what was actually heard.

With no ids on the web mark, those lookups are empty on a web call, so heard-text-by-turn is never recorded and `sync_history` falls back to blunt heuristics. A barge-in mid-response then trims the assistant message by the wrong amount, and the transcript sent back to the LLM no longer matches what was spoken. Telephony is unaffected.

### Fix

Stamp the same `turn_id`/`response_uid`/`response_group_uid` on the web post-mark that the telephony handler already sets. One-line-per-field change, no behavioural change for telephony.

### Tests

Added `tests/test_webcall_mark_turn_response_ids.py`:
- the post-mark carries all three identifiers,
- an incoming ack then attributes heard text to the correct turn and response.

Both tests fail on `master` and pass with the change. Full suite: `1365 passed, 1 skipped` locally (Python 3.10, matching CI).