### PR TITLE
fix: route a cross-provider graph routing hop on its own credentials [BOLNA-2594]

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.226"
+__version__ = "0.10.227"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1872,8 +1872,7 @@ class TaskManager(BaseManager):
                 injected_cfg["routing_reasoning_effort"] = self.kwargs["routing_reasoning_effort"]
             if "routing_max_tokens" in self.kwargs:
                 injected_cfg["routing_max_tokens"] = self.kwargs["routing_max_tokens"]
-            # Credentials for a routing hop on a different provider than the conversation, resolved by the
-            # caller (Azure routing needs an endpoint the runtime does not carry in its env).
+            # Credentials for a routing hop on a different provider than the conversation.
             for key in ("routing_llm_key", "routing_base_url", "routing_api_version"):
                 if self.kwargs.get(key) is not None:
                     injected_cfg[key] = self.kwargs[key]

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1872,6 +1872,11 @@ class TaskManager(BaseManager):
                 injected_cfg["routing_reasoning_effort"] = self.kwargs["routing_reasoning_effort"]
             if "routing_max_tokens" in self.kwargs:
                 injected_cfg["routing_max_tokens"] = self.kwargs["routing_max_tokens"]
+            # Credentials for a routing hop on a different provider than the conversation, resolved by the
+            # caller (Azure routing needs an endpoint the runtime does not carry in its env).
+            for key in ("routing_llm_key", "routing_base_url", "routing_api_version"):
+                if self.kwargs.get(key) is not None:
+                    injected_cfg[key] = self.kwargs[key]
             # Set when the caller serves the conversation LLM from a different backend than the agent's own.
             for key in ("aux_model", "aux_provider", "route_routing_to_conversation"):
                 if key in self.kwargs:

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1872,7 +1872,6 @@ class TaskManager(BaseManager):
                 injected_cfg["routing_reasoning_effort"] = self.kwargs["routing_reasoning_effort"]
             if "routing_max_tokens" in self.kwargs:
                 injected_cfg["routing_max_tokens"] = self.kwargs["routing_max_tokens"]
-            # Credentials for a routing hop on a different provider than the conversation.
             for key in ("routing_llm_key", "routing_base_url", "routing_api_version"):
                 if self.kwargs.get(key) is not None:
                     injected_cfg[key] = self.kwargs[key]

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -272,8 +272,7 @@ class GraphAgent(BaseAgent):
             "api_version": self.config.get("routing_api_version"),
         }
         if not follow_conversation and any(explicit_routing_creds.values()):
-            # Creds the caller resolved for a routing provider that differs from the conversation.
-            # follow_conversation (a PTU swap) overrides them: routing then rides the conversation's own.
+            # follow_conversation (a PTU swap) overrides these: routing then rides the conversation's own.
             routing_kwargs.update({k: v for k, v in explicit_routing_creds.items() if v})
         elif self.routing_provider == conv_provider:
             for key in ("llm_key", "base_url", "api_version"):
@@ -293,20 +292,7 @@ class GraphAgent(BaseAgent):
             routing_kwargs["overflow_llm"] = self.config["overflow_llm"]
 
         self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
-        try:
-            self.routing_llm = llm_class(**routing_kwargs)
-        except Exception as e:
-            # Routing is one call per turn; degrade to the platform OpenAI router rather than fail the call.
-            logger.error(f"Routing client for {self.routing_provider} failed to build: {e}. Routing on OpenAI")
-            self.routing_provider = "openai"
-            self.routing_model = os.getenv("DEFAULT_ROUTING_MODEL_OPENAI", "gpt-4.1-mini")
-            self._routing_reasoning_effort_used = None
-            self.routing_llm = OpenAiLLM(
-                model=self.routing_model,
-                provider=self.routing_provider,
-                temperature=0,
-                max_tokens=routing_kwargs["max_tokens"],
-            )
+        self.routing_llm = llm_class(**routing_kwargs)
         logger.info(f"Routing initialized with {self.routing_provider} ({self.routing_model})")
 
     async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -279,7 +279,10 @@ class GraphAgent(BaseAgent):
             "base_url": self.config.get("routing_base_url"),
             "api_version": self.config.get("routing_api_version"),
         }
