### PR TITLE
feat(synthesizer): add Google Gemini TTS via Vertex generateContent

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.229"
+__version__ = "0.10.230"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -1,3 +1,4 @@
+import os
 from datetime import datetime, timezone
 from bolna.enums import ReasoningEffort as RE
 
@@ -326,6 +327,11 @@ MAYA_TTS_SUPPORTED_LANGUAGES = {
     "en",
     "auto",
 }
+
+# Gemini TTS (Vertex generateContent). The model id is supplied per agent, so none is pinned.
+GEMINI_TTS_DEFAULT_MODEL = os.getenv("GEMINI_TTS_MODEL", "gemini-tts")
+GEMINI_TTS_NATIVE_SAMPLE_RATE = 24000
+GEMINI_TTS_LOCATION = "global"
 
 MODEL_REASONING_EFFORT_MAP = {
     "gpt-5": [RE.MINIMAL, RE.LOW, RE.MEDIUM, RE.HIGH],

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -63,6 +63,7 @@ class SynthesizerProvider(str, Enum):
     PIXA = "pixa"
     MAYA = "maya"
     KALPA = "kalpa"
+    GEMINI = "gemini"
 
     @classmethod
     def all_values(cls):

--- a/bolna/helpers/gcp_auth.py
+++ b/bolna/helpers/gcp_auth.py
@@ -1,0 +1,34 @@
+"""Google Cloud OAuth2 tokens via ADC for Vertex endpoints, which take a bearer token rather
+than the generativelanguage API key the other Gemini integrations use."""
+
+import asyncio
+import threading
+
+import google.auth
+import google.auth.transport.requests
+
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+_lock = threading.Lock()
+_credentials = None
+_adc_project = None
+
+
+def _refresh_locked():
+    global _credentials, _adc_project
+    if _credentials is None:
+        _credentials, _adc_project = google.auth.default(scopes=_SCOPES)
+    # `valid` applies its own clock skew, so refreshing when it flips covers expiry.
+    if not _credentials.valid:
+        _credentials.refresh(google.auth.transport.requests.Request())
+    return _credentials.token, _adc_project
+
+
+async def get_gcp_credentials():
+    """(access_token, adc_project) from ADC, in a thread since load and refresh block."""
+
+    def _sync():
+        with _lock:
+            return _refresh_locked()
+
+    return await asyncio.get_event_loop().run_in_executor(None, _sync)

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -130,6 +130,11 @@ class AzureConfig(BaseModel):
     speed: Optional[float] = 1.0
 
 
+class GeminiConfig(StandardVoiceConfig):
+    # voice_id holds the Gemini voice_name; style feeds structured speech_metadata.
+    style: Optional[str] = None
+
+
 # The config class each provider's provider_config is validated against. Adding a provider means
 # one entry here.
 SYNTHESIZER_CONFIG_MODELS = {
@@ -145,6 +150,7 @@ SYNTHESIZER_CONFIG_MODELS = {
     SynthesizerProvider.PIXA.value: PixaConfig,
     SynthesizerProvider.MAYA.value: MayaConfig,
     SynthesizerProvider.KALPA.value: KalpaConfig,
+    SynthesizerProvider.GEMINI.value: GeminiConfig,
 }
 
 

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -12,6 +12,7 @@ from .synthesizer import (
     PixaSynthesizer,
     MayaSynthesizer,
     KalpaSynthesizer,
+    GeminiSynthesizer,
 )
 from .transcriber import (
     DeepgramTranscriber,
@@ -71,6 +72,7 @@ SUPPORTED_SYNTHESIZER_MODELS = {
     SynthesizerProvider.PIXA.value: PixaSynthesizer,
     SynthesizerProvider.MAYA.value: MayaSynthesizer,
     SynthesizerProvider.KALPA.value: KalpaSynthesizer,
+    SynthesizerProvider.GEMINI.value: GeminiSynthesizer,
 }
 
 SUPPORTED_TRANSCRIBER_PROVIDERS = {

--- a/bolna/synthesizer/__init__.py
+++ b/bolna/synthesizer/__init__.py
@@ -12,4 +12,5 @@ from .sarvam_synthesizer import SarvamSynthesizer
 from .pixa_synthesizer import PixaSynthesizer
 from .maya_synthesizer import MayaSynthesizer
 from .kalpa_synthesizer import KalpaSynthesizer
+from .gemini_synthesizer import GeminiSynthesizer
 from .synthesizer_pool import SynthesizerPool

--- a/bolna/synthesizer/gemini_synthesizer.py
+++ b/bolna/synthesizer/gemini_synthesizer.py
@@ -1,0 +1,156 @@
+"""Google Gemini TTS over the Vertex generateContent endpoint.
+
+Non-streaming HTTP, rendered one-shot like the OpenAI path. Style goes in structured
+`speech_metadata`; inline `<tags>` stay in the text. Audio returns as base64 PCM in inlineData.
+"""
+
+import asyncio
+import base64
+import os
+import re
+
+import aiohttp
+
+from .base_synthesizer import BaseSynthesizer
+from bolna.constants import GEMINI_TTS_DEFAULT_MODEL, GEMINI_TTS_LOCATION, GEMINI_TTS_NATIVE_SAMPLE_RATE
+from bolna.helpers.gcp_auth import get_gcp_credentials
+from bolna.helpers.logger_config import configure_logger
+from bolna.helpers.utils import pcm_to_ulaw, pcm_to_wav_bytes, resample
+from bolna.memory.cache.inmemory_scalar_cache import InmemoryScalarCache
+
+logger = configure_logger(__name__)
+
+MULAW_SAMPLE_RATE = 8000
+_VERTEX_HOST = "https://aiplatform.googleapis.com"
+_MIME_RATE = re.compile(r"rate=(\d+)")
+_REQUEST_TIMEOUT_SECONDS = 20
+
+
+class GeminiSynthesizer(BaseSynthesizer):
+    def __init__(
+        self,
+        voice="Puck",
+        voice_id=None,
+        model=GEMINI_TTS_DEFAULT_MODEL,
+        language="en",
+        style=None,
+        sampling_rate="24000",
+        stream=False,
+        buffer_size=400,
+        caching=True,
+        **kwargs,
+    ):
+        super().__init__(kwargs.get("task_manager_instance"), stream, buffer_size)
+        # voice_id is the Gemini voice_name; voice is only the label. Never None.
+        self.voice = voice_id or voice
+        self.model = model
+        self.language = language
+        self.style = style or None
+        self.stream = False
+
+        # Auth is ADC, not a synthesizer_key; the project is stamped in x-goog-user-project.
+        self.project = kwargs.get("project") or os.getenv("GEMINI_TTS_PROJECT") or os.getenv("GOOGLE_CLOUD_PROJECT")
+
+        self.use_mulaw = kwargs.get("use_mulaw", False)
+        self.target_sample_rate = MULAW_SAMPLE_RATE if self.use_mulaw else int(sampling_rate)
+        self.sampling_rate = self.target_sample_rate
+
+        self.caching = caching
+        if caching:
+            self.cache = InmemoryScalarCache()
+
+    def _endpoint(self, project):
+        return (
+            f"{_VERTEX_HOST}/v1beta1/projects/{project}/locations/{GEMINI_TTS_LOCATION}"
+            f"/publishers/google/models/{self.model}:generateContent"
+        )
+
+    def _build_payload(self, text):
+        part = {"text": text}
+        if self.style:
+            part["speech_metadata"] = {"style": self.style}
+        return {
+            # role is required; the endpoint 400s ("valid role: user, model") without it.
+            "contents": [{"role": "user", "parts": [part]}],
+            "generation_config": {
+                "response_modalities": ["AUDIO"],
+                "speech_config": {"voice_config": {"prebuilt_voice_config": {"voice_name": self.voice}}},
+            },
+        }
+
+    @staticmethod
+    def _extract_audio(response_json):
+        """First inlineData part as (pcm_bytes, sample_rate), or (None, None)."""
+        for candidate in response_json.get("candidates", []):
+            for part in (candidate.get("content") or {}).get("parts", []):
+                inline = part.get("inlineData") or part.get("inline_data")
+                if inline and inline.get("data"):
+                    pcm = base64.b64decode(inline["data"])
+                    mime = inline.get("mimeType") or inline.get("mime_type") or ""
+                    match = _MIME_RATE.search(mime)
+                    rate = int(match.group(1)) if match else GEMINI_TTS_NATIVE_SAMPLE_RATE
+                    return pcm, rate
+        return None, None
+
+    async def _fetch_pcm(self, text):
+        """One generateContent call. Returns raw PCM at Gemini's native rate, or (None, None)."""
+        # Off the event loop, and bounded like the audio POST so a stalled mint ends the turn.
+        try:
+            token, adc_project = await asyncio.wait_for(get_gcp_credentials(), timeout=_REQUEST_TIMEOUT_SECONDS)
+        except Exception as e:
+            logger.error(f"Gemini TTS: could not obtain GCP credentials: {e}")
+            return None, None
+
+        project = self.project or adc_project
+        if not project:
+            logger.error("Gemini TTS: no GCP project configured (set GEMINI_TTS_PROJECT)")
+            return None, None
+
+        headers = {
+            "Authorization": f"Bearer {token}",
+            "x-goog-user-project": project,
+            "Content-Type": "application/json",
+        }
+        timeout = aiohttp.ClientTimeout(total=_REQUEST_TIMEOUT_SECONDS)
+        try:
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    self._endpoint(project), headers=headers, json=self._build_payload(text)
+                ) as response:
+                    if response.status != 200:
+                        logger.error(f"Gemini TTS HTTP error: {response.status} - {await response.text()}")
+                        return None, None
+                    data = await response.json()
+        except Exception as e:
+            logger.error(f"Gemini TTS request failed: {e}")
+            return None, None
+        return self._extract_audio(data)
+
+    def _to_target(self, pcm, native_rate):
+        """Resample to the target rate; mu-law encode for telephony."""
+        if not pcm:
+            return None
+        try:
+            audio = resample(pcm, self.target_sample_rate, format="pcm", original_sample_rate=native_rate)
+        except Exception as e:
+            logger.error(f"Error resampling Gemini audio: {e}")
+            return None
+        return pcm_to_ulaw(audio) if self.use_mulaw else audio
+
+    def _get_http_audio_format(self):
+        return "mulaw" if self.use_mulaw else "pcm"
+
+    async def _generate_http(self, text):
+        pcm, native_rate = await self._fetch_pcm(text)
+        return self._to_target(pcm, native_rate)
+
+    async def generate(self):
+        async for packet in self._generate_http_loop():
+            yield packet
+
+    async def synthesize(self, text):
+        """WAV-wrapped at the native rate so audio_to_mulaw8k()'s guessed rate_hint can't misread it."""
+        pcm, native_rate = await self._fetch_pcm(text)
+        if not pcm:
+            return None
+        return pcm_to_wav_bytes(pcm, sample_rate=native_rate)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.229"
+version = "0.10.230"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_gemini_synthesizer.py
+++ b/tests/test_gemini_synthesizer.py
@@ -1,0 +1,217 @@
+"""Gemini TTS: the generateContent payload, inlineData parsing, 24 kHz -> telephony
+conversion, and the one-shot clip paths. No network, no ADC."""
+
+import asyncio
+import audioop
+import base64
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bolna.models import Synthesizer
+from bolna.providers import SUPPORTED_SYNTHESIZER_MODELS
+from bolna.synthesizer.gemini_synthesizer import GeminiSynthesizer
+
+
+def _synth(**kwargs):
+    kwargs.setdefault("voice", "Puck")
+    kwargs.setdefault("voice_id", "Puck")
+    kwargs.setdefault("use_mulaw", True)
+    kwargs.setdefault("caching", False)
+    kwargs.setdefault("project", "test-project")
+    s = GeminiSynthesizer(task_manager_instance=MagicMock(), **kwargs)
+    s.task_manager_instance.is_sequence_id_in_current_ids.return_value = True
+    return s
+
+
+def _pcm(seconds, rate=24000):
+    """A silent-but-nonzero 16-bit mono buffer of a known length."""
+    return (b"\x10\x00") * int(seconds * rate)
+
+
+def _response(pcm, mime="audio/L16;codec=pcm;rate=24000"):
+    return {
+        "candidates": [
+            {"content": {"parts": [{"inlineData": {"mimeType": mime, "data": base64.b64encode(pcm).decode()}}]}}
+        ]
+    }
+
+
+# ----------------------------------------------------------------------
+# Construction
+# ----------------------------------------------------------------------
+
+
+def test_voice_id_is_the_gemini_voice_name_and_wins_over_the_label():
+    assert _synth(voice="Label", voice_id="Kore").voice == "Kore"
+    assert GeminiSynthesizer(voice="Puck", voice_id=None, project="p").voice == "Puck"
+
+
+def test_telephony_pins_8k_mulaw_and_web_keeps_native_24k():
+    tel = _synth(use_mulaw=True)
+    assert (tel.target_sample_rate, tel._get_http_audio_format()) == (8000, "mulaw")
+
+    web = _synth(use_mulaw=False, sampling_rate="24000")
+    assert (web.target_sample_rate, web._get_http_audio_format()) == (24000, "pcm")
+
+
+def test_endpoint_carries_project_location_and_model():
+    s = _synth(model="gemini-tts-x")
+    assert s._endpoint("proj-123") == (
+        "https://aiplatform.googleapis.com/v1beta1/projects/proj-123/locations/global"
+        "/publishers/google/models/gemini-tts-x:generateContent"
+    )
+
+
+def test_voice_id_survives_the_config_model_and_reaches_the_synthesizer():
+    cfg = Synthesizer(
+        provider="gemini",
+        provider_config={"voice_id": "Kore", "voice": "Kore", "model": "gemini-tts", "language": "en"},
+        stream=False,
+    ).model_dump()
+    cfg.pop("caching", None)
+    cfg.pop("provider")
+    provider_config = cfg.pop("provider_config")
+    assert provider_config["voice_id"] == "Kore"
+
+    s = SUPPORTED_SYNTHESIZER_MODELS["gemini"](
+        **cfg, **provider_config, caching=False, project="p", task_manager_instance=MagicMock()
+    )
+    assert s.voice == "Kore"
+
+
+# ----------------------------------------------------------------------
+# Payload
+# ----------------------------------------------------------------------
+
+
+def test_payload_puts_the_voice_in_prebuilt_voice_config():
+    payload = _synth(voice_id="Puck")._build_payload("Hello there.")
+    # role is mandatory: the endpoint 400s without it.
+    assert payload["contents"][0]["role"] == "user"
+    assert payload["contents"][0]["parts"][0] == {"text": "Hello there."}
+    voice = payload["generation_config"]["speech_config"]["voice_config"]["prebuilt_voice_config"]
+    assert voice == {"voice_name": "Puck"}
+    assert payload["generation_config"]["response_modalities"] == ["AUDIO"]
+
+
+def test_style_goes_into_structured_speech_metadata_not_the_transcript():
+    # The model speaks inline direction verbatim; style must ride in metadata instead.
+    part = _synth(style="calm and reassuring")._build_payload("Welcome to the flight deck.")["contents"][0]["parts"][0]
+    assert part == {"text": "Welcome to the flight deck.", "speech_metadata": {"style": "calm and reassuring"}}
+
+
+def test_no_style_means_no_speech_metadata_key():
+    part = _synth(style=None)._build_payload("Hi <breath> there!")["contents"][0]["parts"][0]
+    assert part == {"text": "Hi <breath> there!"}  # inline tags stay in the text
+
+
+# ----------------------------------------------------------------------
+# Response parsing
+# ----------------------------------------------------------------------
+
+
+def test_extract_audio_decodes_base64_pcm_and_reads_the_rate_from_the_mime_type():
+    pcm, rate = GeminiSynthesizer._extract_audio(_response(b"\x01\x02\x03\x04", mime="audio/L16;codec=pcm;rate=16000"))
+    assert pcm == b"\x01\x02\x03\x04"
+    assert rate == 16000
+
+
+def test_extract_audio_falls_back_to_native_rate_when_the_mime_type_omits_it():
+    _, rate = GeminiSynthesizer._extract_audio(_response(b"\x01\x02", mime="audio/pcm"))
+    assert rate == 24000
+
+
+def test_extract_audio_accepts_snake_case_inline_data():
+    resp = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [
+                        {"inline_data": {"mime_type": "rate=24000", "data": base64.b64encode(b"\x05\x06").decode()}}
+                    ]
+                }
+            }
+        ]
+    }
+    pcm, rate = GeminiSynthesizer._extract_audio(resp)
+    assert (pcm, rate) == (b"\x05\x06", 24000)
+
+
+def test_extract_audio_returns_none_when_there_is_no_audio_part():
+    assert GeminiSynthesizer._extract_audio({"candidates": []}) == (None, None)
+    assert GeminiSynthesizer._extract_audio({"candidates": [{"content": {"parts": [{"text": "oops"}]}}]}) == (
+        None,
+        None,
+    )
+
+
+# ----------------------------------------------------------------------
+# Audio conversion
+# ----------------------------------------------------------------------
+
+
+def test_telephony_audio_is_resampled_to_8k_and_mulaw_encoded():
+    s = _synth(use_mulaw=True)
+    out = s._to_target(_pcm(1.0), 24000)
+    # 24k 16-bit in -> 8k 8-bit out: one sixth of the bytes, and decodable as mu-law.
+    assert len(out) == 8000
+    assert len(audioop.ulaw2lin(out, 2)) == 16000
+
+
+def test_web_audio_stays_pcm_at_the_target_rate():
+    s = _synth(use_mulaw=False, sampling_rate="24000")
+    chunk = _pcm(0.5)
+    assert s._to_target(chunk, 24000) == chunk
+
+
+def test_empty_audio_is_dropped_rather_than_converted():
+    assert _synth()._to_target(None, 24000) is None
+    assert _synth()._to_target(b"", 24000) is None
+
+
+# ----------------------------------------------------------------------
+# Turn render + one-shot
+# ----------------------------------------------------------------------
+
+
+def test_generate_http_converts_the_fetched_pcm_to_the_target_format():
+    s = _synth(use_mulaw=True)
+    s._fetch_pcm = AsyncMock(return_value=(_pcm(1.0), 24000))
+    assert len(asyncio.run(s._generate_http("hi"))) == 8000
+
+
+def test_synthesize_wraps_pcm_in_wav_so_the_rate_is_self_describing():
+    from bolna.helpers.utils import audio_to_mulaw8k
+
+    s = _synth(use_mulaw=True)
+    s._fetch_pcm = AsyncMock(return_value=(_pcm(1.0), 24000))
+    out = asyncio.run(s.synthesize("hi"))
+    assert out[:4] == b"RIFF"
+    # One second in stays one second out (8000 mu-law bytes) even with a wrong hint.
+    assert len(audio_to_mulaw8k(out, rate_hint=8000, format_hint="")) == 8000
+
+
+def test_synthesize_returns_none_when_the_api_returns_nothing():
+    s = _synth()
+    s._fetch_pcm = AsyncMock(return_value=(None, None))
+    assert asyncio.run(s.synthesize("hi")) is None
+
+
+def test_fetch_pcm_bails_when_no_project_resolves(monkeypatch):
+    """No configured project and ADC resolves none: bail before posting a malformed URL."""
+    s = GeminiSynthesizer(voice="Puck", project=None, caching=False, task_manager_instance=MagicMock())
+    s.project = None
+    monkeypatch.setattr(
+        "bolna.synthesizer.gemini_synthesizer.get_gcp_credentials", AsyncMock(return_value=("tok", None))
+    )
+    assert asyncio.run(s._fetch_pcm("hi")) == (None, None)
+
+
+def test_fetch_pcm_bails_when_credentials_cannot_be_obtained(monkeypatch):
+    """A stalled or failing token mint ends the turn cleanly instead of raising into the loop."""
+    s = _synth(project="p")
+    monkeypatch.setattr(
+        "bolna.synthesizer.gemini_synthesizer.get_gcp_credentials", AsyncMock(side_effect=asyncio.TimeoutError)
+    )
+    assert asyncio.run(s._fetch_pcm("hi")) == (None, None)

