### PR TITLE
feat: add explicit Chat and Responses request controls

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -579,12 +579,20 @@ class TaskManager(BaseManager):
                         "temperature": self.llm_agent_config["temperature"],
                     }
 
+                    # This dict is rebuilt for simple agents, so copy opt-ins before transport auto-selection.
+                    for key in ("prompt_cache_key", "omit_request_parameters", "use_responses_api"):
+                        value = self.llm_agent_config.get(key)
+                        if value is not None:
+                            self.llm_config[key] = value
+
                 for key in ("reasoning_effort", "verbosity", "reasoning_summary", "thinking_budget"):
                     if key in self.llm_agent_config:
                         self.llm_config[key] = self.llm_agent_config[key]
 
-                if self.llm_agent_config.get("use_responses_api") or any(
-                    p in self.llm_config.get("model", "") for p in RESPONSES_API_MODEL_PREFIXES
+                # An explicit simple-agent Chat choice must not be overridden by model-prefix defaults.
+                if self.llm_config.get("use_responses_api") is not False and (
+                    self.llm_agent_config.get("use_responses_api")
+                    or any(p in self.llm_config.get("model", "") for p in RESPONSES_API_MODEL_PREFIXES)
                 ):
                     self.llm_config["use_responses_api"] = True
 
@@ -1825,7 +1833,8 @@ class TaskManager(BaseManager):
 
             if llm_config["provider"] in SUPPORTED_LLM_PROVIDERS.keys():
                 llm_class = SUPPORTED_LLM_PROVIDERS.get(llm_config["provider"])
-                llm = llm_class(language=self.language, **llm_config, **self.kwargs)
+                # Stored and runtime controls can overlap; merge once to avoid duplicate-key TypeError.
+                llm = llm_class(**{"language": self.language, **llm_config, **self.kwargs})
                 return llm
             else:
                 raise Exception(f"LLM {llm_config['provider']} not supported")

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -580,7 +580,15 @@ class TaskManager(BaseManager):
                     }
 
                     # This dict is rebuilt for simple agents, so copy opt-ins before transport auto-selection.
-                    for key in ("prompt_cache_key", "omit_request_parameters", "use_responses_api"):
+                    for key in (
+                        "prompt_cache_key",
+                        "omit_request_parameters",
+                        "use_responses_api",
+                        "responses_store",
+                        "responses_history",
+                        "responses_omit_parameters",
+                        "strict_websocket",
+                    ):
                         value = self.llm_agent_config.get(key)
                         if value is not None:
                             self.llm_config[key] = value

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -86,8 +86,8 @@ class MessageFormatAdapter:
     def chat_to_responses_input(messages: list[dict]) -> tuple[str, list[dict]]:
         """Chat Completions messages -> (instructions, Responses API input items).
 
-        System is emitted as a role=system input item, not as `instructions`,
-        because the instructions field breaks prompt-cache hashing.
+        System remains a role=system input item so the caller's visible history
+        retains its role order. Response storage and prompt caching are separate controls.
         """
         instructions = ""
         input_items = []

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -61,6 +61,10 @@ class OpenAICompatibleLLM(BaseLLM):
     # A reasoning summary streams ahead of the answer text, so it is opt-in: requesting one costs
     # time to first spoken token on a live call. Set from config by subclasses; None omits it.
     reasoning_summary = None
+    responses_store = None
+    responses_history = "chained"
+    responses_omit_parameters = ()
+    strict_websocket = False
 
     @property
     def request_log_model(self):
@@ -294,7 +298,8 @@ class OpenAICompatibleLLM(BaseLLM):
         hint = self._interruption_hint
         self._interruption_hint = None
 
-        chained = bool(self.previous_response_id)
+        # Keep the response ID for cancellation, but never use hidden chain state in full-history mode.
+        chained = self.responses_history == "chained" and bool(self.previous_response_id)
         if chained and self._pending_call_ids:
             completed = {m.get("tool_call_id") for m in messages if m.get("role") == ChatRole.TOOL}
             if not self._pending_call_ids.issubset(completed):
@@ -517,7 +522,29 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
+        self._apply_responses_request_controls(create_kwargs)
         return create_kwargs, responses_tools
+
+    def _apply_responses_request_controls(self, create_kwargs):
+        """Apply opt-ins after defaults without changing tools, caps or shared model_args."""
+        if self.responses_store is not None:
+            create_kwargs["store"] = self.responses_store
+        if self.responses_history == "full":
+            create_kwargs["previous_response_id"] = None
+            create_kwargs.setdefault("text", {}).setdefault("format", {"type": "text"})
+        cache_key = getattr(self, "prompt_cache_key", None)
+        if cache_key is not None:
+            create_kwargs["prompt_cache_key"] = cache_key
+        omissions = getattr(self, "omit_request_parameters", ())
+        if "temperature" in omissions:
+            create_kwargs.pop("temperature", None)
+        if "verbosity" in omissions and "text" in create_kwargs:
+            create_kwargs["text"].pop("verbosity", None)
+            if not create_kwargs["text"]:
+                create_kwargs.pop("text")
+        for key in self.responses_omit_parameters:
+            if key in {"truncation", "include"}:
+                create_kwargs.pop(key, None)
 
     async def _generate_stream_responses(
         self,
@@ -529,6 +556,8 @@ class OpenAICompatibleLLM(BaseLLM):
         tools=None,
         retry_on_empty=True,
     ):
+        if self.strict_websocket:
+            raise ValueError("strict_websocket requires WebSocket generate_stream; HTTP fallback is disabled")
         if not messages:
             raise ValueError("No messages provided")
 
@@ -771,6 +800,7 @@ class OpenAICompatibleLLM(BaseLLM):
         if request_json:
             create_kwargs.setdefault("text", {})["format"] = {"type": "json_object"}
 
+        self._apply_responses_request_controls(create_kwargs)
         llm_host = getattr(self, "llm_host", None)
 
         try:

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -1,6 +1,7 @@
 import os
 import asyncio
 import json
+import copy
 from contextlib import suppress
 import re
 import time
@@ -42,7 +43,7 @@ class OpenAIWSConnection:
 
     - Eager connect at init, ready before first LLM call
     - Auto-reconnect on connection drop or before 60-min server limit