-        if any(explicit_routing_creds.values()):
+        if not follow_conversation and any(explicit_routing_creds.values()):
+            # Credentials the caller resolved for a routing provider that differs from the conversation.
+            # follow_conversation (e.g. a PTU swap) overrides these: routing then rides the conversation's
+            # own credentials, which may point at a different deployment than these were resolved for.
             routing_kwargs.update({k: v for k, v in explicit_routing_creds.items() if v})
         elif self.routing_provider == conv_provider:
             for key in ("llm_key", "base_url", "api_version"):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -239,9 +239,12 @@ class GraphAgent(BaseAgent):
     def _init_routing_client(self):
         """Build the routing LLM from the same registry as the conversation model.
 
-        Routing reuses the conversation credentials only when it runs on the same provider;
-        otherwise each provider class resolves its own platform key. A provider with no usable
-        credentials falls back to the platform OpenAI router instead of failing the call.
+        Credentials come from one of three places, in order: routing_llm_key/base_url/api_version the
+        caller resolved for a routing provider that differs from the conversation (Azure needs an
+        endpoint the runtime does not carry); the conversation credentials when routing shares its
+        provider; otherwise the provider class resolves its own platform key from the env. A provider
+        left with no usable credentials falls back to the platform OpenAI router instead of failing the
+        call.
         """
         conv_provider = self.config.get("provider") or self.config.get("llm_provider") or "openai"
         # Self-hosted OpenAI-compatible endpoints (custom/ola) have no platform router, so they route on
@@ -271,7 +274,14 @@ class GraphAgent(BaseAgent):
             "temperature": 0,
             "max_tokens": self.routing_max_tokens or 250,
         }
-        if self.routing_provider == conv_provider:
+        explicit_routing_creds = {
+            "llm_key": self.config.get("routing_llm_key"),
+            "base_url": self.config.get("routing_base_url"),
+            "api_version": self.config.get("routing_api_version"),
+        }
+        if any(explicit_routing_creds.values()):
+            routing_kwargs.update({k: v for k, v in explicit_routing_creds.items() if v})
+        elif self.routing_provider == conv_provider:
             for key in ("llm_key", "base_url", "api_version"):
                 if self.config.get(key):
                     routing_kwargs[key] = self.config[key]

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -240,7 +240,8 @@ class GraphAgent(BaseAgent):
         """Build the routing LLM from the same registry as the conversation model.
 
         Routing reuses the conversation credentials only when it runs on the same provider;
-        otherwise each provider class resolves its own platform key.
+        otherwise each provider class resolves its own platform key. A provider with no usable
+        credentials falls back to the platform OpenAI router instead of failing the call.
         """
         conv_provider = self.config.get("provider") or self.config.get("llm_provider") or "openai"
         # Self-hosted OpenAI-compatible endpoints (custom/ola) have no platform router, so they route on
@@ -288,7 +289,22 @@ class GraphAgent(BaseAgent):
             routing_kwargs["overflow_llm"] = self.config["overflow_llm"]
 
         self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
-        self.routing_llm = llm_class(**routing_kwargs)
+        try:
+            self.routing_llm = llm_class(**routing_kwargs)
+        except Exception as e:
+            # A provider the runtime holds no credentials for raises here, and routing is one call per
+            # turn: fall back to the platform router an unspecified routing provider resolves to rather
+            # than take the call down before it reaches the caller.
+            logger.error(f"Routing client for {self.routing_provider} failed to build: {e}. Routing on OpenAI")
+            self.routing_provider = "openai"
+            self.routing_model = os.getenv("DEFAULT_ROUTING_MODEL_OPENAI", "gpt-4.1-mini")
+            self._routing_reasoning_effort_used = None
+            self.routing_llm = OpenAiLLM(
+                model=self.routing_model,
+                provider=self.routing_provider,
+                temperature=0,
+                max_tokens=routing_kwargs["max_tokens"],
+            )
         logger.info(f"Routing initialized with {self.routing_provider} ({self.routing_model})")
 
     async def check_for_completion(self, messages, check_for_completion_prompt, meta_info=None):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -237,15 +237,7 @@ class GraphAgent(BaseAgent):
         }
 
     def _init_routing_client(self):
