### PR TITLE
feat: accept per-call Deepgram host override for multi-cloud ASR routing

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.230"
+__version__ = "0.10.231"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.231"
+__version__ = "0.10.232"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1588,22 +1588,14 @@ class TaskManager(BaseManager):
 
                     is_sip = provider == TelephonyProvider.SIP_TRUNK.value
 
-                    # Per-call Deepgram host override lives at the transcriber-config top level; each
-                    # per-label cfg is a separate dict, so carry it down (a per-label value wins).
-                    host_override = {
-                        k: transcriber_config[k]
-                        for k in ("deepgram_host", "deepgram_flux_host", "deepgram_host_protocol")
-                        if transcriber_config.get(k) is not None
-                    }
-
                     transcribers = {}
                     for label, cfg in multilingual.items():
                         private_queue = asyncio.Queue()
                         cfg["input_queue"] = private_queue
                         cfg["output_queue"] = self.transcriber_output_queue
-                        for k, v in host_override.items():
-                            if cfg.get(k) is None:
-                                cfg[k] = v
+                        # Per-call Deepgram host override arrives per-label on cfg itself (the caller
+                        # stamps only the legs a chosen endpoint can serve); do not inherit from the
+                        # top-level config, or an unsupported leg would be forced onto that endpoint.
                         if is_sip:
                             cfg["encoding"] = "mulaw"
                             cfg["sampling_rate"] = 8000

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1588,11 +1588,22 @@ class TaskManager(BaseManager):
 
                     is_sip = provider == TelephonyProvider.SIP_TRUNK.value
 
+                    # Per-call Deepgram host override lives at the transcriber-config top level; each
+                    # per-label cfg is a separate dict, so carry it down (a per-label value wins).
+                    host_override = {
+                        k: transcriber_config[k]
+                        for k in ("deepgram_host", "deepgram_flux_host", "deepgram_host_protocol")
+                        if transcriber_config.get(k) is not None
+                    }
+
                     transcribers = {}
                     for label, cfg in multilingual.items():
                         private_queue = asyncio.Queue()
                         cfg["input_queue"] = private_queue
                         cfg["output_queue"] = self.transcriber_output_queue
+                        for k, v in host_override.items():
+                            if cfg.get(k) is None:
+                                cfg[k] = v
                         if is_sip:
                             cfg["encoding"] = "mulaw"
                             cfg["sampling_rate"] = 8000

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -166,6 +166,10 @@ class Transcriber(BaseModel):
     provider: Optional[str] = "deepgram"
     multilingual: Optional[Dict[str, Any]] = None
     active: Optional[str] = None
+    # Per-call self-hosted Deepgram endpoint override; unset falls back to DEEPGRAM_HOST* env.
+    deepgram_host: Optional[str] = None
+    deepgram_flux_host: Optional[str] = None
+    deepgram_host_protocol: Optional[str] = None
     # Flux model parameters
     eot_threshold: Optional[float] = None
     eager_eot_threshold: Optional[float] = None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -1317,12 +1317,6 @@ class DeepgramTranscriber(BaseTranscriber):
             if self.meta_info is not None and "deepgram_duration" in self.meta_info:
                 self.meta_info["transcriber_duration"] = self.meta_info["deepgram_duration"]
 
-            # Record the endpoint that actually served the call (multi-cloud attribution).
-            if self.meta_info is not None:
-                self.meta_info["deepgram_host"] = (
-                    self.deepgram_flux_host if self.is_flux_model else self.deepgram_host
-                )
-
             meta = dict(getattr(self, "meta_info", None) or {})
             if self.connection_error:
                 meta["connection_error"] = self.connection_error

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -62,7 +62,9 @@ class DeepgramTranscriber(BaseTranscriber):
         self.api_key = kwargs.get("transcriber_key", os.getenv("DEEPGRAM_AUTH_TOKEN"))
         # Per-call host override (multi-cloud router) takes precedence over the fleet-wide env default.
         self.deepgram_host = kwargs.get("deepgram_host") or os.getenv("DEEPGRAM_HOST", "api.deepgram.com")