-    - Sequential: one in-flight response at a time (API constraint)
+    - Sequential: one in-flight response at a time in this client
     """
 
     WS_URL = "wss://api.openai.com/v1/responses"
@@ -193,6 +194,16 @@ class OpenAiLLM(OpenAICompatibleLLM):
         # Keep these opt-ins separate: shared model_args also feed routing and other transports.
         self.prompt_cache_key = kwargs.get("prompt_cache_key")
         self.omit_request_parameters = kwargs.get("omit_request_parameters") or ()
+        self.responses_store = kwargs.get("responses_store")
+        self.responses_history = kwargs.get("responses_history", "chained")
+        self.responses_omit_parameters = kwargs.get("responses_omit_parameters") or ()
+        self.strict_websocket = kwargs.get("strict_websocket", False)
+        if self.strict_websocket and (
+            not kwargs.get("use_responses_api")
+            or kwargs.get("provider", "openai") != "openai"
+            or kwargs.get("base_url")
+        ):
+            raise ValueError("strict_websocket requires native OpenAI Responses without a custom base_url")
 
         self.custom_tools = kwargs.get("api_tools", None)
         self.language = language
@@ -272,6 +283,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
     async def generate_stream(
         self, messages, synthesize=True, request_json=False, meta_info=None, tool_choice=None, tools=None
     ):
+        if self.strict_websocket and (not self.use_responses_api or self._ws_transport is None):
+            raise ValueError("strict_websocket requires an available WebSocket transport")
         await self._ensure_base_url_allowed()
         if self.use_responses_api:
             if self._ws_transport:
@@ -510,6 +523,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.started_streaming = False
 
     async def generate(self, messages, request_json=False, ret_metadata=False, meta_info=None):
+        if self.strict_websocket:
+            raise ValueError("strict_websocket requires generate_stream, not HTTP generate")
         await self._ensure_base_url_allowed()
         if self.use_responses_api:
             return await self._generate_responses(messages, request_json, ret_metadata, meta_info)
@@ -588,8 +603,7 @@ class OpenAiLLM(OpenAICompatibleLLM):
         if not messages:
             raise ValueError("No messages provided")
 
-        # store=True activates server-side prompt-cache (cached_tokens in usage)
-        # on top of the WS connection-local cache. Storage is free per OpenAI.
+        # The shared builder applies storage/history opt-ins independently of prompt caching.
         create_params, responses_tools = self._build_responses_create_kwargs(
             messages, meta_info, request_json, tool_choice, store=True, tools=tools
         )
@@ -616,15 +630,49 @@ class OpenAiLLM(OpenAICompatibleLLM):
         incomplete = False
         incomplete_reason = None
 
+        # Strict callers need the original terminal usage, including zero/missing fields,
+        # even when the attempt raises. These timings start before transport setup, not at response.created.
+        attempt = None
+        if self.strict_websocket:
+            attempt = {
+                "transport": "websocket",
+                "status": "started",
+                "response_id": None,
+                "model": None,
+                "service_tier": None,
+                "usage": None,
+                "first_visible_text_ms": None,
+                "duration_ms": None,
+            }
+            if isinstance(meta_info, dict):
+                meta_info.setdefault("responses_ws_attempts", []).append(attempt)
+
         try:
             async for evt in self._ws_transport.stream_response(create_params):
                 now = now_ms()
                 evt_type = evt.get("type", "")
 
+                if attempt is not None:
+                    resp = evt.get("response") or {}
+                    for key, source in (("response_id", "id"), ("model", "model"), ("service_tier", "service_tier")):
+                        if source in resp:
+                            attempt[key] = resp[source]
+                    if evt_type == ResponseStreamEvent.OUTPUT_TEXT_DELTA and evt.get("delta"):
+                        if attempt["first_visible_text_ms"] is None:
+                            attempt["first_visible_text_ms"] = now - start_time
+                    if evt_type in OpenAIWSConnection.RESPONSE_TERMINAL_EVENTS:
+                        attempt["status"] = evt_type.removeprefix("response.")
+                        attempt["usage"] = copy.deepcopy(resp.get("usage"))
+                        attempt["incomplete_details"] = copy.deepcopy(resp.get("incomplete_details"))
+
                 if evt_type == ResponseStreamEvent.ERROR:
                     error_info = evt.get("error", {})
                     error_code = error_info.get("code", "")
-                    if error_code == "previous_response_not_found" and self.previous_response_id:
+                    if (
+                        not self.strict_websocket
+                        and error_code == "previous_response_not_found"
+                        and self.previous_response_id
+                    ):
                         logger.warning(f"WS previous_response_id not found, retrying with full history")
                         async for chunk in self._retry_full_history(
                             messages, synthesize, request_json, meta_info, tool_choice, tools
@@ -635,7 +683,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     # "No tool output found ...") gets one full-history retry; nothing yielded yet.
                     # Coded errors like context_length_exceeded raise — a retry can't fix those.
                     if (
-                        self.previous_response_id
+                        not self.strict_websocket
+                        and self.previous_response_id
                         and error_info.get("type") == "invalid_request_error"
                         and not error_code
                         and error_info.get("param") == "input"
@@ -687,6 +736,8 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     incomplete_reason = ((evt.get("response") or {}).get("incomplete_details") or {}).get("reason")
                     logger.warning(f"WS Responses API stream incomplete, reason={incomplete_reason}")
                     self.invalidate_response_chain()
+                    if self.strict_websocket:
+                        raise APIError(message=f"WS response incomplete: {incomplete_reason}", request=None, body=None)
                     break
 
                 if not first_token_time and evt_type in (
@@ -760,11 +811,24 @@ class OpenAiLLM(OpenAICompatibleLLM):
                     response_usage = resp.get("usage")
                     break
 
+            if attempt is not None and attempt["status"] != "completed":
+                raise APIError(message="WebSocket ended without response.completed", request=None, body=None)
+
         except APIError:
+            if attempt is not None:
+                if attempt["status"] == "started":
+                    attempt["status"] = "error"
+                self.invalidate_response_chain()
             raise
         except asyncio.CancelledError:
+            if attempt is not None:
+                attempt["status"] = "cancelled"
             raise
         except Exception as e:
+            if self.strict_websocket:
+                attempt["status"] = "error"
+                self.invalidate_response_chain()
+                raise
             logger.error(f"WS streaming error: {e}, falling back to HTTP SSE")
             self.invalidate_response_chain()
             async for chunk in self._generate_stream_responses(
@@ -772,6 +836,11 @@ class OpenAiLLM(OpenAICompatibleLLM):
             ):
                 yield chunk
             return
+        finally:
+            if attempt is not None:
+                attempt["duration_ms"] = now_ms() - start_time
+                if attempt["status"] == "started":
+                    attempt["status"] = "cancelled"
 
         # Nothing was yielded yet, so a retry cannot duplicate speech.
         if incomplete and not answer and not func_call_args:
@@ -807,10 +876,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 fc_chunk.input_tokens = response_usage.get("input_tokens")
                 fc_chunk.output_tokens = response_usage.get("output_tokens")
                 _od = response_usage.get("output_tokens_details") or {}
-                if _od.get("reasoning_tokens"):
+                if _od.get("reasoning_tokens") is not None:
                     fc_chunk.reasoning_tokens = _od["reasoning_tokens"]
                 _id = response_usage.get("input_tokens_details") or {}
-                if _id.get("cached_tokens"):
+                if _id.get("cached_tokens") is not None:
                     fc_chunk.cached_tokens = _id["cached_tokens"]
             yield fc_chunk
 
@@ -819,10 +888,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
             usage_kwargs["input_tokens"] = response_usage.get("input_tokens")
             usage_kwargs["output_tokens"] = response_usage.get("output_tokens")
             output_details = response_usage.get("output_tokens_details", {}) or {}
-            if output_details.get("reasoning_tokens"):
+            if output_details.get("reasoning_tokens") is not None:
                 usage_kwargs["reasoning_tokens"] = output_details["reasoning_tokens"]
             input_details = response_usage.get("input_tokens_details", {}) or {}
-            if input_details.get("cached_tokens"):
+            if input_details.get("cached_tokens") is not None:
                 usage_kwargs["cached_tokens"] = input_details["cached_tokens"]
 
         reasoning_content = "".join(reasoning_summary_parts) if reasoning_summary_parts else None

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -190,6 +190,9 @@ class OpenAiLLM(OpenAICompatibleLLM):
     ):
         super().__init__(max_tokens, buffer_size)
         self.model = model
+        # Keep these opt-ins separate: shared model_args also feed routing and other transports.
+        self.prompt_cache_key = kwargs.get("prompt_cache_key")
+        self.omit_request_parameters = kwargs.get("omit_request_parameters") or ()
 
         self.custom_tools = kwargs.get("api_tools", None)
         self.language = language
@@ -311,6 +314,14 @@ class OpenAiLLM(OpenAICompatibleLLM):
                 model_args["tools"] = _tools
                 model_args["tool_choice"] = tool_choice or "auto"
                 model_args["parallel_tool_calls"] = False
+
+        # Apply omissions after defaults, on this request only; core messages, tools and caps stay intact.
+        for key in ("temperature", "stop", "verbosity"):
+            if key in self.omit_request_parameters:
+                model_args.pop(key, None)
+        # A caller-supplied workload key enables cache routing without changing unconfigured requests.
+        if self.prompt_cache_key is not None:
+            model_args["prompt_cache_key"] = self.prompt_cache_key
 
         answer, buffer = "", ""
         tools = model_args.get("tools", [])

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -323,6 +323,12 @@ class Llm(BaseModel):
 
 
 class SimpleLlmAgent(Llm):
+    # Unspecified keeps automatic selection; explicit False must survive schema serialization.
+    use_responses_api: Optional[bool] = None
+    # Persist an optional workload cache key instead of silently dropping it from agent config.
+    prompt_cache_key: Optional[str] = Field(default=None, min_length=1, strict=True)
+    # Some endpoints reject these defaults. Do not allow callers to omit messages, tools or caps.
+    omit_request_parameters: List[Literal["temperature", "stop", "verbosity"]] = Field(default_factory=list)
     agent_flow_type: Optional[str] = "streaming"  # It is used for backwards compatibility
     extraction_details: Optional[str] = None
     summarization_details: Optional[str] = None

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -329,9 +329,23 @@ class SimpleLlmAgent(Llm):
     prompt_cache_key: Optional[str] = Field(default=None, min_length=1, strict=True)
     # Some endpoints reject these defaults. Do not allow callers to omit messages, tools or caps.
     omit_request_parameters: List[Literal["temperature", "stop", "verbosity"]] = Field(default_factory=list)
+    # Storage and history are independent: a caller may replay visible history without storing responses.
+    responses_store: Optional[bool] = Field(default=None, strict=True)
+    responses_history: Literal["chained", "full"] = "chained"
+    # Keep endpoint defaults unless the caller explicitly requests an exact Responses projection.
+    responses_omit_parameters: List[Literal["truncation", "include"]] = Field(default_factory=list)
+    # Evaluation callers must be able to reject fallback/replay instead of silently changing transport.
+    strict_websocket: bool = Field(default=False, strict=True)
     agent_flow_type: Optional[str] = "streaming"  # It is used for backwards compatibility
     extraction_details: Optional[str] = None
     summarization_details: Optional[str] = None
+
+    @model_validator(mode="after")
+    def validate_strict_websocket(self):
+        # Reject incompatible endpoints before simple-agent config assembly can discard base_url.
+        if self.strict_websocket and (self.provider != "openai" or self.base_url or self.use_responses_api is False):
+            raise ValueError("strict_websocket requires native OpenAI Responses without a custom base_url")
+        return self
 
 
 class Node(BaseModel):

--- a/examples/openai_chat_completions.md
+++ b/examples/openai_chat_completions.md
@@ -27,5 +27,11 @@ agent; absent/null retains it. Chat routing and non-streaming behavior are uncha
 For Responses history, storage and strict WebSocket controls, see
 [the Responses example](openai_responses_controls.md). Keep credentials in the existing environment.
 
+Bolna forwards the caller-supplied `prompt_cache_key`; it does not automatically
+distribute traffic across keys. Keep all turns of a call on the same key. If
+high traffic reduces cache hits, distribute calls across a stable key pool using
+a deterministic mapping, then tune the pool size using measured cache hits.
+See [OpenAI's cache-key guidance](https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-key-best-practices).
+
 Tests use mocked SDK transport, not live model quality or voice validation.
 [API fields](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create).

--- a/examples/openai_chat_completions.md
+++ b/examples/openai_chat_completions.md
@@ -1,0 +1,30 @@
+# Simple-agent streaming Chat Completions
+
+Use this LLM fragment at `tasks[].tools_config.llm_agent.llm_config` with
+`agent_type: simple_llm_agent`. It is not a complete voice-agent configuration.
+
+```json
+{
+  "provider": "openai",
+  "model": "YOUR_COMPATIBLE_REASONING_MODEL",
+  "max_tokens": 4096,
+  "reasoning_effort": "medium",
+  "use_responses_api": false,
+  "prompt_cache_key": "support-assistant-v1",
+  "omit_request_parameters": ["temperature", "stop", "verbosity"]
+}
+```
+
+Use a model supported by Bolna's existing reasoning-model mapping and your account.
+Existing `max_tokens` mapping supplies its completion cap; no second cap setting
+or new model detection is added. The existing service tier remains `default`.
+
+The optional cache key is forwarded only on streaming Chat requests. The omission
+list removes only the three listed tuning fields after defaults are applied, never
+messages, tools or the cap. Unset options preserve existing behavior. Explicit
+`use_responses_api: false` overrides automatic transport selection for this simple
+agent; absent/null retains it. This does not add graph, routing, non-streaming,
+Responses API or WebSocket controls. Keep credentials in the existing environment.
+
+Tests use mocked SDK transport, not live model quality or voice validation.
+[API fields](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create).

--- a/examples/openai_chat_completions.md
+++ b/examples/openai_chat_completions.md
@@ -19,12 +19,13 @@ Use a model supported by Bolna's existing reasoning-model mapping and your accou
 Existing `max_tokens` mapping supplies its completion cap; no second cap setting
 or new model detection is added. The existing service tier remains `default`.
 
-The optional cache key is forwarded only on streaming Chat requests. The omission
+The optional cache key is forwarded on streaming Chat requests. The omission
 list removes only the three listed tuning fields after defaults are applied, never
 messages, tools or the cap. Unset options preserve existing behavior. Explicit
 `use_responses_api: false` overrides automatic transport selection for this simple
-agent; absent/null retains it. This does not add graph, routing, non-streaming,
-Responses API or WebSocket controls. Keep credentials in the existing environment.
+agent; absent/null retains it. Chat routing and non-streaming behavior are unchanged.
+For Responses history, storage and strict WebSocket controls, see
+[the Responses example](openai_responses_controls.md). Keep credentials in the existing environment.
 
 Tests use mocked SDK transport, not live model quality or voice validation.
 [API fields](https://developers.openai.com/api/reference/resources/chat/subresources/completions/methods/create).

--- a/examples/openai_responses_controls.md
+++ b/examples/openai_responses_controls.md
@@ -45,6 +45,12 @@ chaining, truncation, reasoning include and fallback defaults remain unchanged.
 [OpenAI's WebSocket guide](https://developers.openai.com/api/docs/guides/websocket-mode)
 describes `store: false` and full-context starts with a null previous response ID.
 
+Bolna forwards the caller-supplied `prompt_cache_key`; it does not automatically
+distribute traffic across keys. Keep all turns of a call on the same key. If
+high traffic reduces cache hits, distribute calls across a stable key pool using
+a deterministic mapping, then tune the pool size using measured cache hits.
+See [OpenAI's cache-key guidance](https://developers.openai.com/api/docs/guides/prompt-caching#prompt-cache-key-best-practices).
+
 ## Strict text evaluation
 
 Use `generate_stream(..., synthesize=False, meta_info=metadata)` on the native

--- a/examples/openai_responses_controls.md
+++ b/examples/openai_responses_controls.md
@@ -1,0 +1,70 @@
+# Explicit Responses request and transport controls
+
+For a simple agent, put this fragment in `tools_config.llm_agent`. Select a model
+that supports your requested reasoning effort and Responses configuration:
+
+```json
+{
+  "agent_type": "simple_llm_agent",
+  "agent_flow_type": "streaming",
+  "llm_config": {
+    "model": "YOUR_COMPATIBLE_REASONING_MODEL",
+    "provider": "openai",
+    "max_tokens": 4096,
+    "reasoning_effort": "medium",
+    "use_responses_api": true,
+    "prompt_cache_key": "example-agent-v1",
+    "omit_request_parameters": [
+      "temperature",
+      "stop",
+      "verbosity"
+    ],
+    "responses_store": false,
+    "responses_history": "full",
+    "responses_omit_parameters": [
+      "truncation",
+      "include"
+    ],
+    "strict_websocket": true,
+    "compact_threshold": null
+  }
+}
+```
+
+`max_tokens` already maps to `max_output_tokens`; the provider's default service
+tier is `default`. Full history uses the existing Chat-message adapter for system, user, assistant
+and tool messages, with `previous_response_id: null` and text output format. It does
+not replay hidden response/reasoning items. Supply the complete supported-role history each turn; arbitrary Responses input
+items and developer-role messages are not supported by this adapter.
+JSON output and explicitly configured tools remain intact. Compaction stays off
+when its threshold is unset. `stop` is not emitted by the Responses builder;
+`verbosity` omission removes only `text.verbosity`, not `text.format`.
+
+Storage and history are independent. Without these opt-ins, existing storage,
+chaining, truncation, reasoning include and fallback defaults remain unchanged.
+[OpenAI's WebSocket guide](https://developers.openai.com/api/docs/guides/websocket-mode)
+describes `store: false` and full-context starts with a null previous response ID.
+
+## Strict text evaluation
+
+Use `generate_stream(..., synthesize=False, meta_info=metadata)` on the native
+OpenAI endpoint, with a fresh metadata dict per turn. Strict mode rejects HTTP
+and non-streaming `generate`, disables automatic response replay and HTTP fallback,
+and raises on failed/incomplete responses or a stream without completion. It does
+not undo text already yielded before a failure. Existing connection reuse,
+reconnection, cancellation and tool handling are retained; strict mode does not
+promise successful server cancellation or disable connection establishment retries.
+Always close the provider in `finally`.
+
+`metadata["responses_ws_attempts"]` retains each strict attempt's transport, status,
+response ID, reported model/tier, and raw terminal `usage`, including unknown fields.
+Missing usage (`null`) is not zero usage or an empty object. Record failed attempts
+as well as successful ones when accounting for cost. `first_visible_text_ms` starts
+at the first nonempty text delta, not tool arguments or an empty delta. It and
+`duration_ms` are measured from provider request start, including setup that occurs
+inside the request but excluding eager connection work already completed. They are
+not handshake-only, ASR, TTS or telephony timings. Existing chunk latency fields
+retain their original first-event semantics.
+
+The example is a configuration contract, not a live quality or voice acceptance
+result. The no-network tests verify request projection and transport behavior.

--- a/tests/test_openai_chat_request_controls.py
+++ b/tests/test_openai_chat_request_controls.py
@@ -1,0 +1,214 @@
+"""Simple-agent opt-ins survive native setup and real SDK streaming without changing defaults."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.llms.openai_llm import OpenAiLLM
+from bolna.models import Llm, LlmAgent, SimpleLlmAgent
+
+
+MESSAGES = [{"role": "user", "content": "Hello", "turn_id": 3}]
+OPTIONS = {"prompt_cache_key": "example-agent-v1", "omit_request_parameters": ["temperature", "stop", "verbosity"]}
+TOOLS = [{"type": "function", "function": {"name": "lookup_item", "parameters": {"type": "object", "properties": {}}}}]
+USAGE = {
+    "prompt_tokens": 24,
+    "completion_tokens": 8,
+    "total_tokens": 32,
+    "prompt_tokens_details": {"cached_tokens": 16},
+    "completion_tokens_details": {"reasoning_tokens": 3},
+}
+
+
+def native_config(**options):
+    agent = LlmAgent.model_validate(
+        {
+            "agent_type": "simple_llm_agent",
+            "agent_flow_type": "streaming",
+            "llm_config": {"model": "gpt-5", "provider": "openai", **options},
+        }
+    ).model_dump(mode="json")
+    task = {
+        "task_type": "conversation",
+        "toolchain": {"execution": "sequential", "pipelines": [["llm"]]},
+        "tools_config": {
+            "llm_agent": agent,
+            "synthesizer": {"provider": "elevenlabs", "provider_config": {}, "stream": True, "buffer_size": 100},
+            "transcriber": {
+                "provider": "deepgram",
+                "model": "nova-3",
+                "language": "en",
+                "stream": True,
+                "encoding": "linear16",
+                "sampling_rate": 16000,
+                "endpointing": 250,
+            },
+            "input": {"provider": "default"},
+            "output": {"provider": "default"},
+        },
+        "task_config": {},
+    }
+    # Keep real config assembly while replacing unrelated audio/task startup.
+    with (
+        patch.object(TaskManager, "_TaskManager__setup_transcriber"),
+        patch.object(TaskManager, "_TaskManager__setup_synthesizer"),
+        patch.object(TaskManager, "_TaskManager__setup_llm"),
+        patch.object(TaskManager, "_TaskManager__setup_tasks"),
+    ):
+        return TaskManager("example", 0, task, MagicMock(), turn_based_conversation=True)
+
+
+@pytest.fixture
+async def sdk(monkeypatch):
+    clients = []
+
+    def build(config, **runtime):
+        requests = []
+
+        def respond(request):
+            body = json.loads(request.content)
+            assert request.url.path == "/v1/chat/completions" and body["stream"] is True
+            requests.append(body)
+            delta = {"content": "Hello."}
+            if body.get("tools"):
+                delta = {
+                    "tool_calls": [
+                        {
+                            "index": 0,
+                            "id": "call_example",
+                            "type": "function",
+                            "function": {"name": "lookup_item", "arguments": "{}"},
+                        }
+                    ]
+                }
+            chunk = {
+                "id": "example",
+                "object": "chat.completion.chunk",
+                "created": 1,
+                "model": body["model"],
+                "choices": [{"index": 0, "delta": delta, "finish_reason": None}],
+            }
+            usage = {**chunk, "choices": [], "usage": USAGE}
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/event-stream"},
+                content="".join("data: " + json.dumps(c) + "\n\n" for c in [chunk, usage]) + "data: [DONE]\n\n",
+            )
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(respond))
+        clients.append(client)
+        monkeypatch.setattr("bolna.llms.openai_llm.get_shared_http_client", lambda **kw: client)
+        # Invoke the actual constructor boundary, including stored/runtime precedence.
+        tm = MagicMock(task_config={"tools_config": {"llm_agent": {}}}, language="en", kwargs=runtime)
+        llm = TaskManager._TaskManager__setup_llm(tm, config)
+        return llm, requests
+
+    yield build
+    for client in clients:
+        await client.aclose()
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("prompt_cache_key", ""),
+        ("prompt_cache_key", 123),
+        ("omit_request_parameters", ["messages"]),
+        ("omit_request_parameters", ["max_tokens"]),
+        ("omit_request_parameters", "temperature"),
+    ],
+)
+def test_schema_rejects_invalid_opt_ins(field, value):
+    with pytest.raises(ValidationError):
+        SimpleLlmAgent(**{field: value})
+
+
+@pytest.mark.parametrize("transport,expected", [(None, True), (False, False), (True, True)])
+async def test_simple_transport_override_and_automatic_default(transport, expected):
+    values = {} if transport is None else {"use_responses_api": transport}
+    tm = native_config(model="gpt-5.4-mini", **values)
+    assert tm.llm_agent_config["use_responses_api"] is transport
+    assert tm.llm_config["use_responses_api"] is expected
+    assert Llm().use_responses_api is False  # Other agent schemas retain their existing default.
+
+
+async def test_native_simple_config_reaches_exact_sdk_stream(sdk):
+    tm = native_config(max_tokens=4096, reasoning_effort="medium", temperature=0.2, use_responses_api=False, **OPTIONS)
+    llm, requests = sdk(tm.llm_config)
+    shared_args = llm.model_args.copy()
+    chunks = [c async for c in llm.generate_stream(MESSAGES, synthesize=False)]
+    assert requests == [
+        {
+            "model": "gpt-5",
+            "max_completion_tokens": 4096,
+            "reasoning_effort": "medium",
+            "service_tier": "default",
+            "prompt_cache_key": "example-agent-v1",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "response_format": {"type": "text"},
+            "stream": True,
+            "stream_options": {"include_usage": True},
+        }
+    ]
+    assert llm.model_args == shared_args
+    assert not llm.use_responses_api and llm._ws_transport is None
+    assert chunks[-1].data == "Hello." and chunks[-1].end_of_stream
+    assert (
+        chunks[-1].input_tokens,
+        chunks[-1].output_tokens,
+        chunks[-1].reasoning_tokens,
+        chunks[-1].cached_tokens,
+    ) == (24, 8, 3, 16)
+
+
+async def test_absent_opt_ins_preserve_legacy_stream(sdk):
+    llm, requests = sdk(native_config(model="gpt-4.1-mini", max_tokens=100, temperature=0.2).llm_config)
+    _ = [c async for c in llm.generate_stream(MESSAGES, synthesize=False)]
+    assert requests == [
+        {
+            "model": "gpt-4.1-mini",
+            "max_tokens": 100,
+            "temperature": 0.2,
+            "service_tier": "default",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "response_format": {"type": "text"},
+            "stream": True,
+            "stream_options": {"include_usage": True},
+            "stop": ["User:"],
+        }
+    ]
+
+
+async def test_streamed_tools_and_core_fields_survive_runtime_omissions(sdk):
+    config = native_config(model="gpt-4.1-mini", max_tokens=100, **OPTIONS).llm_config
+    # Runtime overrides also use the real factory, and cannot remove required request fields.
+    llm, requests = sdk(
+        config,
+        prompt_cache_key="runtime-key",
+        omit_request_parameters=["temperature", "stop", "tools", "messages", "max_tokens"],
+        api_tools={"tools": TOOLS, "tools_params": {"lookup_item": {}}},
+    )
+    chunks = [c async for c in llm.generate_stream(MESSAGES, synthesize=False, meta_info={})]
+    assert requests[0]["prompt_cache_key"] == "runtime-key"
+    assert requests[0]["tools"] == TOOLS and requests[0]["tool_choice"] == "auto"
+    assert requests[0]["parallel_tool_calls"] is False and requests[0]["max_tokens"] == 100
+    assert requests[0]["messages"] == [{"role": "user", "content": "Hello"}]
+    assert "temperature" not in requests[0] and "stop" not in requests[0]
+    assert config["prompt_cache_key"] == "example-agent-v1"
+    calls = [c for c in chunks if c.is_function_call]
+    assert len(calls) == 1 and calls[0].data.called_fun == "lookup_item"
+    assert calls[0].data.tool_call_id == "call_example"
+
+
+async def test_custom_endpoint_guard_still_runs_before_stream(sdk, monkeypatch):
+    guard = AsyncMock()
+    monkeypatch.setattr("bolna.llms.openai_llm.guard_llm_base_url", guard)
+    config = native_config(model="gpt-4.1-mini", **OPTIONS).llm_config
+    llm, requests = sdk(config, provider="custom", base_url="https://example.com/v1")
+    _ = [c async for c in llm.generate_stream(MESSAGES, synthesize=False)]
+    guard.assert_awaited_once_with("https://example.com/v1")
+    assert requests[0]["prompt_cache_key"] == "example-agent-v1"

