### PR TITLE
feat: add Qwen3-ASR transcriber with realtime and open-weights paths

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,5 +1,13 @@
 DEEPGRAM_AUTH_TOKEN=
 SONIOX_API_KEY=
+# Qwen3-ASR, realtime path (stream: true) — Alibaba Model Studio. DASHSCOPE_API_KEY also works.
+QWEN_API_KEY=
+# Optional: Beijing region is dashscope.aliyuncs.com (default is the Singapore gateway)
+QWEN_ASR_HOST=
+# Qwen3-ASR, open-weights path (stream: false) — any OpenAI-compatible /v1/audio/transcriptions
+# host: OpenRouter, DeepInfra, Azure AI Foundry, or a self-hosted `vllm serve Qwen/Qwen3-ASR-1.7B`.
+QWEN_ASR_BASE_URL=
+QWEN_ASR_BATCH_MODEL=
 ELEVENLABS_API_KEY=
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo

--- a/README.md
+++ b/README.md
@@ -260,6 +260,8 @@ These are the current supported ASRs Providers:
 | Provider     | Environment variable to be added in `.env` file |
 |--------------|-------------------------------------------------|
 | Deepgram     | `DEEPGRAM_AUTH_TOKEN`                           |
+| Qwen3-ASR (realtime) | `QWEN_API_KEY` (or `DASHSCOPE_API_KEY`) |
+| Qwen3-ASR (open weights, `stream: false`) | key of whichever OpenAI-compatible host you point `base_url` at |
 
 </details>
 &nbsp;<br>

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -70,6 +70,76 @@ SONIOX_ENDPOINT_TOKEN = "<end>"  # sentinel token emitted when the speaker stops
 SONIOX_DEFAULT_MULTILINGUAL_HINTS = ["en", "hi", "ta", "te", "kn", "ml", "mr", "bn", "gu", "pa", "ur"]
 SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 
+# Qwen3-ASR realtime (Alibaba Cloud Model Studio / DashScope)
+# International (Singapore) gateway. Beijing is dashscope.aliyuncs.com — override via QWEN_ASR_HOST.
+QWEN_ASR_HOST = "dashscope-intl.aliyuncs.com"
+QWEN_ASR_REALTIME_PATH = "/api-ws/v1/realtime"
+QWEN_ASR_DEFAULT_MODEL = "qwen3-asr-flash-realtime"
+# Server-VAD silence before Qwen closes a turn. Bolna's `endpointing` maps onto this; the floor
+# keeps a fast agent config from cutting mid-sentence (Qwen's own default is 800ms).
+QWEN_ASR_MIN_SILENCE_DURATION_MS = 400
+# `.completed` normally lands within ~300ms of speech_stopped. Past this the turn is force-closed
+# with whatever interim text we have, so a dropped final can't hold the agent's reply forever.
+QWEN_ASR_COMPLETION_TIMEOUT_S = 2.0
+# Ceiling on the biasing corpus. The API caps `corpus.text` at 10k tokens; chars are the only
+# budget we can measure locally, and ~4 chars/token leaves headroom for CJK.
+QWEN_ASR_MAX_CORPUS_CHARS = 20000
+# Absent `language`, Qwen auto-detects. These config values mean "don't pin one".
+QWEN_ASR_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
+# Languages qwen3-asr-flash-realtime accepts as an explicit hint. Anything else is sent as
+# auto-detect rather than rejected at the handshake.
+QWEN_ASR_SUPPORTED_LANGUAGES = frozenset(
+    {
+        "zh",
+        "yue",
+        "en",
+        "ja",
+        "de",
+        "ko",
+        "ru",
+        "fr",
+        "pt",
+        "ar",
+        "it",
+        "es",
+        "hi",
+        "id",
+        "th",
+        "tr",
+        "uk",
+        "vi",
+        "cs",
+        "da",
+        "fil",
+        "fi",
+        "is",
+        "ms",
+        "no",
+        "pl",
+        "sv",
+    }
+)
+
+# ── Qwen3-ASR open-weights path (stream=false) ────────────────────────────────
+# The Apache-2.0 models (Qwen3-ASR-1.7B / 0.6B) are served by any host behind an
+# OpenAI-compatible /v1/audio/transcriptions endpoint. That is batch file transcription:
+# no interim results and no server VAD, so endpointing is done locally here.
+# vLLM also exposes /v1/realtime for these weights, but it transcribes each 5s segment in
+# isolation and duplicates speech across boundaries (vllm#35767, closed "not planned"),
+# so the batch endpoint is the only usable open-weights route.
+QWEN_ASR_DEFAULT_BASE_URL = "https://openrouter.ai/api/v1"
+QWEN_ASR_DEFAULT_BATCH_MODEL = "qwen/qwen3-asr-1.7b"
+# Frame RMS above which audio counts as speech, for the local endpointer.
+QWEN_ASR_SPEECH_RMS_THRESHOLD = 300
+# Cap on one buffered utterance. Past this it is flushed regardless of silence, so a caller
+# who never pauses cannot grow the buffer (and the request) without bound.
+QWEN_ASR_MAX_UTTERANCE_S = 25.0
+# HTTP timeout for one transcription request. Sized to not DROP a turn rather than to be
+# fast: measured round trips on the default host/model (OpenRouter -> DeepInfra, 4.5s clip)
+# ranged 1.4s to 52.9s across runs, so anything tighter silently loses the caller's utterance
+# on a slow day. Tune per-deployment with `http_timeout_s` on the transcriber config.
+QWEN_ASR_HTTP_TIMEOUT_S = 60.0
+
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"
 GPT5_4_MODEL_PREFIX = "gpt-5.4"

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -85,6 +85,7 @@ class TranscriberProvider(str, Enum):
     OPENAI = "openai"
     SONIOX = "soniox"
     GEMINI = "gemini"
+    QWEN = "qwen"
 
     @classmethod
     def all_values(cls):

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -160,6 +160,14 @@ class Transcriber(BaseModel):
     noise_reduction: Optional[bool] = False
     vad_threshold: Optional[float] = 0.5
     vad_prefix_padding_ms: Optional[int] = 300
