### PR TITLE
fix: default routing reasoning_effort per model for the gpt-5 family

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.220"
+__version__ = "0.10.221"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -25,7 +25,7 @@ from bolna.llms.types import LLMStreamChunk, LatencyData
 from bolna.llms import OpenAiLLM, LiteLLM
 from bolna.providers import SUPPORTED_LLM_PROVIDERS
 from bolna.prompts import VOICEMAIL_DETECTION_PROMPT
-from bolna.constants import LANGUAGE_NAMES
+from bolna.constants import GPT5_MODEL_PREFIX, LANGUAGE_NAMES, canonical_model, default_reasoning_effort
 
 from typing import List, Tuple, AsyncGenerator, Optional, Dict, Any
 
@@ -274,14 +274,20 @@ class GraphAgent(BaseAgent):
             for key in ("llm_key", "base_url", "api_version"):
                 if self.config.get(key):
                     routing_kwargs[key] = self.config[key]
-        if self.routing_reasoning_effort:
-            routing_kwargs["reasoning_effort"] = self.routing_reasoning_effort
+        # Only gpt-5 models take an effort; resolve deployment names to the model family first.
+        routing_family = canonical_model(self.routing_model)
+        if routing_family.startswith(GPT5_MODEL_PREFIX):
+            routing_kwargs["reasoning_effort"] = (
+                self.routing_reasoning_effort
+                or os.getenv("GPT5_ROUTING_REASONING_EFFORT")
+                or default_reasoning_effort(routing_family)
+            )
         if self.service_tier:
             routing_kwargs["service_tier"] = self.service_tier
         if self.config.get("overflow_llm"):
             routing_kwargs["overflow_llm"] = self.config["overflow_llm"]
 
-        self._routing_reasoning_effort_used = self.routing_reasoning_effort
+        self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
         self.routing_llm = llm_class(**routing_kwargs)
         logger.info(f"Routing initialized with {self.routing_provider} ({self.routing_model})")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.220"
+version = "0.10.221"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_graph_routing_credentials.py
+++ b/tests/test_graph_routing_credentials.py
@@ -110,7 +110,9 @@ def test_explicit_azure_routing_with_openai_conversation_uses_platform_creds():
 
 
 def test_routing_forwards_service_tier_and_reasoning_effort():
-    agent, _ = _build(provider="openai", service_tier="priority", routing_reasoning_effort="low")
+    agent, _ = _build(
+        provider="openai", routing_model="gpt-5.4-mini", service_tier="priority", routing_reasoning_effort="low"
+    )
     kw = _routing_kwargs(agent)
     assert kw["service_tier"] == "priority"
     assert kw["reasoning_effort"] == "low"

