### PR TITLE
fix: trim an interrupted static node to what was actually spoken

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.230"
+__version__ = "0.10.231"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6918,7 +6918,9 @@ class TaskManager(BaseManager):
     def _stamp_cached_clip_text(self, meta_info):
         """Give the mark its text so an interrupted clip can be trimmed. Cached-send branch
         only: the cache-miss path re-synthesizes live and would stamp every chunk. See INIT.md."""
-        if meta_info.get("message_category") != "static_node" or meta_info.get("is_silence_trigger"):
+        if meta_info.get("message_category") not in CACHED_SINGLE_MARK_CATEGORIES or meta_info.get(
+            "is_silence_trigger"
+        ):
             return
         meta_info["text_synthesized"] = meta_info.get("text", "")
 

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -6916,14 +6916,8 @@ class TaskManager(BaseManager):
             await self.tools["synthesizer"].cleanup()
 
     def _stamp_cached_clip_text(self, meta_info):
-        """A pre-generated clip skips the synthesizer, which is what normally stamps
-        text_synthesized, so its single mark would carry no text and an interrupted node could
-        not be trimmed. Only on the branch that sends the cached bytes: the cache-miss path
-        re-synthesizes live with this same meta_info, and every streaming provider but
-        ElevenLabs and Azure reuses one meta_info for all chunks, which would put the whole
-        message on every mark. Silence re-prompts stay unstamped: history deliberately never
-        records them, and mark text would let sync_history materialise an interrupted one.
-        """
+        """Give the mark its text so an interrupted clip can be trimmed. Cached-send branch
+        only: the cache-miss path re-synthesizes live and would stamp every chunk. See INIT.md."""
         if meta_info.get("message_category") != "static_node" or meta_info.get("is_silence_trigger"):
             return
         meta_info["text_synthesized"] = meta_info.get("text", "")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -22,6 +22,7 @@ from pydub import AudioSegment
 
 from bolna.constants import (
     ACCIDENTAL_INTERRUPTION_PHRASES,
+    CACHED_SINGLE_MARK_CATEGORIES,
     DEFAULT_USER_ONLINE_MESSAGE,
     DEFAULT_USER_ONLINE_MESSAGE_TRIGGER_DURATION,
     FILLER_DICT,
@@ -2788,7 +2789,13 @@ class TaskManager(BaseManager):
                 ):
                     break
 
-            if first_item.get("text_synthesized") and first_item.get("is_final_chunk") is True:
+            # Cached clips are a single mark that is always the final chunk, so this shortcut
+            # would skip waiting for the whole message rather than just its tail.
+            if (
+                first_item.get("text_synthesized")
+                and first_item.get("is_final_chunk") is True
+                and first_item.get("type") not in CACHED_SINGLE_MARK_CATEGORIES
+            ):
                 break
 
             # Use entry_time (not time.time()) so the deadline is a fixed point in the
@@ -3821,6 +3828,9 @@ class TaskManager(BaseManager):
 
                     meta_info["end_of_llm_stream"] = True
                     meta_info["text"] = static_text
+                    # The clip skips the synthesizer, which is what normally stamps this. Without
+                    # it the mark carries no text and an interrupted node cannot be trimmed.
+                    meta_info["text_synthesized"] = static_text
                     meta_info["cached"] = True
                     meta_info["message_category"] = "static_node"
                     ws_packet = create_ws_data_packet(static_hash, meta_info=meta_info, is_md5_hash=True)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3828,11 +3828,9 @@ class TaskManager(BaseManager):
 
                     meta_info["end_of_llm_stream"] = True
                     meta_info["text"] = static_text
-                    # The clip skips the synthesizer, which is what normally stamps this. Without
-                    # it the mark carries no text and an interrupted node cannot be trimmed.
-                    meta_info["text_synthesized"] = static_text
                     meta_info["cached"] = True
                     meta_info["message_category"] = "static_node"
+                    meta_info["is_silence_trigger"] = is_silence_trigger
                     ws_packet = create_ws_data_packet(static_hash, meta_info=meta_info, is_md5_hash=True)
                     await self._synthesize(ws_packet)
                     return
