### PR TITLE
feat: send prompt_cache_key on OpenAI and Azure conversation turns

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.230"
+__version__ = "0.10.231"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1866,6 +1866,8 @@ class TaskManager(BaseManager):
                 injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
+            if "prompt_cache_key" in self.kwargs:
+                injected_cfg["prompt_cache_key"] = self.kwargs["prompt_cache_key"]
             if "overflow_llm" in self.kwargs:
                 injected_cfg["overflow_llm"] = self.kwargs["overflow_llm"]
             if "routing_reasoning_effort" in self.kwargs:
@@ -1917,6 +1919,8 @@ class TaskManager(BaseManager):
                 injected_cfg["reasoning_summary"] = self.kwargs["reasoning_summary"]
             if "service_tier" in self.kwargs:
                 injected_cfg["service_tier"] = self.kwargs["service_tier"]
+            if "prompt_cache_key" in self.kwargs:
+                injected_cfg["prompt_cache_key"] = self.kwargs["prompt_cache_key"]
             if "overflow_llm" in self.kwargs:
                 injected_cfg["overflow_llm"] = self.kwargs["overflow_llm"]
             if self.llm_config.get("use_responses_api"):

--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -150,6 +150,7 @@ class GraphAgent(BaseAgent):
                 "verbosity",
                 "reasoning_summary",
                 "service_tier",
+                "prompt_cache_key",
                 "use_responses_api",
                 "compact_threshold",
                 "overflow_llm",

--- a/bolna/agent_types/knowledgebase_agent.py
+++ b/bolna/agent_types/knowledgebase_agent.py
@@ -74,6 +74,7 @@ class KnowledgeBaseAgent(BaseAgent):
                 "verbosity",
                 "reasoning_summary",
                 "service_tier",
+                "prompt_cache_key",
                 "use_responses_api",
                 "compact_threshold",
                 "overflow_llm",

--- a/bolna/llms/azure_llm.py
+++ b/bolna/llms/azure_llm.py
@@ -89,6 +89,10 @@ class AzureLLM(OpenAICompatibleLLM):
 
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")
+        # Opaque routing hint: same key lands on the same server, so a warm prompt prefix is reused.
+        # Only sent when the caller supplies one, since an OpenAI-compatible base_url may reject it.
+        if kwargs.get("prompt_cache_key"):
+            self.model_args["prompt_cache_key"] = kwargs["prompt_cache_key"]
 
         azure_endpoint = kwargs.get("base_url", os.getenv("AZURE_OPENAI_ENDPOINT"))
         api_key = kwargs.get("llm_key", os.getenv("AZURE_OPENAI_API_KEY"))

--- a/bolna/llms/openai_base.py
+++ b/bolna/llms/openai_base.py
@@ -491,6 +491,10 @@ class OpenAICompatibleLLM(BaseLLM):
         if service_tier:
             create_kwargs["service_tier"] = service_tier
 
+        prompt_cache_key = self.model_args.get("prompt_cache_key")
+        if prompt_cache_key:
+            create_kwargs["prompt_cache_key"] = prompt_cache_key
+
         if is_reasoning_model(self.model_family):
             create_kwargs["temperature"] = 1
             reasoning_effort = self.model_args.get("reasoning_effort")

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -218,6 +218,10 @@ class OpenAiLLM(OpenAICompatibleLLM):
         self.model_args.update({max_tokens_key: self.max_tokens, "temperature": self.temperature, "model": self.model})
 
         self.model_args["service_tier"] = kwargs.get("service_tier", "default")
