### PR TITLE
fix: run Azure transcriber end-of-stream cleanup off the event loop

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.208"
+__version__ = "0.10.209"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -82,10 +82,11 @@ class AzureTranscriber(BaseTranscriber):
             meta["connection_error"] = self.connection_error
             await self.transcriber_output_queue.put(create_ws_data_packet("transcriber_connection_closed", meta))
 
-    def _check_and_process_end_of_stream(self, ws_data_packet):
+    async def _check_and_process_end_of_stream(self, ws_data_packet):
         if "eos" in ws_data_packet["meta_info"] and ws_data_packet["meta_info"]["eos"] is True:
             logger.info("End of stream detected")
-            self._sync_cleanup()
+            # Azure teardown blocks (SDK stop + native recognizer __del__); run it off the event loop.
+            await asyncio.get_event_loop().run_in_executor(None, self._sync_cleanup)
             return True
         return False
 
@@ -126,7 +127,7 @@ class AzureTranscriber(BaseTranscriber):
                     except Exception:
                         pass
 
-                end_of_stream = self._check_and_process_end_of_stream(ws_data_packet)
+                end_of_stream = await self._check_and_process_end_of_stream(ws_data_packet)
                 if end_of_stream:
                     break
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.208"
+version = "0.10.209"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
## Problem

`AzureTranscriber._check_and_process_end_of_stream` runs the synchronous `_sync_cleanup()` **directly on the event loop**. It's a plain `def` called un-awaited from inside the `async def send_audio_to_transcriber` receive loop, and on end-of-stream it calls `_sync_cleanup()` inline.

`_sync_cleanup` blocks the calling thread:
- `self.recognizer.stop_continuous_recognition_async().get()` — blocks on the Azure SDK future
- `self.recognizer = None` — dereference triggers the Azure Speech SDK's native `__del__`, which blocks on native teardown

Because this happens on the loop thread, an end-of-stream teardown freezes the **entire worker's event loop** (~10s observed), starving every other concurrent call on that worker — callers hear the agent go silent. When several Azure-ASR calls end at once, it stalls many workers at the same time.

Confirmed from a production faulthandler stack dump — the event-loop thread was wedged in:
```
send_audio_to_transcriber → _check_and_process_end_of_stream → _sync_cleanup
  → azure/cognitiveservices/speech/interop.py __del__
```

## Fix

Make `_check_and_process_end_of_stream` `async` and offload `_sync_cleanup` via `run_in_executor`, then `await` it at the call site.

This mirrors patterns already in the same file — `cleanup()` does `await loop.run_in_executor(None, self._sync_cleanup)` ("Run sync cleanup in executor to not block event loop"), and `_release_previous_connection` was likewise moved off the loop — and matches every other transcriber (deepgram, elevenlabs, gladia, sarvam, assemblyai, openai, smallest), all of which already have this method as `async` + awaited. The Azure implementation was the lone synchronous outlier.

## Scope / risk

- No behavior change other than where `_sync_cleanup` runs. `_sync_cleanup` is unchanged and guarded/idempotent.
- `_check_and_process_end_of_stream` has a single caller (the loop above), now awaited.
- ruff clean.