-        self.deepgram_flux_host = kwargs.get("deepgram_flux_host") or os.getenv("DEEPGRAM_FLUX_HOST", "api.deepgram.com")
+        self.deepgram_flux_host = kwargs.get("deepgram_flux_host") or os.getenv(
+            "DEEPGRAM_FLUX_HOST", "api.deepgram.com"
+        )
         self.deepgram_host_protocol = kwargs.get("deepgram_host_protocol") or os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss")
         self.transcriber_output_queue = output_queue
         self.transcription_task = None

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -60,8 +60,10 @@ class DeepgramTranscriber(BaseTranscriber):
         self.sampling_rate = int(sampling_rate) if isinstance(sampling_rate, (str, int)) else 16000
         self.encoding = encoding
         self.api_key = kwargs.get("transcriber_key", os.getenv("DEEPGRAM_AUTH_TOKEN"))
-        self.deepgram_host = os.getenv("DEEPGRAM_HOST", "api.deepgram.com")
-        self.deepgram_flux_host = os.getenv("DEEPGRAM_FLUX_HOST", "api.deepgram.com")
+        # Per-call host override (multi-cloud router) takes precedence over the fleet-wide env default.
+        self.deepgram_host = kwargs.get("deepgram_host") or os.getenv("DEEPGRAM_HOST", "api.deepgram.com")
+        self.deepgram_flux_host = kwargs.get("deepgram_flux_host") or os.getenv("DEEPGRAM_FLUX_HOST", "api.deepgram.com")
+        self.deepgram_host_protocol = kwargs.get("deepgram_host_protocol") or os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss")
         self.transcriber_output_queue = output_queue
         self.transcription_task = None
         self.keywords = keywords
@@ -191,7 +193,7 @@ class DeepgramTranscriber(BaseTranscriber):
             dg_params["tag"] = self.run_id
             dg_params["extra"] = f"run_id:{self.run_id}"
 
-        websocket_api = "{}://{}/v1/listen?".format(os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_host)
+        websocket_api = "{}://{}/v1/listen?".format(self.deepgram_host_protocol, self.deepgram_host)
         websocket_url = websocket_api + urlencode(dg_params)
 
         if self.keywords:
@@ -250,7 +252,7 @@ class DeepgramTranscriber(BaseTranscriber):
         if self.run_id:
             dg_params["tag"] = self.run_id
 
-        websocket_api = "{}://{}/v2/listen?".format(os.getenv("DEEPGRAM_HOST_PROTOCOL", "wss"), self.deepgram_flux_host)
+        websocket_api = "{}://{}/v2/listen?".format(self.deepgram_host_protocol, self.deepgram_flux_host)
         websocket_url = websocket_api + urlencode(dg_params, doseq=True)
         return websocket_url
 
@@ -1314,6 +1316,12 @@ class DeepgramTranscriber(BaseTranscriber):
             # Use Deepgram's actual audio duration for billing
             if self.meta_info is not None and "deepgram_duration" in self.meta_info:
                 self.meta_info["transcriber_duration"] = self.meta_info["deepgram_duration"]
+
+            # Record the endpoint that actually served the call (multi-cloud attribution).
+            if self.meta_info is not None:
+                self.meta_info["deepgram_host"] = (
+                    self.deepgram_flux_host if self.is_flux_model else self.deepgram_host
+                )
 
             meta = dict(getattr(self, "meta_info", None) or {})
             if self.connection_error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.230"
+version = "0.10.231"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.231"
+version = "0.10.232"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_deepgram_host_override.py
+++ b/tests/test_deepgram_host_override.py
@@ -29,9 +29,13 @@ def test_kwarg_host_overrides_env(monkeypatch):
     monkeypatch.setenv("DEEPGRAM_HOST", "env-host:8080")
     monkeypatch.setenv("DEEPGRAM_FLUX_HOST", "env-flux:8080")
     monkeypatch.setenv("DEEPGRAM_HOST_PROTOCOL", "wss")
-    nova = urlparse(_make(model="nova-2", deepgram_host="kwarg-host:8080", deepgram_host_protocol="ws")._get_nova_ws_url())
+    nova = urlparse(
+        _make(model="nova-2", deepgram_host="kwarg-host:8080", deepgram_host_protocol="ws")._get_nova_ws_url()
+    )
     flux = urlparse(
-        _make(model="flux-general-en", deepgram_flux_host="kwarg-flux:8080", deepgram_host_protocol="ws")._get_flux_ws_url()
+        _make(
+            model="flux-general-en", deepgram_flux_host="kwarg-flux:8080", deepgram_host_protocol="ws"
+        )._get_flux_ws_url()
     )
     assert (nova.scheme, nova.netloc) == ("ws", "kwarg-host:8080")
     assert (flux.scheme, flux.netloc) == ("ws", "kwarg-flux:8080")

