### PR TITLE
fix(llm): stop a cancelled WS turn from leaking its answer into the next turn

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.221"
+__version__ = "0.10.222"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.223"
+__version__ = "0.10.224"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.225"
+__version__ = "0.10.226"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -172,6 +172,12 @@ class ResponseStreamEvent(str, Enum):
         return frozenset({cls.COMPLETED, cls.FAILED, cls.INCOMPLETE, cls.ERROR})
 
     @classmethod
+    def response_terminal_events(cls):
+        """Terminals that settle the response itself. `error` is excluded: it can be raised
+        against the session and still be followed by the response's own terminal event."""
+        return frozenset({cls.COMPLETED, cls.FAILED, cls.INCOMPLETE})
+
+    @classmethod
     def all_values(cls):
         return [e.value for e in cls]
 

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -51,6 +51,7 @@ class OpenAIWSConnection:
     def __init__(self, api_key: str):
         self._api_key = api_key
         self._ws = None
+        self._needs_reset = False
         self._connected_at: float = 0
         self._lock = asyncio.Lock()
         self._connect_task: Optional[asyncio.Task] = None
@@ -72,7 +73,12 @@ class OpenAIWSConnection:
             self._connect_task = None
 
         if self._ws is not None:
-            if self._ws.state is not WSState.OPEN:
+            if self._needs_reset:
+                # An abandoned stream left its events queued here; reading them as the next
+                # turn's would answer the previous utterance.
+                logger.info("WebSocket dirty after an abandoned stream, reconnecting")
+                await self._close_ws()
+            elif self._ws.state is not WSState.OPEN:
                 logger.info("WebSocket closed unexpectedly, reconnecting")
                 await self._close_ws()
             elif time.monotonic() - self._connected_at >= self.RECONNECT_BEFORE_SECS:
@@ -81,6 +87,7 @@ class OpenAIWSConnection:
             else:
                 return
 
+        self._needs_reset = False
         await self._connect()
 
     async def _connect(self):
@@ -99,13 +106,21 @@ class OpenAIWSConnection:
         async with self._lock:
             await self.ensure_connected()
             await self._ws.send(json.dumps({"type": ResponseStreamEvent.CREATE, **create_params}))
+            # Cleared only once a terminal event is actually consumed. Any other exit —
+            # cancellation, error, the consumer breaking early — leaves the response's
+            # remaining events on the socket, so it must not be reused.
+            self._needs_reset = True
 
             async for raw_msg in self._ws:
                 evt = json.loads(raw_msg)
                 evt_type = evt.get("type", "")
-                yield evt
                 if evt_type in self.TERMINAL_EVENTS:
+                    # Before the yield: consumers break on COMPLETED/INCOMPLETE and never
+                    # let this generator resume to run the line after.
+                    self._needs_reset = False
+                    yield evt
                     return