@@ -6917,6 +6915,19 @@ class TaskManager(BaseManager):
         finally:
             await self.tools["synthesizer"].cleanup()
 
+    def _stamp_cached_clip_text(self, meta_info):
+        """A pre-generated clip skips the synthesizer, which is what normally stamps
+        text_synthesized, so its single mark would carry no text and an interrupted node could
+        not be trimmed. Only on the branch that sends the cached bytes: the cache-miss path
+        re-synthesizes live with this same meta_info, and every streaming provider but
+        ElevenLabs and Azure reuses one meta_info for all chunks, which would put the whole
+        message on every mark. Silence re-prompts stay unstamped: history deliberately never
+        records them, and mark text would let sync_history materialise an interrupted one.
+        """
+        if meta_info.get("message_category") != "static_node" or meta_info.get("is_silence_trigger"):
+            return
+        meta_info["text_synthesized"] = meta_info.get("text", "")
+
     async def __send_preprocessed_audio(self, meta_info, text):
         meta_info = copy.deepcopy(meta_info)
         yield_in_chunks = self.yield_chunks
@@ -6959,6 +6970,7 @@ class TaskManager(BaseManager):
                     await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
                     return
                 logger.info("Sending preprocessed audio")
+                self._stamp_cached_clip_text(meta_info)
                 meta_info["format"] = audio_format
                 meta_info["end_of_synthesizer_stream"] = True
                 await self.tools["output"].handle(create_ws_data_packet(audio_chunk, meta_info))
@@ -6994,6 +7006,7 @@ class TaskManager(BaseManager):
                         meta_info["cached"] = False
                         await self._synthesize(create_ws_data_packet(meta_info["text"], meta_info=meta_info))
                         return
+                    self._stamp_cached_clip_text(meta_info)
                 else:
                     start_time = time.perf_counter()
                     audio_chunk = self.preloaded_welcome_audio if self.preloaded_welcome_audio else None

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -81,10 +81,8 @@ SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 # "content management policy" and carries code content_filter.
 CONTENT_POLICY_ERROR_MARKERS = ("content policy", "content_policy", "content_filter", "content management")
 
-# Pre-generated clips that bypass the synthesizer and go out as one mark covering the whole
-# message, unlike streamed speech which arrives as many marks. event_proactive is deliberately
-# absent: it runs on sequence_id -1, which every output handler blanks text_synthesized for, so
-# its mark never carries text and neither the hangup guard nor the trim can act on it.
+# Pre-generated clips sent as one mark for the whole message. Not event_proactive: on
+# sequence_id -1 the handlers blank text_synthesized, so its mark never carries text.
 CACHED_SINGLE_MARK_CATEGORIES = ("static_node",)
 
 # Model prefixes

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -81,6 +81,10 @@ SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 # "content management policy" and carries code content_filter.
 CONTENT_POLICY_ERROR_MARKERS = ("content policy", "content_policy", "content_filter", "content management")
 
+# Pre-generated clips that bypass the synthesizer and go out as one mark covering the whole
+# message, unlike streamed speech which arrives as many marks.
+CACHED_SINGLE_MARK_CATEGORIES = ("static_node", "event_proactive")
+
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"
 GPT5_4_MODEL_PREFIX = "gpt-5.4"

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -82,8 +82,10 @@ SONIOX_AUTO_LANGUAGE_VALUES = {"", "multi", "auto", "multilingual", "unknown"}
 CONTENT_POLICY_ERROR_MARKERS = ("content policy", "content_policy", "content_filter", "content management")
 
 # Pre-generated clips that bypass the synthesizer and go out as one mark covering the whole
-# message, unlike streamed speech which arrives as many marks.
-CACHED_SINGLE_MARK_CATEGORIES = ("static_node", "event_proactive")
+# message, unlike streamed speech which arrives as many marks. event_proactive is deliberately
+# absent: it runs on sequence_id -1, which every output handler blanks text_synthesized for, so
+# its mark never carries text and neither the hangup guard nor the trim can act on it.
+CACHED_SINGLE_MARK_CATEGORIES = ("static_node",)
 
 # Model prefixes
 GPT5_MODEL_PREFIX = "gpt-5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.230"