--- a/tests/test_deepgram_host_override.py
+++ b/tests/test_deepgram_host_override.py
@@ -1,0 +1,53 @@
+"""Unit tests for per-call Deepgram host/protocol override used by multi-cloud routing."""
+
+from urllib.parse import urlparse
+
+from bolna.transcriber.deepgram_transcriber import DeepgramTranscriber
+
+
+def _make(model="nova-2", language="en", **kwargs):
+    return DeepgramTranscriber(
+        telephony_provider="plivo",
+        model=model,
+        language=language,
+        stream=True,
+        **kwargs,
+    )
+
+
+def test_default_host_when_unset(monkeypatch):
+    monkeypatch.delenv("DEEPGRAM_HOST", raising=False)
+    monkeypatch.delenv("DEEPGRAM_FLUX_HOST", raising=False)
+    monkeypatch.delenv("DEEPGRAM_HOST_PROTOCOL", raising=False)
+    nova = urlparse(_make(model="nova-2")._get_nova_ws_url())
+    flux = urlparse(_make(model="flux-general-en")._get_flux_ws_url())
+    assert (nova.scheme, nova.netloc) == ("wss", "api.deepgram.com")
+    assert (flux.scheme, flux.netloc) == ("wss", "api.deepgram.com")
+
+
+def test_kwarg_host_overrides_env(monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_HOST", "env-host:8080")
+    monkeypatch.setenv("DEEPGRAM_FLUX_HOST", "env-flux:8080")
+    monkeypatch.setenv("DEEPGRAM_HOST_PROTOCOL", "wss")
+    nova = urlparse(_make(model="nova-2", deepgram_host="kwarg-host:8080", deepgram_host_protocol="ws")._get_nova_ws_url())
+    flux = urlparse(
+        _make(model="flux-general-en", deepgram_flux_host="kwarg-flux:8080", deepgram_host_protocol="ws")._get_flux_ws_url()
+    )
+    assert (nova.scheme, nova.netloc) == ("ws", "kwarg-host:8080")
+    assert (flux.scheme, flux.netloc) == ("ws", "kwarg-flux:8080")
+
+
+def test_env_used_when_no_kwarg(monkeypatch):
+    monkeypatch.setenv("DEEPGRAM_HOST", "env-host:8080")
+    monkeypatch.setenv("DEEPGRAM_HOST_PROTOCOL", "ws")
+    nova = urlparse(_make(model="nova-2")._get_nova_ws_url())
+    assert (nova.scheme, nova.netloc) == ("ws", "env-host:8080")
+
+
+def test_flux_host_independent_of_nova_kwarg(monkeypatch):
+    monkeypatch.delenv("DEEPGRAM_HOST", raising=False)
+    monkeypatch.delenv("DEEPGRAM_FLUX_HOST", raising=False)
+    monkeypatch.delenv("DEEPGRAM_HOST_PROTOCOL", raising=False)
+    # deepgram_host set but deepgram_flux_host omitted -> flux still resolves to its own default.
+    flux = urlparse(_make(model="flux-general-en", deepgram_host="nova-only:8080")._get_flux_ws_url())
+    assert flux.netloc == "api.deepgram.com"

--- a/tests/test_multilingual_deepgram_host_override.py
+++ b/tests/test_multilingual_deepgram_host_override.py
@@ -1,0 +1,77 @@
+"""The per-call Deepgram host override must reach every label in the multilingual transcriber pool."""
+
+from unittest.mock import MagicMock
+
+import bolna.agent_manager.task_manager as tmmod
+from bolna.agent_manager.task_manager import TaskManager
+
+
+def _run_setup(monkeypatch, transcriber_config):
+    """Drive the real __setup_transcriber multilingual branch against a mock TaskManager.
+
+    The branch mutates each per-label cfg dict in place before spreading it into the
+    transcriber, so we assert on the mutated multilingual dicts directly.
+    """
+    monkeypatch.setattr(tmmod, "SUPPORTED_TRANSCRIBER_PROVIDERS", {"deepgram": MagicMock()})
+    monkeypatch.setattr(tmmod, "TranscriberPool", MagicMock())
+
+    tm = MagicMock()
+    tm.task_config = {"tools_config": {"transcriber": transcriber_config}}
+    tm.turn_based_conversation = True  # provider='playground'; skips input-provider lookup
+    tm.is_web_based_call = False
+    tm.enforce_streaming = True
+    tm.kwargs = {}
+    tm._TaskManager__language_switch_enabled = MagicMock(return_value=False)
+    tm._TaskManager__setup_transcriber = TaskManager._TaskManager__setup_transcriber.__get__(tm, TaskManager)
+
+    tm._TaskManager__setup_transcriber()
+
+
+def test_override_propagates_to_every_label(monkeypatch):
+    cfg = {
+        "provider": "deepgram",
+        "deepgram_host": "self-hosted:8080",
+        "deepgram_flux_host": "self-hosted-flux:8080",
+        "deepgram_host_protocol": "ws",
+        "multilingual": {
+            "en": {"provider": "deepgram", "model": "nova-2"},
+            "hi": {"provider": "deepgram", "model": "flux-general-hi"},
+        },
+    }
+    _run_setup(monkeypatch, cfg)
+
+    for label in ("en", "hi"):
+        per_label = cfg["multilingual"][label]
+        assert per_label["deepgram_host"] == "self-hosted:8080"
+        assert per_label["deepgram_flux_host"] == "self-hosted-flux:8080"
+        assert per_label["deepgram_host_protocol"] == "ws"
+
+
+def test_per_label_override_wins(monkeypatch):
+    cfg = {
+        "provider": "deepgram",
+        "deepgram_host": "top-level:8080",
+        "deepgram_host_protocol": "ws",
+        "multilingual": {
+            "en": {"provider": "deepgram", "model": "nova-2", "deepgram_host": "en-specific:9090"},
+            "hi": {"provider": "deepgram", "model": "nova-2"},
+        },
+    }
+    _run_setup(monkeypatch, cfg)
+
+    assert cfg["multilingual"]["en"]["deepgram_host"] == "en-specific:9090"
+    assert cfg["multilingual"]["hi"]["deepgram_host"] == "top-level:8080"
+    # Protocol has no per-label value, so both inherit the top-level one.
+    assert cfg["multilingual"]["en"]["deepgram_host_protocol"] == "ws"
+    assert cfg["multilingual"]["hi"]["deepgram_host_protocol"] == "ws"
+
+
+def test_no_override_leaves_labels_untouched(monkeypatch):
+    cfg = {
+        "provider": "deepgram",
+        "multilingual": {"en": {"provider": "deepgram", "model": "nova-2"}},
+    }
+    _run_setup(monkeypatch, cfg)
+
+    assert "deepgram_host" not in cfg["multilingual"]["en"]
+    assert "deepgram_host_protocol" not in cfg["multilingual"]["en"]

--- a/tests/test_multilingual_deepgram_host_override.py
+++ b/tests/test_multilingual_deepgram_host_override.py
@@ -1,4 +1,8 @@
-"""The per-call Deepgram host override must reach every label in the multilingual transcriber pool."""
+"""Per-label Deepgram host overrides reach the pool; the top-level host is NOT inherited into legs.
+
+The router (dashboard-backend) stamps only the legs a chosen endpoint can actually serve, so an
+unstamped leg must keep its default host rather than inherit a base host it may not support.
+"""
 
 from unittest.mock import MagicMock
 
@@ -7,11 +11,7 @@ from bolna.agent_manager.task_manager import TaskManager
 
 
 def _run_setup(monkeypatch, transcriber_config):
-    """Drive the real __setup_transcriber multilingual branch against a mock TaskManager.
-
-    The branch mutates each per-label cfg dict in place before spreading it into the
-    transcriber, so we assert on the mutated multilingual dicts directly.
-    """
+    """Drive the real __setup_transcriber multilingual branch against a mock TaskManager."""
     monkeypatch.setattr(tmmod, "SUPPORTED_TRANSCRIBER_PROVIDERS", {"deepgram": MagicMock()})
     monkeypatch.setattr(tmmod, "TranscriberPool", MagicMock())
 
@@ -27,43 +27,49 @@ def _run_setup(monkeypatch, transcriber_config):
     tm._TaskManager__setup_transcriber()
 
 
-def test_override_propagates_to_every_label(monkeypatch):
+def test_per_label_hosts_are_preserved(monkeypatch):
     cfg = {
         "provider": "deepgram",
-        "deepgram_host": "self-hosted:8080",
-        "deepgram_flux_host": "self-hosted-flux:8080",
-        "deepgram_host_protocol": "ws",
         "multilingual": {
-            "en": {"provider": "deepgram", "model": "nova-2"},
-            "hi": {"provider": "deepgram", "model": "flux-general-hi"},
+            "en": {
+                "provider": "deepgram",
+                "model": "nova-3",
+                "deepgram_host": "gcp:8080",
+                "deepgram_host_protocol": "ws",
+            },
+            "hi": {
+                "provider": "deepgram",
+                "model": "nova-2",
+                "deepgram_host": "modal:443",
+                "deepgram_host_protocol": "wss",
+            },
         },
     }
     _run_setup(monkeypatch, cfg)
 
-    for label in ("en", "hi"):
-        per_label = cfg["multilingual"][label]
-        assert per_label["deepgram_host"] == "self-hosted:8080"
-        assert per_label["deepgram_flux_host"] == "self-hosted-flux:8080"
-        assert per_label["deepgram_host_protocol"] == "ws"
-
-
-def test_per_label_override_wins(monkeypatch):
-    cfg = {
-        "provider": "deepgram",
-        "deepgram_host": "top-level:8080",
-        "deepgram_host_protocol": "ws",
-        "multilingual": {
-            "en": {"provider": "deepgram", "model": "nova-2", "deepgram_host": "en-specific:9090"},
-            "hi": {"provider": "deepgram", "model": "nova-2"},
-        },
-    }
-    _run_setup(monkeypatch, cfg)
-
-    assert cfg["multilingual"]["en"]["deepgram_host"] == "en-specific:9090"
-    assert cfg["multilingual"]["hi"]["deepgram_host"] == "top-level:8080"
-    # Protocol has no per-label value, so both inherit the top-level one.
+    assert cfg["multilingual"]["en"]["deepgram_host"] == "gcp:8080"
     assert cfg["multilingual"]["en"]["deepgram_host_protocol"] == "ws"
-    assert cfg["multilingual"]["hi"]["deepgram_host_protocol"] == "ws"
+    assert cfg["multilingual"]["hi"]["deepgram_host"] == "modal:443"
+    assert cfg["multilingual"]["hi"]["deepgram_host_protocol"] == "wss"
+
+
+def test_top_level_host_not_inherited_into_legs(monkeypatch):
+    # An unstamped leg (no per-label host) must NOT pick up the top-level host — that inheritance is
+    # exactly what would force an unsupported model onto the wrong endpoint.
+    cfg = {
+        "provider": "deepgram",
+        "deepgram_host": "gcp:8080",
+        "deepgram_host_protocol": "ws",
+        "multilingual": {
+            "en": {"provider": "deepgram", "model": "nova-3", "deepgram_host": "gcp:8080"},
+            "hi": {"provider": "deepgram", "model": "flux-general-hi"},  # deliberately left on default
+        },
+    }
+    _run_setup(monkeypatch, cfg)
+
+    assert cfg["multilingual"]["en"]["deepgram_host"] == "gcp:8080"
+    assert "deepgram_host" not in cfg["multilingual"]["hi"]
+    assert "deepgram_host_protocol" not in cfg["multilingual"]["hi"]
 
 
 def test_no_override_leaves_labels_untouched(monkeypatch):


### PR DESCRIPTION
## What
Teach `DeepgramTranscriber` to accept a **per-call host** so a caller can pin a call to a specific self-hosted Deepgram endpoint, instead of only the fleet-wide `DEEPGRAM_HOST` env.

- `bolna/models.py` — add `deepgram_host` / `deepgram_flux_host` / `deepgram_host_protocol` to the `Transcriber` model. Explicit fields (not kwarg passthrough) so they survive pydantic validation.
- `bolna/transcriber/deepgram_transcriber.py` — `__init__` prefers the kwarg, falls back to env (`kwargs.get(...) or os.getenv(...)`), so behaviour is unchanged when unset. Nova + Flux WS URL builders use the resolved protocol. Served host recorded in `meta_info["deepgram_host"]`.

## Backward compatibility
Fully backward compatible — all three fields default to `None`; with none set, host and protocol resolve exactly as before.
