### PR TITLE
fix: release the Azure recognizer off the event loop on end-of-stream and toggle teardown [BOLNA-2386]

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.227"
+__version__ = "0.10.228"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/transcriber/azure_transcriber.py
+++ b/bolna/transcriber/azure_transcriber.py
@@ -82,10 +82,12 @@ class AzureTranscriber(BaseTranscriber):
             meta["connection_error"] = self.connection_error
             await self.transcriber_output_queue.put(create_ws_data_packet("transcriber_connection_closed", meta))
 
-    def _check_and_process_end_of_stream(self, ws_data_packet):
+    async def _check_and_process_end_of_stream(self, ws_data_packet):
         if "eos" in ws_data_packet["meta_info"] and ws_data_packet["meta_info"]["eos"] is True:
             logger.info("End of stream detected")
-            self._sync_cleanup()
+            # Native SDK teardown blocks for seconds against a degraded endpoint, so release
+            # the recognizer off the loop rather than freezing every other call on this worker.
+            await asyncio.get_event_loop().run_in_executor(None, self._sync_cleanup)
             return True
         return False
 
@@ -126,7 +128,7 @@ class AzureTranscriber(BaseTranscriber):
                     except Exception:
                         pass
 
-                end_of_stream = self._check_and_process_end_of_stream(ws_data_packet)
+                end_of_stream = await self._check_and_process_end_of_stream(ws_data_packet)
                 if end_of_stream:
                     break
 
@@ -382,7 +384,7 @@ class AzureTranscriber(BaseTranscriber):
                 pass
             self.send_audio_to_transcriber_task = None
 
-        self._sync_cleanup()
+        await asyncio.get_event_loop().run_in_executor(None, self._sync_cleanup)
 
     def _sync_cleanup(self):
         """Synchronous cleanup of Azure resources."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.227"
+version = "0.10.228"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_azure_transcriber_teardown_off_loop.py
+++ b/tests/test_azure_transcriber_teardown_off_loop.py
@@ -1,0 +1,63 @@
+"""AzureTranscriber tears the native recognizer down off the event loop.
+
+The SDK's recognizer teardown blocks for seconds against a degraded endpoint. Running it inline
+on the loop freezes every other call on the worker, which stays silent until /healthz starves.
+These pin the end-of-stream teardown to a worker thread so a slow teardown cannot block the loop.
+"""
+
+import asyncio
+import threading
+import time
+
+from bolna.transcriber.azure_transcriber import AzureTranscriber
+
+
+def _transcriber():
+    # telephony_provider="twilio" takes the 8k mulaw telephony branch; no network until run().
+    return AzureTranscriber(
+        telephony_provider="twilio",
+        input_queue=asyncio.Queue(),
+        output_queue=asyncio.Queue(),
+    )
+
+
+async def test_end_of_stream_tears_down_off_the_loop():
+    t = _transcriber()
+    ran_on_main = {}
+
+    def slow_cleanup():
+        ran_on_main["value"] = threading.current_thread() is threading.main_thread()
+        time.sleep(0.2)
+
+    t._sync_cleanup = slow_cleanup
+
+    ticks = 0
+
+    async def heartbeat():
+        nonlocal ticks
+        while True:
+            await asyncio.sleep(0.01)
+            ticks += 1
+
+    hb = asyncio.create_task(heartbeat())
+    result = await t._check_and_process_end_of_stream({"meta_info": {"eos": True}})
+    hb.cancel()
+
+    assert result is True
+    assert ran_on_main["value"] is False
+    assert ticks > 0
+
+
+async def test_non_end_of_stream_leaves_the_connection_open():
+    t = _transcriber()
+    called = False
+
+    def cleanup():
+        nonlocal called
+        called = True
+
+    t._sync_cleanup = cleanup
+    result = await t._check_and_process_end_of_stream({"meta_info": {}})
+
+    assert result is False
+    assert called is False


### PR DESCRIPTION
The Azure Speech SDK recognizer teardown blocks for seconds against a degraded endpoint. `_sync_cleanup` calls `stop_continuous_recognition_async().get()` and then drops the last reference to the recognizer, whose native `__del__` is what blocks. Two call sites ran it inline on the event loop, so one call's teardown froze every other call on the worker until the liveness probe started failing:

- `_check_and_process_end_of_stream`, on the hot input-queue loop
- `toggle_connection`

Both now release the recognizer via `run_in_executor`, matching what #965 already did for the reconnect path and what `cleanup` already did for normal end-of-call. `_check_and_process_end_of_stream` becomes a coroutine, in line with every other transcriber.

This removes the loop blocking, not the Azure-side teardown latency, which now runs on a worker thread.