+version = "0.10.231"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_static_node_interruption_trim.py
+++ b/tests/test_static_node_interruption_trim.py
@@ -1,0 +1,173 @@
+"""An interrupted static node must record what was actually spoken, not the whole message.
+
+Static clips skip the synthesizer, so nothing stamps `text_synthesized` and the whole message
+goes out as one mark. Without text on that mark sync_history can only choose between the full
+row and no row; with it, the existing time-proportional estimator slices the message at the
+interruption point.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.constants import CACHED_SINGLE_MARK_CATEGORIES
+from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.mark_event_meta_data import MarkEventMetaData
+
+FULL_TEXT = "aapka registration complete ho gaya hai aur details aapke email par bhej di gayi hain"
+CLIP_SECONDS = 8.0
+TURN_ID = 4
+RESPONSE_UID = "r4"
+
+
+class _InputStub:
+    last_heard_turn_id = TURN_ID
+    last_heard_response_uid = RESPONSE_UID
+    response_heard_by_user = ""
+
+    def get_response_heard_for_response(self, uid):
+        return ""
+
+    def get_response_heard_for_turn(self, turn_id):
+        return ""
+
+    def get_current_mark_started_time(self):
+        return 0.0
+
+
+def _make_tm(sent_ts, text_synthesized=FULL_TEXT):
+    tm = TaskManager.__new__(TaskManager)
+    history = ConversationHistory()
+    history.append_user("haan bilkul")
+    history.append_assistant(FULL_TEXT, turn_id=TURN_ID, response_uid=RESPONSE_UID)
+    tm.conversation_history = history
+    tm.tools = {"input": _InputStub()}
+    tm._turn_msg_map = {}
+
+    marks = MarkEventMetaData()
+    marks.update_data(
+        "m1",
+        {
+            "type": "static_node",
+            "turn_id": TURN_ID,
+            "response_uid": RESPONSE_UID,
+            "sequence_id": TURN_ID,
+            "duration": CLIP_SECONDS,
+            "text_synthesized": text_synthesized,
+            "sent_ts": sent_ts,
+            "is_final_chunk": True,
+        },
+    )
+    tm.mark_event_meta_data = marks
+    return tm, history, marks
+
+
+def _assistant(history):
+    return next((m["content"] for m in reversed(history.messages) if m["role"] == "assistant"), None)
+
+
+async def test_interrupted_static_node_keeps_only_what_was_spoken():
+    sent = time.time() - 3.0  # barge-in ~3s into an 8s clip
+    tm, history, marks = _make_tm(sent)
+    await tm.sync_history(marks.mark_event_meta_data.items(), time.time())
+
+    content = _assistant(history)
+    assert content and content != FULL_TEXT
+    assert FULL_TEXT.startswith(content)  # a word-aligned prefix of the real message
+    assert content.split() == FULL_TEXT.split()[: len(content.split())]
+
+
+async def test_a_static_node_cut_before_any_audio_played_is_removed():
+    sent = time.time()
+    tm, history, marks = _make_tm(sent)
+    await tm.sync_history(marks.mark_event_meta_data.items(), sent)
+    assert _assistant(history) is None
+
+
+async def test_a_fully_played_static_node_keeps_its_whole_message():
+    sent = time.time() - 30
+    tm, history, marks = _make_tm(sent)
+    marks.record_heard_text(marks.fetch_data("m1"), FULL_TEXT)
+    await tm.sync_history(marks.mark_event_meta_data.items(), time.time())
+    assert _assistant(history) == FULL_TEXT
+
+
+async def test_without_text_on_the_mark_the_turn_is_all_or_nothing():
+    """The pre-fix shape: no text_synthesized, so the estimator is skipped and the single
+    mark's own duration makes heard == 0 — the whole message is lost rather than trimmed."""
+    sent = time.time() - 3.0
+    tm, history, marks = _make_tm(sent, text_synthesized="")
+    await tm.sync_history(marks.mark_event_meta_data.items(), time.time())
+    assert _assistant(history) is None  # no partial is recoverable
+
+
+# --------------------------------------------------------- the hangup-drain shortcut
+
+
+def _wait_tm(mark_data):
+    tm = TaskManager.__new__(TaskManager)
+    marks = MarkEventMetaData()
+    marks.update_data("m1", mark_data)
+    tm.mark_event_meta_data = marks
+    tm.conversation_ended = False
+    tm.hangup_mark_event_timeout = 0.5
+    tm._turn_audio_flushed = asyncio.Event()
+    tm._turn_audio_flushed.set()
+    return tm
+
+
+async def test_a_streamed_final_chunk_still_shortcuts_the_hangup_drain():
+    # Everything before the tail has ACKed; not waiting on it is the intended latency win.
+    tm = _wait_tm({"type": "", "text_synthesized": "tail", "is_final_chunk": True, "duration": 8.0})
+    await asyncio.wait_for(tm.wait_for_current_message(), timeout=1.0)
+
+
+@pytest.mark.parametrize("category", CACHED_SINGLE_MARK_CATEGORIES)
+async def test_a_cached_single_mark_is_waited_for_at_hangup(category):
+    """Its one mark is always the final chunk, so the shortcut would cut the whole clip off."""
+    tm = _wait_tm({"type": category, "text_synthesized": FULL_TEXT, "is_final_chunk": True, "duration": CLIP_SECONDS})
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(tm.wait_for_current_message(), timeout=0.2)
+
+
+# --------------------------------------------------------- the field the mark reads
+
+
+async def test_the_static_packet_carries_the_text_the_mark_needs():
+    """The mark is built from meta_info["text_synthesized"]; the synthesizer that normally sets
+    it is bypassed here, so the static branch has to stamp it itself."""
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    tm = TaskManager.__new__(TaskManager)
+    tm.hangup_triggered = False
+    tm.conversation_ended = False
+    tm.run_id = "run"
+    tm.language = "en"
+    tm.stream = True
+    tm.on_turn_usage = None
+    tm.on_overflow = None
+    tm.llm_config = {"model": "gpt-4.1-mini", "provider": "openai"}
+    tm.routing_latencies = {}
+    tm._usage_tasks = set()
+    tm.repeat_after_silence_seconds = None
+    tm.tools = {"input": MagicMock(), "llm_agent": MagicMock()}
+    tm.conversation_history = ConversationHistory()
+    tm._stage_assistant_history = MagicMock()
+    tm._inject_language_instruction = lambda messages: messages
+    tm._synthesize = AsyncMock()
+
+    async def _generate(*args, **kwargs):
+        yield {"routing_info": {"current_node": "n1", "is_silence_trigger": False}}
+        yield {"static_message": FULL_TEXT, "static_audio_hash": "hash123"}
+
+    tm.tools["llm_agent"].generate = _generate
+
+    with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
+        await TaskManager._TaskManager__do_llm_generation_impl(tm, [], {"turn_id": 4}, "synthesizer")
+
+    tm._synthesize.assert_awaited_once()
+    sent_meta = tm._synthesize.await_args.args[0]["meta_info"]
+    assert sent_meta["text_synthesized"] == FULL_TEXT
+    assert sent_meta["text"] == FULL_TEXT