-        """Build the routing LLM from the same registry as the conversation model.
-
-        Credentials come from one of three places, in order: routing_llm_key/base_url/api_version the
-        caller resolved for a routing provider that differs from the conversation (Azure needs an
-        endpoint the runtime does not carry); the conversation credentials when routing shares its
-        provider; otherwise the provider class resolves its own platform key from the env. A provider
-        left with no usable credentials falls back to the platform OpenAI router instead of failing the
-        call.
-        """
+        """Build the routing LLM from the same registry as the conversation model."""
         conv_provider = self.config.get("provider") or self.config.get("llm_provider") or "openai"
         # Self-hosted OpenAI-compatible endpoints (custom/ola) have no platform router, so they route on
         # their own model and endpoint; everything else defaults to the platform OpenAI router. Either can
@@ -280,9 +272,8 @@ class GraphAgent(BaseAgent):
             "api_version": self.config.get("routing_api_version"),
         }
         if not follow_conversation and any(explicit_routing_creds.values()):
-            # Credentials the caller resolved for a routing provider that differs from the conversation.
-            # follow_conversation (e.g. a PTU swap) overrides these: routing then rides the conversation's
-            # own credentials, which may point at a different deployment than these were resolved for.
+            # Creds the caller resolved for a routing provider that differs from the conversation.
+            # follow_conversation (a PTU swap) overrides them: routing then rides the conversation's own.
             routing_kwargs.update({k: v for k, v in explicit_routing_creds.items() if v})
         elif self.routing_provider == conv_provider:
             for key in ("llm_key", "base_url", "api_version"):
@@ -305,9 +296,7 @@ class GraphAgent(BaseAgent):
         try:
             self.routing_llm = llm_class(**routing_kwargs)
         except Exception as e:
-            # A provider the runtime holds no credentials for raises here, and routing is one call per
-            # turn: fall back to the platform router an unspecified routing provider resolves to rather
-            # than take the call down before it reaches the caller.
+            # Routing is one call per turn; degrade to the platform OpenAI router rather than fail the call.
             logger.error(f"Routing client for {self.routing_provider} failed to build: {e}. Routing on OpenAI")
             self.routing_provider = "openai"
             self.routing_model = os.getenv("DEFAULT_ROUTING_MODEL_OPENAI", "gpt-4.1-mini")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.226"
+version = "0.10.227"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_graph_routing_credentials.py
+++ b/tests/test_graph_routing_credentials.py
@@ -126,6 +126,24 @@ def test_injected_routing_credentials_reach_the_routing_client():
     assert kw["api_version"] == "2024-12-01-preview"
 
 
+def test_route_routing_to_conversation_overrides_injected_routing_credentials():
+    # A PTU swap resolves routing creds for the original provider, then flips the conversation onto its
+    # own deployment and sets route_routing_to_conversation. Routing must follow the conversation's
+    # (PTU) credentials, not the standalone ones resolved before the swap.
+    agent, _ = _build(
+        provider="azure",
+        llm_key="ptu-conv-key",
+        base_url="https://ptu.azure.example",
+        route_routing_to_conversation=True,
+        routing_provider="azure",
+        routing_llm_key="standalone-azure-key",
+        routing_base_url="https://standalone.azure.example",
+    )
+    kw = _routing_kwargs(agent)
+    assert kw["llm_key"] == "ptu-conv-key"
+    assert kw["base_url"] == "https://ptu.azure.example"
+
+
 def test_injected_routing_credentials_win_over_conversation_inheritance():
     # Same provider on both hops, but the caller supplied a distinct routing endpoint: use it, not the
     # conversation's, so a routing hop on a different deployment is not silently sent to the conv one.

--- a/tests/test_graph_routing_credentials.py
+++ b/tests/test_graph_routing_credentials.py
@@ -109,6 +109,40 @@ def test_explicit_azure_routing_with_openai_conversation_uses_platform_creds():
     assert "base_url" not in kw
 
 