--- a/tests/test_routing_reasoning_effort_default.py
+++ b/tests/test_routing_reasoning_effort_default.py
@@ -1,0 +1,105 @@
+"""Routing sends a reasoning_effort only for the gpt-5 family, and one the model accepts.
+
+"minimal" is accepted only by gpt-5, gpt-5-mini and gpt-5-nano, so it cannot be the blanket
+default. The family check reads the model a deployment resolves to, or Azure deployment names
+such as "ptu-gpt-5.4-mini" miss the branch entirely. Non-gpt-5 routers never receive an effort,
+even an explicit one, since chat completions reject it there.
+"""
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.constants import GPT5_MODEL_PREFIX, MODEL_REASONING_EFFORT_MAP
+
+# The map also carries realtime speech-to-speech models, which are never a routing model.
+GPT5_MODELS = sorted(m for m in MODEL_REASONING_EFFORT_MAP if m.startswith(GPT5_MODEL_PREFIX))
+AZURE_DEPLOYMENT_FORMS = ["azure/gpt-5.4-mini", "ptu-gpt-5.4-mini"]
+PLATFORM_ENV = {"OPENAI_API_KEY": "platform-openai-key", "AZURE_OPENAI_API_KEY": "platform-azure-key"}
+
+
+def _registry():
+    def make(**kwargs):
+        client = MagicMock()
+        client.captured_kwargs = kwargs
+        return client
+
+    return {p: make for p in ["openai", "azure", "custom"]}
+
+
+def _build(env=None, **config_overrides):
+    config = {
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "current_node_id": "start",
+        "nodes": [{"id": "start", "prompt": "hi", "edges": []}],
+    }
+    config.update(config_overrides)
+    with (
+        patch.dict(os.environ, env if env is not None else PLATFORM_ENV, clear=True),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", _registry()),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+    ):
+        return GraphAgent(config)
+
+
+def _kwargs(agent):
+    return agent.routing_llm.captured_kwargs
+
+
+def _accepted(model):
+    return [e.value for e in MODEL_REASONING_EFFORT_MAP[model]]
+
+
+@pytest.mark.parametrize("model", GPT5_MODELS)
+def test_default_effort_is_accepted_by_the_model(model):
+    agent = _build(routing_model=model, routing_provider="openai")
+    assert _kwargs(agent)["reasoning_effort"] in _accepted(model)
+
+
+@pytest.mark.parametrize("deployment", AZURE_DEPLOYMENT_FORMS)
+def test_azure_deployment_names_take_the_gpt5_branch(deployment):
+    agent = _build(routing_model=deployment, routing_provider="azure", provider="azure")
+    kw = _kwargs(agent)
+    assert kw["reasoning_effort"] in _accepted("gpt-5.4-mini")
+    assert kw["model"] == deployment  # the deployment name itself is what Azure is asked for
+
+
+def test_explicit_effort_wins_over_the_default():
+    agent = _build(routing_model="gpt-5.4-mini", routing_provider="openai", routing_reasoning_effort="high")
+    assert _kwargs(agent)["reasoning_effort"] == "high"
+
+
+def test_env_override_applies_when_unset():
+    env = {**PLATFORM_ENV, "GPT5_ROUTING_REASONING_EFFORT": "medium"}
+    agent = _build(env=env, routing_model="gpt-5.4-mini", routing_provider="openai")
+    assert _kwargs(agent)["reasoning_effort"] == "medium"
+
+
+def test_non_gpt5_routing_gets_no_effort():
+    agent = _build(routing_model="gpt-4.1-mini", routing_provider="openai")
+    kw = _kwargs(agent)
+    assert "reasoning_effort" not in kw
+    assert kw["max_tokens"] == 250
+    assert kw["temperature"] == 0
+
+
+def test_explicit_effort_on_non_gpt5_is_dropped():
+    agent = _build(routing_model="gpt-4.1-mini", routing_provider="openai", routing_reasoning_effort="minimal")
+    assert "reasoning_effort" not in _kwargs(agent)
+
+
+def test_recorded_effort_mirrors_what_was_sent():
+    assert (
+        _build(routing_model="gpt-5.4-mini", routing_provider="openai")._routing_reasoning_effort_used
+        == (_kwargs(_build(routing_model="gpt-5.4-mini", routing_provider="openai"))["reasoning_effort"])
+    )
+    assert _build(routing_model="gpt-4.1-mini", routing_provider="openai")._routing_reasoning_effort_used is None
+
+
+def test_routing_max_tokens_override_is_respected():
+    agent = _build(routing_model="gpt-5.4-mini", routing_provider="openai", routing_max_tokens=99)
+    assert _kwargs(agent)["max_tokens"] == 99


### PR DESCRIPTION
#999 rewrote `_init_routing_client` and dropped the per-model default `reasoning_effort` that #948 added for gpt-5-family routers, along with its test. Since then a gpt-5 routing model with no explicit effort sends none and runs at the model default (medium), and an explicit effort is forwarded to any model, including non-reasoning ones that reject it.

Restores #948 on top of the registry-based routing client:
- gpt-5-family routers get `routing_reasoning_effort`, then `GPT5_ROUTING_REASONING_EFFORT`, then the model's lowest supported effort, with the family read from the model a deployment resolves to (`ptu-gpt-5.4-mini` resolves to `gpt-5.4-mini`).
- non-gpt-5 routers never receive an effort, explicit or not.
- `_routing_reasoning_effort_used` records what was actually sent.

Restores `test_routing_reasoning_effort_default.py` adapted to the constructor-kwarg pattern, adds a case for dropping an explicit effort on a non-gpt-5 router, and moves the #999 forwarding test onto a gpt-5 router.