### PR TITLE
fix: drop the Responses chain on a language switch so the new system prompt reaches the model

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.222"
+__version__ = "0.10.223"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6463,6 +6463,8 @@ class TaskManager(BaseManager):
         new_prompt = f"{base}\n\n{context_note or self.__language_directive(label)}"
         self.conversation_history.update_system_prompt(new_prompt)
         self.system_prompt["content"] = new_prompt
+        # Responses API keeps the system prompt server-side, so a rewrite only ships once the chain drops.
+        self._invalidate_response_chain()
 
     def __log_committed_speculation(self, spec_text: str, capture):
         """Log a committed speculative follow-up exactly like a normal turn:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.222"
+version = "0.10.223"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_language_switch_response_chain.py
+++ b/tests/test_language_switch_response_chain.py
@@ -1,0 +1,92 @@
+"""A language switch must reach the model on the OpenAI Responses API path.
+
+Once `previous_response_id` is set, `_extract_new_input` sends `instructions=""` and the
+system prompt lives on OpenAI's server-side chain. Rewriting the local system message is
+then invisible to the model, so the agent flips voice and transcriber to the new language
+while the LLM keeps reasoning against the old-language prompt for the rest of the call
+(prod: aedd97c3, 8a9d82f0 — Marathi voice quoting Hindi-only scripted lines).
+"""
+
+import inspect
+from unittest.mock import MagicMock
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.llms.openai_base import OpenAICompatibleLLM
+
+APPLY = TaskManager._TaskManager__apply_language_directive
+
+
+def _make_tm(multilingual_prompts=None):
+    tm = MagicMock()
+    tm.multilingual_prompts = multilingual_prompts if multilingual_prompts is not None else {}
+    tm.system_prompt = {"role": "system", "content": "OLD HINDI PROMPT"}
+    tm.conversation_history = MagicMock()
+    tm._TaskManager__language_directive = TaskManager._TaskManager__language_directive.__get__(tm, TaskManager)
+    tm._invalidate_response_chain = MagicMock()
+    return tm
+
+
+class TestDirectiveDropsTheChain:
+    def test_switch_with_a_variant_invalidates(self):
+        tm = _make_tm({"mr": "MARATHI PROMPT"})
+        APPLY(tm, "mr")
+        tm._invalidate_response_chain.assert_called_once_with()
+
+    def test_switch_without_a_variant_still_invalidates(self):
+        # No per-language prompt, but the directive text itself changed language.
+        tm = _make_tm({})
+        APPLY(tm, "mr")
+        tm._invalidate_response_chain.assert_called_once_with()
+
+    def test_new_prompt_reaches_local_state_too(self):
+        tm = _make_tm({"mr": "MARATHI PROMPT"})
+        APPLY(tm, "mr")
+        assert tm.system_prompt["content"].startswith("MARATHI PROMPT")
+        assert "Marathi" in tm.system_prompt["content"]
+        tm.conversation_history.update_system_prompt.assert_called_once_with(tm.system_prompt["content"])
+
+    def test_invalidation_happens_after_the_rewrite(self):
+        # Dropping the chain before the rewrite would resend the prompt being replaced.
+        tm = _make_tm({"mr": "MARATHI PROMPT"})
+        seen = {}
+        tm._invalidate_response_chain = MagicMock(side_effect=lambda: seen.update(at_call=tm.system_prompt["content"]))
+        APPLY(tm, "mr")
+        assert seen["at_call"].startswith("MARATHI PROMPT")
+
+
+class TestCallSites:
+    def test_apply_language_directive_invalidates(self):
+        src = inspect.getsource(TaskManager._TaskManager__apply_language_directive)
+        assert "_invalidate_response_chain" in src, (
+            "a language switch must drop the Responses chain or the model never sees the new prompt"
+        )
+
+
+class TestChainedRequestOmitsSystemPrompt:
+    """Why the fix is needed at all — guards the assumption it rests on."""
+
+    def test_chained_input_sends_no_instructions(self):
+        llm = MagicMock(spec=OpenAICompatibleLLM)
+        llm.previous_response_id = "resp_abc"
+        messages = [
+            {"role": "system", "content": "MARATHI PROMPT"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "user", "content": "next"},
+        ]
+        instructions, items = OpenAICompatibleLLM._extract_new_input(llm, messages)
+        assert instructions == ""
+        assert not any("MARATHI PROMPT" in str(i) for i in items)
+
+    def test_unchained_input_carries_the_system_prompt(self):
+        llm = MagicMock(spec=OpenAICompatibleLLM)
+        llm.previous_response_id = None
+        llm._interruption_hint = None
+        llm._pending_call_ids = set()
+        messages = [
+            {"role": "system", "content": "MARATHI PROMPT"},
+            {"role": "user", "content": "hello"},
+        ]
+        # The system prompt travels as a role=system input item, not as `instructions`.
+        _, items = OpenAICompatibleLLM._build_responses_input(llm, messages)
+        assert any("MARATHI PROMPT" in str(i) for i in items)


### PR DESCRIPTION
## Problem

On the OpenAI Responses API path, a language switch never reaches the LLM. The agent flips
its transcriber and voice to the new language while the model keeps reasoning against the
original-language system prompt for the rest of the call.

Once `previous_response_id` is set, `_build_responses_input` takes the chained branch and
calls `_extract_new_input`, which sends only the items after the last assistant. Its own
docstring says it plainly:

> Send only items after the last assistant; prior context (including system) lives on the chain.

So the system prompt goes out once, on turn 1, and every later turn is a delta against
OpenAI's server-side state. `switch_language` → `__apply_language_directive` rewrites
`conversation_history._messages[0]` and `self.system_prompt["content"]`, which on this path
is dead state — those bytes are never transmitted again.

`TaskManager._invalidate_response_chain()` is the hook that forces a full-history resend.
It had **zero call sites in `task_manager.py`**; only tests referenced it, after it was
deliberately removed from the barge-in path in favour of `_set_interruption_hint`.

## Evidence

Prod calls `aedd97c3` and `8a9d82f0` (agent `b3977644`, langs hi/mr/ta, `gpt-5.4-mini`,
`use_responses_api: True`). Everything platform-side is correct:

- `Loaded multilingual prompts for languages: ['hi', 'mr', 'ta']`
- switch hi→mr on idle_flush; `Language switched to 'mr'` and `Switched system prompt
  language directive to 'mr'`; later LID decisions show `active=mr`
- the `mr` prompt is a complete Marathi translation — `आहे` ×53 vs `हूँ` ×0, `नमस्कार` not
  `नमस्ते`, all 13 FAQ answers keyed `mr:`

Yet after the switch the agent spoke `क्या मैं किसी और चीज़ में आपकी मदद कर सकता हूँ?` and
`problem आ रही है`. Both strings occur **once in the `hi` prompt and zero times in `mr`**.
The model quoted lines that exist only in a prompt it should no longer have had — proof the
Hindi system prompt was still in its context. Not drift, not a bad translation.

## Fix

One line, one site. `__apply_language_directive` is the single funnel for LID switches,
tool-driven switches and initial setup, so invalidating there covers all three.

Placement is deliberate: the call goes *after* the rewrite. Dropping the chain first would
resend the prompt being replaced.

## Blast radius

- Chat-completions agents are unaffected — they resend full history every turn, which is why
  this never surfaced before. `invalidate_response_chain()` is a `pass` on providers without
  server-side state, and the call is try/except-wrapped.
- Safe at setup, before `tools["llm_agent"]` exists.
- The existing source guards (`sync_history` and `_handle_transcriber_output` must *not*
  invalidate) target different functions and are untouched.
- Cost: one full-history resend per language switch, not per turn.

## Tests

`tests/test_language_switch_response_chain.py`, 7 tests:

- invalidation fires with a per-language variant, and without one (the directive text alone
  changed language)
- invalidation fires after the rewrite
- source guard against silent removal
- two tests pinning the mechanism the fix rests on: chained `_extract_new_input` omits the
  system prompt; unchained carries it as a `role=system` input item

Red/green proven — with the one line reverted, 4 of 7 fail.

Full suite 1432 passed / 1 skipped. `ruff check` and `ruff format --check` clean.