+                yield evt
 
     async def cancel_response(self, response_id: str):
         """Best-effort cancel: signal the server to terminate the in-flight

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -74,8 +74,7 @@ class OpenAIWSConnection:
 
         if self._ws is not None:
             if self._needs_reset:
-                # An abandoned stream left its events queued here; reading them as the next
-                # turn's would answer the previous utterance.
+                # An abandoned stream's queued events would be read as the next turn's.
                 logger.info("WebSocket dirty after an abandoned stream, reconnecting")
                 await self._close_ws()
             elif self._ws.state is not WSState.OPEN:
@@ -106,17 +105,13 @@ class OpenAIWSConnection:
         async with self._lock:
             await self.ensure_connected()
             await self._ws.send(json.dumps({"type": ResponseStreamEvent.CREATE, **create_params}))
-            # Cleared only once a terminal event is actually consumed. Any other exit —
-            # cancellation, error, the consumer breaking early — leaves the response's
-            # remaining events on the socket, so it must not be reused.
-            self._needs_reset = True
+            self._needs_reset = True  # cleared only once a terminal event is consumed
 
             async for raw_msg in self._ws:
                 evt = json.loads(raw_msg)
                 evt_type = evt.get("type", "")
                 if evt_type in self.TERMINAL_EVENTS:
-                    # Before the yield: consumers break on COMPLETED/INCOMPLETE and never
-                    # let this generator resume to run the line after.
+                    # Before the yield: consumers break here and never let this resume.
                     self._needs_reset = False
                     yield evt
                     return

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -47,6 +47,7 @@ class OpenAIWSConnection:
     WS_URL = "wss://api.openai.com/v1/responses"
     RECONNECT_BEFORE_SECS = 55 * 60
     TERMINAL_EVENTS = ResponseStreamEvent.terminal_events()
+    RESPONSE_TERMINAL_EVENTS = ResponseStreamEvent.response_terminal_events()
 
     def __init__(self, api_key: str):
         self._api_key = api_key
@@ -76,7 +77,7 @@ class OpenAIWSConnection:
             if self._needs_reset:
                 # An abandoned stream's queued events would be read as the next turn's.
                 logger.info("WebSocket dirty after an abandoned stream, reconnecting")
-                await self._close_ws()
+                self.discard_socket(prewarm=False)
             elif self._ws.state is not WSState.OPEN:
                 logger.info("WebSocket closed unexpectedly, reconnecting")
                 await self._close_ws()
@@ -104,18 +105,25 @@ class OpenAIWSConnection:
         """Send response.create and yield raw event dicts until terminal event."""
         async with self._lock:
             await self.ensure_connected()
-            await self._ws.send(json.dumps({"type": ResponseStreamEvent.CREATE, **create_params}))
-            self._needs_reset = True  # cleared only once a terminal event is consumed
-
-            async for raw_msg in self._ws:
-                evt = json.loads(raw_msg)
-                evt_type = evt.get("type", "")
-                if evt_type in self.TERMINAL_EVENTS:
-                    # Before the yield: consumers break here and never let this resume.
-                    self._needs_reset = False
+            # Before the send: a cancelled send may still have put the frame on the wire,
+            # and leaves the connection inconsistent either way. The try covers it too.
+            self._needs_reset = True
+            try:
+                await self._ws.send(json.dumps({"type": ResponseStreamEvent.CREATE, **create_params}))
+                async for raw_msg in self._ws:
+                    evt = json.loads(raw_msg)
+                    evt_type = evt.get("type", "")
+                    if evt_type in self.RESPONSE_TERMINAL_EVENTS:
+                        # Before the yield: consumers break here and never let this resume.
+                        self._needs_reset = False
+                        yield evt
+                        return
                     yield evt
-                    return
-                yield evt
+                    if evt_type in self.TERMINAL_EVENTS:
+                        return
+            finally:
+                if self._needs_reset:
+                    self.discard_socket()
 
     async def cancel_response(self, response_id: str):
         """Best-effort cancel: signal the server to terminate the in-flight
@@ -140,6 +148,23 @@ class OpenAIWSConnection:
             except Exception:
                 pass
             self._ws = None
+
+    def discard_socket(self, prewarm=True):
+        """Drop a socket carrying an abandoned response. The close is not awaited and the
+        replacement is warmed in the background, so no handshake lands on the next turn."""
+        ws, self._ws = self._ws, None
+        self._needs_reset = False
+        if ws is not None:
+            asyncio.ensure_future(self._close_quietly(ws))
+        if prewarm:
+            self.start_connect()
+
+    @staticmethod
+    async def _close_quietly(ws):
+        try:
+            await ws.close()
+        except Exception:
+            pass
 
 
 class OpenAiLLM(OpenAICompatibleLLM):

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import json
+from contextlib import suppress
 import re
 import time
 from typing import Optional
@@ -139,6 +140,13 @@ class OpenAIWSConnection:
             pass
 
     async def disconnect(self):
