### PR TITLE
fix: handle streaming ASR events with buffered TTS

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4944,7 +4944,16 @@ class TaskManager(BaseManager):
                         break
                     continue
 
-                if self.stream:
+                # The TTS streaming flag does not describe the ASR packet format.
+                # Keep ASR control packets out of plain-text transcription handling.
+                data = message["data"]
+                is_asr_event = isinstance(data, dict) or data in (
+                    "speech_started",
+                    "speech_ended",
+                    "session_started",
+                    "transcriber_error",
+                )
+                if self.stream or is_asr_event:
                     self._set_call_details(message)
                     meta_info = message["meta_info"]
                     sequence = await self.process_transcriber_request(meta_info)
@@ -5263,7 +5272,8 @@ class TaskManager(BaseManager):
                             await self._handle_transcriber_output(next_task, transcriber_message, meta_info)
 
                     # Handle speech_ended notification (UtteranceEnd with no new transcript)
-                    elif isinstance(message.get("data"), dict) and message["data"].get("type", "") == "speech_ended":
+                    elif data == "speech_ended" or (isinstance(data, dict) and data.get("type") == "speech_ended"):
+                        # Sarvam sends a bare event; other adapters use a typed packet.
                         logger.info(f"Received speech_ended notification, resetting callee_speaking state")
                         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
                         self._speech_started_before_welcome = False

--- a/tests/test_split_utterance_tail_not_dropped.py
+++ b/tests/test_split_utterance_tail_not_dropped.py
@@ -8,6 +8,7 @@ tail and supersedes the in-flight turn, so dropping it would lose the user's rea
 import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 
 from bolna.agent_manager.task_manager import TaskManager
 from bolna.agent_manager.interruption_manager import InterruptionManager
@@ -44,6 +45,11 @@ def _make_tm(*, audio_playing, response_in_pipeline, function_call_in_flight=Fal
     tm._TaskManager__cleanup_downstream_tasks = AsyncMock()
     tm._end_call_on_component_error = AsyncMock()
     tm._report_component_health = AsyncMock()
+    tm.transcriber_duration = 0
+    tm._log_transcriber_connection_error = AsyncMock()
+    tm._TaskManager__process_http_transcription = AsyncMock(
+        wraps=TaskManager._TaskManager__process_http_transcription.__get__(tm, TaskManager)
+    )
     tm.task_config = {"tools_config": {"transcriber": {"provider": "deepgram"}}}
     tm._should_ignore_transcriber_input = TaskManager._should_ignore_transcriber_input.__get__(tm, TaskManager)
     tm._listen_transcriber = TaskManager._listen_transcriber.__get__(tm, TaskManager)
@@ -89,3 +95,65 @@ async def test_long_final_processed_while_audio_playing():
     }
     await _drive(tm, long_final)
     tm._handle_transcriber_output.assert_awaited_once()
+
+
+async def _drive_event_and_close(tm, data):
+    message = {"data": data, "meta_info": _TAIL_FINAL["meta_info"].copy()}
+    await tm.transcriber_output_queue.put(message)
+    await tm.transcriber_output_queue.put(
+        {"data": "transcriber_connection_closed", "meta_info": {"transcriber_duration": 2.5}}
+    )
+    await asyncio.wait_for(tm._listen_transcriber(), timeout=1)
+    assert tm.transcriber_duration == 2.5
+    tm._log_transcriber_connection_error.assert_awaited_once_with(None)
+    tm._end_call_on_component_error.assert_not_awaited()
+    return message
+
+
+@pytest.mark.parametrize("tts_stream", [False, True])
+@pytest.mark.parametrize(
+    "data",
+    [
+        "speech_started",
+        "session_started",
+        "transcriber_error",
+        {"type": "transcript", "content": "Please continue"},
+    ],
+)
+async def test_asr_events_do_not_use_http_transcription(tts_stream, data):
+    # ASR event packets must not become user text when speech output is buffered.
+    tm = _make_tm(audio_playing=False, response_in_pipeline=False)
+    tm.stream = tts_stream
+    message = await _drive_event_and_close(tm, data)
+
+    tm._TaskManager__process_http_transcription.assert_not_awaited()
+    if isinstance(data, dict):
+        tm._handle_transcriber_output.assert_awaited_once_with("llm", data["content"], message["meta_info"])
+    else:
+        tm._handle_transcriber_output.assert_not_awaited()
+    assert tm.stream is tts_stream
+
+
+@pytest.mark.parametrize("tts_stream", [False, True])
+@pytest.mark.parametrize("data", ["speech_ended", {"type": "speech_ended"}])
+async def test_both_speech_end_formats_reset_speaking_state(tts_stream, data):
+    # Sarvam can emit a bare string; other adapters use a typed event packet.
+    tm = _make_tm(audio_playing=False, response_in_pipeline=False)
+    tm.stream = tts_stream
+    tm._speech_started_before_welcome = True
+    tm.interruption_manager.on_user_speech_started()
+    await _drive_event_and_close(tm, data)
+
+    assert tm.interruption_manager.callee_speaking is False
+    assert tm._speech_started_before_welcome is False
+    tm._TaskManager__process_http_transcription.assert_not_awaited()
+    tm._handle_transcriber_output.assert_not_awaited()
+
+
+async def test_plain_http_transcript_still_reaches_conversation():
+    tm = _make_tm(audio_playing=False, response_in_pipeline=False)
+    tm.stream = False
+    message = await _drive_event_and_close(tm, "Please continue")
+
+    tm._TaskManager__process_http_transcription.assert_awaited_once_with(message)
+    tm._handle_transcriber_output.assert_awaited_once_with("llm", "Please continue", message["meta_info"])


### PR DESCRIPTION
With streaming speech recognition and `tools_config.synthesizer.stream=false`, `_listen_transcriber` uses the plain-text transcription path because its `self.stream` flag comes from TTS. Structured transcript or speech-end packets can then reach string operations and terminate the call with `transcriber_error`; control strings can also be treated as user text.

This fix:

- Routes structured ASR packets and known control events through the existing event handler, including when TTS is buffered.
- Accepts Sarvam's plain `"speech_ended"` event as well as the dictionary form, so both reset the speaking state.
- Preserves the TTS streaming setting, existing streaming paths and normal HTTP transcription. Comments explain both changes.

Validation: 13 new regression cases cover both streaming settings, both speech-end formats, transcript forwarding and connection closure. Seven cases failed before the fix. After the fix, the full suite passed locally on Python 3.12: **1,541 passed, 1 skipped**. Repository-wide Ruff lint and formatting checks passed.

The speech-provider interactions are mocked in these tests. Live microphone/provider acceptance has not been verified by this PR.