--- a/tests/test_responses_api.py
+++ b/tests/test_responses_api.py
@@ -20,6 +20,9 @@ def _make_llm(**overrides):
     defaults.update(overrides)
     with patch.object(OpenAiLLM, "__init__", lambda self, **kw: None):
         llm = OpenAiLLM.__new__(OpenAiLLM)
+    # This fixture bypasses __init__; retain the absent opt-ins for its legacy Chat-path checks.
+    llm.prompt_cache_key = None
+    llm.omit_request_parameters = ()
     llm.model = defaults["model"]
     llm.max_tokens = defaults["max_tokens"]
     llm.buffer_size = defaults["buffer_size"]

--- a/tests/test_responses_request_controls.py
+++ b/tests/test_responses_request_controls.py
@@ -1,0 +1,412 @@
+"""Native Responses controls preserve visible context and cannot disguise a strict WS failure."""
+
+import asyncio
+import json
+import time
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from openai import APIError
+from pydantic import ValidationError
+from websockets.protocol import State
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.llms.openai_llm import OpenAIWSConnection
+from bolna.models import LlmAgent, SimpleLlmAgent
+
+
+HISTORY = [
+    {"role": "system", "content": "Be concise."},
+    {"role": "user", "content": "Hello", "turn_id": 1},
+    {"role": "assistant", "content": "Hello."},
+    {"role": "user", "content": "Continue", "turn_id": 2},
+]
+OPTIONS = {
+    "use_responses_api": True,
+    "responses_store": False,
+    "responses_history": "full",
+    "responses_omit_parameters": ["truncation", "include"],
+    "prompt_cache_key": "example-agent-v1",
+    "omit_request_parameters": ["temperature", "stop", "verbosity"],
+    "strict_websocket": True,
+}
+USAGE = {
+    "input_tokens": 24,
+    "output_tokens": 8,
+    "total_tokens": 32,
+    "input_tokens_details": {"cached_tokens": 16},
+    "output_tokens_details": {"reasoning_tokens": 3},
+}
+
+
+def native_config(**options):
+    agent = LlmAgent.model_validate(
+        {
+            "agent_type": "simple_llm_agent",
+            "agent_flow_type": "streaming",
+            "llm_config": {
+                "provider": "openai",
+                "model": "gpt-5",
+                "max_tokens": 4096,
+                "reasoning_effort": "medium",
+                "use_responses_api": True,
+                **options,
+            },
+        }
+    ).model_dump(mode="json")
+    task = {
+        "task_type": "conversation",
+        "toolchain": {"execution": "sequential", "pipelines": [["llm"]]},
+        "tools_config": {
+            "llm_agent": agent,
+            "synthesizer": {"provider": "elevenlabs", "provider_config": {}, "stream": True, "buffer_size": 100},
+            "transcriber": {
+                "provider": "deepgram",
+                "model": "nova-3",
+                "language": "en",
+                "stream": True,
+                "encoding": "linear16",
+                "sampling_rate": 16000,
+                "endpointing": 250,
+            },
+            "input": {"provider": "default"},
+            "output": {"provider": "default"},
+        },
+        "task_config": {},
+    }
+    # Exercise production configuration assembly without starting unrelated audio services.
+    with (
+        patch.object(TaskManager, "_TaskManager__setup_transcriber"),
+        patch.object(TaskManager, "_TaskManager__setup_synthesizer"),
+        patch.object(TaskManager, "_TaskManager__setup_llm"),
+        patch.object(TaskManager, "_TaskManager__setup_tasks"),
+        patch.object(TaskManager, "_TaskManager__setup_input_handlers"),
+        patch.object(TaskManager, "_TaskManager__setup_output_handlers"),
+        patch.object(TaskManager, "message_task_new", new_callable=AsyncMock),
+    ):
+        return TaskManager("example", 0, task, MagicMock(), turn_based_conversation=True).llm_config
+
+
+class Socket:
+    """A deterministic socket boundary; framing, locking and reset remain production code."""
+
+    state = State.OPEN
+
+    def __init__(self, events):
+        self.events = iter(events)
+        self.sent = []
+        self.closed = False
+
+    async def send(self, frame):
+        self.sent.append(json.loads(frame))
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        event = next(self.events, None)
+        if event is None:
+            raise StopAsyncIteration
+        if isinstance(event, BaseException):
+            raise event
+        return json.dumps(event)
+
+    async def close(self):
+        self.closed = True
+
+
+def terminal(status="completed", **response):
+    return {
+        "type": "response." + status,
+        "response": {"id": "resp_example", "status": status, "model": "gpt-5", "service_tier": "default", **response},
+    }
+
+
+@pytest.fixture
+async def native(monkeypatch):
+    providers = []
+    http_requests = []
+
+    def reject_http(request):
+        http_requests.append(request)
+        raise AssertionError("No HTTP request belongs in this WebSocket test")
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(reject_http))
+    monkeypatch.setattr("bolna.llms.openai_llm.get_shared_http_client", lambda **kwargs: client)
+    monkeypatch.setattr(OpenAIWSConnection, "start_connect", lambda self: None)
+
+    def build(events=(), runtime=None, **options):
+        config = native_config(**options)
+        tm = MagicMock(task_config={"tools_config": {"llm_agent": {}}}, language="en", kwargs=runtime or {})
+        llm = TaskManager._TaskManager__setup_llm(tm, config)
+        providers.append(llm)
+        socket = Socket(events)
+        if llm._ws_transport:
+            llm._ws_transport._ws = socket
+            llm._ws_transport._connected_at = time.monotonic()
+        return llm, socket
+
+    yield build
+    for llm in providers:
+        await llm.close()
+    await asyncio.sleep(0)  # Let abandoned-socket close tasks settle.
+    await client.aclose()
+    assert http_requests == []
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"responses_history": "unknown"},
+        {"responses_omit_parameters": ["input"]},
+        {"responses_omit_parameters": ["store"]},
+        {"responses_omit_parameters": "include"},
+    ],
+)
+def test_schema_rejects_unsupported_state_and_omissions(options):
+    with pytest.raises(ValidationError):
+        SimpleLlmAgent(**options)
+
+
+async def test_native_full_history_exact_ws_request_and_usage(native):
+    events = [
+        terminal("created"),
+        {"type": "response.output_text.delta", "delta": "Hello."},
+        terminal(usage=USAGE),
+    ]
+    llm, socket = native(events, **OPTIONS)
+    llm.previous_response_id = "resp_do_not_chain"
+    original_history, original_args = deepcopy(HISTORY), deepcopy(llm.model_args)
+    meta = {}
+    chunks = [chunk async for chunk in llm.generate_stream(HISTORY, synthesize=False, meta_info=meta)]
+    assert socket.sent == [
+        {
+            "type": "response.create",
+            "model": "gpt-5",
+            "input": [{"type": "message", "role": m["role"], "content": m["content"]} for m in HISTORY],
+            "store": False,
+            "previous_response_id": None,
+            "max_output_tokens": 4096,
+            "service_tier": "default",
+            "reasoning": {"effort": "medium"},
+            "text": {"format": {"type": "text"}},
+            "prompt_cache_key": "example-agent-v1",
+        }
+    ]
+    assert HISTORY == original_history and llm.model_args == original_args
+    assert llm.previous_response_id == "resp_example"  # Still available for cancellation, not chaining.
+    assert chunks[-1].data == "Hello." and chunks[-1].end_of_stream
+    assert (chunks[-1].input_tokens, chunks[-1].output_tokens, chunks[-1].cached_tokens) == (24, 8, 16)
+    attempt = meta["responses_ws_attempts"][0]
+    assert len(meta["responses_ws_attempts"]) == 1
+    assert attempt["transport"] == "websocket" and attempt["status"] == "completed"
+    assert attempt["usage"] == USAGE and attempt["response_id"] == "resp_example"
+    assert attempt["model"] == "gpt-5" and attempt["service_tier"] == "default"
+    assert 0 <= attempt["first_visible_text_ms"] <= attempt["duration_ms"]
+    assert not llm._ws_transport._needs_reset
+
+
+async def test_default_responses_request_retains_chaining_and_tuning(native):
+    llm, _ = native()
+    llm.previous_response_id = "resp_previous"
+    params, _ = llm._build_responses_create_kwargs(HISTORY, None, False, None)
+    assert params == {
+        "model": "gpt-5",
+        "input": [{"type": "message", "role": "user", "content": "Continue"}],
+        "store": True,
+        "truncation": "auto",
+        "max_output_tokens": 4096,
+        "temperature": 1,
+        "service_tier": "default",
+        "reasoning": {"effort": "medium"},
+        "text": {"verbosity": "low"},
+        "include": ["reasoning.encrypted_content"],
+        "previous_response_id": "resp_previous",
+    }
+
+
+async def test_storage_and_history_are_independent_and_json_format_survives(native):
+    llm, _ = native(responses_store=False)
+    llm.previous_response_id = "resp_previous"
+    params, _ = llm._build_responses_create_kwargs(HISTORY, None, False, None, store=True)
+    assert params["store"] is False and params["previous_response_id"] == "resp_previous"
+    assert params["input"] == [{"type": "message", "role": "user", "content": "Continue"}]
+    llm, _ = native(responses_history="full", omit_request_parameters=["verbosity"])
+    llm.previous_response_id = "resp_previous"
+    params, _ = llm._build_responses_create_kwargs(HISTORY, None, True, None)
+    assert params["store"] is True and params["previous_response_id"] is None
+    assert params["text"] == {"format": {"type": "json_object"}}
+    assert len(params["input"]) == len(HISTORY)
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"use_responses_api": False},
+        {"base_url": "https://example.com/v1"},
+        {"provider": "custom"},
+        {"provider": "azure"},
+    ],
+)
+async def test_strict_mode_rejects_non_ws_configuration(native, options):
+    with pytest.raises(ValueError, match="[Ww]eb[Ss]ocket|strict"):
+        native(strict_websocket=True, **options)
+
+
+async def test_strict_mode_rejects_http_dispatch_and_nonstream_generate(native):
+    llm, _ = native(**OPTIONS)
+    with pytest.raises(ValueError, match="[Ww]eb[Ss]ocket|strict"):
+        await llm.generate(HISTORY)
+    transport, llm._ws_transport = llm._ws_transport, None
+    try:
+        with pytest.raises(ValueError, match="[Ww]eb[Ss]ocket|strict"):
+            _ = [chunk async for chunk in llm.generate_stream(HISTORY)]
+    finally:
+        llm._ws_transport = transport
+
+
+@pytest.mark.parametrize(
+    "events,status",
+    [
+        ([{"type": "error", "error": {"code": "previous_response_not_found", "message": "gone"}}], "error"),
+        ([{"type": "error", "error": {"type": "invalid_request_error", "param": "input"}}], "error"),
+        ([terminal("failed", error={"message": "failed"})], "failed"),
+        ([terminal("incomplete", usage={}, incomplete_details={"reason": "max_output_tokens"})], "incomplete"),
+        ([OSError("socket interrupted")], "error"),
+        ([], "error"),
+    ],
+)
+async def test_strict_failure_is_one_ws_attempt_without_replay_or_http(native, events, status):
+    llm, socket = native(events, strict_websocket=True)
+    llm.previous_response_id = "resp_previous"
+    meta = {}
+    with pytest.raises((APIError, OSError)):
+        _ = [chunk async for chunk in llm.generate_stream(HISTORY, synthesize=False, meta_info=meta)]
+    assert len(socket.sent) == 1
+    assert len(meta["responses_ws_attempts"]) == 1
+    attempt = meta["responses_ws_attempts"][0]
+    assert attempt["status"] == status and attempt["transport"] == "websocket"
+    assert attempt["usage"] == ({} if status == "incomplete" else None)
+    assert attempt["first_visible_text_ms"] is None and attempt["duration_ms"] >= 0
+    assert llm.previous_response_id is None
+
+
+@pytest.mark.parametrize(
+    "usage",
+    [
+        None,
+        {},
+        {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "input_tokens_details": {"cached_tokens": 0},
+            "output_tokens_details": {"reasoning_tokens": 0},
+        },
+    ],
+)
+async def test_usage_presence_and_first_visible_text_are_not_inferred_from_other_events(native, usage, monkeypatch):
+    events = [
+        terminal("created"),
+        {"type": "response.reasoning_summary_text.delta", "delta": "Thinking"},
+        {"type": "response.output_text.delta", "delta": ""},
+        {"type": "response.output_text.delta", "delta": "Visible"},
+        terminal(**({"usage": usage} if usage is not None else {})),
+    ]
+    llm, _ = native(events, **OPTIONS)
+    ticks = iter(range(100, 1000, 10))
+    monkeypatch.setattr("bolna.llms.openai_llm.now_ms", lambda: next(ticks))
+    meta = {}
+    chunks = [chunk async for chunk in llm.generate_stream(HISTORY, synthesize=False, meta_info=meta)]
+    attempt = meta["responses_ws_attempts"][0]
+    assert attempt["usage"] == usage
+    assert attempt["first_visible_text_ms"] == 40
+    if usage:
+        assert (chunks[-1].input_tokens, chunks[-1].cached_tokens, chunks[-1].reasoning_tokens) == (0, 0, 0)
+
+
+async def test_persistent_full_history_tool_turn_does_not_chain_hidden_state(native):
+    tool = {"type": "function", "function": {"name": "lookup", "parameters": {"type": "object", "properties": {}}}}
+    events = [
+        terminal("created"),
+        {
+            "type": "response.output_item.added",
+            "item": {"type": "function_call", "id": "item_example", "call_id": "call_example", "name": "lookup"},
+        },
+        {"type": "response.function_call_arguments.delta", "item_id": "item_example", "delta": "{}"},
+        terminal(usage={}),
+        terminal("created"),
+        {"type": "response.output_text.delta", "delta": "Found."},
+        terminal(usage=USAGE),
+    ]
+    llm, socket = native(events, runtime={"api_tools": {"tools": [tool], "tools_params": {"lookup": {}}}}, **OPTIONS)
+    meta = {}
+    _ = [chunk async for chunk in llm.generate_stream(HISTORY, synthesize=False, meta_info=meta, tools=[tool])]
+    assert meta["responses_ws_attempts"][0]["first_visible_text_ms"] is None
+    messages = HISTORY + [
+        {
+            "role": "assistant",
+            "tool_calls": [{"id": "call_example", **tool, "function": {"name": "lookup", "arguments": "{}"}}],
+        },
+        {"role": "tool", "tool_call_id": "call_example", "content": "Found item"},
+    ]
+    chunks = [chunk async for chunk in llm.generate_stream(messages, synthesize=False, meta_info=meta, tools=[tool])]
+    assert len(socket.sent) == 2 and llm._ws_transport._ws is socket
+    assert all(frame["previous_response_id"] is None and frame["store"] is False for frame in socket.sent)
+    assert socket.sent[1]["input"] == socket.sent[0]["input"] + [
+        {"type": "function_call", "call_id": "call_example", "name": "lookup", "arguments": "{}"},
+        {"type": "function_call_output", "call_id": "call_example", "output": "Found item"},
+    ]
+    assert socket.sent[1]["tools"] == [
+        {
+            "type": "function",
+            "name": "lookup",
+            "description": "",
+            "parameters": {"type": "object", "properties": {}},
+            "strict": False,
+        }
+    ]
+    assert socket.sent[1]["parallel_tool_calls"] is False and socket.sent[1]["tool_choice"] == "auto"
+    assert chunks[-1].data == "Found." and len(meta["responses_ws_attempts"]) == 2
+
+
+async def test_full_history_still_cancels_the_in_flight_response(native):
+    llm, socket = native(
+        [terminal("created"), {"type": "response.output_text.delta", "delta": "Hello. "}, terminal()], **OPTIONS
+    )
+    llm.buffer_size = 1
+    stream = llm.generate_stream(HISTORY, meta_info={})
+    try:
+        await stream.__anext__()
+        assert llm.previous_response_id == "resp_example"
+        llm.cancel_in_flight_response()
+        await asyncio.sleep(0)
+        assert socket.sent[-1] == {"type": "response.cancel", "response_id": "resp_example"}
+        assert llm.previous_response_id is None
+    finally:
+        await stream.aclose()
+
+
+async def test_cancelled_strict_attempt_retains_cancellation_and_socket_cleanup(native):
+    llm, socket = native([terminal("created"), asyncio.CancelledError()], **OPTIONS)
+    meta = {}
+    with pytest.raises(asyncio.CancelledError):
+        _ = [chunk async for chunk in llm.generate_stream(HISTORY, meta_info=meta)]
+    await asyncio.sleep(0)
+    assert len(socket.sent) == 1 and socket.closed
+    assert meta["responses_ws_attempts"][0]["status"] == "cancelled"
+
+
+async def test_default_socket_failure_still_falls_back_to_http(native, monkeypatch):
+    llm, socket = native([OSError("socket interrupted")])
+    fallback_calls = []
+
+    async def fallback(*args, **kwargs):
+        fallback_calls.append((args, kwargs))
+        yield "http-fallback"
+
+    monkeypatch.setattr(llm, "_generate_stream_responses", fallback)
+    assert [chunk async for chunk in llm.generate_stream(HISTORY)] == ["http-fallback"]
+    assert len(socket.sent) == len(fallback_calls) == 1
+    assert llm.previous_response_id is None


