### PR TITLE
fix: stall backstop can be permanently defeated by a hung LLM task (BOLNA-2563)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.223"
+__version__ = "0.10.224"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3210,7 +3210,15 @@ class TaskManager(BaseManager):
 
             self.hangup_detail = HangupReason.END_CALL_TOOL
             self.call_hangup_message_config = None
-            await self.process_call_hangup()
+            # Detached, not awaited: this call site runs inside __do_llm_generation's own
+            # LLM_GENERATION_TIMEOUT_S window (the end_call tool is handled here, mid-generation).
+            # process_call_hangup's teardown (goodbye playout wait, hangup-chunk wait,
+            # stop_handler) can legitimately take longer than that and must not be cancelled
+            # mid-way - same failure mode as BOLNA-2563, reached via the end_call tool instead
+            # of the hangup-decision check. Held on self, not _usage_tasks, so a reference
+            # survives (see _usage_tasks' own comment) without an unrelated cleanup sweep
+            # ever cancelling this specific task.
+            self._end_call_hangup_task = asyncio.create_task(self.process_call_hangup())
             return
 
         if called_fun.startswith("transfer_call"):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -42,9 +42,10 @@ from bolna.constants import (
     END_CALL_FUNCTION_PREFIX,
     END_CALL_TOOL_DEFINITION,
     RESPONSES_API_MODEL_PREFIXES,
+    LLM_GENERATION_TIMEOUT_S,
     S2S_GOODBYE_TIMEOUT_S,
     S2S_STREAM_SID_TIMEOUT_S,
-    STALL_HANGUP_FLOOR_S,
+    STALL_HANGUP_HARD_CAP_S,
     STUCK_AUDIO_GATE_RELEASE_S,
     WEB_BASED_CALL_PROVIDER,
     WEBCALL_TTS_SAMPLE_RATE,
@@ -4437,9 +4438,11 @@ class TaskManager(BaseManager):
 
         try:
             if self._is_extraction_task() or self._is_summarization_task():
-                await self._process_followup_task(message)
+                await asyncio.wait_for(self._process_followup_task(message), timeout=LLM_GENERATION_TIMEOUT_S)
             elif self._is_conversation_task():
-                await self._process_conversation_task(message, sequence, meta_info)
+                await asyncio.wait_for(
+                    self._process_conversation_task(message, sequence, meta_info), timeout=LLM_GENERATION_TIMEOUT_S
+                )
             else:
                 logger.error("unsupported task type: {}".format(self.task_config["task_type"]))
             self.llm_task = None
@@ -4448,6 +4451,21 @@ class TaskManager(BaseManager):
             self._synthesis_awaiting_first_audio = False
             await self._end_call_on_component_error(e, HangupReason.LLM_ERROR)
             raise
+        except asyncio.TimeoutError:
+            # The LLM never came back within LLM_GENERATION_TIMEOUT_S seconds - treat it as
+            # stuck and hang up, same as any other LLM failure, instead of waiting forever.
+            # BOLNA-2563.
+            logger.error(f"LLM generation stuck for {LLM_GENERATION_TIMEOUT_S}s (run_id={self.run_id}) - hanging up")
+            self.response_in_pipeline = False
+            self._synthesis_awaiting_first_audio = False
+            await self._end_call_on_component_error(
+                LLMError(
+                    f"LLM generation timed out after {LLM_GENERATION_TIMEOUT_S}s",
+                    provider=self.llm_config.get("provider", "unknown"),
+                    model=self.llm_config.get("model"),
+                ),
+                HangupReason.LLM_ERROR,
+            )
         except Exception as e:
             self.response_in_pipeline = False
             self._synthesis_awaiting_first_audio = False
@@ -7254,22 +7272,23 @@ class TaskManager(BaseManager):
             logger.info("Silence repeat generation cancelled by interruption")
             return
 
-    def _should_stall_hangup(
-        self, audio_playing, has_pending_generation, time_since_last_spoken_ai_word, time_since_user_last_spoke
-    ):
-        """Hang up when the call has made no forward progress at all: no audio playing, nothing
-        in flight, and both sides silent past the floor. Runs above the audio/pipeline gate so it
-        still applies when a pipeline flag is stuck. Floor stays above hangup_after_silence so the
-        normal inactivity path takes precedence whenever it is reachable."""
+    def _should_stall_hangup(self, audio_playing, time_since_last_spoken_ai_word, time_since_user_last_spoke):
+        """Hang up when the call has made no forward progress at all: no audio playing and both
+        sides silent past the hard cap. Runs above the audio/pipeline gate so it still applies
+        when a pipeline flag is stuck (e.g. a hung LLM call)."""
         if self.hang_conversation_after <= 0:
             return False
-        stall_timeout = max(self.hang_conversation_after, STALL_HANGUP_FLOOR_S)
-        return (
+        fires = (
             not audio_playing
-            and not has_pending_generation
-            and time_since_last_spoken_ai_word > stall_timeout
-            and time_since_user_last_spoke > stall_timeout
+            and time_since_last_spoken_ai_word > STALL_HANGUP_HARD_CAP_S
+            and time_since_user_last_spoke > STALL_HANGUP_HARD_CAP_S
         )
+        if fires:
+            logger.debug(
+                f"_should_stall_hangup: firing (ai_silent={time_since_last_spoken_ai_word:.1f}s "
+                f"user_silent={time_since_user_last_spoke:.1f}s hard_cap={STALL_HANGUP_HARD_CAP_S}s)"
+            )
+        return fires
 
     def _pipeline_busy(self, audio_playing):
         """True while the agent is speaking or about to: response_in_pipeline can read False in the gap between a response's synth push and its first audio chunk, so _synthesis_awaiting_first_audio covers it."""
@@ -7350,14 +7369,13 @@ class TaskManager(BaseManager):
             # Must run above the audio/pipeline gate below (see method docstring).
             if self._should_stall_hangup(
                 audio_playing=self.tools["input"].is_audio_being_played_to_user(),
-                has_pending_generation=has_pending_generation,
                 time_since_last_spoken_ai_word=time_since_last_spoken_ai_word,
                 time_since_user_last_spoke=time_since_user_last_spoke,
             ):
                 logger.warning(
                     f"Stall backstop: no forward progress for {time_since_last_spoken_ai_word:.1f}s "
-                    f"(audio_playing=False, no pending generation, response_in_pipeline={self.response_in_pipeline}) "
-                    f"- forcing hangup"
+                    f"(audio_playing=False, has_pending_generation={has_pending_generation}, "
+                    f"response_in_pipeline={self.response_in_pipeline}) - forcing hangup"
                 )
                 await self._hangup_after_goodbye(HangupReason.INACTIVITY_TIMEOUT)
                 break

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3217,8 +3217,10 @@ class TaskManager(BaseManager):
             # mid-way - same failure mode as BOLNA-2563, reached via the end_call tool instead
             # of the hangup-decision check. Held on self, not _usage_tasks, so a reference
             # survives (see _usage_tasks' own comment) without an unrelated cleanup sweep
-            # ever cancelling this specific task.
+            # ever cancelling this specific task. Done callback so a raised exception doesn't
+            # just vanish with the task (mirrors _s2s_on_task_done, same reasoning).
             self._end_call_hangup_task = asyncio.create_task(self.process_call_hangup())
+            self._end_call_hangup_task.add_done_callback(self.__log_detached_hangup_exception)
             return
 
         if called_fun.startswith("transfer_call"):
@@ -4178,6 +4180,15 @@ class TaskManager(BaseManager):
 
     def _should_ignore_transcriber_input(self) -> bool:
         return self.hangup_triggered or self._end_call_in_progress or self.has_transfer
+
+    def __log_detached_hangup_exception(self, task: asyncio.Task) -> None:
+        """A bare create_task with no done callback drops the exception along with the task, so
+        a failed hangup would look identical to a successful one. Mirrors _s2s_on_task_done."""
+        if task.cancelled():
+            return
+        exception = task.exception()
+        if exception is not None:
+            logger.error(f"Detached end_call hangup failed | error={type(exception).__name__}: {exception}")
 
     async def process_call_hangup(self):
         if self.hangup_decision_at is None:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3574,6 +3574,20 @@ class TaskManager(BaseManager):
     async def __do_llm_generation(
         self, messages, meta_info, next_step, should_bypass_synth=False, should_trigger_function_call=False
     ):
+        """Bounds one generation call to LLM_GENERATION_TIMEOUT_S. Scoped here (not around the
+        whole conversation task) so a hung LLM raises promptly without also racing the
+        hangup-decision call or the hangup teardown that can follow it - those can legitimately
+        take a while and must not be cut off mid-way. BOLNA-2563."""
+        await asyncio.wait_for(
+            self.__do_llm_generation_impl(
+                messages, meta_info, next_step, should_bypass_synth, should_trigger_function_call
+            ),
+            timeout=LLM_GENERATION_TIMEOUT_S,
+        )
+
+    async def __do_llm_generation_impl(
+        self, messages, meta_info, next_step, should_bypass_synth=False, should_trigger_function_call=False
+    ):
         if self.hangup_triggered or self.conversation_ended:
             logger.info(
                 f"__do_llm_generation: Skipping — hangup_triggered={self.hangup_triggered}, conversation_ended={self.conversation_ended}"
@@ -4438,11 +4452,16 @@ class TaskManager(BaseManager):
 
         try:
             if self._is_extraction_task() or self._is_summarization_task():
-                await asyncio.wait_for(self._process_followup_task(message), timeout=LLM_GENERATION_TIMEOUT_S)
+                # No timeout: this is post-call extraction/summarization, not a live call - there
+                # is no caller to rescue. Capping it here only risks discarding a slow-but-working
+                # result and running live-call cleanup (_report_provider_health(False),
+                # __process_end_of_conversation) against a task manager with no telephony handler.
+                await self._process_followup_task(message)
             elif self._is_conversation_task():
-                await asyncio.wait_for(
-                    self._process_conversation_task(message, sequence, meta_info), timeout=LLM_GENERATION_TIMEOUT_S
-                )
+                # No outer timeout here: __do_llm_generation bounds each individual generation
+                # call on its own. The hangup-decision LLM call and any hangup teardown that
+                # follows it in _process_conversation_task must not share that same clock.
+                await self._process_conversation_task(message, sequence, meta_info)
             else:
                 logger.error("unsupported task type: {}".format(self.task_config["task_type"]))
             self.llm_task = None
@@ -7275,18 +7294,21 @@ class TaskManager(BaseManager):
     def _should_stall_hangup(self, audio_playing, time_since_last_spoken_ai_word, time_since_user_last_spoke):
         """Hang up when the call has made no forward progress at all: no audio playing and both
         sides silent past the hard cap. Runs above the audio/pipeline gate so it still applies
-        when a pipeline flag is stuck (e.g. a hung LLM call)."""
+        when a pipeline flag is stuck (e.g. a hung LLM call). An agent's own hangup_after_silence
+        wins over the hard cap when configured higher - this is insurance on top of that
+        configured patience, not a replacement for it."""
         if self.hang_conversation_after <= 0:
             return False
+        stall_timeout = max(self.hang_conversation_after, STALL_HANGUP_HARD_CAP_S)
         fires = (
             not audio_playing
-            and time_since_last_spoken_ai_word > STALL_HANGUP_HARD_CAP_S
-            and time_since_user_last_spoke > STALL_HANGUP_HARD_CAP_S
+            and time_since_last_spoken_ai_word > stall_timeout
+            and time_since_user_last_spoke > stall_timeout
         )
         if fires:
             logger.debug(
                 f"_should_stall_hangup: firing (ai_silent={time_since_last_spoken_ai_word:.1f}s "
-                f"user_silent={time_since_user_last_spoke:.1f}s hard_cap={STALL_HANGUP_HARD_CAP_S}s)"
+                f"user_silent={time_since_user_last_spoke:.1f}s stall_timeout={stall_timeout}s)"
             )
         return fires
 
@@ -7349,13 +7371,15 @@ class TaskManager(BaseManager):
             # running inside it) means a response is still being produced even though
             # response_in_pipeline has flipped False after the filler audio. Treat that
             # window as busy so we don't synthesize "are you still there" over the
-            # upcoming follow-up response. hang_conversation_after intentionally remains
-            # ungated so a truly hung task still triggers the inactivity hangup.
+            # upcoming follow-up response, or repeat-after-silence over it either (both checks
+            # below are gated on this). hang_conversation_after intentionally remains ungated so
+            # a truly hung task still triggers the inactivity hangup - and so does the stall
+            # backstop's own hard cap (_should_stall_hangup, below, does not look at this flag
+            # at all): a tool call or s2s call that outlasts that cap with no audio playing can
+            # still be read as no forward progress and hung up mid-tool. BOLNA-2563.
             has_pending_generation = (
                 (self.llm_task is not None and not self.llm_task.done())
                 or (self.execute_function_call_task is not None and not self.execute_function_call_task.done())
-                # An s2s tool call lives here instead, and outlasting the floor would otherwise
-                # read as no forward progress and hang up mid-tool.
                 or any(not task.done() for task in getattr(self, "_s2s_tool_tasks", ()))
             )
 

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -22,8 +22,17 @@ DEEPGRAM_FLUX_EAGER_EOT_THRESHOLD = 0.5  # confidence to trigger speculative LLM
 DEEPGRAM_FLUX_EOT_TIMEOUT_MS = 500  # max silence before forcing end-of-turn
 # Min time a Flux turn may stay open with no transcriber events before it is force-closed.
 DEEPGRAM_FLUX_TURN_STALL_FLOOR_S = 3.0
-# Min idle time before the inactivity backstop hangs up; kept above hangup_after_silence.
-STALL_HANGUP_FLOOR_S = 20.0
+# Past this much silence (no audio playing, both sides silent), force a hangup - the call has
+# made no forward progress at all, e.g. a hung LLM call or an s2s tool task that never
+# completes. BOLNA-2563.
+STALL_HANGUP_HARD_CAP_S = 60.0
+# Max time to wait for one LLM reply (_run_llm_task). If the LLM never comes back - no reply,
+# no error, it just hangs - force it to fail after this many seconds and hang up, instead of
+# leaving the call stuck forever. BOLNA-2563.
+LLM_GENERATION_TIMEOUT_S = 60.0
+# Same idea, applied to the voicemail-check LLM call (agent_manager/voicemail_handler.py),
+# which has its own unguarded await and is not covered by _run_llm_task's timeout. BOLNA-2563.
+VOICEMAIL_CHECK_TIMEOUT_S = 12.0
 
 # LLM-driven language-switch defaults, all overridable by the matching LANGUAGE_SWITCH_* env.
 # Read via os.getenv(..., CONSTANT) at call time, never frozen at import (load_dotenv runs later).

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -30,9 +30,6 @@ STALL_HANGUP_HARD_CAP_S = 60.0
 # no error, it just hangs - force it to fail after this many seconds and hang up, instead of
 # leaving the call stuck forever. BOLNA-2563.
 LLM_GENERATION_TIMEOUT_S = 60.0
-# Same idea, applied to the voicemail-check LLM call (agent_manager/voicemail_handler.py),
-# which has its own unguarded await and is not covered by _run_llm_task's timeout. BOLNA-2563.
-VOICEMAIL_CHECK_TIMEOUT_S = 12.0
 
 # LLM-driven language-switch defaults, all overridable by the matching LANGUAGE_SWITCH_* env.
 # Read via os.getenv(..., CONSTANT) at call time, never frozen at import (load_dotenv runs later).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.223"
+version = "0.10.224"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_check_completion_stall_backstop.py
+++ b/tests/test_check_completion_stall_backstop.py
@@ -54,3 +54,11 @@ def test_does_not_fire_below_the_hard_cap():
     below_cap = STALL_HANGUP_HARD_CAP_S - 5
     assert below_cap > 0
     assert _decide(15, audio_playing=False, ai_silent_s=below_cap, user_silent_s=below_cap) is False
+
+
+def test_configured_patience_above_the_hard_cap_wins():
+    # An agent that asked for more patience than the hard cap must get it - the cap is a
+    # floor/insurance policy, not a ceiling that overrides what the agent configured.
+    above_cap = STALL_HANGUP_HARD_CAP_S + 30
+    assert _decide(above_cap, audio_playing=False, ai_silent_s=STALL_HANGUP_HARD_CAP_S + 5, user_silent_s=STALL_HANGUP_HARD_CAP_S + 5) is False
+    assert _decide(above_cap, audio_playing=False, ai_silent_s=above_cap + 5, user_silent_s=above_cap + 5) is True

--- a/tests/test_check_completion_stall_backstop.py
+++ b/tests/test_check_completion_stall_backstop.py
@@ -60,5 +60,13 @@ def test_configured_patience_above_the_hard_cap_wins():
     # An agent that asked for more patience than the hard cap must get it - the cap is a
     # floor/insurance policy, not a ceiling that overrides what the agent configured.
     above_cap = STALL_HANGUP_HARD_CAP_S + 30
-    assert _decide(above_cap, audio_playing=False, ai_silent_s=STALL_HANGUP_HARD_CAP_S + 5, user_silent_s=STALL_HANGUP_HARD_CAP_S + 5) is False
+    assert (
+        _decide(
+            above_cap,
+            audio_playing=False,
+            ai_silent_s=STALL_HANGUP_HARD_CAP_S + 5,
+            user_silent_s=STALL_HANGUP_HARD_CAP_S + 5,
+        )
+        is False
+    )
     assert _decide(above_cap, audio_playing=False, ai_silent_s=above_cap + 5, user_silent_s=above_cap + 5) is True

--- a/tests/test_check_completion_stall_backstop.py
+++ b/tests/test_check_completion_stall_backstop.py
@@ -2,74 +2,55 @@
 
 Guarantees that a wedged pipeline (e.g. a stuck transcriber turn that holds audio and never
 clears response_in_pipeline) cannot produce an endless call, while never firing during healthy
-playback, in-flight tool/LLM generation, or normal short silences.
+playback or normal short silences.
 """
 
 from types import SimpleNamespace
 
 from bolna.agent_manager.task_manager import TaskManager
-from bolna.constants import STALL_HANGUP_FLOOR_S
+from bolna.constants import STALL_HANGUP_HARD_CAP_S
 
 
 # _should_stall_hangup only reads self.hang_conversation_after, so we can exercise the pure
 # predicate on a lightweight stand-in via the unbound method.
-def _decide(hang_conversation_after, *, audio_playing, has_pending_generation, ai_silent_s, user_silent_s):
+def _decide(hang_conversation_after, *, audio_playing, ai_silent_s, user_silent_s):
     fake = SimpleNamespace(hang_conversation_after=hang_conversation_after)
     return TaskManager._should_stall_hangup(
         fake,
         audio_playing=audio_playing,
-        has_pending_generation=has_pending_generation,
         time_since_last_spoken_ai_word=ai_silent_s,
         time_since_user_last_spoke=user_silent_s,
     )
 
 
-AGED = STALL_HANGUP_FLOOR_S + 5  # comfortably past the floor
+AGED = STALL_HANGUP_HARD_CAP_S + 5  # comfortably past the hard cap
 
 
 def test_fires_on_wedged_pipeline_stall():
-    # The bug: audio held (not playing), nothing in flight, both sides long silent.
-    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is True
+    # The bug: audio held (not playing), both sides long silent past the hard cap.
+    assert _decide(15, audio_playing=False, ai_silent_s=AGED, user_silent_s=AGED) is True
 
 
 def test_does_not_fire_during_audio_playback():
     # A long healthy TTS response: audio is playing -> never force-hangup.
-    assert _decide(15, audio_playing=True, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is False
-
-
-def test_does_not_fire_during_pending_generation():
-    # A slow tool/LLM call in flight with no audio yet -> must not hang up.
-    assert _decide(15, audio_playing=False, has_pending_generation=True, ai_silent_s=AGED, user_silent_s=AGED) is False
+    assert _decide(15, audio_playing=True, ai_silent_s=AGED, user_silent_s=AGED) is False
 
 
 def test_does_not_fire_when_timers_fresh():
-    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=1.0, user_silent_s=1.0) is False
+    assert _decide(15, audio_playing=False, ai_silent_s=1.0, user_silent_s=1.0) is False
 
 
 def test_requires_both_sides_silent():
     # User just spoke (fresh) even though agent has been silent -> not a stall.
-    assert _decide(15, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=1.0) is False
+    assert _decide(15, audio_playing=False, ai_silent_s=AGED, user_silent_s=1.0) is False
 
 
 def test_disabled_when_hang_conversation_after_zero():
     # hangup_after_silence disabled -> backstop also disabled.
-    assert _decide(0, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is False
+    assert _decide(0, audio_playing=False, ai_silent_s=AGED, user_silent_s=AGED) is False
 
 
-def test_floor_applies_when_hangup_after_silence_small():
-    # hang_conversation_after=5, but floor is STALL_HANGUP_FLOOR_S: a 10s stall must NOT fire
-    # (would be past the 5s normal timeout, but the backstop deliberately waits longer so the
-    # normal inactivity path wins whenever it is reachable).
-    short = STALL_HANGUP_FLOOR_S - 5
-    assert short > 0
-    assert (
-        _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=short, user_silent_s=short) is False
-    )
-    # Past the floor it does fire.
-    assert _decide(5, audio_playing=False, has_pending_generation=False, ai_silent_s=AGED, user_silent_s=AGED) is True
-
-
-def test_uses_larger_of_floor_and_configured_timeout():
-    # A long configured timeout (60s) must be respected over the floor: a 30s stall must not fire.
-    assert _decide(60, audio_playing=False, has_pending_generation=False, ai_silent_s=30, user_silent_s=30) is False
-    assert _decide(60, audio_playing=False, has_pending_generation=False, ai_silent_s=65, user_silent_s=65) is True
+def test_does_not_fire_below_the_hard_cap():
+    below_cap = STALL_HANGUP_HARD_CAP_S - 5
+    assert below_cap > 0
+    assert _decide(15, audio_playing=False, ai_silent_s=below_cap, user_silent_s=below_cap) is False

--- a/tests/test_end_call_teardown_self_cancel.py
+++ b/tests/test_end_call_teardown_self_cancel.py
@@ -109,3 +109,31 @@ async def test_end_call_hangup_teardown_is_not_awaited_inline():
 
     assert elapsed < 0.1  # returned well before the mocked 0.2s teardown finished
     await asyncio.wait_for(hangup_started.wait(), timeout=1.0)  # the detached task did start
+
+
+async def test_end_call_hangup_failure_is_logged_not_swallowed(caplog):
+    """A bare create_task with no done callback would drop the exception along with the task,
+    so a failed hangup would look identical to a successful one. The done callback must
+    surface it instead."""
+    tm = TaskManager.__new__(TaskManager)
+    tm.run_id = "test-run"
+    tm.conversation_history = MagicMock()
+    tm.hangup_decision_at = None
+    tm.interruption_manager = MagicMock()
+    tm.wait_for_current_message = AsyncMock()
+
+    async def _boom():
+        raise RuntimeError("teardown exploded")
+
+    tm.process_call_hangup = AsyncMock(side_effect=_boom)
+
+    meta_info = {"request_id": "r1", "turn_id": 1, "response_uid": "u1"}
+    resp = {"model_response": [], "tool_call_id": "tc1", "textual_response": "Goodbye!"}
+
+    with caplog.at_level("ERROR"):
+        await TaskManager._TaskManager__execute_function_call(
+            tm, None, None, None, None, None, None, meta_info, None, END_CALL_FUNCTION_PREFIX, **resp
+        )
+        await asyncio.gather(tm._end_call_hangup_task, return_exceptions=True)
+
+    assert any("teardown exploded" in r.message for r in caplog.records)

--- a/tests/test_end_call_teardown_self_cancel.py
+++ b/tests/test_end_call_teardown_self_cancel.py
@@ -7,9 +7,10 @@ hangup instead of on a stray generation, and the input handler was never stopped
 
 import asyncio
 from types import SimpleNamespace
-
+from unittest.mock import AsyncMock, MagicMock
 
 from bolna.agent_manager.task_manager import TaskManager
+from bolna.constants import END_CALL_FUNCTION_PREFIX
 
 
 class _RecordingInputHandler:
@@ -75,4 +76,36 @@ async def test_a_concurrent_llm_task_is_still_cancelled():
     await asyncio.gather(stray, return_exceptions=True)
 
     assert stray.cancelled()
-    assert handler.stop_calls == 1
+
+
+async def test_end_call_hangup_teardown_is_not_awaited_inline():
+    """The end_call tool is handled inside __do_llm_generation's own LLM_GENERATION_TIMEOUT_S
+    window. process_call_hangup's teardown can legitimately outlast that window, so it must be
+    fired off detached rather than awaited inline here - otherwise a slow-but-normal teardown
+    gets cancelled mid-way by the same timeout meant to catch a hung LLM. BOLNA-2563."""
+    tm = TaskManager.__new__(TaskManager)
+    tm.run_id = "test-run"
+    tm.conversation_history = MagicMock()
+    tm.hangup_decision_at = None
+    tm.interruption_manager = MagicMock()
+    tm.wait_for_current_message = AsyncMock()
+
+    hangup_started = asyncio.Event()
+
+    async def _slow_teardown():
+        hangup_started.set()
+        await asyncio.sleep(0.2)
+
+    tm.process_call_hangup = AsyncMock(side_effect=_slow_teardown)
+
+    meta_info = {"request_id": "r1", "turn_id": 1, "response_uid": "u1"}
+    resp = {"model_response": [], "tool_call_id": "tc1", "textual_response": "Goodbye!"}
+
+    start = asyncio.get_event_loop().time()
+    await TaskManager._TaskManager__execute_function_call(
+        tm, None, None, None, None, None, None, meta_info, None, END_CALL_FUNCTION_PREFIX, **resp
+    )
+    elapsed = asyncio.get_event_loop().time() - start
+
+    assert elapsed < 0.1  # returned well before the mocked 0.2s teardown finished
+    await asyncio.wait_for(hangup_started.wait(), timeout=1.0)  # the detached task did start

--- a/tests/test_hung_llm_task_defeats_hangup_backstops.py
+++ b/tests/test_hung_llm_task_defeats_hangup_backstops.py
@@ -1,0 +1,115 @@
+"""BOLNA-2563: a hung LLM task (no token, no error, never completes) used to silently disable
+both hangup backstops in __check_for_completion, so a call with voicemail detection +
+hangup-after-silence enabled would sit in dead air until the carrier dropped it.
+
+response_in_pipeline is only ever cleared back to False inside _run_llm_task's exception
+handlers (task_manager.py ~4419-4432). A generation that never raises and never yields a token
+never reaches that cleanup, so both signals downstream stay "busy" indefinitely:
+
+  - has_pending_generation (task_manager.py ~7352-7358) reads llm_task.done(), which is False
+    for the life of the hang.
+  - response_in_pipeline stays True, so _pipeline_busy() (task_manager.py ~7296-7298) stays True.
+
+_should_stall_hangup is the backstop for exactly "no forward progress at all": past
+STALL_HANGUP_HARD_CAP_S of mutual silence with no audio playing, it fires unconditionally -
+it no longer takes has_pending_generation into account at all, so a hung task (or any other
+in-flight work) can never wedge the call open past the hard cap. _run_llm_task's own
+LLM_GENERATION_TIMEOUT_S is what protects legitimate in-flight generation from being cut off
+before that point.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.constants import STALL_HANGUP_HARD_CAP_S
+
+AGED = STALL_HANGUP_HARD_CAP_S - 5  # comfortably below the hard cap
+VERY_AGED = STALL_HANGUP_HARD_CAP_S + 300  # 5 minutes past the hard cap - "it's just stuck"
+
+
+@pytest.fixture
+async def hung_llm_task():
+    """A task standing in for a generation that never yields a token and never raises -
+    it just hangs. Never completes on its own; the fixture cancels it during teardown."""
+    task = asyncio.create_task(asyncio.Event().wait())
+    yield task
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def _has_pending_generation(llm_task):
+    # Mirrors task_manager.py:7352-7358 for the llm_task clause (the other two clauses -
+    # execute_function_call_task and s2s tool tasks - are not part of this bug).
+    return llm_task is not None and not llm_task.done()
+
+
+async def test_hung_llm_task_keeps_has_pending_generation_true_forever(hung_llm_task):
+    assert _has_pending_generation(hung_llm_task) is True
+    # Simulate the watchdog's 2s-interval passing many times over; nothing about a hung task
+    # (no completion, no exception) ever flips this.
+    await asyncio.sleep(0)
+    assert _has_pending_generation(hung_llm_task) is True
+
+
+async def test_short_lived_pending_generation_is_still_protected_below_the_hard_cap(hung_llm_task):
+    """Below STALL_HANGUP_HARD_CAP_S, a task that's merely still running (not yet provably hung)
+    must not be force-hungup on - that's real in-flight work, protected by _run_llm_task's own
+    LLM_GENERATION_TIMEOUT_S rather than by _should_stall_hangup."""
+    fake = SimpleNamespace(hang_conversation_after=15)
+
+    fires = TaskManager._should_stall_hangup(
+        fake,
+        audio_playing=False,
+        time_since_last_spoken_ai_word=AGED,
+        time_since_user_last_spoke=AGED,
+    )
+    assert fires is False
+
+
+async def test_hung_llm_task_no_longer_defeats_the_stall_backstop_past_hard_cap(hung_llm_task):
+    """Past STALL_HANGUP_HARD_CAP_S the backstop fires regardless of any in-flight task, so a
+    hung task (this one included) can no longer wedge the call open forever."""
+    fake = SimpleNamespace(hang_conversation_after=15)
+
+    fires = TaskManager._should_stall_hangup(
+        fake,
+        audio_playing=False,
+        time_since_last_spoken_ai_word=VERY_AGED,
+        time_since_user_last_spoke=VERY_AGED,
+    )
+    assert fires is True
+
+
+async def test_hung_llm_task_leaves_response_in_pipeline_stuck_so_pipeline_stays_busy(hung_llm_task):
+    """response_in_pipeline is set True when the turn kicks off (task_manager.py:4554) and is
+    only cleared in _run_llm_task's except blocks (task_manager.py:4419-4432). A hang that never
+    raises never reaches that clear, so _pipeline_busy() reads busy indefinitely - and
+    __check_for_completion's `if self._pipeline_busy(...): continue` (task_manager.py:7338-7339)
+    means the normal hang_conversation_after check below it is never reached."""
+    assert _has_pending_generation(hung_llm_task) is True  # the hang is still "in flight"
+
+    stuck_response_in_pipeline = True  # never cleared - the exception handler never ran
+    fake = SimpleNamespace(response_in_pipeline=stuck_response_in_pipeline, _synthesis_awaiting_first_audio=False)
+
+    busy = TaskManager._pipeline_busy(fake, audio_playing=False)
+    assert busy is True  # bug: __check_for_completion `continue`s here, forever
+
+
+async def test_stall_backstop_eventually_fires_no_matter_how_long_the_task_stays_hung(hung_llm_task):
+    """End-to-end: as the same hung task ages, the backstop stays protective early (does not
+    punish real in-flight work) but is guaranteed to fire by the hard cap - unlike before the
+    fix, where it would have stayed silent even at 20+ minutes."""
+    fake_stall = SimpleNamespace(hang_conversation_after=15)
+
+    for silence_s, expected in ((AGED, False), (VERY_AGED, True), (VERY_AGED * 4, True)):
+        stall_fires = TaskManager._should_stall_hangup(
+            fake_stall,
+            audio_playing=False,
+            time_since_last_spoken_ai_word=silence_s,
+            time_since_user_last_spoke=silence_s,
+        )
+        assert stall_fires is expected

--- a/tests/test_hung_llm_task_defeats_hangup_backstops.py
+++ b/tests/test_hung_llm_task_defeats_hangup_backstops.py
@@ -2,31 +2,32 @@
 both hangup backstops in __check_for_completion, so a call with voicemail detection +
 hangup-after-silence enabled would sit in dead air until the carrier dropped it.
 
-response_in_pipeline is only ever cleared back to False inside _run_llm_task's exception
-handlers (task_manager.py ~4419-4432). A generation that never raises and never yields a token
-never reaches that cleanup, so both signals downstream stay "busy" indefinitely:
+response_in_pipeline is cleared in several places (the generation path, the audio-playback path,
+teardown, and _run_llm_task's own exception handlers) - but all of them require the in-flight
+work to actually finish or raise. A generation that never does either reaches none of them, so
+both signals downstream stay "busy" indefinitely:
 
-  - has_pending_generation (task_manager.py ~7352-7358) reads llm_task.done(), which is False
-    for the life of the hang.
-  - response_in_pipeline stays True, so _pipeline_busy() (task_manager.py ~7296-7298) stays True.
+  - has_pending_generation reads llm_task.done(), which is False for the life of the hang.
+  - response_in_pipeline stays True, so _pipeline_busy() stays True.
 
 _should_stall_hangup is the backstop for exactly "no forward progress at all": past
-STALL_HANGUP_HARD_CAP_S of mutual silence with no audio playing, it fires unconditionally -
-it no longer takes has_pending_generation into account at all, so a hung task (or any other
-in-flight work) can never wedge the call open past the hard cap. _run_llm_task's own
-LLM_GENERATION_TIMEOUT_S is what protects legitimate in-flight generation from being cut off
-before that point.
+STALL_HANGUP_HARD_CAP_S of mutual silence with no audio playing, it fires unconditionally - it
+does not take has_pending_generation into account at all, so a hung task (or any other in-flight
+work) can never wedge the call open past the hard cap. _run_llm_task's own LLM_GENERATION_TIMEOUT_S
+(scoped to __do_llm_generation) is what protects legitimate in-flight generation from being cut
+off before that point, and from being confused with unrelated work that runs after it.
 """
 
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
+import bolna.agent_manager.task_manager as task_manager_module
 from bolna.agent_manager.task_manager import TaskManager
 from bolna.constants import STALL_HANGUP_HARD_CAP_S
 
-AGED = STALL_HANGUP_HARD_CAP_S - 5  # comfortably below the hard cap
 VERY_AGED = STALL_HANGUP_HARD_CAP_S + 300  # 5 minutes past the hard cap - "it's just stuck"
 
 
@@ -41,75 +42,55 @@ async def hung_llm_task():
         await task
 
 
-def _has_pending_generation(llm_task):
-    # Mirrors task_manager.py:7352-7358 for the llm_task clause (the other two clauses -
-    # execute_function_call_task and s2s tool tasks - are not part of this bug).
-    return llm_task is not None and not llm_task.done()
-
-
-async def test_hung_llm_task_keeps_has_pending_generation_true_forever(hung_llm_task):
-    assert _has_pending_generation(hung_llm_task) is True
-    # Simulate the watchdog's 2s-interval passing many times over; nothing about a hung task
-    # (no completion, no exception) ever flips this.
-    await asyncio.sleep(0)
-    assert _has_pending_generation(hung_llm_task) is True
-
-
-async def test_short_lived_pending_generation_is_still_protected_below_the_hard_cap(hung_llm_task):
-    """Below STALL_HANGUP_HARD_CAP_S, a task that's merely still running (not yet provably hung)
-    must not be force-hungup on - that's real in-flight work, protected by _run_llm_task's own
-    LLM_GENERATION_TIMEOUT_S rather than by _should_stall_hangup."""
-    fake = SimpleNamespace(hang_conversation_after=15)
-
-    fires = TaskManager._should_stall_hangup(
-        fake,
-        audio_playing=False,
-        time_since_last_spoken_ai_word=AGED,
-        time_since_user_last_spoke=AGED,
-    )
-    assert fires is False
-
-
-async def test_hung_llm_task_no_longer_defeats_the_stall_backstop_past_hard_cap(hung_llm_task):
-    """Past STALL_HANGUP_HARD_CAP_S the backstop fires regardless of any in-flight task, so a
-    hung task (this one included) can no longer wedge the call open forever."""
-    fake = SimpleNamespace(hang_conversation_after=15)
-
-    fires = TaskManager._should_stall_hangup(
-        fake,
-        audio_playing=False,
-        time_since_last_spoken_ai_word=VERY_AGED,
-        time_since_user_last_spoke=VERY_AGED,
-    )
-    assert fires is True
-
-
 async def test_hung_llm_task_leaves_response_in_pipeline_stuck_so_pipeline_stays_busy(hung_llm_task):
-    """response_in_pipeline is set True when the turn kicks off (task_manager.py:4554) and is
-    only cleared in _run_llm_task's except blocks (task_manager.py:4419-4432). A hang that never
-    raises never reaches that clear, so _pipeline_busy() reads busy indefinitely - and
-    __check_for_completion's `if self._pipeline_busy(...): continue` (task_manager.py:7338-7339)
+    """response_in_pipeline is set True when a turn kicks off and only clears once that turn
+    finishes or raises. A hang that never does either never reaches that clear, so
+    _pipeline_busy() reads busy indefinitely - and __check_for_completion's pipeline-busy gate
     means the normal hang_conversation_after check below it is never reached."""
-    assert _has_pending_generation(hung_llm_task) is True  # the hang is still "in flight"
+    has_pending_generation = hung_llm_task is not None and not hung_llm_task.done()
+    assert has_pending_generation is True  # the hang is still "in flight"
 
-    stuck_response_in_pipeline = True  # never cleared - the exception handler never ran
+    stuck_response_in_pipeline = True  # never cleared - the turn never finished or raised
     fake = SimpleNamespace(response_in_pipeline=stuck_response_in_pipeline, _synthesis_awaiting_first_audio=False)
 
     busy = TaskManager._pipeline_busy(fake, audio_playing=False)
     assert busy is True  # bug: __check_for_completion `continue`s here, forever
 
 
-async def test_stall_backstop_eventually_fires_no_matter_how_long_the_task_stays_hung(hung_llm_task):
-    """End-to-end: as the same hung task ages, the backstop stays protective early (does not
-    punish real in-flight work) but is guaranteed to fire by the hard cap - unlike before the
-    fix, where it would have stayed silent even at 20+ minutes."""
-    fake_stall = SimpleNamespace(hang_conversation_after=15)
+async def test_hung_generation_still_times_out_via_the_wrapper(monkeypatch):
+    """The timeout now lives on __do_llm_generation itself, not around the whole conversation
+    task - confirm a hung implementation still raises within LLM_GENERATION_TIMEOUT_S instead
+    of hanging forever."""
+    monkeypatch.setattr(task_manager_module, "LLM_GENERATION_TIMEOUT_S", 0.05)
+    tm = TaskManager.__new__(TaskManager)
 
-    for silence_s, expected in ((AGED, False), (VERY_AGED, True), (VERY_AGED * 4, True)):
-        stall_fires = TaskManager._should_stall_hangup(
-            fake_stall,
-            audio_playing=False,
-            time_since_last_spoken_ai_word=silence_s,
-            time_since_user_last_spoke=silence_s,
-        )
-        assert stall_fires is expected
+    async def _hang(*args, **kwargs):
+        await asyncio.Event().wait()
+
+    tm._TaskManager__do_llm_generation_impl = AsyncMock(side_effect=_hang)
+
+    # A 1.0s outer bound only guards the test itself against hanging; asserting elapsed time
+    # stays well under it proves LLM_GENERATION_TIMEOUT_S (0.05s) is what actually fired.
+    start = asyncio.get_event_loop().time()
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(TaskManager._TaskManager__do_llm_generation(tm, None, None, None), timeout=1.0)
+    assert asyncio.get_event_loop().time() - start < 0.5
+
+
+async def test_slow_work_after_generation_is_no_longer_capped(monkeypatch):
+    """_run_llm_task no longer wraps the whole conversation task - work that runs after
+    generation (the hangup-decision call, or hangup teardown) can legitimately outlast
+    LLM_GENERATION_TIMEOUT_S without being cut off mid-way. BOLNA-2563."""
+    monkeypatch.setattr(task_manager_module, "LLM_GENERATION_TIMEOUT_S", 0.05)
+    tm = TaskManager.__new__(TaskManager)
+    tm.task_config = {"task_type": "conversation"}
+
+    async def _slow(*args, **kwargs):
+        await asyncio.sleep(0.15)  # deliberately past the patched timeout above
+
+    tm._process_conversation_task = AsyncMock(side_effect=_slow)
+    tm._end_call_on_component_error = AsyncMock()
+
+    await asyncio.wait_for(tm._run_llm_task({}), timeout=1.0)
+
+    tm._end_call_on_component_error.assert_not_awaited()


### PR DESCRIPTION
## Problem

Reported on two calls (execs `d409c7cd…`, `7c70407a…`, both Plivo): the agent
never disconnected after the callee's voicemail response, and the call sat in ~90-130s of
dead silence until the carrier itself dropped the line. Both calls also came back with an
empty transcript. `hangup_after_silence` and voicemail detection were both enabled.

**Direct fix** — _run_llm_task now wraps generation in asyncio.wait_for(LLM_GENERATION_TIMEOUT_S) (60s). A hang raises a timeout, routes through the normal error-hangup path, and the call recovers on its own.
**Backstop** — _should_stall_hangup catches anything else that leaves the pipeline looking stuck (no audio playing, both sides silent) past STALL_HANGUP_HARD_CAP_S, now tuned down to match at 60s.