+def test_injected_routing_credentials_reach_the_routing_client():
+    agent, _ = _build(
+        provider="google",
+        model="gemini-3.7-flash",
+        routing_provider="azure",
+        routing_model="azure/gpt-4.1-mini",
+        routing_llm_key="routing-azure-key",
+        routing_base_url="https://routing.azure.example",
+        routing_api_version="2024-12-01-preview",
+    )
+    kw = _routing_kwargs(agent)
+    assert kw["provider"] == "azure"
+    assert kw["llm_key"] == "routing-azure-key"
+    assert kw["base_url"] == "https://routing.azure.example"
+    assert kw["api_version"] == "2024-12-01-preview"
+
+
+def test_injected_routing_credentials_win_over_conversation_inheritance():
+    # Same provider on both hops, but the caller supplied a distinct routing endpoint: use it, not the
+    # conversation's, so a routing hop on a different deployment is not silently sent to the conv one.
+    agent, _ = _build(
+        provider="azure",
+        llm_key="conv-key",
+        base_url="https://conv.azure.example",
+        routing_provider="azure",
+        routing_model="azure/gpt-4.1-mini",
+        routing_llm_key="routing-azure-key",
+        routing_base_url="https://routing.azure.example",
+    )
+    kw = _routing_kwargs(agent)
+    assert kw["llm_key"] == "routing-azure-key"
+    assert kw["base_url"] == "https://routing.azure.example"
+
+
 def test_routing_forwards_service_tier_and_reasoning_effort():
     agent, _ = _build(
         provider="openai", routing_model="gpt-5.4-mini", service_tier="priority", routing_reasoning_effort="low"
@@ -224,3 +258,22 @@ def test_azure_routing_fallback_drops_the_unbuilt_models_reasoning_effort():
     fell_back = _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **gpt5_routing)
     assert fell_back.routing_provider == "openai"
     assert fell_back._routing_reasoning_effort_used is None
+
+
+def test_injected_azure_routing_creds_build_the_real_client_without_a_platform_endpoint():
+    """The proper fix: a Gemini conversation with caller-resolved Azure routing creds routes ON Azure,
+    even though the runtime env carries no AZURE_OPENAI_ENDPOINT (the production shape)."""
+    from bolna.llms import AzureLLM
+
+    agent = _real_agent(
+        env=AZURE_KEY_ONLY_ENV,
+        provider="google",
+        model="gemini-3.7-flash",
+        routing_llm_key="routing-azure-key",
+        routing_base_url="https://routing.azure.example",
+        routing_api_version="2024-12-01-preview",
+        **AZURE_ROUTING,
+    )
+    assert isinstance(agent.routing_llm, AzureLLM)
+    assert agent.routing_provider == "azure"
+    assert agent.routing_llm.llm_host == "routing.azure.example"

--- a/tests/test_graph_routing_credentials.py
+++ b/tests/test_graph_routing_credentials.py
@@ -130,7 +130,7 @@ def test_openai_conversation_aux_llm_reuses_its_own_key():
 
 
 # Real construction (no registry mock) for the paths whose behavior depends on the concrete LLM class.
-def _real_agent(**overrides):
+def _real_agent(env=None, **overrides):
     config = {
         "agent_information": "Test agent",
         "model": "gpt-4o-mini",
@@ -140,7 +140,9 @@ def _real_agent(**overrides):
         "nodes": [{"id": "start", "prompt": "hi", "edges": []}],
     }
     config.update(overrides)
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "plat", "GOOGLE_API_KEY": "gg"}, clear=True):
+    with patch.dict(
+        os.environ, env if env is not None else {"OPENAI_API_KEY": "plat", "GOOGLE_API_KEY": "gg"}, clear=True
+    ):
         return GraphAgent(config)
 
 
@@ -164,3 +166,61 @@ def test_explicit_litellm_routing_prefixes_bare_model():
 def test_already_prefixed_litellm_model_not_doubled():
     agent = _real_agent(routing_provider="anthropic", routing_model="anthropic/claude-3-5-sonnet")
     assert agent.routing_model == "anthropic/claude-3-5-sonnet"