+        # Opaque routing hint: same key lands on the same server, so a warm prompt prefix is reused.
+        # Only sent when the caller supplies one, since an OpenAI-compatible base_url may reject it.
+        if kwargs.get("prompt_cache_key"):
+            self.model_args["prompt_cache_key"] = kwargs["prompt_cache_key"]
 
         # http2=False: cancelled h2 requests leak streams until the connection pins at 100 (barge-in)
         http_client = get_shared_http_client(base_url=kwargs.get("base_url"), http2=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.230"
+version = "0.10.231"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_prompt_cache_key_passthrough.py
+++ b/tests/test_prompt_cache_key_passthrough.py
@@ -1,0 +1,198 @@
+"""prompt_cache_key is the routing hint that keeps a call's turns on one server.
+
+It rides in kwargs rather than the stored agent config, so it crosses four boundaries that
+each used to drop unknown keys silently: the two TaskManager injected_cfg blocks, the graph
+and knowledgebase agents' own kwarg allowlists, and model_args, which every chat-completions
+call spreads. A drop at any of them is invisible at runtime and only shows up as a cold cache.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.agent_types.knowledgebase_agent import KnowledgeBaseAgent
+
+KEY = "agent-4f2b1c90"
+
+
+def _task_config(agent_type="simple_llm_agent"):
+    return {
+        "task_type": "conversation",
+        "toolchain": {"execution": "sequential", "pipelines": [["llm"]]},
+        "tools_config": {
+            "llm_agent": {
+                "agent_type": agent_type,
+                "agent_flow_type": "streaming",
+                "llm_config": {
+                    "model": "gpt-4.1-mini",
+                    "max_tokens": 150,
+                    "provider": "openai",
+                    "temperature": 0.2,
+                },
+            },
+            "synthesizer": {
+                "provider": "elevenlabs",
+                "provider_config": {
+                    "voice": "Nila",
+                    "voice_id": "test",
+                    "model": "eleven_turbo_v2_5",
+                    "synthesizer_key": "test-key",
+                },
+                "stream": True,
+                "buffer_size": 100,
+            },
+            "transcriber": {
+                "provider": "deepgram",
+                "model": "nova-3",
+                "language": "en",
+                "stream": True,
+                "encoding": "linear16",
+                "sampling_rate": 16000,
+                "endpointing": 250,
+            },
+            "input": {"provider": "default"},
+            "output": {"provider": "default"},
+        },
+        "task_config": {},
+    }
+
+
+def _openai_llm(**kwargs):
+    from bolna.llms.openai_llm import OpenAiLLM
+
+    return OpenAiLLM(
+        model="gpt-4.1-mini",
+        max_tokens=150,
+        temperature=0.2,
+        llm_key="test-key",
+        base_url="https://api.openai.com/v1",
+        **kwargs,
+    )
+
+
+def _azure_llm(**kwargs):
+    from bolna.llms.azure_llm import AzureLLM
+
+    return AzureLLM(
+        model="ptu-gpt-4-1-mini",
+        max_tokens=150,
+        temperature=0.2,
+        llm_key="test-key",
+        base_url="https://example.openai.azure.com",
+        **kwargs,
+    )
+
+
+def _captured_llm_kwargs(agent_cls, config):
+    """Build the agent's LLM through its own factory and return the kwargs it passed."""
+    captured = {}
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", return_value=MagicMock()),
+        patch(f"{agent_cls.__module__}.SUPPORTED_LLM_PROVIDERS", {"openai": _capture}),
+    ):
+        agent_cls(config)
+    return captured
+
+
+class TestModelArgs:
+    """model_args is spread into every chat-completions call, including route and PTU overflow."""
+
+    @pytest.mark.parametrize("build", [_openai_llm, _azure_llm], ids=["openai", "azure"])
+    def test_key_reaches_model_args(self, build):
+        assert build(prompt_cache_key=KEY).model_args["prompt_cache_key"] == KEY
+
+    @pytest.mark.parametrize("build", [_openai_llm, _azure_llm], ids=["openai", "azure"])
+    def test_absent_key_sends_nothing(self, build):
+        assert "prompt_cache_key" not in build().model_args
+
+    @pytest.mark.parametrize("build", [_openai_llm, _azure_llm], ids=["openai", "azure"])
+    def test_empty_key_sends_nothing(self, build):
+        """An empty string is a valid dict value but not a valid routing key."""
+        assert "prompt_cache_key" not in build(prompt_cache_key="").model_args
+
+
+class TestResponsesPayload:
+    def test_key_reaches_the_responses_payload(self):
+        llm = _openai_llm(prompt_cache_key=KEY, use_responses_api=True)
+        create_kwargs, _ = llm._build_responses_create_kwargs(
+            [{"role": "user", "content": "hi"}], None, False, None, stream=True
+        )
+        assert create_kwargs["prompt_cache_key"] == KEY
+
+    def test_absent_key_is_not_invented(self):
+        llm = _openai_llm(use_responses_api=True)
+        create_kwargs, _ = llm._build_responses_create_kwargs(
+            [{"role": "user", "content": "hi"}], None, False, None, stream=True
+        )
+        assert "prompt_cache_key" not in create_kwargs
+
+
+class TestTaskManagerForwarding:
+    """Graph and knowledgebase agents get their config through injected_cfg, not **kwargs."""
+
+    @pytest.mark.parametrize("agent_type", ["graph_agent", "knowledgebase_agent"])
+    async def test_injected_cfg_carries_the_key(self, agent_type):
+        tm = TaskManager("agent", 0, _task_config(agent_type), MagicMock(), prompt_cache_key=KEY)
+        captured = {}
+
+        def _capture(config):
+            captured.update(config)
+            return MagicMock()
+
+        with (
+            patch("bolna.agent_manager.task_manager.GraphAgent", _capture),
+            patch("bolna.agent_manager.task_manager.KnowledgeBaseAgent", _capture),
+        ):
+            tm._TaskManager__get_agent_object(MagicMock(), agent_type)
+        assert captured["prompt_cache_key"] == KEY
+
+    @pytest.mark.parametrize("agent_type", ["graph_agent", "knowledgebase_agent"])
+    async def test_absent_key_is_not_invented(self, agent_type):
+        tm = TaskManager("agent", 0, _task_config(agent_type), MagicMock())
+        captured = {}
+
+        def _capture(config):
+            captured.update(config)
+            return MagicMock()
+
+        with (
+            patch("bolna.agent_manager.task_manager.GraphAgent", _capture),
+            patch("bolna.agent_manager.task_manager.KnowledgeBaseAgent", _capture),
+        ):
+            tm._TaskManager__get_agent_object(MagicMock(), agent_type)
+        assert "prompt_cache_key" not in captured
+
+
+class TestAgentPassthrough:
+    """Each agent filters its config through a second allowlist before reaching the LLM."""
+
+    def test_graph_agent_forwards_the_key(self):
+        config = {
+            "agent_information": "Test agent",
+            "model": "gpt-4.1-mini",
+            "provider": "openai",
+            "temperature": 0.2,
+            "max_tokens": 150,
+            "prompt_cache_key": KEY,
+            "current_node_id": "start",
+            "nodes": [{"id": "start", "prompt": "hi", "edges": []}],
+        }
+        assert _captured_llm_kwargs(GraphAgent, config).get("prompt_cache_key") == KEY
+
+    def test_knowledgebase_agent_forwards_the_key(self):
+        config = {
+            "model": "gpt-4.1-mini",
+            "provider": "openai",
+            "temperature": 0.2,
+            "max_tokens": 150,
+            "prompt_cache_key": KEY,
+            "vector_store": {"provider": "lancedb", "vector_id": "test"},
+        }
+        assert _captured_llm_kwargs(KnowledgeBaseAgent, config).get("prompt_cache_key") == KEY