+        # Settle any in-flight pre-warm first: it assigns _ws after the fact, so closing
+        # before it lands would leave a live socket nobody owns.
+        task, self._connect_task = self._connect_task, None
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError, Exception):
+                await task
         await self._close_ws()
 
     async def _close_ws(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.225"
+version = "0.10.226"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.221"
+version = "0.10.222"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.223"
+version = "0.10.224"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_ws_responses_stream_reset.py
+++ b/tests/test_ws_responses_stream_reset.py
@@ -1,15 +1,8 @@
 """A cancelled WS Responses turn must not leak its events into the next turn.
 
-One WebSocket serves every turn of a call, and `stream_response` yields whatever it reads
-with no response_id filter. When `llm_task.cancel()` abandons the generator mid-stream, the
-cancelled response's remaining events stay queued on the socket — the next turn then reads
-them and answers the PREVIOUS utterance, in ~0ms (run 23323c9e: seq4 cancelled, seq5 7.81ms,
-seq6 0.52ms, agent replied to 'ठीक है' instead of the question that followed).
-
-The guarantee: a stream that does not consume a terminal event marks the socket dirty, and
-the next use reconnects. Consumers `break` on COMPLETED/INCOMPLETE and never let the
-generator resume, so the flag must be cleared BEFORE the terminal event is yielded —
-otherwise every healthy turn would reconnect too.
+One socket serves every turn and `stream_response` reads it without a response_id filter, so
+an abandoned stream's leftovers get read as the next turn's (run 23323c9e). The guarantee: no
+terminal event consumed => socket dirty => reconnect before reuse. See INIT.md.
 """
 
 import asyncio
@@ -37,8 +30,7 @@ def created(rid="resp_x"):
 
 
 class FakeWS:
-    """Models the real socket: a response's events are queued when its create is sent, and
-    whatever nobody consumes stays queued on THIS socket. A reconnect yields a fresh one."""
+    """Events queue on send and stay queued until read; a reconnect yields a fresh socket."""
 
     def __init__(self, script, hang=False, gate=None):
         self.state = WSState.OPEN
@@ -46,8 +38,8 @@ class FakeWS:
         self.closed = False
         self._script = script  # shared across reconnects; each send pops one response
         self._queue = []
-        self._hang = hang  # block instead of ending, to model "server has not answered yet"
-        self._gate = gate  # when set, events are withheld until the gate opens
+        self._hang = hang  # block instead of ending, so a turn can be cancelled mid-stream
+        self._gate = gate  # withhold events until opened
 
     async def send(self, raw):
         self.sent.append(json.loads(raw))
@@ -118,8 +110,7 @@ async def test_two_healthy_turns_reuse_one_socket():
 
 
 async def test_a_consumer_that_breaks_on_completed_does_not_dirty_the_socket():
-    # The real consumer breaks on COMPLETED and never lets the generator resume, so the
-    # flag has to be cleared before the yield. Clearing it after would reconnect every turn.
+    # Clearing the flag after the yield instead would reconnect on every healthy turn.
     t = _transport([delta("hi"), completed()], [completed("r2")])
     async for evt in t.stream_response({"input": "a"}):
         if evt["type"] == ResponseStreamEvent.COMPLETED.value:
@@ -160,9 +151,7 @@ async def test_the_next_turn_after_an_abandoned_stream_reconnects():
 
 
 async def test_leftover_events_can_never_reach_the_next_turn():
-    """The regression itself. Turn 1 ('ठीक है') is cancelled with its answer still queued;
-    turn 2 (the loan question) must see only its own events. Unfixed, turn 2 reads turn 1's
-    answer and its terminal event, i.e. it replies to the previous utterance in ~0ms."""
+    """The regression: turn 1 is cancelled with its answer still queued, turn 2 must not read it."""
     t = _transport(
         [created("r1"), delta("कुछ और पूछना था?"), completed("r1")],
         [created("r2"), delta("loan answer"), completed("r2")],
@@ -179,7 +168,7 @@ async def test_leftover_events_can_never_reach_the_next_turn():
 
 
 async def test_a_generator_that_never_ran_sends_nothing_and_stays_clean():
-    # Nothing was sent, so nothing is queued — reconnecting here would be pure cost.
+    # Nothing sent means nothing queued; reconnecting here would be pure cost.
     t = _transport([completed("r1")])
     agen = t.stream_response({"input": "a"})
     await agen.aclose()  # never iterated, so the body never ran
@@ -188,8 +177,7 @@ async def test_a_generator_that_never_ran_sends_nothing_and_stays_clean():
 
 
 async def test_task_cancellation_while_awaiting_the_first_event_dirties_the_socket():
-    """The reported call exactly: llm_task.cancel() 6ms after the create was sent, while the
-    turn is still awaiting its first event. The response is already committed server-side."""
+    """The reported call: cancelled 6ms after the create, before any event arrived."""
     t = _transport([], hang=True)
 
     async def consume():
@@ -273,9 +261,7 @@ def _text(chunks):
 
 
 async def test_real_consumer_completes_a_turn_without_dirtying_the_socket():
-    """The ordering guarantee against the actual consumer, which breaks on COMPLETED and
-    never lets the generator resume. If the flag were cleared after the yield instead of
-    before, every healthy turn would reconnect."""
+    """The ordering guarantee against the actual consumer, which breaks on COMPLETED."""
     t = _transport(
         [created("r1"), delta("नमस्ते"), completed("r1")],
         [created("r2"), delta("दूसरा"), completed("r2")],
@@ -292,8 +278,7 @@ async def test_real_consumer_completes_a_turn_without_dirtying_the_socket():
 
 
 async def test_real_consumer_does_not_inherit_a_cancelled_turns_answer():
-    """End to end reproduction of run 23323c9e: turn 1 is cancelled mid-flight, turn 2 must
-    still generate its own answer rather than replay turn 1's."""
+    """End to end reproduction of run 23323c9e, through the real consumer."""
     gate = asyncio.Event()  # the server answers turn 1 only after it has been cancelled
     t = _transport(
         [created("r1"), delta("कुछ और पूछना था?"), completed("r1")],

--- a/tests/test_ws_responses_stream_reset.py
+++ b/tests/test_ws_responses_stream_reset.py
@@ -1,8 +1,8 @@
 """A cancelled WS Responses turn must not leak its events into the next turn.
 
-One socket serves every turn and `stream_response` reads it without a response_id filter, so
-an abandoned stream's leftovers get read as the next turn's (run 23323c9e). The guarantee: no
-terminal event consumed => socket dirty => reconnect before reuse. See INIT.md.
+One socket serves every turn and `stream_response` reads it without a response_id filter, so an
+abandoned stream's leftovers would be read as the next turn's. The guarantee: no response
+terminal consumed => socket dirty => it is replaced before reuse.
 """
 
 import asyncio
@@ -90,6 +90,17 @@ async def _drain(agen):
     return [e async for e in agen]
 
 
+async def _settle():
+    """Let discard_socket's background close and pre-warm run."""
+    for _ in range(4):
+        await asyncio.sleep(0)
+
+
+def _discarded(t, ws):
+    """The socket was dropped and a replacement warmed, so no handshake lands on the next turn."""
+    return t._ws is not ws and ws.closed and t.connects == 2
+
+
 # ---------------------------------------------------------------- healthy turns unchanged
 
 
@@ -130,12 +141,13 @@ async def test_every_terminal_event_clears_the_flag(terminal):
 # ---------------------------------------------------------------- abandoned turns reconnect
 
 
-async def test_a_cancelled_stream_marks_the_socket_dirty():
-    t = _transport([delta("कुछ"), delta(" और"), completed()])
-    agen = t.stream_response({"input": "ठीक है"})
+async def test_an_abandoned_stream_discards_its_socket():
+    t = _transport([delta("one"), delta("two"), completed()], [completed("r2")])
+    agen = t.stream_response({"input": "a"})
     await agen.__anext__()  # consume one delta, then walk away
     await agen.aclose()
-    assert t._needs_reset is True
+    await _settle()
+    assert _discarded(t, t.sockets[0])
 
 
 async def test_the_next_turn_after_an_abandoned_stream_reconnects():
@@ -176,9 +188,9 @@ async def test_a_generator_that_never_ran_sends_nothing_and_stays_clean():
     assert t.connects == 0
 
 
-async def test_task_cancellation_while_awaiting_the_first_event_dirties_the_socket():
-    """The reported call: cancelled 6ms after the create, before any event arrived."""
-    t = _transport([], hang=True)
+async def test_task_cancellation_while_awaiting_the_first_event_discards_the_socket():
+    """Cancelled milliseconds after the create, before any event arrived."""
+    t = _transport([], [completed("r2")], hang=True)
 
     async def consume():
         async for _ in t.stream_response({"input": "ठीक है"}):
@@ -191,13 +203,14 @@ async def test_task_cancellation_while_awaiting_the_first_event_dirties_the_sock
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert t._needs_reset is True
+    await _settle()
+    assert _discarded(t, t.sockets[0])
     assert t._lock.locked() is False  # cancellation lands inside the generator, freeing it
 
 
-async def test_a_turn_cancelled_mid_stream_dirties_the_socket():
+async def test_a_turn_cancelled_mid_stream_discards_the_socket():
     # Partial output delivered, terminal event still to come — the leak window.
-    t = _transport([delta("one"), delta("two")], hang=True)
+    t = _transport([delta("one"), delta("two")], [completed("r2")], hang=True)
     started = asyncio.Event()
 
     async def consume():
@@ -210,7 +223,8 @@ async def test_a_turn_cancelled_mid_stream_dirties_the_socket():
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert t._needs_reset is True
+    await _settle()
+    assert _discarded(t, t.sockets[0])
 
 
 async def test_the_dirty_flag_is_cleared_by_the_reconnect():
@@ -278,7 +292,7 @@ async def test_real_consumer_completes_a_turn_without_dirtying_the_socket():
 
 
 async def test_real_consumer_does_not_inherit_a_cancelled_turns_answer():
-    """End to end reproduction of run 23323c9e, through the real consumer."""
+    """End to end, through the real consumer."""
     gate = asyncio.Event()  # the server answers turn 1 only after it has been cancelled
     t = _transport(
         [created("r1"), delta("कुछ और पूछना था?"), completed("r1")],
@@ -304,3 +318,98 @@ async def test_real_consumer_does_not_inherit_a_cancelled_turns_answer():
     assert "loan answer" in text
     assert "कुछ और पूछना था?" not in text
     assert t.connects == 2
+
+
+# ---------------------------------------------------------------- review: cancel during send
+
+
+async def test_a_send_cancelled_mid_frame_still_discards_the_socket():
+    """The frame may already be on the wire, and a cancelled send leaves the connection
+    inconsistent either way. Marking after the send would miss both."""
+    t = _transport([created("r1"), delta("leftover"), completed("r1")], [completed("r2")])
+    await t.ensure_connected()
+    ws = t._ws
+    delivered = asyncio.Event()
+    real_send = ws.send
+
+    async def slow_send(raw):
+        await real_send(raw)  # frame delivered...
+        delivered.set()
+        await asyncio.Event().wait()  # ...then the send suspends and never returns
+
+    ws.send = slow_send
+
+    async def consume():
+        async for _ in t.stream_response({"input": "a"}):
+            pass
+
+    task = asyncio.create_task(consume())
+    await delivered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    await _settle()
+    assert _discarded(t, ws)
+
+
+# ---------------------------------------------------------------- review: error is not a settle
+
+
+async def test_an_error_event_does_not_mark_the_socket_clean():
+    """`error` can be raised against the session and still be followed by the response's own
+    terminal event. Treating it as a settle would leave that event on a socket called clean."""
+    t = _transport([{"type": "error", "error": {"code": "x"}}, completed("r1")], [completed("r2")])
+    events = await _drain(t.stream_response({"input": "a"}))
+    assert [e["type"] for e in events] == ["error"]
+    await _settle()
+    assert _discarded(t, t.sockets[0])
+
+
+async def test_a_terminal_trailing_an_error_cannot_reach_the_next_turn():
+    t = _transport(
+        [{"type": "error", "error": {"code": "x"}}, delta("stale"), completed("r1")],
+        [created("r2"), delta("fresh"), completed("r2")],
+    )
+    await _drain(t.stream_response({"input": "a"}))
+    await _settle()
+
+    events = await _drain(t.stream_response({"input": "b"}))
+    assert [e["delta"] for e in events if "delta" in e] == ["fresh"]
+
+
+# ---------------------------------------------------------------- review: no handshake on the turn
+
+
+async def test_the_replacement_socket_is_warm_before_the_next_turn():
+    """discard_socket pre-warms, so the next turn finds a connected socket instead of paying
+    a close handshake plus TLS inside the lock."""
+    t = _transport([delta("one")], [completed("r2")], hang=True)
+
+    async def consume():
+        async for _ in t.stream_response({"input": "a"}):
+            pass
+
+    task = asyncio.create_task(consume())
+    while t._ws is None or not t._ws.sent:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await _settle()
+
+    assert t.connects == 2  # already reconnected, before the next turn asked
+    connects_before = t.connects
+    await _drain(t.stream_response({"input": "b"}))
+    assert t.connects == connects_before  # the turn itself opened nothing
+
+
+async def test_the_old_socket_close_is_never_awaited_on_the_critical_path():
+    t = _transport([delta("one"), completed("r1")], [completed("r2")])
+    agen = t.stream_response({"input": "a"})
+    await agen.__anext__()
+    await agen.aclose()
+    # discard_socket hands the close to the loop; it has not run yet.
+    assert t.sockets[0].closed is False
+    await _settle()
+    assert t.sockets[0].closed is True

--- a/tests/test_ws_responses_stream_reset.py
+++ b/tests/test_ws_responses_stream_reset.py
@@ -1,0 +1,321 @@
+"""A cancelled WS Responses turn must not leak its events into the next turn.
+
+One WebSocket serves every turn of a call, and `stream_response` yields whatever it reads
+with no response_id filter. When `llm_task.cancel()` abandons the generator mid-stream, the
+cancelled response's remaining events stay queued on the socket — the next turn then reads
+them and answers the PREVIOUS utterance, in ~0ms (run 23323c9e: seq4 cancelled, seq5 7.81ms,
+seq6 0.52ms, agent replied to 'ठीक है' instead of the question that followed).
+
+The guarantee: a stream that does not consume a terminal event marks the socket dirty, and
+the next use reconnects. Consumers `break` on COMPLETED/INCOMPLETE and never let the
+generator resume, so the flag must be cleared BEFORE the terminal event is yielded —
+otherwise every healthy turn would reconnect too.
+"""
+
+import asyncio
+import json
+import time
+
+import pytest
+from unittest.mock import patch
+from websockets.protocol import State as WSState
+
+from bolna.enums import ResponseStreamEvent
+from bolna.llms.openai_llm import OpenAIWSConnection, OpenAiLLM
+
+
+def delta(text):
+    return {"type": ResponseStreamEvent.OUTPUT_TEXT_DELTA.value, "delta": text}
+
+
+def completed(rid="resp_x"):
+    return {"type": ResponseStreamEvent.COMPLETED.value, "response": {"id": rid}}
+
+
+def created(rid="resp_x"):
+    return {"type": ResponseStreamEvent.CREATED.value, "response": {"id": rid}}
+
+
+class FakeWS:
+    """Models the real socket: a response's events are queued when its create is sent, and
+    whatever nobody consumes stays queued on THIS socket. A reconnect yields a fresh one."""
+
+    def __init__(self, script, hang=False, gate=None):
+        self.state = WSState.OPEN
+        self.sent = []
+        self.closed = False
+        self._script = script  # shared across reconnects; each send pops one response
+        self._queue = []
+        self._hang = hang  # block instead of ending, to model "server has not answered yet"
+        self._gate = gate  # when set, events are withheld until the gate opens
+
+    async def send(self, raw):
+        self.sent.append(json.loads(raw))
+        if self._script:
+            self._queue.extend(json.dumps(e) for e in self._script.pop(0))
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._gate is not None:
+            await self._gate.wait()
+        if not self._queue:
+            if self._hang:
+                await asyncio.Event().wait()
+            raise StopAsyncIteration
+        return self._queue.pop(0)
+
+    async def close(self):
+        self.closed = True
+        self.state = WSState.CLOSED
+
+
+def _transport(*responses, hang=False, gate=None):
+    """Transport whose connects are counted; `responses` is one event-list per create sent."""
+    t = OpenAIWSConnection.__new__(OpenAIWSConnection)
+    t._api_key = "k"
+    t._ws = None
+    t._needs_reset = False
+    t._connected_at = 0.0
+    t._lock = asyncio.Lock()
+    t._connect_task = None
+    t.connects = 0
+    t.sockets = []
+    script = [list(r) for r in responses]
+
+    async def fake_connect():
+        t.connects += 1
+        t._ws = FakeWS(script, hang=hang, gate=gate)
+        t._connected_at = time.monotonic()
+        t.sockets.append(t._ws)
+
+    t._connect = fake_connect
+    return t
+
+
+async def _drain(agen):
+    return [e async for e in agen]
+
+
+# ---------------------------------------------------------------- healthy turns unchanged
+
+
+async def test_a_completed_turn_leaves_the_socket_clean():
+    t = _transport([delta("hi"), completed()])
+    events = await _drain(t.stream_response({"input": "a"}))
+    assert [e["type"] for e in events] == ["response.output_text.delta", "response.completed"]
+    assert t._needs_reset is False
+    assert t.connects == 1
+
+
+async def test_two_healthy_turns_reuse_one_socket():
+    t = _transport([completed("r1")], [completed("r2")])
+    await _drain(t.stream_response({"input": "a"}))
+    await _drain(t.stream_response({"input": "b"}))
+    assert t.connects == 1  # no reconnect on the happy path
+    assert len(t.sockets) == 1
+
+
+async def test_a_consumer_that_breaks_on_completed_does_not_dirty_the_socket():
+    # The real consumer breaks on COMPLETED and never lets the generator resume, so the
+    # flag has to be cleared before the yield. Clearing it after would reconnect every turn.
+    t = _transport([delta("hi"), completed()], [completed("r2")])
+    async for evt in t.stream_response({"input": "a"}):
+        if evt["type"] == ResponseStreamEvent.COMPLETED.value:
+            break
+    assert t._needs_reset is False
+    await _drain(t.stream_response({"input": "b"}))
+    assert t.connects == 1
+
+
+@pytest.mark.parametrize("terminal", ["response.failed", "response.incomplete", "error"])
+async def test_every_terminal_event_clears_the_flag(terminal):
+    t = _transport([{"type": terminal}])
+    await _drain(t.stream_response({"input": "a"}))
+    assert t._needs_reset is False
+
+
+# ---------------------------------------------------------------- abandoned turns reconnect
+
+
+async def test_a_cancelled_stream_marks_the_socket_dirty():
+    t = _transport([delta("कुछ"), delta(" और"), completed()])
+    agen = t.stream_response({"input": "ठीक है"})
+    await agen.__anext__()  # consume one delta, then walk away
+    await agen.aclose()
+    assert t._needs_reset is True
+
+
+async def test_the_next_turn_after_an_abandoned_stream_reconnects():
+    t = _transport([delta("leftover"), completed("r1")], [delta("real"), completed("r2")])
+    agen = t.stream_response({"input": "a"})
+    await agen.__anext__()
+    await agen.aclose()
+
+    events = await _drain(t.stream_response({"input": "b"}))
+    assert t.connects == 2
+    assert t.sockets[0].closed is True
+    assert t._needs_reset is False
+
+
+async def test_leftover_events_can_never_reach_the_next_turn():
+    """The regression itself. Turn 1 ('ठीक है') is cancelled with its answer still queued;
+    turn 2 (the loan question) must see only its own events. Unfixed, turn 2 reads turn 1's
+    answer and its terminal event, i.e. it replies to the previous utterance in ~0ms."""
+    t = _transport(
+        [created("r1"), delta("कुछ और पूछना था?"), completed("r1")],
+        [created("r2"), delta("loan answer"), completed("r2")],
+    )
+    agen = t.stream_response({"input": "ठीक है"})
+    assert (await agen.__anext__())["type"] == "response.created"
+    await agen.aclose()  # cancelled here; the answer is still on the socket
+
+    events = await _drain(t.stream_response({"input": "loan question"}))
+    texts = [e["delta"] for e in events if "delta" in e]
+    assert texts == ["loan answer"]
+    assert "कुछ और पूछना था?" not in texts
+    assert [e["response"]["id"] for e in events if "response" in e] == ["r2", "r2"]
+
+
+async def test_a_generator_that_never_ran_sends_nothing_and_stays_clean():
+    # Nothing was sent, so nothing is queued — reconnecting here would be pure cost.
+    t = _transport([completed("r1")])
+    agen = t.stream_response({"input": "a"})
+    await agen.aclose()  # never iterated, so the body never ran
+    assert t._needs_reset is False
+    assert t.connects == 0
+
+
+async def test_task_cancellation_while_awaiting_the_first_event_dirties_the_socket():
+    """The reported call exactly: llm_task.cancel() 6ms after the create was sent, while the
+    turn is still awaiting its first event. The response is already committed server-side."""
+    t = _transport([], hang=True)
+
+    async def consume():
+        async for _ in t.stream_response({"input": "ठीक है"}):
+            pass
+
+    task = asyncio.create_task(consume())
+    while t._ws is None or not t._ws.sent:  # let the create go out
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert t._needs_reset is True
+    assert t._lock.locked() is False  # cancellation lands inside the generator, freeing it
+
+
+async def test_a_turn_cancelled_mid_stream_dirties_the_socket():
+    # Partial output delivered, terminal event still to come — the leak window.
+    t = _transport([delta("one"), delta("two")], hang=True)
+    started = asyncio.Event()
+
+    async def consume():
+        async for _ in t.stream_response({"input": "a"}):
+            started.set()
+
+    task = asyncio.create_task(consume())
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert t._needs_reset is True
+
+
+async def test_the_dirty_flag_is_cleared_by_the_reconnect():
+    t = _transport([delta("x"), completed()], [completed("r2")], [completed("r3")])
+    agen = t.stream_response({"input": "a"})
+    await agen.__anext__()
+    await agen.aclose()
+
+    await _drain(t.stream_response({"input": "b"}))
+    assert t.connects == 2
+    await _drain(t.stream_response({"input": "c"}))
+    assert t.connects == 2  # clean again, no further reconnect
+
+
+# ---------------------------------------------------- end to end through the real consumer
+
+
+def _make_ws_llm(transport):
+    """Real OpenAiLLM driving the real WS consumer over a faked socket."""
+    with patch.object(OpenAiLLM, "__init__", lambda self, **kw: None):
+        llm = OpenAiLLM.__new__(OpenAiLLM)
+    llm.model = "gpt-5.6-luna"
+    llm.max_tokens = 100
+    llm.buffer_size = 40
+    llm.temperature = 0.1
+    llm.run_id = "run_123"
+    llm.language = "en"
+    llm.trigger_function_call = False
+    llm.api_params = {}
+    llm.tools = []
+    llm.started_streaming = False
+    llm.llm_host = None
+    llm.use_responses_api = True
+    llm.previous_response_id = None
+    llm._pending_call_ids = set()
+    llm.compact_threshold = None
+    llm._interruption_hint = None
+    llm._ws_transport = transport
+    llm.model_args = {"model": llm.model, "max_tokens": 100, "temperature": 0.1}
+    return llm
+
+
+MESSAGES = [{"role": "system", "content": "sys"}, {"role": "user", "content": "hi"}]
+
+
+def _text(chunks):
+    return "".join(c.data for c in chunks if getattr(c, "data", None))
+
+
+async def test_real_consumer_completes_a_turn_without_dirtying_the_socket():
+    """The ordering guarantee against the actual consumer, which breaks on COMPLETED and
+    never lets the generator resume. If the flag were cleared after the yield instead of
+    before, every healthy turn would reconnect."""
+    t = _transport(
+        [created("r1"), delta("नमस्ते"), completed("r1")],
+        [created("r2"), delta("दूसरा"), completed("r2")],
+    )
+    llm = _make_ws_llm(t)
+
+    chunks = [c async for c in llm._generate_stream_ws_responses(MESSAGES, meta_info={"sequence_id": 1})]
+    assert "नमस्ते" in _text(chunks)
+    assert t._needs_reset is False
+
+    chunks = [c async for c in llm._generate_stream_ws_responses(MESSAGES, meta_info={"sequence_id": 2})]
+    assert "दूसरा" in _text(chunks)
+    assert t.connects == 1  # one socket served both healthy turns
+
+
+async def test_real_consumer_does_not_inherit_a_cancelled_turns_answer():
+    """End to end reproduction of run 23323c9e: turn 1 is cancelled mid-flight, turn 2 must
+    still generate its own answer rather than replay turn 1's."""
+    gate = asyncio.Event()  # the server answers turn 1 only after it has been cancelled
+    t = _transport(
+        [created("r1"), delta("कुछ और पूछना था?"), completed("r1")],
+        [created("r2"), delta("loan answer"), completed("r2")],
+        gate=gate,
+    )
+    llm = _make_ws_llm(t)
+
+    async def turn_one():
+        async for _ in llm._generate_stream_ws_responses(MESSAGES, meta_info={"sequence_id": 4}):
+            pass
+
+    task = asyncio.create_task(turn_one())
+    while t._ws is None or not t._ws.sent:
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    gate.set()  # turn 1's answer lands on the socket now, with nobody reading it
+
+    chunks = [c async for c in llm._generate_stream_ws_responses(MESSAGES, meta_info={"sequence_id": 5})]
+    text = _text(chunks)
+    assert "loan answer" in text
+    assert "कुछ और पूछना था?" not in text
+    assert t.connects == 2

--- a/tests/test_ws_responses_stream_reset.py
+++ b/tests/test_ws_responses_stream_reset.py
@@ -131,11 +131,14 @@ async def test_a_consumer_that_breaks_on_completed_does_not_dirty_the_socket():
     assert t.connects == 1
 
 
-@pytest.mark.parametrize("terminal", ["response.failed", "response.incomplete", "error"])
-async def test_every_terminal_event_clears_the_flag(terminal):
-    t = _transport([{"type": terminal}])
+@pytest.mark.parametrize("terminal", ["response.completed", "response.failed", "response.incomplete"])
+async def test_every_response_terminal_settles_the_socket(terminal):
+    # `error` is deliberately absent: test_an_error_event_does_not_mark_the_socket_clean owns it.
+    t = _transport([{"type": terminal}], [completed("r2")])
     await _drain(t.stream_response({"input": "a"}))
+    await _settle()
     assert t._needs_reset is False
+    assert t.connects == 1 and t.sockets[0].closed is False  # settled, so kept
 
 
 # ---------------------------------------------------------------- abandoned turns reconnect
@@ -413,3 +416,34 @@ async def test_the_old_socket_close_is_never_awaited_on_the_critical_path():
     assert t.sockets[0].closed is False
     await _settle()
     assert t.sockets[0].closed is True
+
+
+# ---------------------------------------------------------------- review: teardown vs pre-warm
+
+
+async def test_disconnect_does_not_leak_the_socket_a_prewarm_is_still_opening():
+    """discard_socket clears _ws and opens a replacement in the background. A teardown landing
+    inside that window would find nothing to close, then inherit a live socket nobody owns."""
+    t = _transport([completed("r1")], [completed("r2")])
+    await t.ensure_connected()
+    first = t._ws
+
+    opening = asyncio.Event()
+    release = asyncio.Event()
+    finish_connect = t._connect
+
+    async def slow_connect():
+        opening.set()
+        await release.wait()
+        await finish_connect()
+
+    t._connect = slow_connect
+    t.discard_socket()  # hands off the close, starts the replacement
+    await opening.wait()
+
+    await t.disconnect()  # call ends mid-handshake
+    release.set()
+    await _settle()
+
+    assert t._ws is None
+    assert all(ws.closed for ws in t.sockets)


### PR DESCRIPTION
Problem 

 after a barge-in the agent answered the previous utterance (user: ठीक है / user: <loan question> / assistant: कुछ और पूछना था?). The per-sequence latencies prove no generation happened: seq 4 cancelled, seq 5 = 7.81 ms, seq 6 = 0.52 ms, seq 7 = 1160 ms (normal again). Loki shows zero LLM activity across the 4-second gap.

Root cause

OpenAIWSConnection holds one WebSocket for the whole call (connected once at 12:58:56.603, never reconnected across 8 sequences). stream_response yields every event with no response_id filter. llm_task.cancel() abandons the generator mid-stream, leaving the cancelled response's events queued; the next turn reads them and returns on their terminal event. The server-side cancel can't help — it's gated on previous_response_id, only set on CREATED, which hadn't arrived 6 ms after the create.

Fix 

 _needs_reset on the connection: set when the create is sent, cleared only when a terminal event is actually consumed, and ensure_connected reconnects when set. 17 insertions / 2 deletions, one class. Placed in stream_response rather than at a caller because kickoff_llm_generation also cancels llm_task directly — the overlapping-speech path, i.e. this exact bug. Notes the load-bearing clear-before-yield ordering.

Tests 

15 tests in three groups (healthy path unchanged / abandonment reconnects / end-to-end through the real consumer). Red/green proven by reverting to HEAD: 7 of 15 fail, the end-to-end one as assert 'loan answer' in 'कुछ और पूछना था?'. Suite 1404 passed / 1 skipped, ruff clean.