--- a/tests/test_static_node_interruption_trim.py
+++ b/tests/test_static_node_interruption_trim.py
@@ -135,9 +135,8 @@ async def test_a_cached_single_mark_is_waited_for_at_hangup(category):
 # --------------------------------------------------------- the field the mark reads
 
 
-async def test_the_static_packet_carries_the_text_the_mark_needs():
-    """The mark is built from meta_info["text_synthesized"]; the synthesizer that normally sets
-    it is bypassed here, so the static branch has to stamp it itself."""
+async def _static_turn(is_silence_trigger=False):
+    """Drive the static branch of __do_llm_generation_impl and return the synthesized packet's meta."""
     from unittest.mock import AsyncMock, MagicMock, patch
 
     tm = TaskManager.__new__(TaskManager)
@@ -159,15 +158,55 @@ async def test_the_static_packet_carries_the_text_the_mark_needs():
     tm._synthesize = AsyncMock()
 
     async def _generate(*args, **kwargs):
-        yield {"routing_info": {"current_node": "n1", "is_silence_trigger": False}}
+        yield {"routing_info": {"current_node": "n1", "is_silence_trigger": is_silence_trigger}}
         yield {"static_message": FULL_TEXT, "static_audio_hash": "hash123"}
 
     tm.tools["llm_agent"].generate = _generate