### PR DESCRIPTION
Adds request controls for simple agents and a strict mode for Bolna's existing Responses/WebSocket transport. The new controls are opt-in.

Major changes:

1. **API selection:** honor an explicit Chat Completions choice instead of overriding it based on the model name.
2. **Request controls:** forward caller-supplied cache keys and allow unsupported defaults to be omitted, preserving messages, tools and token caps. Traffic is not automatically distributed across cache keys.
3. **History and storage:** allow full visible conversation history on each turn, with response storage controlled independently.
4. **Strict WebSockets:** reject HTTP fallback, automatic response replay and unsuccessful completion so transport failures remain visible.
5. **Measurements:** record attempt status, raw token/cache usage and response timings, including available usage on failures. Keep zero distinct from missing data.
6. **Configuration merging:** apply runtime overrides without duplicate-keyword crashes when settings overlap.
7. **Tests and examples:** document setup and rationale; cover request construction, defaults, tools, cancellation and failure accounting.

Validation:

- 191 focused tests passed, including 25 new cases.
- Repository Ruff lint/format, configured Bandit, requirements fixer and diff checks passed.
- Earlier full suite: 1,530 passed, 12 failed, 1 skipped. Ten failures matched baseline under the offline socket guard. The other two (tool-projection expectation and timing-sensitive teardown) passed in final focused checks. The full suite was not rerun after the fixture correction.

Validation used mocked requests and transports. Live model quality and end-to-end voice acceptance remain untested by this change.