+
+
+# The runtime holds no Azure endpoint of its own, so an Azure routing hop under a non-Azure
+# conversation model has no credentials to resolve and its client cannot be built.
+AZURE_ROUTING = {"routing_provider": "azure", "routing_model": "azure/gpt-4.1-mini"}
+AZURE_PLATFORM_ENV = {
+    "OPENAI_API_KEY": "plat",
+    "GOOGLE_API_KEY": "gg",
+    "AZURE_OPENAI_ENDPOINT": "https://platform.azure.example",
+    "AZURE_OPENAI_API_KEY": "platform-azure-key",
+}
+# What the runtime actually carries: an Azure key, and no endpoint to spend it against.
+AZURE_KEY_ONLY_ENV = {k: v for k, v in AZURE_PLATFORM_ENV.items() if k != "AZURE_OPENAI_ENDPOINT"}
+
+
+def test_azure_routing_falls_back_to_openai_without_a_platform_azure_endpoint():
+    """A Gemini conversation routing on Azure: the agent is built, and the call is not lost."""
+    from bolna.llms import OpenAiLLM
+
+    agent = _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
+    assert isinstance(agent.routing_llm, OpenAiLLM)
+    assert agent.routing_provider == "openai"
+    assert agent.routing_model == "gpt-4.1-mini"
+    assert agent.routing_llm.max_tokens == 250
+
+
+def test_azure_routing_fallback_honours_routing_max_tokens():
+    agent = _real_agent(
+        env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", routing_max_tokens=64, **AZURE_ROUTING
+    )
+    assert agent.routing_llm.max_tokens == 64
+
+
+def test_azure_routing_falls_back_with_no_azure_credentials_at_all():
+    from bolna.llms import OpenAiLLM
+
+    agent = _real_agent(provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
+    assert isinstance(agent.routing_llm, OpenAiLLM)
+    assert agent.routing_provider == "openai"
+
+
+def test_azure_routing_stays_on_azure_when_the_platform_endpoint_is_set():
+    from bolna.llms import AzureLLM
+
+    agent = _real_agent(env=AZURE_PLATFORM_ENV, provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
+    assert isinstance(agent.routing_llm, AzureLLM)
+    assert agent.routing_provider == "azure"
+
+
+def test_azure_routing_fallback_drops_the_unbuilt_models_reasoning_effort():
+    gpt5_routing = {"routing_provider": "azure", "routing_model": "azure/gpt-5.4-mini"}
+
+    on_azure = _real_agent(env=AZURE_PLATFORM_ENV, provider="google", model="gemini-3.7-flash", **gpt5_routing)
+    assert on_azure._routing_reasoning_effort_used is not None
+
+    fell_back = _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **gpt5_routing)
+    assert fell_back.routing_provider == "openai"
+    assert fell_back._routing_reasoning_effort_used is None

--- a/tests/test_graph_routing_credentials.py
+++ b/tests/test_graph_routing_credentials.py
@@ -8,6 +8,8 @@ is what stops a Gemini conversation from lending its key to an OpenAI router (BO
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from bolna.agent_types.graph_agent import GraphAgent
 
 PLATFORM_ENV = {
@@ -220,66 +222,13 @@ def test_already_prefixed_litellm_model_not_doubled():
     assert agent.routing_model == "anthropic/claude-3-5-sonnet"
 
 
-# The runtime holds no Azure endpoint of its own, so an Azure routing hop under a non-Azure
-# conversation model has no credentials to resolve and its client cannot be built.
 AZURE_ROUTING = {"routing_provider": "azure", "routing_model": "azure/gpt-4.1-mini"}
-AZURE_PLATFORM_ENV = {
-    "OPENAI_API_KEY": "plat",
-    "GOOGLE_API_KEY": "gg",
-    "AZURE_OPENAI_ENDPOINT": "https://platform.azure.example",
-    "AZURE_OPENAI_API_KEY": "platform-azure-key",
-}
-# What the runtime actually carries: an Azure key, and no endpoint to spend it against.
-AZURE_KEY_ONLY_ENV = {k: v for k, v in AZURE_PLATFORM_ENV.items() if k != "AZURE_OPENAI_ENDPOINT"}
-
-
-def test_azure_routing_falls_back_to_openai_without_a_platform_azure_endpoint():
-    """A Gemini conversation routing on Azure: the agent is built, and the call is not lost."""
-    from bolna.llms import OpenAiLLM
-
-    agent = _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
-    assert isinstance(agent.routing_llm, OpenAiLLM)
-    assert agent.routing_provider == "openai"
-    assert agent.routing_model == "gpt-4.1-mini"
-    assert agent.routing_llm.max_tokens == 250
-
-
-def test_azure_routing_fallback_honours_routing_max_tokens():
-    agent = _real_agent(
-        env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", routing_max_tokens=64, **AZURE_ROUTING
-    )
-    assert agent.routing_llm.max_tokens == 64
-
-
-def test_azure_routing_falls_back_with_no_azure_credentials_at_all():
-    from bolna.llms import OpenAiLLM
-
-    agent = _real_agent(provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
-    assert isinstance(agent.routing_llm, OpenAiLLM)
-    assert agent.routing_provider == "openai"
-
-
-def test_azure_routing_stays_on_azure_when_the_platform_endpoint_is_set():
-    from bolna.llms import AzureLLM
-
-    agent = _real_agent(env=AZURE_PLATFORM_ENV, provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)
-    assert isinstance(agent.routing_llm, AzureLLM)
-    assert agent.routing_provider == "azure"
-
-
-def test_azure_routing_fallback_drops_the_unbuilt_models_reasoning_effort():
-    gpt5_routing = {"routing_provider": "azure", "routing_model": "azure/gpt-5.4-mini"}
-
-    on_azure = _real_agent(env=AZURE_PLATFORM_ENV, provider="google", model="gemini-3.7-flash", **gpt5_routing)
-    assert on_azure._routing_reasoning_effort_used is not None
-
-    fell_back = _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **gpt5_routing)
-    assert fell_back.routing_provider == "openai"
-    assert fell_back._routing_reasoning_effort_used is None
+# What the runtime carries: an Azure key, and no endpoint to spend it against.
+AZURE_KEY_ONLY_ENV = {"OPENAI_API_KEY": "plat", "GOOGLE_API_KEY": "gg", "AZURE_OPENAI_API_KEY": "platform-azure-key"}
 
 
 def test_injected_azure_routing_creds_build_the_real_client_without_a_platform_endpoint():
-    """The proper fix: a Gemini conversation with caller-resolved Azure routing creds routes ON Azure,
+    """The fix: a Gemini conversation with caller-resolved Azure routing creds routes ON Azure,
     even though the runtime env carries no AZURE_OPENAI_ENDPOINT (the production shape)."""
     from bolna.llms import AzureLLM
 
@@ -295,3 +244,10 @@ def test_injected_azure_routing_creds_build_the_real_client_without_a_platform_e
     assert isinstance(agent.routing_llm, AzureLLM)
     assert agent.routing_provider == "azure"
     assert agent.routing_llm.llm_host == "routing.azure.example"
+
+
+def test_azure_routing_without_resolvable_creds_surfaces_the_error():
+    # No silent default: an Azure routing hop the caller could not resolve credentials for raises,
+    # rather than quietly routing on a different provider.
+    with pytest.raises(Exception):
+        _real_agent(env=AZURE_KEY_ONLY_ENV, provider="google", model="gemini-3.7-flash", **AZURE_ROUTING)


### PR DESCRIPTION
The bolna half of the graph-routing-hop credential fix. Pairs with dashboard-backend PR #2982, which resolves and injects the routing credentials this consumes.

## The bug

A graph agent's routing hop is a second LLM with its own provider. `_init_routing_client` lent it the conversation's `llm_key`/`base_url`/`api_version` only when `routing_provider == conversation_provider`, trusting each provider class to resolve its own platform key otherwise. That holds for OpenAI and Google (their keys are in the ws-server env) but not Azure: `AzureLLM` builds `AsyncAzureOpenAI` in `__init__` and needs an endpoint the ws-server does not carry. An Azure routing hop under a non-Azure conversation model therefore raised `Must provide one of the base_url or azure_endpoint arguments, or the AZURE_OPENAI_ENDPOINT environment variable`, out of `GraphAgent.__init__` to the telephony handler, which tore down and let the provider reconnect into the same crash. The caller heard silence until they hung up.

Seen in prod on a Gemini agent with `routing_provider: azure`: 17 handler crashes across 6 pods in 24 seconds, `conversation_duration` 0, no transcript.

## The fix

`_init_routing_client` applies `routing_llm_key`/`routing_base_url`/`routing_api_version` from the config when present (threaded through by TaskManager and resolved by the backend for a cross-provider hop), so the routing hop runs on its configured provider with the credentials the backend resolved. Same-provider inheritance stays as the fallback, and `route_routing_to_conversation` (a PTU swap) still overrides both so routing rides the conversation's own credentials.

No silent default: a routing provider the caller could not resolve credentials for surfaces the error rather than quietly routing on a different provider.

## Tests

`tests/test_graph_routing_credentials.py`: injected routing credentials reach and build the real Azure client with no `AZURE_OPENAI_ENDPOINT` in env (the prod shape); injected creds win over conversation inheritance; `route_routing_to_conversation` overrides injected creds; and an unresolvable Azure routing hop surfaces the error. All through real construction, not the mocked registry that let the original gap through, and verified non-vacuous.
