### PR TITLE
fix(synthesizer): record turn latency for the non-streaming HTTP path

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.230"
+__version__ = "0.10.231"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/synthesizer/base_synthesizer.py
+++ b/bolna/synthesizer/base_synthesizer.py
@@ -1,4 +1,5 @@
 import io
+import time
 import uuid
 import asyncio
 import re
@@ -34,6 +35,21 @@ class BaseSynthesizer:
                 self.turn_latencies[i] = entry
                 return
         self.turn_latencies.append(entry)
+
+    def _record_http_turn_latency(self, meta_info, text, render_ms):
+        """Per-turn latency for the one-shot HTTP path, shaped like the streaming record. A
+        non-streaming render produces the whole utterance at once, so first_result == total."""
+        self._upsert_turn_latency(
+            {
+                "turn_id": meta_info.get("turn_id"),
+                "sequence_id": meta_info.get("sequence_id"),
+                "tts_start_ms": meta_info.get("tts_start_ms"),
+                "first_result_latency_ms": render_ms,
+                "total_stream_duration_ms": render_ms,
+                "characters": len(text or ""),
+                "message_category": meta_info.get("message_category"),
+            }
+        )
 
     async def synthesize_pcm_clip(self, text, sample_rate):
         """Override where the provider renders PCM natively; None → caller converts."""
@@ -145,11 +161,13 @@ class BaseSynthesizer:
                 logger.info(f"Not synthesizing: sequence_id {meta_info.get('sequence_id')} not current")
                 return
 
+            render_start = time.perf_counter()
             audio = await self._fetch_http_audio(text, meta_info)
             audio = self._process_http_audio(audio)
             # A failed render still terminates the turn: a None packet crashes the output handler.
             if not audio:
                 audio = b"\x00"
+            render_ms = round((time.perf_counter() - render_start) * 1000)
 
             self._stamp_first_chunk(meta_info)
             self._stamp_end_of_stream(meta_info)
@@ -158,6 +176,7 @@ class BaseSynthesizer:
             meta_info["text"] = text
             meta_info["text_synthesized"] = f"{text} "
             self._stamp_mark_id(meta_info)
+            self._record_http_turn_latency(meta_info, text, render_ms)
             yield create_ws_data_packet(audio, meta_info)
 
     async def _fetch_http_audio(self, text, meta_info=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.230"
+version = "0.10.231"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_http_synth_turn_latency.py
+++ b/tests/test_http_synth_turn_latency.py
@@ -1,0 +1,56 @@
+"""The non-streaming HTTP synth loop records a turn-latency entry, so HTTP-only providers
+(gemini, openai) report synthesizer latency the same way the streaming synths do."""
+
+import asyncio
+from unittest.mock import MagicMock
+
+from bolna.synthesizer.base_synthesizer import BaseSynthesizer
+
+
+class _HttpSynth(BaseSynthesizer):
+    def __init__(self, audio=b"\x01\x02", **kwargs):
+        super().__init__(kwargs.get("task_manager_instance"))
+        self.caching = False
+        self._audio = audio
+
+    async def _generate_http(self, text):
+        return self._audio
+
+    def _get_http_audio_format(self):
+        return "pcm"
+
+
+def _synth(**kwargs):
+    tm = MagicMock()
+    tm.is_sequence_id_in_current_ids.return_value = True
+    return _HttpSynth(task_manager_instance=tm, **kwargs)
+
+
+def _drive_one(synth, text, meta):
+    synth.internal_queue.put_nowait({"data": text, "meta_info": meta})
+
+    async def run():
+        async for _ in synth._generate_http_loop():
+            return
+
+    asyncio.run(run())
+
+
+def test_http_loop_records_one_turn_latency():
+    s = _synth()
+    _drive_one(s, "hello there", {"sequence_id": 3, "turn_id": 3, "message_category": "", "tts_start_ms": 1234.5})
+    assert len(s.turn_latencies) == 1
+    rec = s.turn_latencies[0]
+    assert (rec["sequence_id"], rec["turn_id"]) == (3, 3)
+    assert rec["characters"] == len("hello there")
+    assert rec["tts_start_ms"] == 1234.5
+    # Non-streaming: the whole utterance renders at once, so first_result == total.
+    assert rec["first_result_latency_ms"] == rec["total_stream_duration_ms"] >= 0
+
+
+def test_failed_render_still_records_latency():
+    """A None render becomes the b\"\\x00\" sentinel, but the time it took is still recorded."""
+    s = _synth(audio=None)
+    _drive_one(s, "hi", {"sequence_id": 1, "turn_id": 1})
+    assert len(s.turn_latencies) == 1
+    assert s.turn_latencies[0]["first_result_latency_ms"] >= 0


### PR DESCRIPTION
The one-shot HTTP synth loop (`_generate_http_loop`) never recorded into `turn_latencies`, so HTTP-only providers (gemini, openai) reported empty `synthesizer_latencies` in the execution telemetry while the streaming synths populated theirs.

Records a per-turn entry shaped like the streaming path's, measuring the render time. A non-streaming render produces the whole utterance at once, so `first_result_latency_ms` equals `total_stream_duration_ms`. Now HTTP-only TTS latency shows up in the usage/latency dashboards like every other provider.