-
     with patch("bolna.agent_manager.task_manager.convert_to_request_log"):
         await TaskManager._TaskManager__do_llm_generation_impl(tm, [], {"turn_id": 4}, "synthesizer")
-
     tm._synthesize.assert_awaited_once()
-    sent_meta = tm._synthesize.await_args.args[0]["meta_info"]
-    assert sent_meta["text_synthesized"] == FULL_TEXT
-    assert sent_meta["text"] == FULL_TEXT
+    return tm._synthesize.await_args.args[0]["meta_info"]
+
+
+async def test_the_generation_branch_leaves_the_text_unstamped():
+    """It must not stamp here: on a cache miss __send_preprocessed_audio re-synthesizes live with
+    this same meta_info, and every streaming provider but ElevenLabs/Azure reuses one meta_info
+    for all chunks — the whole message would land on every mark."""
+    meta = await _static_turn()
+    assert meta["text"] == FULL_TEXT
+    assert "text_synthesized" not in meta
+    assert meta["message_category"] == "static_node"
+
+
+async def test_the_generation_branch_carries_the_silence_flag_forward():
+    assert (await _static_turn(is_silence_trigger=True))["is_silence_trigger"] is True
+
+
+def _stamp(**meta):
+    TaskManager._stamp_cached_clip_text(TaskManager.__new__(TaskManager), meta)
+    return meta
+
+
+def test_the_cached_send_branch_stamps_the_text():
+    meta = _stamp(message_category="static_node", text=FULL_TEXT)
+    assert meta["text_synthesized"] == FULL_TEXT
+
+
+def test_a_silence_reprompt_is_never_stamped():
+    """History deliberately never records a re-prompt; mark text would let sync_history
+    materialise one that was interrupted, so a barged re-prompt would appear and a fully
+    played one would not."""
+    meta = _stamp(message_category="static_node", text=FULL_TEXT, is_silence_trigger=True)
+    assert "text_synthesized" not in meta
+
+
+def test_other_cached_clips_are_not_stamped():
+    for category in ("agent_welcome_message", "filler", "event_proactive"):
+        assert "text_synthesized" not in _stamp(message_category=category, text=FULL_TEXT)
+
+
+def test_event_proactive_is_not_a_cached_single_mark_category():
+    """It runs on sequence_id -1, which every output handler blanks text_synthesized for, so its
+    mark never carries text and neither the hangup guard nor the trim can act on it."""
+    assert "event_proactive" not in CACHED_SINGLE_MARK_CATEGORIES
+    assert CACHED_SINGLE_MARK_CATEGORIES == ("static_node",)


### PR DESCRIPTION
Problem. Barge-in during a static (say) node left the whole node message in history and the transcript, not the part the caller heard.

Root cause. Static clips bypass the synthesizer, which is what normally stamps meta_info["text_synthesized"] (base_synthesizer.py:156), and __send_preprocessed_audio sends them with yield_in_chunks = False. So a static node produces exactly one mark, carrying text_synthesized = "" plus the whole clip's duration.

In sync_history that dead-ends twice: the pending_chunks loop skips marks with no text, so the time-proportional estimator never runs; and the duration-only fallback sees a single mark where pending_dur == total_dur, giving proportion 0. With one mark, no text, and heard-vs-pending being all-or-nothing, no partial is recoverable — you get the full row or none.

Fix. Stamp meta_info["text_synthesized"] = static_text on the static packet. Nothing else was needed: estimate_played_text_for_time already slices a single chunk proportionally by elapsed time and trims to whole words, and sent_ts/duration were already on the mark.