--- a/tests/test_synthesizer_config_registry.py
+++ b/tests/test_synthesizer_config_registry.py
@@ -7,6 +7,7 @@ from bolna.models import (
     SYNTHESIZER_CONFIG_MODELS,
     CartesiaConfig,
     ElevenLabsConfig,
+    GeminiConfig,
     PixaConfig,
     RimeConfig,
     SarvamConfig,
@@ -44,6 +45,7 @@ EXPECTED_FIELDS = {
         "repetition_penalty": False,
     },
     "maya": {"voice_id": True, "voice": True, "model": True, "language": False},
+    "gemini": {"voice": True, "voice_id": True, "model": True, "language": True, "style": False},
     "kalpa": {
         "voice": False,
         "voice_id": False,
@@ -72,7 +74,9 @@ def test_config_shapes_are_stable(provider):
     assert {name: f.is_required() for name, f in fields.items()} == EXPECTED_FIELDS[provider]
 
 
-@pytest.mark.parametrize("config_model", [CartesiaConfig, RimeConfig, SmallestConfig, SarvamConfig, PixaConfig])
+@pytest.mark.parametrize(
+    "config_model", [CartesiaConfig, RimeConfig, SmallestConfig, SarvamConfig, PixaConfig, GeminiConfig]
+)
 def test_standard_shape_providers_extend_the_base(config_model):
     assert issubclass(config_model, StandardVoiceConfig)
 


### PR DESCRIPTION
Adds a `gemini` TTS synthesizer using the Vertex `generateContent` endpoint.

- Non-streaming HTTP, rendered one-shot like the OpenAI path
- Style via structured `speech_metadata`; inline `<tags>` pass through in the text
- ADC bearer-token auth (new `helpers/gcp_auth.py`); project and model id come from config/env, none pinned
- Enum + `GeminiConfig` + registry; no voice allowlist

Output is base64 PCM in `inlineData`, converted to the target rate (mu-law for telephony) like the Maya HTTP path.
