### PR TITLE
fix: keep a strong reference to ObservableVariable async-observer tasks

### DIFF
--- a/bolna/helpers/observable_variable.py
+++ b/bolna/helpers/observable_variable.py
@@ -9,6 +9,11 @@ class ObservableVariable:
     def __init__(self, value):
         self._value = value
         self._observers = []
+        # Strong references to in-flight async-observer tasks. asyncio only keeps a weak
+        # reference to a bare task, so without this the event loop may garbage-collect an
+        # observer coroutine before it finishes — silently dropping lifecycle events such as
+        # agent hangup, end-of-call teardown, and web-call init.
+        self._pending_tasks = set()
 
     def add_observer(self, observer):
         """
@@ -37,9 +42,12 @@ class ObservableVariable:
         for observer in self._observers:
             if inspect.iscoroutinefunction(observer):
                 try:
-                    # If an event loop is already running, schedule the async observer
+                    # If an event loop is already running, schedule the async observer and
+                    # keep a strong reference to the task until it completes (see _pending_tasks).
                     loop = asyncio.get_running_loop()
-                    loop.create_task(observer(new_value))
+                    task = loop.create_task(observer(new_value))
+                    self._pending_tasks.add(task)
+                    task.add_done_callback(self._pending_tasks.discard)
                 except RuntimeError:
                     # No running loop; run the async function in a temporary event loop
                     asyncio.run(observer(new_value))

--- a/tests/test_observable_variable_task_gc.py
+++ b/tests/test_observable_variable_task_gc.py
@@ -1,0 +1,77 @@
+"""ObservableVariable must keep a strong reference to async-observer tasks.
+
+asyncio only holds a weak reference to a bare task returned by loop.create_task, so a
+fire-and-forget observer coroutine can be garbage-collected before it runs to completion.
+The observers registered in TaskManager (agent hangup, end-of-call teardown, web-call init)
+are exactly this pattern, so a dropped task means a dropped lifecycle event.
+"""
+
+import asyncio
+import gc
+
+from bolna.helpers.observable_variable import ObservableVariable
+
+
+async def test_async_observer_task_is_held_until_it_finishes():
+    ov = ObservableVariable(0)
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def observer(_value):
+        started.set()
+        await release.wait()
+
+    ov.add_observer(observer)
+    ov.value = 1
+
+    await asyncio.wait_for(started.wait(), timeout=1)
+    # While the observer is still running, its task must be referenced.
+    assert len(ov._pending_tasks) == 1
+
+    release.set()
+    for _ in range(100):
+        if not ov._pending_tasks:
+            break
+        await asyncio.sleep(0)
+    # Once it completes, the reference is released so nothing leaks.
+    assert len(ov._pending_tasks) == 0
+
+
+async def test_async_observer_runs_to_completion_even_after_gc():
+    ov = ObservableVariable(0)
+    ran = []
+    done = asyncio.Event()
+
+    async def observer(value):
+        await asyncio.sleep(0.02)
+        ran.append(value)
+        done.set()
+
+    ov.add_observer(observer)
+    ov.value = 5
+    # A collection cycle here would reap an unreferenced task; the strong ref must survive it.
+    gc.collect()
+
+    await asyncio.wait_for(done.wait(), timeout=1)
+    assert ran == [5]
+
+
+async def test_sync_observer_is_still_called_directly():
+    ov = ObservableVariable(0)
+    seen = []
+    ov.add_observer(lambda value: seen.append(value))
+
+    ov.value = 42
+
+    assert seen == [42]
+    assert ov._pending_tasks == set()
+
+
+async def test_no_notification_when_value_is_unchanged():
+    ov = ObservableVariable(7)
+    seen = []
+    ov.add_observer(lambda value: seen.append(value))
+
+    ov.value = 7  # unchanged -> observers must not fire
+
+    assert seen == []


### PR DESCRIPTION
Fixes #1004

### Problem

`ObservableVariable._notify_observers` (`bolna/helpers/observable_variable.py`) schedules async observers with `loop.create_task(observer(new_value))` and drops the returned task. asyncio holds only a weak reference to a bare task, so — per the asyncio docs — it "may be garbage-collected at any time, even before it's done."

`TaskManager` registers three async observers this way:

- `agent_hangup_observer`
- `final_chunk_played_observer` (end-of-call teardown)
- `handle_init_event` (web-call init)

so a collected task means a silently dropped lifecycle event — an intermittent hang/teardown/init miss.

### Fix

Hold each scheduled task in a set and remove it on completion via `add_done_callback`, so it stays referenced until it runs to completion without leaking afterwards. Sync observers and the change-detection behaviour are untouched.

### Tests

Added `tests/test_observable_variable_task_gc.py`:
- the task is referenced while running and released once done,
- the observer still runs to completion across a `gc.collect()`,
- sync observers are still called directly,
- observers don't fire when the value is unchanged.

Full suite: `1367 passed, 1 skipped` locally (Python 3.10, matching CI).