### PR DESCRIPTION
> **Closed unmerged 2026-09-07.** Re-measuring the cache shortfall by turn index *and* pool load
> together showed it is mostly prefix eviction under heavy load, which a routing key cannot fix,
> rather than the routing gap this addresses. Azure additionally scopes `prompt_cache_key` to
> GPT-5.6 and later model families, and our conversation model is `gpt-4.1-mini`. The consumer side
> (dashboard-backend#3016) is closed with it. The branch is intact and cheap to revive.

Sends `prompt_cache_key` on OpenAI and Azure conversation turns so a call's turns route to the same server and reuse the warm prompt prefix, instead of racing cache population on whichever machine each request lands on.

Measured on the provisioned Azure pool over three weekday mornings, 281,994 turns: cache hit rate by turn index is 25.8% on the first turn, 49.8% on turns 2-3, 73.6% on turns 4-7 and 88.5% from turn 8. Between turns the system prompt is unchanged and only the suffix grows, so everything the previous turn sent is already cacheable and the ceiling is about 88%. Late turns hit that ceiling; early turns do not, and the first four turns carry 71% of all metered input. Closing that gap is worth roughly a quarter of the pool's metered load.

Revives #653, which was closed unmerged.

## What changed

| File | Change |
|---|---|
| `azure_llm.py`, `openai_llm.py` | store the key in `model_args` when the caller supplies one |
| `openai_base.py` | `_build_responses_create_kwargs` reads it from `model_args`, the same way it reads `service_tier` |
| `task_manager.py` | forward the kwarg into `injected_cfg` at both agent-construction sites |
| `graph_agent.py`, `knowledgebase_agent.py` | add it to each agent's own kwarg allowlist |

`model_args` is spread into every chat-completions call, so streaming turns, the graph routing completion and the PTU overflow retry all carry the key without a line each. Simple agents receive it through `llm_class(**llm_config, **self.kwargs)`; graph and knowledgebase agents filter kwargs twice, so both allowlists needed the entry.

The key is opaque to bolna and only sent when a caller passes one, so an OpenAI-compatible `base_url` that does not understand the parameter is unaffected. `openai==2.36.0` accepts `prompt_cache_key` as a first-class parameter on both Chat Completions and Responses, so there is no `extra_body` wrapping and the WebSocket Responses path needs no special handling.

Aux LLMs (voicemail, extraction, summarisation, hangup checks) and the graph routing LLM are excluded. They run different prompts, so keying them to the conversation would place unrelated load on the machine holding the conversation prefix.

No behaviour change until a caller sets the key.