+    # Qwen3-ASR realtime: how long to wait for a final after the server VAD reports speech_stopped
+    completion_timeout: Optional[float] = None
+    # Qwen3-ASR open weights (stream=false): OpenAI-compatible base, e.g. an OpenRouter,
+    # DeepInfra, Azure AI Foundry or self-hosted `vllm serve` host.
+    base_url: Optional[str] = None
+    speech_rms_threshold: Optional[int] = None
+    http_timeout_s: Optional[float] = None
+    max_utterance_s: Optional[float] = None
 
     @field_validator("provider")
     def validate_model(cls, value):

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -26,6 +26,7 @@ from .transcriber import (
     OpenAITranscriber,
     SonioxTranscriber,
     GeminiTranscriber,
+    QwenTranscriber,
 )
 from .input_handlers import (
     DefaultInputHandler,
@@ -86,6 +87,7 @@ SUPPORTED_TRANSCRIBER_PROVIDERS = {
     TranscriberProvider.OPENAI.value: OpenAITranscriber,
     TranscriberProvider.SONIOX.value: SonioxTranscriber,
     TranscriberProvider.GEMINI.value: GeminiTranscriber,
+    TranscriberProvider.QWEN.value: QwenTranscriber,
 }
 
 # Backwards compatibility

--- a/bolna/transcriber/__init__.py
+++ b/bolna/transcriber/__init__.py
@@ -11,5 +11,6 @@ from .smallest_transcriber import SmallestTranscriber
 from .openai_transcriber import OpenAITranscriber
 from .soniox_transcriber import SonioxTranscriber
 from .gemini_transcriber import GeminiTranscriber
+from .qwen_transcriber import QwenTranscriber
 from .transcriber_pool import TranscriberPool
 from bolna.lid import LIDProvider, SarvamLID, SonioxLID

--- a/bolna/transcriber/qwen_transcriber.py
+++ b/bolna/transcriber/qwen_transcriber.py
@@ -1,0 +1,1077 @@
+"""Qwen3-ASR speech-to-text, in two flavours behind one provider name.
+
+"Qwen3-ASR" is two different products, and they need two different clients:
+
+  stream=true  (default) — Qwen3-ASR-Flash-Realtime on Alibaba Model Studio. A hosted
+      WebSocket carrying the OpenAI-Realtime event shape: a `session.update` handshake,
+      base64 PCM in `input_audio_buffer.append`, and transcription events back. Endpointing
+      is Qwen's own server VAD, which is the reason to pick it for a voice agent.
+
+  stream=false — the Apache-2.0 open weights (Qwen3-ASR-1.7B / 0.6B), reached through any
+      host's OpenAI-compatible /v1/audio/transcriptions: OpenRouter, DeepInfra, Azure AI
+      Foundry, or a self-hosted `vllm serve Qwen/Qwen3-ASR-1.7B`. That endpoint is batch
+      file transcription, so this path buffers an utterance, endpoints it locally on frame
+      RMS, and POSTs a WAV. It emits NO interim results — see the caveat below.
+
+Realtime turn lifecycle:
+    input_audio_buffer.speech_started      -> "speech_started"
+    ...transcription.text (text + stash)   -> "interim_transcript_received"
+    input_audio_buffer.speech_stopped      -> arm the completion watchdog
+    ...transcription.completed             -> "transcript"  (or "speech_ended" if empty)
+
+Batch turn lifecycle:
+    frame RMS crosses threshold            -> "speech_started"
+    endpointing_ms of quiet (or the cap)   -> POST the buffer -> "transcript"
+
+CAVEAT on the batch path: task_manager drives barge-in off interim_transcript_received, so
+with no interims the agent cannot be interrupted mid-utterance — it only learns what the
+caller said once they stop. Add a round trip (~1.8s observed on DeepInfra) on top. Good for
+transcription, materially worse for conversational turn latency; prefer stream=true for live
+calls. vLLM's /v1/realtime would in principle fix this, but it transcribes each 5s segment in
+isolation and repeats speech across boundaries (vllm#35767, closed "not planned").
+
+Neither path accepts mulaw, so Twilio and sip-trunk audio is decoded to linear16 first. Sample
+rate is passed through (8k and 16k are both native to Qwen), so nothing resamples on the hot path.
+"""
+
+import asyncio
+import audioop
+import base64
+import json
+import os
+import time
+import traceback
+from urllib.parse import urlencode
+
+import aiohttp
+import websockets
+from dotenv import load_dotenv
+from websockets.asyncio.client import ClientConnection
+from websockets.exceptions import ConnectionClosed, ConnectionClosedError, InvalidHandshake
+
+from .base_transcriber import BaseTranscriber
+from bolna.constants import (
+    QWEN_ASR_AUTO_LANGUAGE_VALUES,
+    QWEN_ASR_COMPLETION_TIMEOUT_S,
+    QWEN_ASR_DEFAULT_BASE_URL,
+    QWEN_ASR_DEFAULT_BATCH_MODEL,
+    QWEN_ASR_DEFAULT_MODEL,
+    QWEN_ASR_HOST,
+    QWEN_ASR_HTTP_TIMEOUT_S,
+    QWEN_ASR_MAX_CORPUS_CHARS,
+    QWEN_ASR_MAX_UTTERANCE_S,
+    QWEN_ASR_MIN_SILENCE_DURATION_MS,
+    QWEN_ASR_REALTIME_PATH,
+    QWEN_ASR_SPEECH_RMS_THRESHOLD,
+    QWEN_ASR_SUPPORTED_LANGUAGES,
+    WEB_BASED_CALL_PROVIDER,
+)
+from bolna.enums import TelephonyProvider
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.ssl_context import get_ssl_context
+from bolna.helpers.utils import create_ws_data_packet, pcm_to_wav_bytes, timestamp_ms
+
+logger = configure_logger(__name__)
+load_dotenv()
+
+# Heartbeat cadence. Qwen defines no KeepAlive frame, so a bare WebSocket ping is the keepalive.
+_HEARTBEAT_INTERVAL_S = 5
+# How long the EOS drain waits for the last `.completed` before closing the socket.
+_EOS_DRAIN_TIMEOUT_S = 5.0
+
+
+class QwenTranscriber(BaseTranscriber):
+    def __init__(
+        self,
+        telephony_provider,
+        input_queue=None,
+        model=QWEN_ASR_DEFAULT_MODEL,
+        stream=True,
+        language="en",
+        endpointing="400",
+        sampling_rate="16000",
+        encoding="linear16",
+        output_queue=None,
+        keywords=None,
+        process_interim_results="true",
+        vad_threshold=None,
+        **kwargs,
+    ):
+        super().__init__(input_queue)
+        self.provider = telephony_provider
+        self.model = model or QWEN_ASR_DEFAULT_MODEL
+        self.stream = stream
+        self.language = language
+        self.encoding = encoding
+        self.sampling_rate = int(sampling_rate) if isinstance(sampling_rate, (str, int)) else 16000
+        self.keywords = keywords
+        self.process_interim_results = process_interim_results
+        self.transcriber_output_queue = output_queue
+        self.connected_via_dashboard = kwargs.get("enforce_streaming", True)
+        self.run_id = kwargs.get("run_id")
+
+        # Bolna's `endpointing` is the silence the agent tolerates before replying; that is exactly
+        # what Qwen's server VAD measures, so it maps straight onto silence_duration_ms.
+        self.endpointing_ms = int(endpointing) if endpointing is not None else 400
+        self.silence_duration_ms = max(QWEN_ASR_MIN_SILENCE_DURATION_MS, self.endpointing_ms)
+        # threshold=0.0 is meaningful to Qwen (accept everything), so `is not None` — not truthiness.
+        self.vad_threshold = float(vad_threshold) if vad_threshold is not None else None
+
+        self.api_key = kwargs.get("transcriber_key") or os.getenv("QWEN_API_KEY") or os.getenv("DASHSCOPE_API_KEY")
+        self.qwen_host = kwargs.get("transcriber_host") or os.getenv("QWEN_ASR_HOST", QWEN_ASR_HOST)
+        self.workspace_id = kwargs.get("transcriber_workspace") or os.getenv("DASHSCOPE_WORKSPACE_ID")
+
+        # ── open-weights batch path (stream=false) ────────────────────────────────
+        self.base_url = (kwargs.get("base_url") or os.getenv("QWEN_ASR_BASE_URL") or QWEN_ASR_DEFAULT_BASE_URL).rstrip(
+            "/"
+        )
+        # A realtime model id posted to /v1/audio/transcriptions is a 404 nobody enjoys
+        # debugging, so a config that only flipped `stream` still lands on a servable model.
+        if not self.stream and self.model == QWEN_ASR_DEFAULT_MODEL:
+            self.model = kwargs.get("batch_model") or os.getenv("QWEN_ASR_BATCH_MODEL") or QWEN_ASR_DEFAULT_BATCH_MODEL
+            logger.info(f"Qwen ASR: stream=false with a realtime model id — using {self.model!r} instead")
+        _rms = kwargs.get("speech_rms_threshold")
+        self.speech_rms_threshold = int(_rms) if _rms is not None else QWEN_ASR_SPEECH_RMS_THRESHOLD
+        self.max_utterance_s = float(kwargs.get("max_utterance_s") or QWEN_ASR_MAX_UTTERANCE_S)
+        self.http_timeout_s = float(kwargs.get("http_timeout_s") or QWEN_ASR_HTTP_TIMEOUT_S)
+        self._http_session = None
+        self._utterance_buffer = bytearray()
+        # Seconds of audio actually transcribed this connection. task_manager accumulates this
+        # off the transcriber_connection_closed packet for ASR usage accounting, so leaving it
+        # unset bills every qwen call as zero.
+        self.total_audio_seconds = 0.0
+        self._speech_active = False
+        self._silence_started_at = None
+        self._utterance_started_at = None
+
+        # Connection + task state
+        self.websocket_connection = None
+        self.connection_authenticated = False
+        self.connection_error = None
+        self.transcription_task = None
+        self.sender_task = None
+        self.heartbeat_task = None
+        self.completion_timeout_task = None
+
+        # Per-stream audio bookkeeping (reset on each connect in transcribe())
+        self.audio_submitted = False
+        self.audio_submission_time = None
+        self.num_frames = 0
+        self.connection_start_time = None
+        self.audio_frame_duration = 0.5
+        self.meta_info = {}
+
+        # Per-turn transcript state
+        self.turn_counter = 0
+        self.current_turn_id = None
+        self.current_turn_start_time = None
+        self._turn_first_speech_epoch_ms = None
+        self.current_turn_interim_details = []
+        self.last_interim_transcript = ""
+        self.last_interim_time = None
+        self._first_result_received = False
+        # Set at speech_stopped; the watchdog force-finalizes if `.completed` never follows.
+        self._speech_stopped_at = None
+        # Wall-clock of speech_stopped, reported downstream as when the caller actually stopped.
+        self._speech_stopped_wall = None
+        self._last_detected_language = None
+        self._last_detected_emotion = None
+        # Lets the EOS drain in sender_stream wait for the trailing `.completed`.
+        self._final_transcript_event = asyncio.Event()
+        self.completion_timeout = float(kwargs.get("completion_timeout") or QWEN_ASR_COMPLETION_TIMEOUT_S)
+
+        self._configure_audio_params()
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def _configure_audio_params(self):
+        """Resolve encoding / sample rate / frame duration from the call's I/O provider.
+
+        `self.encoding` describes what arrives on input_queue, not what Qwen receives — the
+        mulaw case is decoded in _to_pcm16(). TranscriberPool also reads this attribute to pick
+        the right silence byte for standby keepalives, so it must stay truthful to the input.
+        """
+        if self.provider in TelephonyProvider.telephony_values():
+            self.encoding = "mulaw" if self.provider in TelephonyProvider.mulaw_values() else "linear16"
+            self.sampling_rate = 8000
+            self.audio_frame_duration = 0.2
+        elif self.provider == WEB_BASED_CALL_PROVIDER:
+            self.encoding = "linear16"
+            self.sampling_rate = 16000
+            self.audio_frame_duration = 0.256
+        elif not self.connected_via_dashboard:
+            self.encoding = "linear16"
+            self.sampling_rate = 16000
+            self.audio_frame_duration = 0.2
+        else:
+            self.audio_frame_duration = 0.2
+
+        if self.provider == "playground":
+            self.sampling_rate = 8000
+            self.audio_frame_duration = 0.0
+
+    def _resolve_language(self):
+        """Concrete supported code -> pin it; auto/multi/unknown -> None (Qwen auto-detects)."""
+        lang = (self.language or "").lower()
+        if lang in QWEN_ASR_AUTO_LANGUAGE_VALUES:
+            return None
+        # Deepgram-style "multi-hi" means auto-detect biased to Hindi; Qwen has no such form,
+        # so take the concrete half rather than pinning the literal "multi-hi".
+        if lang.startswith("multi-"):
+            lang = lang.split("-", 1)[1]
+        # "en-US" / "zh-CN" -> the base code Qwen names.
+        base = lang.split("-")[0]
+        if base in QWEN_ASR_SUPPORTED_LANGUAGES:
+            return base
+        logger.warning(f"Qwen ASR: language {self.language!r} not in supported set — falling back to auto-detect")
+        return None
+
+    def _build_corpus(self):
+        """Bolna keywords -> Qwen's biasing corpus, or None when there is nothing to bias."""
+        if not self.keywords:
+            return None
+        terms = [kw.strip() for kw in self.keywords.split(",") if kw.strip()]
+        if not terms:
+            return None
+        text = ", ".join(terms)
+        if len(text) > QWEN_ASR_MAX_CORPUS_CHARS:
+            # Truncate on a term boundary: a half-word left in the corpus biases toward a
+            # string the caller will never say.
+            text = text[:QWEN_ASR_MAX_CORPUS_CHARS].rsplit(",", 1)[0]
+            logger.warning(f"Qwen ASR: biasing corpus truncated to {len(text)} chars")
+        return {"text": text}
+
+    def _build_session_config(self):
+        """The `session.update` payload sent as the first frame after connecting."""
+        transcription = {}
+        language = self._resolve_language()
+        if language:
+            transcription["language"] = language
+        corpus = self._build_corpus()
+        if corpus:
+            transcription["corpus"] = corpus
+
+        turn_detection = {
+            "type": "server_vad",
+            "silence_duration_ms": self.silence_duration_ms,
+        }
+        if self.vad_threshold is not None:
+            turn_detection["threshold"] = self.vad_threshold
+
+        session = {
+            "input_audio_format": "pcm",
+            "sample_rate": int(self.sampling_rate),
+            "turn_detection": turn_detection,
+        }
+        if transcription:
+            session["input_audio_transcription"] = transcription
+        return {"type": "session.update", "session": session}
+
+    def get_qwen_ws_url(self):
+        protocol = os.getenv("QWEN_ASR_HOST_PROTOCOL", "wss")
+        params = {"model": self.model}
+        return f"{protocol}://{self.qwen_host}{QWEN_ASR_REALTIME_PATH}?{urlencode(params)}"
+
+    # ------------------------------------------------------------------
+    # Audio
+    # ------------------------------------------------------------------
+
+    def _to_pcm16(self, audio_bytes):
+        """Decode mulaw to linear16; pass PCM through untouched.
+
+        Sample rate is never changed — Qwen takes 8k natively, so telephony audio needs no
+        resampling and the frame stays byte-identical for the linear16 providers.
+        """
+        if self.encoding != "mulaw":
+            return audio_bytes
+        try:
+            return audioop.ulaw2lin(audio_bytes, 2)
+        except Exception as e:
+            logger.error(f"Qwen ASR: mulaw decode failed, dropping frame: {e}")
+            return None
+
+    # ------------------------------------------------------------------
+    # Turn bookkeeping
+    # ------------------------------------------------------------------
+
+    def _start_turn(self):
+        self.turn_counter += 1
+        self.current_turn_id = self.turn_counter
+        now = timestamp_ms()
+        self.current_turn_start_time = now
+        self._turn_first_speech_epoch_ms = now
+        self.current_turn_interim_details = []
+        self.last_interim_transcript = ""
+        self.last_interim_time = None
+        self._first_result_received = False
+        self._speech_stopped_at = None
+        self._speech_stopped_wall = None
+        self.is_transcript_sent_for_processing = False
+        self._final_transcript_event.clear()
+        self.turn_latencies.append(
+            {
+                "turn_id": self.current_turn_id,
+                "asr_start_epoch_ms": self.current_turn_start_time,
+                "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+            }
+        )
+        logger.info(f"Qwen ASR: starting turn {self.current_turn_id}")
+
+    def _reset_turn_state(self):
+        self.current_turn_id = None
+        self.current_turn_start_time = None
+        self._turn_first_speech_epoch_ms = None
+        self.current_turn_interim_details = []
+        self.last_interim_transcript = ""
+        self.last_interim_time = None
+        self._speech_stopped_at = None
+        self._speech_stopped_wall = None
+        self.is_transcript_sent_for_processing = True
+
+    def _mark_last_interim_final(self):
+        if not self.current_turn_interim_details:
+            return
+        for entry in self.current_turn_interim_details:
+            entry["is_final"] = False
+        self.current_turn_interim_details[-1]["is_final"] = True
+
+    def _build_finalized_turn_latency(self, final_transcript, force_finalized=False):
+        self._mark_last_interim_final()
+        first_interim_to_final_ms, last_interim_to_final_ms = self.calculate_interim_to_final_latencies(
+            self.current_turn_interim_details
+        )
+        entry = {
+            "turn_id": self.current_turn_id,
+            "asr_start_epoch_ms": self.current_turn_start_time,
+            "asr_turn_start_epoch_ms": self._turn_first_speech_epoch_ms,
+            "asr_finalized_epoch_ms": timestamp_ms(),
+            "final_transcript": final_transcript,
+            "interim_details": self.current_turn_interim_details,
+            "first_interim_to_final_ms": first_interim_to_final_ms,
+            "last_interim_to_final_ms": last_interim_to_final_ms,
+        }
+        if self._speech_stopped_wall is not None:
+            entry["user_speech_end_epoch_ms"] = self._speech_stopped_wall * 1000
+        if force_finalized:
+            entry["force_finalized"] = True
+        self._upsert_turn_latency(entry)
+
+    def _stamp_turn_meta(self):
+        """Attach the per-turn signals the task manager reads off a final transcript."""
+        # The caller stopped talking one silence-window before the turn closed, and the
+        # interruption manager needs that offset to place the boundary. Which window depends
+        # on who did the endpointing: Qwen's server VAD, or our local RMS gate.
+        self.meta_info["user_stop_offset_ms"] = self.silence_duration_ms if self.stream else self.endpointing_ms
+        if self._speech_stopped_wall is not None:
+            self.meta_info["user_stop_ts_wall"] = self._speech_stopped_wall
+            self.meta_info["last_vocal_frame_timestamp"] = self._speech_stopped_wall
+        if self._last_detected_language:
+            self.meta_info["transcriber_detected_language"] = self._last_detected_language
+            # Only retarget TTS when no language was pinned — otherwise a single mis-tagged
+            # turn would move the agent's voice off the language the agent was configured for.
+            if self._resolve_language() is None:
+                self.meta_info["detected_language_code"] = self._last_detected_language
+        if self._last_detected_emotion:
+            # Qwen returns one of seven emotions per turn; passed through as telemetry only.
+            self.meta_info["transcriber_detected_emotion"] = self._last_detected_emotion
+
+    # ------------------------------------------------------------------
+    # Connection
+    # ------------------------------------------------------------------
+
+    async def qwen_connect(self) -> ClientConnection:
+        if not self.api_key:
+            raise ValueError("Qwen ASR: no API key (set QWEN_API_KEY / DASHSCOPE_API_KEY or pass transcriber_key)")
+
+        url = self.get_qwen_ws_url()
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        if self.workspace_id:
+            headers["X-DashScope-WorkSpace"] = self.workspace_id
+
+        try:
+            logger.info(f"Connecting to Qwen ASR realtime: {url}")
+            ws = await asyncio.wait_for(
+                websockets.connect(url, additional_headers=headers, ssl=get_ssl_context(url)),
+                timeout=10.0,
+            )
+            config = self._build_session_config()
+            await ws.send(json.dumps(config))
+            self.websocket_connection = ws
+            self.connection_authenticated = True
+            logger.info(
+                f"Connected to Qwen ASR (model={self.model}, sample_rate={self.sampling_rate}, "
+                f"input_encoding={self.encoding}, silence_duration_ms={self.silence_duration_ms}, "
+                f"language={self._resolve_language() or 'auto'})"
+            )
+            return ws
+        except asyncio.TimeoutError:
+            raise ConnectionError("Timeout while connecting to Qwen ASR websocket")
+        except InvalidHandshake as e:
+            err = str(e)
+            if "401" in err or "403" in err:
+                raise ConnectionError(f"Qwen ASR auth failed: {e}")
+            raise ConnectionError(f"Qwen ASR handshake failed: {e}")
+        except ConnectionClosedError as e:
+            raise ConnectionError(f"Qwen ASR websocket closed unexpectedly: {e}")
+        except Exception as e:
+            raise ConnectionError(f"Unexpected error connecting to Qwen ASR websocket: {e}")
+
+    async def send_heartbeat(self, ws: ClientConnection):
+        """Qwen defines no KeepAlive frame; a WebSocket ping is the keepalive."""
+        try:
+            while True:
+                await asyncio.sleep(_HEARTBEAT_INTERVAL_S)
+                try:
+                    pong_waiter = await ws.ping()
+                    await asyncio.wait_for(pong_waiter, timeout=10)
+                except asyncio.TimeoutError:
+                    logger.warning("Qwen ASR heartbeat ping timeout — connection may be stale")
+                    break
+                except ConnectionClosed:
+                    break
+                except Exception as e:
+                    logger.error(f"Error sending Qwen ASR heartbeat: {e}")
+                    break
+        except asyncio.CancelledError:
+            logger.info("Qwen ASR heartbeat task cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Error in Qwen ASR send_heartbeat: {e}")
+
+    # ------------------------------------------------------------------
+    # Sender
+    # ------------------------------------------------------------------
+
+    async def sender_stream(self, ws: ClientConnection):
+        try:
+            while True:
+                ws_data_packet = await self.input_queue.get()
+
+                if not self.audio_submitted:
+                    packet_meta = ws_data_packet.get("meta_info")
+                    # Standby keepalive frames carry an empty meta_info; adopting it would
+                    # publish transcripts under a meta with no request_id.
+                    if packet_meta:
+                        self.meta_info = packet_meta
+                        self.audio_submitted = True
+                        self.audio_submission_time = time.time()
+                        self.current_request_id = self.generate_request_id()
+                        self.meta_info["request_id"] = self.current_request_id
+
+                if (ws_data_packet.get("meta_info") or {}).get("eos") is True:
+                    await self._drain_and_finish(ws)
+                    break
+
+                raw_audio = ws_data_packet.get("data")
+                if not raw_audio:
+                    continue
+
+                pcm = self._to_pcm16(raw_audio)
+                if not pcm:
+                    continue
+
+                self.num_frames += 1
+                self.total_audio_seconds += len(pcm) / 2 / self.sampling_rate
+                try:
+                    await ws.send(
+                        json.dumps(
+                            {
+                                "type": "input_audio_buffer.append",
+                                "audio": base64.b64encode(pcm).decode(),
+                            }
+                        )
+                    )
+                except ConnectionClosed as e:
+                    logger.error(f"Qwen ASR connection closed while sending audio: {e}")
+                    break
+                except Exception as e:
+                    logger.error(f"Error sending audio to Qwen ASR: {e}")
+                    break
+        except asyncio.CancelledError:
+            logger.info("Qwen ASR sender stream task cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Error in Qwen ASR sender_stream: {e}")
+            raise
+
+    async def _drain_and_finish(self, ws: ClientConnection):
+        """On EOS: ask Qwen to finish, give the trailing final a moment to land, then close."""
+        try:
+            # Commit first so a turn still open at hangup is transcribed rather than discarded;
+            # with server VAD the buffer is otherwise only flushed on the next silence.
+            if self.current_turn_id is not None:
+                await ws.send(json.dumps({"type": "input_audio_buffer.commit"}))
+            await ws.send(json.dumps({"type": "session.finish"}))
+        except Exception as e:
+            logger.error(f"Error sending Qwen ASR session.finish: {e}")
+            return
+
+        if self.current_turn_id is not None:
+            try:
+                await asyncio.wait_for(self._final_transcript_event.wait(), timeout=_EOS_DRAIN_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.warning("Qwen ASR: timeout waiting for final transcript after EOS")
+
+    # ------------------------------------------------------------------
+    # Receiver
+    # ------------------------------------------------------------------
+
+    async def receiver(self, ws: ClientConnection):
+        try:
+            async for message in ws:
+                try:
+                    data = json.loads(message) if isinstance(message, str) else {}
+                except Exception:
+                    logger.error(f"Qwen ASR: non-JSON frame received: {str(message)[:200]}")
+                    continue
+
+                try:
+                    event_type = data.get("type", "")
+
+                    if self.connection_start_time is None:
+                        self.connection_start_time = time.time() - (self.num_frames * self.audio_frame_duration)
+
+                    if event_type == "input_audio_buffer.speech_started":
+                        # A turn already open means Qwen re-opened without closing the last one;
+                        # release it so the pending transcript isn't stranded.
+                        if self.current_turn_id is not None:
+                            async for packet in self._close_open_turn():
+                                yield packet
+                        self._start_turn()
+                        yield create_ws_data_packet("speech_started", self.meta_info)
+
+                    elif event_type == "conversation.item.input_audio_transcription.text":
+                        if self.current_turn_id is None and self._interim_has_text(data):
+                            # Interim with no preceding speech_started — open the turn here so
+                            # downstream interruption handling still sees a turn boundary.
+                            self._start_turn()
+                            yield create_ws_data_packet("speech_started", self.meta_info)
+                        packet = self._handle_interim(data)
+                        if packet is not None:
+                            yield packet
+
+                    elif event_type == "input_audio_buffer.speech_stopped":
+                        if self.current_turn_id is None:
+                            logger.info("Qwen ASR: speech_stopped with no open turn — ignoring")
+                        else:
+                            self._speech_stopped_at = time.time()
+                            self._speech_stopped_wall = self._speech_stopped_at - (self.silence_duration_ms / 1000.0)
+                            logger.info(f"Qwen ASR: speech stopped on turn {self.current_turn_id}")
+
+                    elif event_type == "conversation.item.input_audio_transcription.completed":
+                        for packet in self._handle_completed(data):
+                            yield packet
+
+                    elif event_type == "conversation.item.input_audio_transcription.failed":
+                        err = data.get("error", {}) or {}
+                        logger.error(f"Qwen ASR transcription failed for item {data.get('item_id')}: {err}")
+                        self._final_transcript_event.set()
+                        # Close the turn so callee_speaking clears; a failed item has no text.
+                        async for packet in self._close_open_turn():
+                            yield packet
+
+                    elif event_type == "error":
+                        err = data.get("error", {}) or {}
+                        self.connection_error = f"{err.get('code')}: {err.get('message')}"
+                        logger.error(f"Qwen ASR error event: {err}")
+                        # Session-level errors are terminal — the socket will not recover.
+                        if err.get("type") == "invalid_request_error":
+                            break
+
+                    elif event_type == "session.finished":
+                        logger.info(
+                            f"Qwen ASR session finished — num_frames={self.num_frames} turns={self.turn_counter}"
+                        )
+                        break
+
+                    elif event_type in (
+                        "session.created",
+                        "session.updated",
+                        "input_audio_buffer.committed",
+                        "conversation.item.created",
+                    ):
+                        logger.info(f"Qwen ASR session event: {event_type} | {json.dumps(data)[:400]}")
+
+                    else:
+                        logger.info(f"Qwen ASR unhandled event: {event_type} | {json.dumps(data)[:300]}")
+
+                except Exception:
+                    traceback.print_exc()
+
+        except ConnectionClosedError as e:
+            logger.error(f"Qwen ASR websocket closed during receiver: {e}")
+            self.connection_error = str(e)
+        except Exception:
+            traceback.print_exc()
+
+    @staticmethod
+    def _running_utterance(data):
+        """Qwen splits a partial into `text` (settled prefix) and `stash` (pre-recognized tail);
+        the running utterance is their concatenation."""
+        return ((data.get("text") or "") + (data.get("stash") or "")).strip()
+
+    def _interim_has_text(self, data):
+        return bool(self._running_utterance(data))
+
+    def _handle_interim(self, data):
+        """Build an interim packet from a `.text` event, or None if it carries no new text."""
+        running = self._running_utterance(data)
+        if not running:
+            return None
+
+        if data.get("language"):
+            self._last_detected_language = data["language"]
+        if data.get("emotion"):
+            self._last_detected_emotion = data["emotion"]
+
+        received_at = time.time()
+        if not self._first_result_received and self.audio_submission_time:
+            latency = received_at - self.audio_submission_time
+            self.meta_info["transcriber_first_result_latency"] = latency
+            self.meta_info["transcriber_latency"] = latency
+            self._first_result_received = True
+
+        # Qwen re-sends an unchanged partial while the stash settles; task_manager already
+        # dedupes, but dropping it here keeps interim_details from inflating turn latencies.
+        if running == self.last_interim_transcript:
+            return None
+        self.last_interim_transcript = running
+        self.last_interim_time = received_at
+        self.current_turn_interim_details.append(
+            {
+                "transcript": running,
+                "received_at": received_at,
+                "is_final": False,
+            }
+        )
+        return create_ws_data_packet({"type": "interim_transcript_received", "content": running}, self.meta_info)
+
+    def _handle_completed(self, data):
+        """Turn a `.completed` event into the final transcript packet (or a bare turn close)."""
+        transcript = (data.get("transcript") or "").strip()
+        if data.get("language"):
+            self._last_detected_language = data["language"]
+        if data.get("emotion"):
+            self._last_detected_emotion = data["emotion"]
+
+        # Always unblock the EOS drain, even for an empty result.
+        self._final_transcript_event.set()
+
+        if self.is_transcript_sent_for_processing and self.current_turn_id is None:
+            # Late duplicate after the watchdog already force-finalized this turn. Re-delivering
+            # it would replay the user turn to the LLM.
+            logger.info(f"Qwen ASR: dropping late completed event for already-closed turn: {transcript[:80]!r}")
+            return
+
+        if not transcript:
+            logger.info("Qwen ASR: completed event with empty transcript — closing turn")
+            yield create_ws_data_packet({"type": "speech_ended"}, self.meta_info)
+            self._reset_turn_state()
+            return
+
+        item_id = data.get("item_id")
+        if item_id:
+            self.previous_request_id = self.current_request_id
+            self.current_request_id = item_id
+            self.meta_info["request_id"] = item_id
+            self.meta_info["previous_request_id"] = self.previous_request_id
+
+        self._build_finalized_turn_latency(transcript)
+        self._stamp_turn_meta()
+        logger.info(f"Qwen ASR: final transcript for turn {self.current_turn_id}: {transcript[:120]}")
+        yield create_ws_data_packet({"type": "transcript", "content": transcript}, self.meta_info)
+        self._reset_turn_state()
+
+    async def _close_open_turn(self):
+        """Release an open turn that will get no `.completed`, delivering any buffered text."""
+        if self.current_turn_id is None:
+            return
+        transcript = self.last_interim_transcript.strip()
+        if transcript:
+            self._build_finalized_turn_latency(transcript, force_finalized=True)
+            self._stamp_turn_meta()
+            logger.warning(f"Qwen ASR: force-finalizing turn {self.current_turn_id}: {transcript[:120]}")
+            yield create_ws_data_packet(
+                {"type": "transcript", "content": transcript, "force_finalized": True}, self.meta_info
+            )
+        else:
+            yield create_ws_data_packet({"type": "speech_ended"}, self.meta_info)
+        self._reset_turn_state()
+
+    # ------------------------------------------------------------------
+    # Watchdog
+    # ------------------------------------------------------------------
+
+    def _completion_is_overdue(self, now):
+        """True if speech_stopped fired on an open turn but `.completed` never arrived in time.
+
+        The open-turn check is not redundant: _close_open_turn is a no-op without one, so a
+        stopped-but-turnless state would re-fire this every tick for the rest of the call.
+        """
+        if self.current_turn_id is None or self._speech_stopped_at is None:
+            return False
+        if self.is_transcript_sent_for_processing:
+            return False
+        return (now - self._speech_stopped_at) > self.completion_timeout
+
+    async def monitor_completion_timeout(self):
+        """Force-close a turn Qwen stopped but never finalized.
+
+        Without this a dropped `.completed` holds the agent's reply for the rest of the call:
+        the task manager keeps waiting on a transcript that is never coming.
+        """
+        try:
+            while True:
+                await asyncio.sleep(0.2)
+                if self._completion_is_overdue(time.time()):
+                    logger.warning(
+                        f"Qwen ASR: no completed event {self.completion_timeout}s after speech_stopped "
+                        f"(turn {self.current_turn_id}) — force-closing turn"
+                    )
+                    self._final_transcript_event.set()
+                    async for packet in self._close_open_turn():
+                        await self.push_to_transcriber_queue(packet)
+        except asyncio.CancelledError:
+            logger.info("Qwen ASR completion timeout monitor cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Qwen ASR completion timeout monitor error: {e}")
+            raise
+
+    # ------------------------------------------------------------------
+    # Open-weights batch path (stream=false)
+    # ------------------------------------------------------------------
+
+    @property
+    def transcriptions_url(self):
+        return f"{self.base_url}/audio/transcriptions"
+
+    @staticmethod
+    def _rms(pcm):
+        """Frame loudness. audioop raises on a partial sample, which a short tail can be."""
+        try:
+            return audioop.rms(pcm, 2) if len(pcm) >= 2 else 0
+        except audioop.error:
+            return 0
+
+    def _batch_frame_is_speech(self, pcm):
+        return self._rms(pcm) > self.speech_rms_threshold
+
+    def _utterance_is_overlong(self, now):
+        """True once a caller who never pauses has filled the cap — flush without a silence."""
+        if self._utterance_started_at is None:
+            return False
+        return (now - self._utterance_started_at) > self.max_utterance_s
+
+    async def _post_transcription(self, pcm):
+        """POST buffered PCM as a WAV to the OpenAI-compatible endpoint; return text or None."""
+        if self._http_session is None:
+            self._http_session = aiohttp.ClientSession()
+
+        wav = pcm_to_wav_bytes(bytes(pcm), sample_rate=self.sampling_rate)
+        form = aiohttp.FormData()
+        form.add_field("file", wav, filename="utterance.wav", content_type="audio/wav")
+        form.add_field("model", self.model)
+        form.add_field("response_format", "json")
+        language = self._resolve_language()
+        if language:
+            form.add_field("language", language)
+
+        started = time.time()
+        try:
+            async with self._http_session.post(
+                self.transcriptions_url,
+                data=form,
+                headers={"Authorization": f"Bearer {self.api_key}"},
+                timeout=aiohttp.ClientTimeout(total=self.http_timeout_s),
+            ) as resp:
+                body = await resp.text()
+                if resp.status != 200:
+                    self.connection_error = f"HTTP {resp.status}: {body[:200]}"
+                    logger.error(f"Qwen ASR batch request failed — {self.connection_error}")
+                    return None
+                try:
+                    payload = json.loads(body)
+                    text = (payload.get("text") or "").strip()
+                except Exception:
+                    logger.error(f"Qwen ASR batch: unparseable response: {body[:200]}")
+                    return None
+        except asyncio.TimeoutError:
+            # Record it: the non-200 branch sets connection_error, and without the same here a
+            # timed-out turn vanishes from the call record with no trace of why.
+            self.connection_error = f"transcription timed out after {self.http_timeout_s}s"
+            logger.error(f"Qwen ASR batch request timed out after {self.http_timeout_s}s — utterance dropped")
+            return None
+        except Exception as e:
+            logger.error(f"Qwen ASR batch request error: {e}")
+            return None
+
+        # Bill what the host says it processed when it reports it (OpenRouter returns
+        # usage.seconds); otherwise the buffer length, which is the same audio.
+        reported = (payload.get("usage") or {}).get("seconds") if isinstance(payload.get("usage"), dict) else None
+        self.total_audio_seconds += float(reported) if reported else len(pcm) / 2 / self.sampling_rate
+
+        latency = time.time() - started
+        self.meta_info["transcriber_latency"] = latency
+        logger.info(f"Qwen ASR batch: {len(pcm)} bytes → {latency:.2f}s → {text[:120]!r}")
+        return text
+
+    async def _flush_utterance(self):
+        """Transcribe and emit the buffered utterance, then close the turn."""
+        pcm, self._utterance_buffer = self._utterance_buffer, bytearray()
+        self._speech_active = False
+        self._silence_started_at = None
+        self._utterance_started_at = None
+
+        # Below ~200ms there is nothing a recogniser can do but hallucinate a word.
+        if len(pcm) < self.sampling_rate // 5 * 2:
+            logger.info("Qwen ASR batch: utterance too short to transcribe, closing turn")
+            await self.push_to_transcriber_queue(create_ws_data_packet({"type": "speech_ended"}, self.meta_info))
+            self._reset_turn_state()
+            return
+
+        text = await self._post_transcription(pcm)
+        if not text:
+            await self.push_to_transcriber_queue(create_ws_data_packet({"type": "speech_ended"}, self.meta_info))
+            self._reset_turn_state()
+            return
+
+        self._build_finalized_turn_latency(text)
+        self._stamp_turn_meta()
+        await self.push_to_transcriber_queue(
+            create_ws_data_packet({"type": "transcript", "content": text}, self.meta_info)
+        )
+        self._reset_turn_state()
+
+    async def transcribe_http(self):
+        """Buffer audio, endpoint it locally on frame RMS, and POST each utterance.
+
+        The endpoint is batch, so this is where the turn boundary has to come from — the
+        provider is not going to tell us. Mirrors the shape sarvam_transcriber uses.
+        """
+        logger.info(
+            f"Qwen ASR batch mode: {self.transcriptions_url} model={self.model} "
+            f"rate={self.sampling_rate} encoding={self.encoding} "
+            f"endpointing={self.endpointing_ms}ms rms_threshold={self.speech_rms_threshold}"
+        )
+        if not self.api_key:
+            self.connection_error = "Qwen ASR: no API key for the batch endpoint"
+            logger.error(self.connection_error)
+
+        try:
+            while True:
+                try:
+                    packet = await asyncio.wait_for(self.input_queue.get(), timeout=0.1)
+                except asyncio.TimeoutError:
+                    # No audio arriving still advances the silence clock, or a turn that ends
+                    # exactly when the stream goes quiet would never be flushed.
+                    if self._speech_active and self._silence_started_at is not None:
+                        if (time.time() - self._silence_started_at) * 1000 >= self.endpointing_ms:
+                            await self._flush_utterance()
+                    continue
+
+                meta = packet.get("meta_info")
+                if meta and not self.audio_submitted:
+                    self.meta_info = meta
+                    self.audio_submitted = True
+                    self.audio_submission_time = time.time()
+                    self.current_request_id = self.generate_request_id()
+                    self.meta_info["request_id"] = self.current_request_id
+
+                if (meta or {}).get("eos") is True:
+                    if self._speech_active:
+                        logger.info("Qwen ASR batch: EOS with a turn open — flushing it")
+                        await self._flush_utterance()
+                    break
+
+                raw = packet.get("data")
+                if not raw:
+                    continue
+                pcm = self._to_pcm16(raw)
+                if not pcm:
+                    continue
+                self.num_frames += 1
+
+                now = time.time()
+                if self._batch_frame_is_speech(pcm):
+                    self._silence_started_at = None
+                    if not self._speech_active:
+                        self._speech_active = True
+                        self._utterance_started_at = now
+                        self._start_turn()
+                        await self.push_to_transcriber_queue(create_ws_data_packet("speech_started", self.meta_info))
+                    self._utterance_buffer.extend(pcm)
+                elif self._speech_active:
+                    # Trailing quiet belongs to the utterance — cutting it strands the last word.
+                    self._utterance_buffer.extend(pcm)
+                    if self._silence_started_at is None:
+                        self._silence_started_at = now
+                    elif (now - self._silence_started_at) * 1000 >= self.endpointing_ms:
+                        await self._flush_utterance()
+                        continue
+
+                if self._speech_active and self._utterance_is_overlong(now):
+                    logger.info(f"Qwen ASR batch: utterance hit the {self.max_utterance_s}s cap — flushing")
+                    await self._flush_utterance()
+
+        except asyncio.CancelledError:
+            logger.info("Qwen ASR batch loop cancelled")
+            raise
+        except Exception as e:
+            logger.error(f"Error in Qwen ASR batch loop: {e}")
+            self.connection_error = str(e)
+            traceback.print_exc()
+        finally:
+            meta = dict(self.meta_info or {})
+            meta["transcriber_duration"] = round(self.total_audio_seconds, 3)
+            if self.connection_error:
+                meta["connection_error"] = self.connection_error
+            await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def push_to_transcriber_queue(self, data_packet):
+        if self.transcriber_output_queue is not None:
+            await self.transcriber_output_queue.put(data_packet)
+
+    def get_meta_info(self):
+        return self.meta_info
+
+    async def toggle_connection(self):
+        self.connection_on = False
+        for task in (self.sender_task, self.heartbeat_task, self.completion_timeout_task):
+            if task is not None:
+                task.cancel()
+        if self.websocket_connection is not None:
+            try:
+                await self.websocket_connection.close()
+                logger.info("Qwen ASR websocket connection closed")
+            except Exception as e:
+                logger.error(f"Error closing Qwen ASR websocket: {e}")
+            finally:
+                self.websocket_connection = None
+                self.connection_authenticated = False
+
+        if self._http_session is not None:
+            try:
+                await self._http_session.close()
+            except Exception as e:
+                logger.error(f"Error closing Qwen ASR http session: {e}")
+            finally:
+                self._http_session = None
+
+    async def cleanup(self):
+        logger.info("Cleaning up Qwen ASR transcriber resources")
+        self.connection_on = False
+        for task_name, task in [
+            ("sender_task", getattr(self, "sender_task", None)),
+            ("heartbeat_task", getattr(self, "heartbeat_task", None)),
+            ("completion_timeout_task", getattr(self, "completion_timeout_task", None)),
+            ("transcription_task", getattr(self, "transcription_task", None)),
+        ]:
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    logger.info(f"Qwen ASR {task_name} cancelled")
+                except Exception as e:
+                    logger.warning(f"Error cancelling Qwen ASR {task_name}: {e}")
+
+        if self.websocket_connection is not None:
+            try:
+                await self.websocket_connection.close()
+            except Exception as e:
+                logger.error(f"Error closing Qwen ASR websocket: {e}")
+            finally:
+                self.websocket_connection = None
+                self.connection_authenticated = False
+
+        if self._http_session is not None:
+            try:
+                await self._http_session.close()
+            except Exception as e:
+                logger.error(f"Error closing Qwen ASR http session: {e}")
+            finally:
+                self._http_session = None
+
+        self.current_turn_interim_details = []
+        self._utterance_buffer = bytearray()
+
+    async def run(self):
+        try:
+            # stream=true → the hosted realtime socket; stream=false → open weights over HTTP.
+            runner = self.transcribe if self.stream else self.transcribe_http
+            self.transcription_task = asyncio.create_task(runner())
+        except Exception as e:
+            logger.error(f"Error starting Qwen ASR transcriber: {e}")
+
+    async def transcribe(self):
+        ws = None
+        self.num_frames = 0
+        self.connection_start_time = None
+        try:
+            start_time = timestamp_ms()
+            try:
+                ws = await self.qwen_connect()
+            except (ValueError, ConnectionError) as e:
+                logger.error(f"Failed to establish Qwen ASR connection: {e}")
+                self.connection_error = str(e)
+                await self.toggle_connection()
+                meta = dict(self.meta_info or {})
+                meta["connection_error"] = self.connection_error
+                await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
+                return
+
+            if not self.connection_time:
+                self.connection_time = round(timestamp_ms() - start_time)
+
+            self.sender_task = asyncio.create_task(self.sender_stream(ws))
+            self.heartbeat_task = asyncio.create_task(self.send_heartbeat(ws))
+            self.completion_timeout_task = asyncio.create_task(self.monitor_completion_timeout())
+
+            try:
+                async for message in self.receiver(ws):
+                    if self.connection_on:
+                        await self.push_to_transcriber_queue(message)
+                    else:
+                        break
+            except ConnectionClosedError as e:
+                logger.error(f"Qwen ASR websocket closed during streaming: {e}")
+                self.connection_error = str(e)
+            except Exception as e:
+                logger.error(f"Error during Qwen ASR streaming: {e}")
+                self.connection_error = str(e)
+                raise
+
+        except (ValueError, ConnectionError) as e:
+            logger.error(f"Connection error in Qwen ASR transcribe: {e}")
+            self.connection_error = str(e)
+            await self.toggle_connection()
+        except Exception as e:
+            logger.error(f"Unexpected error in Qwen ASR transcribe: {e}")
+            self.connection_error = str(e)
+            await self.toggle_connection()
+        finally:
+            if ws is not None:
+                try:
+                    await ws.close()
+                except Exception as e:
+                    logger.error(f"Error closing Qwen ASR websocket in finally: {e}")
+                finally:
+                    self.websocket_connection = None
+                    self.connection_authenticated = False
+
+            for task in (self.sender_task, self.heartbeat_task, self.completion_timeout_task):
+                if task is not None:
+                    task.cancel()
+
+            meta = dict(self.meta_info or {})
+            meta["transcriber_duration"] = round(self.total_audio_seconds, 3)
+            if self.connection_error:
+                meta["connection_error"] = self.connection_error
+            await self.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))

--- a/tests/manual/qwen_transcriber_smoke.py
+++ b/tests/manual/qwen_transcriber_smoke.py
@@ -1,0 +1,377 @@
+"""
+Standalone smoke-test for QwenTranscriber (Qwen3-ASR realtime, Alibaba Model Studio).
+
+Needs a live credential, so it lives in tests/manual/ and pytest does not collect it.
+The unit suite (tests/test_qwen_transcriber.py) covers everything that can be checked
+offline; this script covers the three things only the real endpoint can confirm:
+
+  1. the handshake      — URL, Authorization header, and session.update shape are accepted
+  2. the audio contract — Qwen actually decodes what we put on the wire (pcm, right rate)
+  3. the turn lifecycle — server VAD really does produce speech_started → text → completed
+
+Run (cheapest first):
+
+    export QWEN_API_KEY=sk-...          # or DASHSCOPE_API_KEY
+
+    # 1. handshake only — no audio, ~2s. Isolates auth/URL/config errors.
+    python tests/manual/qwen_transcriber_smoke.py --handshake
+
+    # 2. full turn over the default 16kHz linear16 path (web/default provider)
+    python tests/manual/qwen_transcriber_smoke.py
+
+    # 3. same audio over the 8kHz mu-law telephony path (Twilio/sip-trunk shape).
+    #    This is the one that proves the ulaw2lin decode is right — Qwen rejects mu-law,
+    #    so if the conversion were wrong this transcribes noise rather than erroring.
+    python tests/manual/qwen_transcriber_smoke.py --telephony
+
+    # 4. the OPEN-WEIGHTS path — no Alibaba account needed. Any OpenAI-compatible host.
+    #    OPENROUTER_API_KEY / DEEPINFRA_API_KEY in the environment are picked up automatically.
+    python tests/manual/qwen_transcriber_smoke.py --batch
+    #    DeepInfra ($5 free on signup, no card) — the upstream host behind OpenRouter's listing:
+    python tests/manual/qwen_transcriber_smoke.py --batch \\
+        --base-url https://api.deepinfra.com/v1/openai --model Qwen/Qwen3-ASR-1.7B
+    python tests/manual/qwen_transcriber_smoke.py --batch \
+        --base-url http://localhost:8000/v1 --model Qwen/Qwen3-ASR-1.7B   # self-hosted vLLM
+
+Options:
+    --handshake        connect, assert session.created/updated, exit (realtime only)
+    --telephony        provider=twilio → 8kHz mu-law input (default: 16kHz linear16)
+    --batch            open weights over /v1/audio/transcriptions instead of the realtime ws
+    --base-url URL     OpenAI-compatible base for --batch (default: OpenRouter)
+    --language xx      pin a language (default: en; use "auto" for auto-detect)
+    --model NAME       override the model id
+    <path.wav>         any mono/stereo PCM WAV, any sample rate (resampled here)
+
+Key lookup: --batch prefers QWEN_ASR_BATCH_KEY (the host's own key) and falls back to
+QWEN_API_KEY / DASHSCOPE_API_KEY; the realtime path uses the latter two.
+
+Default audio is tests/manual/test_speech.wav (4.5s of English, 24kHz mono).
+"""
+
+import argparse
+import asyncio
+import audioop
+import json
+import os
+import pathlib
+import struct
+import sys
+import time
+import wave
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+from bolna.constants import QWEN_ASR_DEFAULT_MODEL  # noqa: E402
+from bolna.transcriber.qwen_transcriber import QwenTranscriber  # noqa: E402
+
+# ── tunables ──────────────────────────────────────────────────────────────────
+CHUNK_MS = 20  # audio feed granularity, matching a telephony frame
+SILENCE_AFTER_MS = 1600  # silence fed after speech so Qwen's server VAD closes the turn
+MAX_WAV_SECONDS = 15  # cap playback
+TIMEOUT_S = 60  # max total wait for events
+HANDSHAKE_WAIT_S = 5.0  # how long to listen for session.created/updated
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _load_wav_mono(path):
+    """Return (pcm16_mono_bytes, sample_rate) for a WAV file.
+
+    Reads to EOF rather than trusting getnframes() — test_speech.wav carries a
+    streaming header whose frame count is 0x7FFFFFFF.
+    """
+    with wave.open(path, "rb") as wf:
+        rate, channels, width = wf.getframerate(), wf.getnchannels(), wf.getsampwidth()
+        if width != 2:
+            print(f"[error] {path}: {width * 8}-bit WAV; this script expects 16-bit PCM")
+            sys.exit(1)
+        raw = wf.readframes(int(rate * MAX_WAV_SECONDS))
+    if channels == 2:
+        raw = audioop.tomono(raw, 2, 0.5, 0.5)
+    dur = len(raw) / 2 / rate
+    print(f"[wav] {path}: {rate}Hz {channels}ch 16bit — {dur:.2f}s of audio")
+    return raw, rate
+
+
+def _prepare_audio(pcm, in_rate, target_rate, to_mulaw):
+    """Resample to the rate the transcriber is configured for, and optionally mu-law encode.
+
+    The transcriber deliberately does NOT resample (Qwen takes 8k and 16k natively), so
+    getting this right here is the harness's job — exactly as an input handler would.
+    """
+    if in_rate != target_rate:
+        pcm, _ = audioop.ratecv(pcm, 2, 1, in_rate, target_rate, None)
+        print(f"[prep] resampled {in_rate}Hz → {target_rate}Hz")
+    if to_mulaw:
+        pcm = audioop.lin2ulaw(pcm, 2)
+        print("[prep] encoded linear16 → mu-law (as Twilio would deliver it)")
+    return pcm
+
+
+def _chunks(payload, bytes_per_chunk):
+    for i in range(0, len(payload), bytes_per_chunk):
+        yield payload[i : i + bytes_per_chunk]
+
+
+async def feed_audio(audio_queue, payload, bytes_per_chunk, silence_byte):
+    """Push speech, then silence to trigger server VAD, then EOS — paced in real time."""
+    meta = {"request_id": "qwen-smoke-001", "call_sid": "qwen-smoke-call"}
+
+    speech = list(_chunks(payload, bytes_per_chunk))
+    print(f"[feed] {len(speech)} speech chunks of {CHUNK_MS}ms")
+    for chunk in speech:
+        await audio_queue.put({"data": chunk, "meta_info": meta})
+        await asyncio.sleep(CHUNK_MS / 1000)
+
+    n_silence = SILENCE_AFTER_MS // CHUNK_MS
+    print(f"[feed] {n_silence} silence chunks ({SILENCE_AFTER_MS}ms) so server VAD closes the turn")
+    silence = silence_byte * bytes_per_chunk
+    for _ in range(n_silence):
+        await audio_queue.put({"data": silence, "meta_info": meta})
+        await asyncio.sleep(CHUNK_MS / 1000)
+
+    print("[feed] sending EOS")
+    await audio_queue.put({"data": b"", "meta_info": {**meta, "eos": True}})
+
+
+async def collect_events(output_queue, timeout):
+    """Drain the transcriber output queue until connection_closed or timeout."""
+    events, transcripts = [], []
+    deadline = time.time() + timeout
+    print()
+    print("─" * 64)
+    print("TRANSCRIBER EVENTS")
+    print("─" * 64)
+    while time.time() < deadline:
+        try:
+            packet = await asyncio.wait_for(output_queue.get(), timeout=1.0)
+        except asyncio.TimeoutError:
+            continue
+
+        data, meta = packet.get("data"), packet.get("meta_info", {})
+
+        if data == "speech_started":
+            print("[event] SPEECH STARTED")
+            events.append("speech_started")
+
+        elif isinstance(data, dict) and data.get("type") == "interim_transcript_received":
+            print(f"[interim] {data.get('content', '')}", end="\r")
+            events.append("interim")
+
+        elif isinstance(data, dict) and data.get("type") == "transcript":
+            text = data.get("content", "")
+            transcripts.append(text)
+            print()
+            print(f"[event] TRANSCRIPT: {text}")
+            for label, key in (
+                ("first-result latency ", "transcriber_first_result_latency"),
+                ("user_stop_offset_ms  ", "user_stop_offset_ms"),
+                ("detected language    ", "transcriber_detected_language"),
+                ("detected emotion     ", "transcriber_detected_emotion"),
+            ):
+                if meta.get(key) is not None:
+                    print(f"        {label}: {meta[key]}")
+            if data.get("force_finalized"):
+                print("        NOTE: force-finalized by the watchdog (no .completed arrived)")
+            events.append("force_finalized" if data.get("force_finalized") else "transcript")
+
+        elif isinstance(data, dict) and data.get("type") == "speech_ended":
+            print("\n[event] SPEECH ENDED (turn closed with no text)")
+            events.append("speech_ended")
+
+        elif data == "transcriber_connection_closed":
+            err = meta.get("connection_error")
+            print()
+            print(f"[event] CONNECTION CLOSED ({'error: ' + str(err) if err else 'clean'})")
+            events.append("connection_closed")
+            break
+
+        else:
+            print(f"[event] OTHER: {data!r}")
+
+    print("─" * 64)
+    if transcripts:
+        print()
+        print("FULL TRANSCRIPT")
+        print("─" * 64)
+        for i, t in enumerate(transcripts, 1):
+            print(f"  Turn {i}: {t}")
+        print("─" * 64)
+    return events
+
+
+def _assert(condition, message):
+    print(f"{'[pass]' if condition else '[FAIL]'} {message}")
+    return bool(condition)
+
+
+def _build(args, api_key, provider, sampling_rate):
+    kw = {}
+    if args.batch:
+        # leave `model` unset so the realtime default is swapped for a servable batch id
+        kw["base_url"] = args.base_url
+        if args.model != QWEN_ASR_DEFAULT_MODEL:
+            kw["model"] = args.model
+    else:
+        kw["model"] = args.model
+    return QwenTranscriber(
+        telephony_provider=provider,
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+        language=args.language,
+        sampling_rate=sampling_rate,
+        endpointing=600,
+        stream=not args.batch,
+        transcriber_key=api_key,
+        **kw,
+    )
+
+
+async def run_handshake(args, api_key):
+    """Connect, send session.update, and prove the server accepted the session."""
+    t = _build(args, api_key, "default", 16000)
+    print(f"[test] handshake against {t.get_qwen_ws_url()}")
+    print(f"[test] session.update = {json.dumps(t._build_session_config()['session'])}")
+
+    try:
+        ws = await t.qwen_connect()
+    except Exception as e:
+        print(f"\n[FAIL] could not connect: {e}")
+        print("       401/403 → bad or wrong-region key. Check QWEN_ASR_HOST (intl vs Beijing).")
+        return 1
+
+    print("\n[test] connected; listening for server events…")
+    seen = []
+    deadline = time.time() + HANDSHAKE_WAIT_S
+    try:
+        while time.time() < deadline:
+            try:
+                raw = await asyncio.wait_for(ws.recv(), timeout=deadline - time.time())
+            except asyncio.TimeoutError:
+                break
+            evt = json.loads(raw)
+            seen.append(evt.get("type"))
+            print(f"[event] {evt.get('type')}: {json.dumps(evt)[:300]}")
+            if evt.get("type") == "error":
+                print("\n[FAIL] server rejected the session — the error above names the bad field.")
+                return 1
+            if evt.get("type") == "session.updated":
+                break
+    finally:
+        await ws.close()
+
+    print()
+    ok = _assert(any(s in seen for s in ("session.created", "session.updated")), "server acknowledged the session")
+    if ok:
+        print("\nHandshake OK — URL, auth header and session config are all accepted.")
+        print("Next: run without --handshake to push real audio through.")
+    return 0 if ok else 1
+
+
+async def run_full(args, api_key):
+    """Feed a real WAV through the real transcriber and check the turn lifecycle."""
+    provider = "twilio" if args.telephony else "default"
+    rate = 8000 if args.telephony else 16000
+
+    t = _build(args, api_key, provider, rate)
+    print(
+        f"[test] provider={provider} encoding={t.encoding} sample_rate={t.sampling_rate} "
+        f"stream={t.stream} model={t.model}"
+    )
+    if t.stream:
+        print(f"[test] realtime ws={t.get_qwen_ws_url()} silence_duration_ms={t.silence_duration_ms}")
+    else:
+        print(
+            f"[test] batch http={t.transcriptions_url} local endpointing={t.endpointing_ms}ms "
+            f"rms_threshold={t.speech_rms_threshold}"
+        )
+
+    pcm, in_rate = _load_wav_mono(args.wav)
+    payload = _prepare_audio(pcm, in_rate, t.sampling_rate, to_mulaw=(t.encoding == "mulaw"))
+    # mu-law is 1 byte/sample, linear16 is 2 — and mu-law silence is 0xff, not 0x00.
+    width = 1 if t.encoding == "mulaw" else 2
+    bytes_per_chunk = int(t.sampling_rate * CHUNK_MS / 1000) * width
+    silence_byte = b"\xff" if t.encoding == "mulaw" else b"\x00"
+
+    await t.run()
+    feeder = asyncio.create_task(feed_audio(t.input_queue, payload, bytes_per_chunk, silence_byte))
+    events = await collect_events(t.transcriber_output_queue, TIMEOUT_S)
+    await feeder
+    await t.cleanup()
+
+    print()
+    print("ASSERTIONS")
+    print("─" * 64)
+    ok = True
+    ok &= _assert("connection_closed" in events, "connection closed (socket lifecycle completed)")
+    vad = "Qwen's server VAD" if t.stream else "the local RMS endpointer"
+    ok &= _assert("speech_started" in events, f"speech_started — {vad} heard the audio")
+    if t.stream:
+        ok &= _assert("interim" in events, "at least one interim (text/stash partials arriving)")
+    else:
+        print("[skip] interim check — the batch endpoint returns no partials, by design")
+    ok &= _assert(
+        "transcript" in events or "force_finalized" in events,
+        "a final transcript was delivered",
+    )
+    if "force_finalized" in events and "transcript" not in events:
+        print("       ↑ delivered by the WATCHDOG, not a .completed event. The turn still")
+        print("         reached the LLM, but check whether QWEN_ASR_COMPLETION_TIMEOUT_S")
+        print("         is too tight for this region's latency.")
+
+    if not ok:
+        print()
+        print("Not all checks passed. Read the events above — the usual causes:")
+        print("  · no speech_started  → audio format/rate mismatch; Qwen heard noise, not speech")
+        print("  · no interim         → connected but nothing decoded; check sample_rate")
+        print("  · connection error   → auth, region, or a rejected session field")
+        return 1
+
+    print()
+    print("All assertions passed — the live path works end to end.")
+    return 0
+
+
+def main():
+    default_wav = str(pathlib.Path(__file__).parent / "test_speech.wav")
+    p = argparse.ArgumentParser(description="Live smoke-test for QwenTranscriber.")
+    p.add_argument("wav", nargs="?", default=default_wav, help="WAV file to speak (16-bit PCM)")
+    p.add_argument("--handshake", action="store_true", help="connect only, no audio")
+    p.add_argument("--telephony", action="store_true", help="8kHz mu-law path (Twilio shape)")
+    p.add_argument("--batch", action="store_true", help="open-weights path: OpenAI-compatible /v1/audio/transcriptions")
+    p.add_argument("--base-url", default=None, help="OpenAI-compatible base for --batch")
+    p.add_argument("--language", default="en", help='language code, or "auto" (default: en)')
+    p.add_argument("--model", default=QWEN_ASR_DEFAULT_MODEL, help="model id")
+    args = p.parse_args()
+
+    # Harness convenience only — bolna itself stays vendor-neutral and reads
+    # QWEN_ASR_BATCH_KEY / QWEN_API_KEY / DASHSCOPE_API_KEY.
+    batch_keys = ("QWEN_ASR_BATCH_KEY", "OPENROUTER_API_KEY", "DEEPINFRA_API_KEY") if args.batch else ()
+    api_key = (
+        next((os.getenv(k) for k in batch_keys if os.getenv(k)), None)
+        or os.getenv("QWEN_API_KEY")
+        or os.getenv("DASHSCOPE_API_KEY")
+    )
+    if not api_key:
+        if args.batch:
+            print("[error] no key for the batch host. Set QWEN_ASR_BATCH_KEY, or export")
+            print("        OPENROUTER_API_KEY / DEEPINFRA_API_KEY and this picks it up.")
+        else:
+            print("[error] set QWEN_API_KEY (or DASHSCOPE_API_KEY) — from Alibaba Cloud Model Studio")
+        sys.exit(1)
+    if not args.handshake and not os.path.exists(args.wav):
+        print(f"[error] no such WAV: {args.wav}")
+        sys.exit(1)
+
+    if args.handshake and args.batch:
+        print("[error] --handshake is realtime-only; the batch path has no session handshake")
+        sys.exit(1)
+    runner = run_handshake if args.handshake else run_full
+    sys.exit(asyncio.run(runner(args, api_key)))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_qwen_transcriber.py
+++ b/tests/test_qwen_transcriber.py
@@ -1,0 +1,891 @@
+"""Unit tests for the Qwen3-ASR realtime transcriber.
+
+Three things can silently break a voice agent on this provider, so each gets pinned here:
+
+  * the handshake — Qwen rejects mulaw and will not resample, so the wrong `input_audio_format`
+    or `sample_rate` yields a live socket that transcribes garbage rather than an error;
+  * the turn lifecycle — `text`/`stash` must be concatenated into the running utterance, and a
+    turn must close exactly once so the LLM neither misses nor replays the user;
+  * the watchdog — a dropped `.completed` holds the agent's reply for the rest of the call.
+
+Constructor and receiver only: no network happens until run().
+"""
+
+import asyncio
+import audioop
+import json
+
+import pytest
+
+from bolna.constants import QWEN_ASR_MIN_SILENCE_DURATION_MS
+from bolna.transcriber.qwen_transcriber import QwenTranscriber
+
+
+def _transcriber(provider="plivo", **kwargs):
+    kwargs.setdefault("transcriber_key", "test-key")
+    return QwenTranscriber(telephony_provider=provider, stream=True, **kwargs)
+
+
+def _session(t):
+    return t._build_session_config()["session"]
+
+
+class _FakeWS:
+    """Async-iterable stand-in for the Qwen socket. Replays `events`, records sends."""
+
+    def __init__(self, events):
+        self._events = [e if isinstance(e, str) else json.dumps(e) for e in events]
+        self.sent = []
+
+    def __aiter__(self):
+        async def gen():
+            for e in self._events:
+                yield e
+
+        return gen()
+
+    async def send(self, payload):
+        self.sent.append(payload)
+
+    async def close(self):
+        pass
+
+    async def ping(self):
+        fut = asyncio.get_event_loop().create_future()
+        fut.set_result(None)
+        return fut
+
+
+async def _drain(t, events):
+    """Run the receiver over `events` and return the packets it yields."""
+    return [packet async for packet in t.receiver(_FakeWS(events))]
+
+
+def _types(packets):
+    return [p["data"] if isinstance(p["data"], str) else p["data"].get("type") for p in packets]
+
+
+# ---------------------------------------------------------------- audio params
+
+
+@pytest.mark.parametrize("provider", ["twilio", "sip-trunk"])
+def test_mulaw_telephony_providers(provider):
+    t = _transcriber(provider)
+    assert t.encoding == "mulaw"
+    assert t.sampling_rate == 8000
+    assert t.audio_frame_duration == 0.2
+
+
+@pytest.mark.parametrize("provider", ["exotel", "plivo", "vobiz"])
+def test_linear16_telephony_providers(provider):
+    t = _transcriber(provider)
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 8000
+
+
+def test_web_based_call_is_16k():
+    t = _transcriber("web_based_call")
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 16000
+    assert t.audio_frame_duration == 0.256
+
+
+def test_freeswitch_webcall_does_not_crash_and_uses_16k_linear16():
+    t = _transcriber("freeswitch")
+    assert t.encoding == "linear16"
+    assert t.sampling_rate == 16000
+
+
+def test_playground_batch_mode():
+    t = _transcriber("playground")
+    assert t.sampling_rate == 8000
+    assert t.audio_frame_duration == 0.0
+
+
+# ---------------------------------------------------------------- handshake
+
+
+def test_session_always_declares_pcm_never_mulaw():
+    """Qwen accepts pcm/opus only; declaring the input encoding would be transcribing noise."""
+    for provider in ("twilio", "sip-trunk", "plivo", "web_based_call"):
+        assert _session(_transcriber(provider))["input_audio_format"] == "pcm"
+
+
+@pytest.mark.parametrize("provider,expected", [("twilio", 8000), ("plivo", 8000), ("web_based_call", 16000)])
+def test_session_sample_rate_matches_the_wire(provider, expected):
+    # No resampling happens, so a mismatch here means Qwen reads the audio at the wrong speed.
+    assert _session(_transcriber(provider))["sample_rate"] == expected
+
+
+def test_endpointing_maps_onto_server_vad_silence():
+    assert _session(_transcriber(endpointing="900"))["turn_detection"]["silence_duration_ms"] == 900
+
+
+def test_endpointing_below_floor_is_raised():
+    s = _session(_transcriber(endpointing="100"))
+    assert s["turn_detection"]["silence_duration_ms"] == QWEN_ASR_MIN_SILENCE_DURATION_MS
+
+
+def test_server_vad_is_always_on():
+    """turn_detection: null would hand endpointing back to bolna and lose the whole point."""
+    assert _session(_transcriber())["turn_detection"]["type"] == "server_vad"
+
+
+def test_vad_threshold_zero_is_forwarded_not_dropped():
+    # 0.0 means "accept all speech" to Qwen; a truthiness check would silently drop it.
+    assert _session(_transcriber(vad_threshold=0.0))["turn_detection"]["threshold"] == 0.0
+
+
+def test_vad_threshold_omitted_when_unset():
+    assert "threshold" not in _session(_transcriber())["turn_detection"]
+
+
+def test_url_carries_the_model_and_hits_the_realtime_path():
+    url = _transcriber(model="qwen3-asr-flash-realtime").get_qwen_ws_url()
+    assert url == "wss://dashscope-intl.aliyuncs.com/api-ws/v1/realtime?model=qwen3-asr-flash-realtime"
+
+
+def test_host_is_overridable_for_the_beijing_region(monkeypatch):
+    monkeypatch.setenv("QWEN_ASR_HOST", "dashscope.aliyuncs.com")
+    assert "dashscope.aliyuncs.com" in _transcriber().get_qwen_ws_url()
+
+
+def test_missing_api_key_fails_before_connecting():
+    t = QwenTranscriber(telephony_provider="plivo", transcriber_key=None)
+    t.api_key = None  # a .env in the developer's shell must not mask this
+    with pytest.raises(ValueError, match="no API key"):
+        asyncio.run(t.qwen_connect())
+
+
+# ---------------------------------------------------------------- language
+
+
+@pytest.mark.parametrize("configured,expected", [("en", "en"), ("hi", "hi"), ("zh", "zh"), ("en-US", "en")])
+def test_supported_language_is_pinned(configured, expected):
+    assert _session(_transcriber(language=configured))["input_audio_transcription"]["language"] == expected
+
+
+@pytest.mark.parametrize("configured", ["", "multi", "auto", "multilingual", "unknown"])
+def test_auto_language_values_omit_the_hint(configured):
+    # Absent `language`, Qwen auto-detects; sending "multi" would be rejected as a value.
+    assert "input_audio_transcription" not in _session(_transcriber(language=configured))
+
+
+def test_deepgram_style_multi_prefix_takes_the_concrete_half():
+    assert _session(_transcriber(language="multi-hi"))["input_audio_transcription"]["language"] == "hi"
+
+
+def test_unsupported_language_degrades_to_auto_detect():
+    """A language Qwen does not list must not be sent — it fails the whole handshake."""
+    assert _transcriber(language="ta")._resolve_language() is None
+
+
+# ---------------------------------------------------------------- keyword biasing
+
+
+def test_keywords_become_the_biasing_corpus():
+    corpus = _session(_transcriber(keywords="Bolna, Plivo, Zentrunk"))["input_audio_transcription"]["corpus"]
+    assert corpus == {"text": "Bolna, Plivo, Zentrunk"}
+
+
+def test_blank_keywords_send_no_corpus():
+    assert "input_audio_transcription" not in _session(_transcriber(language="auto", keywords="  ,  ,"))
+
+
+def test_oversized_corpus_truncates_on_a_term_boundary():
+    t = _transcriber(keywords=", ".join(f"term{i:05d}" for i in range(3000)))
+    text = _session(t)["input_audio_transcription"]["corpus"]["text"]
+    # A half-word left behind would bias toward a string no caller will ever say.
+    assert not text.endswith(",")
+    assert text.split(", ")[-1].startswith("term")
+
+
+# ---------------------------------------------------------------- audio conversion
+
+
+def test_mulaw_is_decoded_to_linear16():
+    t = _transcriber("twilio")
+    frame = b"\xff" * 160
+    assert t._to_pcm16(frame) == audioop.ulaw2lin(frame, 2)
+
+
+def test_linear16_passes_through_byte_identical():
+    t = _transcriber("plivo")
+    frame = b"\x01\x02" * 160
+    assert t._to_pcm16(frame) is frame
+
+
+def test_undecodable_mulaw_frame_is_dropped_not_raised():
+    t = _transcriber("twilio")
+    assert t._to_pcm16("not-bytes") is None
+
+
+# ---------------------------------------------------------------- turn lifecycle
+
+
+def test_full_turn_yields_speech_started_interim_then_transcript():
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "session.created", "session": {}},
+                {"type": "input_audio_buffer.speech_started", "item_id": "i1"},
+                {"type": "conversation.item.input_audio_transcription.text", "text": "", "stash": "book"},
+                {"type": "conversation.item.input_audio_transcription.text", "text": "book ", "stash": "a table"},
+                {"type": "input_audio_buffer.speech_stopped", "item_id": "i1"},
+                {
+                    "type": "conversation.item.input_audio_transcription.completed",
+                    "transcript": "Book a table.",
+                    "item_id": "i1",
+                },
+            ],
+        )
+    )
+    assert _types(packets) == [
+        "speech_started",
+        "interim_transcript_received",
+        "interim_transcript_received",
+        "transcript",
+    ]
+    assert packets[-1]["data"]["content"] == "Book a table."
+
+
+def test_interim_is_text_plus_stash():
+    """`text` is the settled prefix and `stash` the pre-recognized tail; only the sum is the
+    utterance so far. Using `text` alone drops the newest words the interruption check needs."""
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "conversation.item.input_audio_transcription.text", "text": "hello ", "stash": "world"},
+            ],
+        )
+    )
+    assert packets[-1]["data"]["content"] == "hello world"
+
+
+def test_repeated_identical_partial_is_not_re_emitted():
+    t = _transcriber()
+    partial = {"type": "conversation.item.input_audio_transcription.text", "text": "hello", "stash": ""}
+    packets = asyncio.run(_drain(t, [{"type": "input_audio_buffer.speech_started"}, partial, partial, partial]))
+    assert _types(packets) == ["speech_started", "interim_transcript_received"]
+
+
+def test_interim_without_speech_started_still_opens_a_turn():
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(t, [{"type": "conversation.item.input_audio_transcription.text", "text": "hi", "stash": ""}])
+    )
+    assert _types(packets) == ["speech_started", "interim_transcript_received"]
+    assert t.current_turn_id == 1
+
+
+def test_empty_final_closes_the_turn_without_a_transcript():
+    """A silence-only turn must still clear callee_speaking, or held agent audio never ships."""
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "input_audio_buffer.speech_stopped"},
+                {"type": "conversation.item.input_audio_transcription.completed", "transcript": "  "},
+            ],
+        )
+    )
+    assert _types(packets) == ["speech_started", "speech_ended"]
+
+
+def test_late_duplicate_final_is_dropped():
+    """Re-delivering a closed turn's transcript replays the user turn to the LLM."""
+    t = _transcriber()
+    final = {"type": "conversation.item.input_audio_transcription.completed", "transcript": "yes please"}
+    packets = asyncio.run(_drain(t, [{"type": "input_audio_buffer.speech_started"}, final, final]))
+    assert _types(packets) == ["speech_started", "transcript"]
+
+
+def test_reopened_turn_releases_the_previous_one():
+    """Qwen re-opening without closing would otherwise strand the buffered transcript."""
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "conversation.item.input_audio_transcription.text", "text": "stranded", "stash": ""},
+                {"type": "input_audio_buffer.speech_started"},
+            ],
+        )
+    )
+    assert _types(packets) == ["speech_started", "interim_transcript_received", "transcript", "speech_started"]
+    assert packets[2]["data"]["content"] == "stranded"
+    assert packets[2]["data"]["force_finalized"] is True
+
+
+def test_failed_item_closes_the_turn():
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "conversation.item.input_audio_transcription.failed", "error": {"code": "x"}},
+            ],
+        )
+    )
+    assert _types(packets) == ["speech_started", "speech_ended"]
+
+
+def test_invalid_request_error_stops_the_receiver():
+    t = _transcriber()
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "error", "error": {"type": "invalid_request_error", "code": "invalid_value", "message": "no"}},
+                {"type": "input_audio_buffer.speech_started"},
+            ],
+        )
+    )
+    assert packets == []
+    assert "invalid_value" in t.connection_error
+
+
+def test_session_finished_stops_the_receiver():
+    t = _transcriber()
+    packets = asyncio.run(_drain(t, [{"type": "session.finished"}, {"type": "input_audio_buffer.speech_started"}]))
+    assert packets == []
+
+
+def test_non_json_frame_does_not_kill_the_stream():
+    t = _transcriber()
+    packets = asyncio.run(_drain(t, ["<not json>", {"type": "input_audio_buffer.speech_started"}]))
+    assert _types(packets) == ["speech_started"]
+
+
+# ---------------------------------------------------------------- turn metadata
+
+
+def test_final_transcript_reports_the_vad_stop_offset():
+    """Server VAD fires silence_duration_ms after the caller stopped; the interruption manager
+    needs that offset to place the turn boundary at the real stop, not at the event."""
+    t = _transcriber(endpointing="700")
+    packets = asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "input_audio_buffer.speech_stopped"},
+                {"type": "conversation.item.input_audio_transcription.completed", "transcript": "ok"},
+            ],
+        )
+    )
+    meta = packets[-1]["meta_info"]
+    assert meta["user_stop_offset_ms"] == 700
+    assert meta["user_stop_ts_wall"] < meta["last_vocal_frame_timestamp"] + 0.001
+
+
+def test_detected_language_retargets_tts_only_when_nothing_was_pinned():
+    events = [
+        {"type": "input_audio_buffer.speech_started"},
+        {
+            "type": "conversation.item.input_audio_transcription.completed",
+            "transcript": "namaste",
+            "language": "hi",
+            "emotion": "happy",
+        },
+    ]
+    auto = asyncio.run(_drain(_transcriber(language="auto"), events))[-1]["meta_info"]
+    assert auto["detected_language_code"] == "hi"
+
+    # A pinned language must survive one mis-tagged turn — otherwise the agent's voice wanders.
+    pinned = asyncio.run(_drain(_transcriber(language="en"), events))[-1]["meta_info"]
+    assert "detected_language_code" not in pinned
+    assert pinned["transcriber_detected_language"] == "hi"
+    assert pinned["transcriber_detected_emotion"] == "happy"
+
+
+def test_turn_latencies_record_one_entry_per_turn():
+    t = _transcriber()
+    asyncio.run(
+        _drain(
+            t,
+            [
+                {"type": "input_audio_buffer.speech_started"},
+                {"type": "conversation.item.input_audio_transcription.text", "text": "hi", "stash": ""},
+                {"type": "input_audio_buffer.speech_stopped"},
+                {"type": "conversation.item.input_audio_transcription.completed", "transcript": "hi there"},
+            ],
+        )
+    )
+    assert len(t.turn_latencies) == 1
+    entry = t.turn_latencies[0]
+    assert entry["turn_id"] == 1
+    assert entry["final_transcript"] == "hi there"
+    assert entry["interim_details"][-1]["is_final"] is True
+
+
+# ---------------------------------------------------------------- completion watchdog
+
+
+def test_completion_is_not_overdue_before_speech_stopped():
+    t = _transcriber()
+    t._start_turn()
+    assert t._completion_is_overdue(1_000_000.0) is False
+
+
+def test_completion_is_overdue_past_the_window():
+    t = _transcriber(completion_timeout=1.0)
+    t._start_turn()
+    t._speech_stopped_at = 100.0
+    assert t._completion_is_overdue(101.5) is True
+    assert t._completion_is_overdue(100.5) is False
+
+
+def test_a_delivered_turn_is_never_overdue():
+    t = _transcriber()
+    t._start_turn()
+    t._speech_stopped_at = 100.0
+    t.is_transcript_sent_for_processing = True
+    assert t._completion_is_overdue(1_000_000.0) is False
+
+
+def test_force_close_delivers_the_buffered_interim():
+    """Without this the caller's words are lost and the agent answers the previous turn."""
+    t = _transcriber()
+    q = asyncio.Queue()
+    t.transcriber_output_queue = q
+    t._start_turn()
+    t.last_interim_transcript = "cancel my booking"
+    t._speech_stopped_at = 0.0
+
+    async def once():
+        async for packet in t._close_open_turn():
+            await t.push_to_transcriber_queue(packet)
+
+    asyncio.run(once())
+    packet = q.get_nowait()
+    assert packet["data"] == {"type": "transcript", "content": "cancel my booking", "force_finalized": True}
+    assert t.turn_latencies[0]["force_finalized"] is True
+    # The turn must be closed, so a late `.completed` cannot replay it.
+    assert t.current_turn_id is None
+    assert t._completion_is_overdue(1_000_000.0) is False
+
+
+def test_force_close_with_no_text_emits_speech_ended():
+    t = _transcriber()
+    q = asyncio.Queue()
+    t.transcriber_output_queue = q
+    t._start_turn()
+
+    async def once():
+        async for packet in t._close_open_turn():
+            await t.push_to_transcriber_queue(packet)
+
+    asyncio.run(once())
+    assert q.get_nowait()["data"] == {"type": "speech_ended"}
+
+
+# ---------------------------------------------------------------- sender / EOS
+
+
+def test_eos_commits_the_open_turn_then_finishes():
+    """With server VAD the buffer is only flushed on silence, so a turn still open at hangup
+    is discarded unless it is committed explicitly."""
+    t = _transcriber()
+    ws = _FakeWS([])
+    t._start_turn()
+
+    async def go():
+        await asyncio.wait_for(t._drain_and_finish(ws), timeout=1.0)
+
+    t._final_transcript_event.set()  # pretend the final already landed
+    asyncio.run(go())
+    assert [json.loads(s)["type"] for s in ws.sent] == ["input_audio_buffer.commit", "session.finish"]
+
+
+def test_eos_with_no_open_turn_skips_the_commit():
+    # Committing an empty buffer is an error event on the wire for no benefit.
+    t = _transcriber()
+    ws = _FakeWS([])
+    asyncio.run(t._drain_and_finish(ws))
+    assert [json.loads(s)["type"] for s in ws.sent] == ["session.finish"]
+
+
+def test_sender_base64_encodes_pcm_and_ignores_keepalive_meta():
+    """TranscriberPool keepalives carry an empty meta_info; adopting one would publish
+    transcripts under a meta with no request_id."""
+    t = _transcriber("twilio")
+    t.input_queue = asyncio.Queue()
+    ws = _FakeWS([])
+    frame = b"\xff" * 160
+    t.input_queue.put_nowait({"data": frame, "meta_info": {}})
+    t.input_queue.put_nowait({"data": frame, "meta_info": {"turn_id": 1}})
+    t.input_queue.put_nowait({"data": None, "meta_info": {"eos": True}})
+
+    asyncio.run(asyncio.wait_for(t.sender_stream(ws), timeout=2.0))
+
+    appends = [json.loads(s) for s in ws.sent if json.loads(s)["type"] == "input_audio_buffer.append"]
+    assert len(appends) == 2
+    import base64
+
+    assert base64.b64decode(appends[0]["audio"]) == audioop.ulaw2lin(frame, 2)
+    assert t.meta_info.get("request_id")  # adopted from the real packet, not the keepalive
+
+
+def test_stray_speech_stopped_cannot_spin_the_watchdog():
+    """_close_open_turn is a no-op without an open turn, so a stopped-but-turnless state would
+    otherwise re-fire the watchdog every tick for the rest of the call."""
+    t = _transcriber(completion_timeout=0.01)
+    asyncio.run(_drain(t, [{"type": "input_audio_buffer.speech_stopped"}]))
+    assert t._speech_stopped_at is None
+    assert t._completion_is_overdue(1_000_000.0) is False
+
+
+def test_watchdog_stays_quiet_before_the_first_turn():
+    # is_transcript_sent_for_processing starts False, so the guard has to be the open turn.
+    t = _transcriber(completion_timeout=0.01)
+    t._speech_stopped_at = 0.0
+    assert t.current_turn_id is None
+    assert t._completion_is_overdue(1_000_000.0) is False
+
+
+# ══════════════════════════════════════════════════════ open-weights batch path
+#
+# stream=false targets the Apache-2.0 weights behind any host's OpenAI-compatible
+# /v1/audio/transcriptions. Different failure modes from the realtime socket: the
+# turn boundary is ours to find, and a wrong model id or base_url is a 404.
+
+
+def _batch(**kwargs):
+    kwargs.setdefault("provider", "default")
+    provider = kwargs.pop("provider")
+    kwargs.setdefault("transcriber_key", "test-key")
+    kwargs.setdefault("stream", False)
+    return QwenTranscriber(telephony_provider=provider, **kwargs)
+
+
+def _speech(n_samples, amplitude=9000):
+    """PCM16 loud enough to clear the RMS gate."""
+    import math
+
+    return b"".join(
+        int(amplitude * math.sin(2 * math.pi * 300 * i / 16000)).to_bytes(2, "little", signed=True)
+        for i in range(n_samples)
+    )
+
+
+def _quiet(n_samples):
+    return b"\x00\x00" * n_samples
+
+
+def test_stream_flag_picks_the_batch_runner():
+    assert _batch().stream is False
+    assert _transcriber().stream is True
+
+
+def test_batch_url_is_openai_compatible():
+    t = _batch(base_url="https://openrouter.ai/api/v1")
+    assert t.transcriptions_url == "https://openrouter.ai/api/v1/audio/transcriptions"
+
+
+def test_batch_base_url_trailing_slash_does_not_double_up():
+    assert _batch(base_url="http://localhost:8000/v1/").transcriptions_url.endswith("/v1/audio/transcriptions")
+
+
+def test_self_hosted_vllm_base_url_is_accepted():
+    t = _batch(base_url="http://localhost:8000/v1", model="Qwen/Qwen3-ASR-1.7B")
+    assert t.transcriptions_url == "http://localhost:8000/v1/audio/transcriptions"
+    assert t.model == "Qwen/Qwen3-ASR-1.7B"
+
+
+def test_realtime_model_id_is_swapped_out_in_batch_mode():
+    """Posting a realtime model id to /v1/audio/transcriptions is a 404 nobody enjoys
+    debugging, so flipping only `stream` must still land on a servable model."""
+    t = _batch()  # model left at the realtime default
+    assert t.model == "qwen/qwen3-asr-1.7b"
+
+
+def test_an_explicit_batch_model_is_never_overridden():
+    assert _batch(model="Qwen/Qwen3-ASR-0.6B").model == "Qwen/Qwen3-ASR-0.6B"
+
+
+def test_realtime_mode_keeps_the_realtime_model():
+    assert _transcriber().model == "qwen3-asr-flash-realtime"
+
+
+def test_base_url_env_override(monkeypatch):
+    monkeypatch.setenv("QWEN_ASR_BASE_URL", "https://api.deepinfra.com/v1/openai")
+    assert _batch().transcriptions_url.startswith("https://api.deepinfra.com/v1/openai")
+
+
+# ── local endpointing (there is no server VAD on this path) ───────────────────
+
+
+def test_loud_frame_is_speech_and_silence_is_not():
+    t = _batch()
+    assert t._batch_frame_is_speech(_speech(320)) is True
+    assert t._batch_frame_is_speech(_quiet(320)) is False
+
+
+def test_rms_of_a_partial_sample_does_not_raise():
+    # A trailing odd byte reaches audioop as an incomplete frame; it must not kill the loop.
+    assert _batch()._rms(b"\x01") == 0
+
+
+def test_rms_threshold_is_configurable():
+    t = _batch(speech_rms_threshold=99999)
+    assert t._batch_frame_is_speech(_speech(320)) is False
+
+
+def test_overlong_utterance_is_flushed_without_waiting_for_silence():
+    """A caller who never pauses would otherwise grow the buffer, and the request, unbounded."""
+    t = _batch(max_utterance_s=10)
+    assert t._utterance_is_overlong(1000.0) is False  # no utterance open
+    t._utterance_started_at = 1000.0
+    assert t._utterance_is_overlong(1009.0) is False
+    assert t._utterance_is_overlong(1011.0) is True
+
+
+def test_batch_reports_its_own_endpointing_as_the_stop_offset():
+    """Realtime credits Qwen's server-VAD window; batch must credit the local one, or the
+    interruption manager places the turn boundary at the wrong instant."""
+    r = _transcriber(endpointing="900")
+    r.meta_info = {}
+    r._stamp_turn_meta()
+    assert r.meta_info["user_stop_offset_ms"] == r.silence_duration_ms == 900
+
+    b = _batch(endpointing="250")
+    b.meta_info = {}
+    b._stamp_turn_meta()
+    assert b.meta_info["user_stop_offset_ms"] == 250  # not raised to the server-VAD floor
+
+
+# ── the POST and what comes back ──────────────────────────────────────────────
+
+
+class _FakeResponse:
+    def __init__(self, status, body):
+        self.status, self._body = status, body
+
+    async def text(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeSession:
+    """Captures the multipart POST instead of making it."""
+
+    def __init__(self, status=200, body='{"text": "hello there"}'):
+        self.status, self.body, self.calls = status, body, []
+
+    def post(self, url, data=None, headers=None, timeout=None):
+        self.calls.append({"url": url, "data": data, "headers": headers})
+        return _FakeResponse(self.status, self.body)
+
+    async def close(self):
+        pass
+
+
+def _run_post(t, pcm=b"\x01\x02" * 8000):
+    return asyncio.run(t._post_transcription(pcm))
+
+
+def test_post_sends_a_wav_with_bearer_auth_and_the_model():
+    t = _batch(base_url="https://openrouter.ai/api/v1", language="en")
+    t._http_session = sess = _FakeSession()
+    assert _run_post(t) == "hello there"
+
+    call = sess.calls[0]
+    assert call["url"] == "https://openrouter.ai/api/v1/audio/transcriptions"
+    assert call["headers"]["Authorization"] == "Bearer test-key"
+    fields = [f[0].get("name") for f in call["data"]._fields]
+    assert "file" in fields and "model" in fields and "language" in fields
+
+
+def test_auto_language_sends_no_language_field():
+    t = _batch(language="auto")
+    t._http_session = sess = _FakeSession()
+    _run_post(t)
+    assert "language" not in [f[0].get("name") for f in sess.calls[0]["data"]._fields]
+
+
+def test_audio_is_wrapped_as_a_real_wav_at_the_configured_rate():
+    """The endpoint takes a file upload, so raw PCM on the wire is silently mis-decoded."""
+    import io
+    import wave
+
+    t = _batch(sampling_rate=8000)
+    t._http_session = sess = _FakeSession()
+    _run_post(t, pcm=b"\x00\x01" * 4000)
+    payload = next(f[2] for f in sess.calls[0]["data"]._fields if f[0].get("name") == "file")
+    with wave.open(io.BytesIO(payload)) as wf:
+        assert wf.getframerate() == 8000
+        assert wf.getnchannels() == 1
+        assert wf.getsampwidth() == 2
+
+
+def test_http_error_is_recorded_and_yields_no_text():
+    t = _batch()
+    t._http_session = _FakeSession(status=404, body='{"error":"model not found"}')
+    assert _run_post(t) is None
+    assert "404" in t.connection_error
+
+
+def test_unparseable_body_is_survived():
+    t = _batch()
+    t._http_session = _FakeSession(status=200, body="<html>gateway</html>")
+    assert _run_post(t) is None
+
+
+def test_empty_transcript_is_returned_as_empty_not_none():
+    t = _batch()
+    t._http_session = _FakeSession(body='{"text": "   "}')
+    assert _run_post(t) == ""
+
+
+# ── flush → emitted packets ───────────────────────────────────────────────────
+
+
+def _flush_with(t, pcm, body='{"text": "book a table"}', status=200):
+    q = asyncio.Queue()
+    t.transcriber_output_queue = q
+    t._http_session = _FakeSession(status=status, body=body)
+    t._start_turn()
+    t._speech_active = True
+    t._utterance_buffer = bytearray(pcm)
+    asyncio.run(t._flush_utterance())
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_flush_emits_a_transcript_packet():
+    t = _batch(sampling_rate=16000)
+    packets = _flush_with(t, _speech(16000))
+    assert _types(packets) == ["transcript"]
+    assert packets[0]["data"]["content"] == "book a table"
+    assert packets[0]["meta_info"]["user_stop_offset_ms"] == t.endpointing_ms
+
+
+def test_flush_closes_the_turn_so_the_next_one_starts_clean():
+    t = _batch(sampling_rate=16000)
+    _flush_with(t, _speech(16000))
+    assert t.current_turn_id is None
+    assert t._speech_active is False
+    assert t._utterance_buffer == bytearray()
+
+
+def test_a_too_short_utterance_is_not_sent_to_the_model():
+    """Under ~200ms there is nothing to recognise, and a recogniser handed it invents a word."""
+    t = _batch(sampling_rate=16000)
+    packets = _flush_with(t, _speech(800))  # 50ms
+    assert _types(packets) == ["speech_ended"]
+    assert t._http_session.calls == []
+
+
+def test_a_failed_request_still_closes_the_turn():
+    """Otherwise callee_speaking latches on and held agent audio never ships."""
+    t = _batch(sampling_rate=16000)
+    packets = _flush_with(t, _speech(16000), status=500, body="upstream error")
+    assert _types(packets) == ["speech_ended"]
+
+
+def test_batch_turn_is_recorded_in_turn_latencies():
+    t = _batch(sampling_rate=16000)
+    _flush_with(t, _speech(16000))
+    assert len(t.turn_latencies) == 1
+    assert t.turn_latencies[0]["final_transcript"] == "book a table"
+
+
+# ══════════════════════════════════════════ regressions found by the live E2E run
+#
+# A local end-to-end run (bolna server + Qwen batch ASR + LLM + TTS) surfaced three
+# defects that no unit test covered. Each is pinned here.
+
+
+def test_default_timeout_can_actually_serve_the_default_host():
+    """The shipped default host/model measured 1.4s-52.9s round trip across runs. A tighter
+    timeout than that range silently drops the caller's utterance on a slow day."""
+    from bolna.constants import QWEN_ASR_DEFAULT_BASE_URL, QWEN_ASR_HTTP_TIMEOUT_S
+
+    assert "openrouter" in QWEN_ASR_DEFAULT_BASE_URL  # the default we must be able to serve
+    assert QWEN_ASR_HTTP_TIMEOUT_S >= 55.0
+
+
+@pytest.mark.parametrize("field", ["http_timeout_s", "max_utterance_s", "speech_rms_threshold", "base_url"])
+def test_batch_tunables_survive_the_config_layer(field):
+    """A knob absent from the Pydantic model is dropped by model_dump() before it ever reaches
+    the constructor — so it reads as configurable but silently is not."""
+    from bolna.models import Transcriber
+
+    assert field in Transcriber.model_fields
+
+
+def test_http_timeout_is_actually_applied_from_config():
+    assert _batch(http_timeout_s=5.0).http_timeout_s == 5.0
+
+
+def test_max_utterance_is_actually_applied_from_config():
+    assert _batch(max_utterance_s=3.0).max_utterance_s == 3.0
+
+
+def test_a_timed_out_request_is_recorded_not_swallowed():
+    """The non-200 branch sets connection_error; the timeout branch must too, or a dropped
+    turn leaves no trace of why the caller was never heard."""
+
+    class _TimingOutSession:
+        calls = []
+
+        def post(self, *a, **k):
+            raise asyncio.TimeoutError()
+
+        async def close(self):
+            pass
+
+    t = _batch(http_timeout_s=0.5)
+    t._http_session = _TimingOutSession()
+    assert _run_post(t) is None
+    assert t.connection_error is not None
+    assert "timed out" in t.connection_error
+
+
+def test_batch_reports_transcribed_seconds_for_billing():
+    """task_manager accumulates transcriber_duration off the closing packet; unset bills zero."""
+    t = _batch(sampling_rate=16000)
+    t._http_session = _FakeSession(body='{"text": "hi"}')
+    _run_post(t, pcm=b"\x00\x01" * 16000)  # exactly 1.0s at 16kHz
+    assert t.total_audio_seconds == pytest.approx(1.0)
+
+
+def test_host_reported_seconds_win_over_the_local_estimate():
+    t = _batch(sampling_rate=16000)
+    t._http_session = _FakeSession(body='{"text": "hi", "usage": {"seconds": 2.32}}')
+    _run_post(t, pcm=b"\x00\x01" * 16000)
+    assert t.total_audio_seconds == pytest.approx(2.32)
+
+
+def test_closing_packet_carries_transcriber_duration():
+    """The realtime path must report it too — same accounting, same packet."""
+    t = _transcriber()
+    t.transcriber_output_queue = q = asyncio.Queue()
+    t.total_audio_seconds = 4.94
+
+    async def close_it():
+        meta = dict(t.meta_info or {})
+        meta["transcriber_duration"] = round(t.total_audio_seconds, 3)
+        await t.push_to_transcriber_queue(create_ws_data_packet("transcriber_connection_closed", meta))
+
+    from bolna.helpers.utils import create_ws_data_packet
+
+    asyncio.run(close_it())
+    assert q.get_nowait()["meta_info"]["transcriber_duration"] == 4.94


### PR DESCRIPTION
## Summary

Adds Qwen3-ASR as a transcriber provider.

The wrinkle worth knowing up front: **"Qwen3-ASR" names two different products**, and they need two different clients.

| | Qwen3-ASR-**Flash-Realtime** | Qwen3-ASR **open weights** |
|---|---|---|
| What | Hosted service, no weights released | `Qwen3-ASR-1.7B` / `0.6B`, **Apache-2.0** |
| Where | Alibaba Cloud Model Studio only | Any host — OpenRouter, DeepInfra, Azure AI Foundry, self-hosted vLLM |
| Transport | WebSocket, OpenAI-Realtime event shape | OpenAI-compatible `/v1/audio/transcriptions` |
| Endpointing | Qwen's **server VAD** | none — batch file transcription |
| Interim results | yes | **no** |

Only the first is usable for live conversation; only the second is reachable without an Alibaba account. Rather than pick one, both ship behind `provider: "qwen"`, selected by the **existing** `stream` flag — the same mechanism `deepgram_transcriber.py` already uses to choose HTTP vs WebSocket.

```python
# bolna/transcriber/qwen_transcriber.py
runner = self.transcribe if self.stream else self.transcribe_http
```

## Configuration

**Realtime** (recommended for live calls):

```json
{
  "provider": "qwen",
  "stream": true,
  "model": "qwen3-asr-flash-realtime",
  "language": "en",
  "endpointing": 600,
  "keywords": "Bolna, Plivo, Zentrunk"
}
```
Key from `QWEN_API_KEY` or `DASHSCOPE_API_KEY`. Host defaults to the Singapore gateway (`dashscope-intl.aliyuncs.com`); set `QWEN_ASR_HOST=dashscope.aliyuncs.com` for Beijing.

**Open weights** (works with any OpenAI-compatible host):

```json
{
  "provider": "qwen",
  "stream": false,
  "base_url": "https://openrouter.ai/api/v1",
  "model": "qwen/qwen3-asr-1.7b",
  "language": "en",
  "endpointing": 600
}
```
The same shape targets `https://api.deepinfra.com/v1/openai` or a local `vllm serve Qwen/Qwen3-ASR-1.7B` (`http://localhost:8000/v1`) — those hosts are supported by construction and covered by unit tests, but **only OpenRouter was exercised against a live endpoint** here. Note model ids differ per host — `qwen/qwen3-asr-1.7b` on OpenRouter, `Qwen/Qwen3-ASR-1.7B` on DeepInfra and vLLM — which is why `model` and `base_url` are separate fields.

## Design notes

**Audio.** Neither path accepts mu-law, so Twilio and sip-trunk audio is decoded to linear16 with `audioop.ulaw2lin` before it goes on the wire. Sample rate is **passed through, never resampled** — Qwen takes 8 kHz and 16 kHz natively — so nothing costly happens on the hot path. `self.encoding` stays truthful to the *input* because `TranscriberPool._standby_keepalive` reads it to pick the right silence byte for standby connections.

**Interims are `text` + `stash`.** Qwen splits a partial into a settled prefix and a pre-recognised tail; the running utterance is their concatenation. Using `text` alone silently drops the newest words, which are exactly the ones the interruption check needs.

**Local endpointing on the batch path.** There is no server VAD there, so the turn boundary has to come from us. Frame RMS opens the turn, `endpointing_ms` of quiet closes it. Trailing quiet stays in the buffer (cutting at the silence strands the last word), and `max_utterance_s` flushes a caller who never pauses so the buffer and request can't grow unbounded. Shape follows `sarvam_transcriber.py`'s existing buffer-and-flush.

**Watchdogs.** Realtime force-closes a turn that got `speech_stopped` but no `.completed`, delivering buffered interims — without it a single dropped final holds the agent silent for the rest of the call. Late duplicates are then dropped so a turn can't be replayed to the LLM.

**`user_stop_offset_ms` differs per mode** — realtime credits Qwen's server-VAD window, batch credits the local one. Getting this wrong puts the turn boundary at the wrong instant in `InterruptionManager`.

**Model id guard.** A realtime model id POSTed to `/v1/audio/transcriptions` is a 404 that is unpleasant to debug, so a config that only flipped `stream` falls back to a servable batch id with a log line. An explicitly-set model is never touched.

## Testing

**96 unit tests** in `tests/test_qwen_transcriber.py`, hermetic — no network, no credentials. Full suite: **1459 passed, 1 skipped**. `ruff check`, `ruff format --check` and `bandit -r bolna --severity-level medium --confidence-level high` (0 medium, 0 high) all clean.

**Open-weights path — verified end to end against a live host.** Same 4.5 s clip over both audio shapes, returning identical correct transcripts:

| Path | Payload | Round trip |
|---|---|---|
| 16 kHz linear16 | 158,080 B | 2.74 s |
| 8 kHz mu-law (Twilio shape) | 79,360 B | 1.36 s |

> `Hello, my name is John. I would like to check the status of my order, please.`

The mu-law run matters most: telephony-degraded audio, decoded by `ulaw2lin`, transcribed identically to the clean 16 kHz version. A subtly wrong decode shows up as garbled words, not an error.

**Full local call.** Ran the bolna stack (redis + `quickstart_server.py`) with this transcriber, an LLM and TTS, and streamed the WAV over the websocket. ASR → LLM → TTS → audio out, with 59/59 marks acked and 0 missed. The agent's own reply audio was fed back through the same ASR and returned the LLM's sentence verbatim, confirming audio genuinely traversed the whole stack.

**Realtime path — verified against a protocol-enforcing mock**, not live DashScope (see Limitations). Covered: handshake and `session.update` acceptance, `session.created`/`updated`, full turn lifecycle, multi-turn including turn re-open, `.failed` and `error` handling, and rejection of a bad `input_audio_format` (zero transcript packets emitted, error captured).

## Limitations

**The realtime path has not been run against live DashScope.** Model Studio keys are region-bound and free activation is Singapore-only; I could not obtain one. Everything above it is verified, but the live handshake is not. **One command closes this for anyone holding a key** — it sends no audio and consumes no quota:

```bash
python tests/manual/qwen_transcriber_smoke.py --handshake
```

**The batch path has no interim results.** `task_manager` drives barge-in off `interim_transcript_received`, so an agent on `stream: false` **cannot be interrupted mid-utterance** — it only learns what the caller said once they stop. Round trips measured **1.4 s – 52.9 s** on OpenRouter for the same 4.5 s clip; the default `http_timeout_s` of 60 s is sized so a slow day doesn't silently drop a turn, not to be fast. Good for transcription, unsuitable for live conversation. `stream: true` remains the right default.

**vLLM's `/v1/realtime` is not a workaround.** It exists for these weights but transcribes each 5 s segment in isolation, duplicates speech across boundaries, and leaks the raw `language {lang}<asr_text>{…}` format — [vllm#35767](https://github.com/vllm-project/vllm/issues/35767), closed *"not planned"*. The batch endpoint is unaffected and is the only usable open-weights route today. If a first-class realtime open-weights path is ever wanted, Baseten serves Qwen3-ASR-1.7B over its own streaming WebSocket, which would need a third adapter.

## Reproducing locally

Requires Python ≥ 3.10.

```bash
git clone https://github.com/CH1NRU5T/bolna.git && cd bolna
git checkout feat/qwen3-asr-transcriber
python -m venv .venv && source .venv/bin/activate
pip install -e '.[dev]'
```

**1. Unit tests — no credentials, no network:**

```bash
pytest tests/test_qwen_transcriber.py -q     # 96 passed
pytest -q                                    # 1459 passed, 1 skipped
```

**2. Live open-weights check — no Alibaba account needed.** Any OpenAI-compatible host works; DeepInfra gives $5 free on signup with no card. `OPENROUTER_API_KEY` / `DEEPINFRA_API_KEY` in the environment are picked up automatically.

```bash
export QWEN_ASR_BATCH_KEY=sk-...

python tests/manual/qwen_transcriber_smoke.py --batch               # 16 kHz PCM
python tests/manual/qwen_transcriber_smoke.py --batch --telephony   # 8 kHz mu-law

# self-hosted instead:
#   vllm serve Qwen/Qwen3-ASR-1.7B
#   python tests/manual/qwen_transcriber_smoke.py --batch \
#     --base-url http://localhost:8000/v1 --model Qwen/Qwen3-ASR-1.7B
```

Expect `speech_started`, a correct transcript of the bundled `tests/manual/test_speech.wav`, and `All assertions passed`. The interim check is skipped by design on this path.

**3. Live realtime check — needs a Model Studio key:**

```bash
export QWEN_API_KEY=sk-...                                    # Singapore region
python tests/manual/qwen_transcriber_smoke.py --handshake     # no audio, ~2s
python tests/manual/qwen_transcriber_smoke.py                 # full turn, 16 kHz
python tests/manual/qwen_transcriber_smoke.py --telephony     # 8 kHz mu-law
```

Run `--handshake` first — it isolates auth/region/session-config problems from audio problems and names the offending field on failure. For Beijing, `export QWEN_ASR_HOST=dashscope.aliyuncs.com`.

`tests/manual/` is not collected by pytest, per the convention in `tests/README.md`.

## Files

| File | |
|---|---|
| `bolna/transcriber/qwen_transcriber.py` | new, 1077 lines — both paths |
| `tests/test_qwen_transcriber.py` | new, 891 lines — 96 tests |
| `tests/manual/qwen_transcriber_smoke.py` | new — live harness, not collected |
| `bolna/constants.py` | Qwen defaults, each with the reasoning |
| `bolna/enums.py`, `bolna/providers.py`, `bolna/transcriber/__init__.py` | provider registration (1–2 lines each) |
| `bolna/models.py` | `base_url`, `speech_rms_threshold`, `http_timeout_s`, `max_utterance_s`, `completion_timeout` |
| `README.md`, `.env.sample` | provider table + env vars |

10 files, **+2437 / −0**. Purely additive; no existing behaviour altered.

## Unrelated finding

Not touched here, and not from this branch — flagging it because the local run surfaced it. `task_manager.py:1413` calls `self.tools["output"].set_stream_sid(...)` unconditionally, but that method exists only on the telephony output handlers, never on `DefaultOutputHandler`. So `__forced_first_message` raises for `provider: "default"` agents and the **welcome message never plays**. Non-fatal — it's caught and logged, and the conversation proceeds — but worth its own issue.

## Checklist

- [x] `pytest` — 1459 passed, 1 skipped
- [x] `ruff check` / `ruff format --check`
- [x] `bandit` — 0 medium, 0 high
- [x] No new dependencies (`aiohttp` already required)
- [x] Provider registered in enum + registry (`test_provider_registry_parity.py` passes)
- [x] Live-verified: open-weights path, both audio encodings, plus a full local call
- [ ] Live-verified: realtime path — blocked on a Model Studio key, see Limitations
