### PR TITLE
chore(lint): clean up unused variables and enable ruff F841 rule

### DIFF
--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -1974,7 +1974,6 @@ class TaskManager(BaseManager):
         if self.task_config["task_type"] == "webhook":
             return
 
-        agent_type = (self.task_config["tools_config"].get("llm_agent") or {}).get("agent_type", "simple_llm_agent")
         self.is_local = local
         if task_id == 0:
             if (
@@ -3075,7 +3074,6 @@ class TaskManager(BaseManager):
             self.synthesizer_tasks.append(asyncio.ensure_future(task))
         elif self.tools["output"] is not None:
             logger.info("Synthesizer not the next step and hence simply returning back")
-            overall_time = time.time() - meta_info["llm_start_time"]
             # self.history = copy.deepcopy(self.interim_history)
             if is_function_call:
                 bos_packet = create_ws_data_packet("<beginning_of_stream>", meta_info)
@@ -3480,16 +3478,13 @@ class TaskManager(BaseManager):
                     logger.info(f"Merged API response into context_data: {list(response_data.keys())}")
             except (json.JSONDecodeError, TypeError) as e:
                 logger.debug(f"Could not parse API response as JSON for context merge: {e}")
-        if called_fun.startswith("check_availability_of_slots") and (
-            not get_res_values or (len(get_res_values) == 1 and len(get_res_values[0]) == 0)
+        if (
+            called_fun.startswith("book_appointment")
+            and "id" not in get_res_keys
+            and get_res_values
+            and get_res_values[0] == "no_available_users_found_error"
         ):
-            set_response_prompt = []
-        elif called_fun.startswith("book_appointment") and "id" not in get_res_keys:
-            if get_res_values and get_res_values[0] == "no_available_users_found_error":
-                function_response = "Sorry, the host isn't available at this time. Are you available at any other time?"
-            set_response_prompt = []
-        else:
-            set_response_prompt = function_response
+            function_response = "Sorry, the host isn't available at this time. Are you available at any other time?"
 
         textual_response = resp.get("textual_response", None)
         self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
@@ -4172,7 +4167,6 @@ class TaskManager(BaseManager):
                 return
 
         self.llm_processed_request_ids.add(self.current_request_id)
-        llm_response = ""
 
     def _enter_hangup_state(self):
         self.hangup_triggered = True
@@ -4242,7 +4236,7 @@ class TaskManager(BaseManager):
         await asyncio.sleep(2)
         try:
             from_number = self.context_data["recipient_data"]["from_number"]
-        except Exception as e:
+        except Exception:
             from_number = None
 
         call_sid = None
@@ -4528,13 +4522,9 @@ class TaskManager(BaseManager):
         sequence = meta_info.get("sequence", 0)
 
         # check if previous request id is not in transmitted request id
-        if self.previous_request_id is None:
-            is_first_message = True
-        elif self.previous_request_id not in self.llm_processed_request_ids:
+        if self.previous_request_id and self.previous_request_id not in self.llm_processed_request_ids:
             logger.info(f"Adding previous request id to LLM rejected request if")
             self.llm_rejected_request_ids.add(self.previous_request_id)
-        else:
-            skip_append_to_data = False
         return sequence
 
     def _trigger_voicemail_check(self, transcriber_message, meta_info, is_final=True):
@@ -6821,7 +6811,6 @@ class TaskManager(BaseManager):
 
                             if self.stream:
                                 if meta_info.get("is_first_chunk", False):
-                                    first_chunk_generation_timestamp = time.time()
                                     # is_first_chunk re-stamps on every frame once the turn's text is flushed.
                                     _ttfb = meta_info.get("synthesizer_latency")
                                     _tts_key = (sequence_id, _ttfb)
@@ -8415,10 +8404,10 @@ class TaskManager(BaseManager):
                         await self._run_llm_task(self.input_parameters)
                 except BolnaComponentError:
                     raise
-                except Exception as e:
+                except Exception:
                     raise
 
-        except asyncio.CancelledError as e:
+        except asyncio.CancelledError:
             traceback.print_exc()
             logger.info(f"Websocket got cancelled {self.task_id}")
 

--- a/bolna/helpers/function_calling_helpers.py
+++ b/bolna/helpers/function_calling_helpers.py
@@ -355,7 +355,7 @@ async def computed_api_response(response):
     try:
         get_res_keys = list(json.loads(response).keys())
         get_res_values = list(json.loads(response).values())
-    except Exception as e:
+    except Exception:
         pass
 
     return get_res_keys, get_res_values

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -395,9 +395,9 @@ def get_required_input_types(task):
     for i, chain in enumerate(task["toolchain"]["pipelines"]):
         first_model = chain[0]
         # An s2s pipeline takes caller audio directly, with no transcriber in front of it.
-        if chain[0] in ("transcriber", "s2s"):
+        if first_model in ("transcriber", "s2s"):
             input_types["audio"] = i
-        elif chain[0] == "synthesizer" or chain[0] == "llm":
+        elif first_model in ("synthesizer", "llm"):
             input_types["text"] = i
     return input_types
 
@@ -420,7 +420,7 @@ def format_messages(messages, use_system_prompt=False, include_tools=False):
             if content:
                 try:
                     formatted_string += "system: " + content + "\n"
-                except Exception as e:
+                except Exception:
                     pass
         elif role == "assistant":
             if content:
@@ -633,7 +633,7 @@ def get_synth_audio_format(audio_bytes):
     # input to this can be WAV or PCM
     try:
         audio_buffer = io.BytesIO(audio_bytes)
-        with wave.open(audio_buffer, "rb") as wav_file:
+        with wave.open(audio_buffer, "rb"):
             return "wav"
     except wave.Error:
         return "pcm"

--- a/bolna/input_handlers/default.py
+++ b/bolna/input_handlers/default.py
@@ -264,7 +264,7 @@ class DefaultInputHandler:
                     request = await self.websocket.receive_json()
                 await self.process_message(request)
 
-        except WebSocketDisconnect as e:
+        except WebSocketDisconnect:
             ws_data_packet = create_ws_data_packet(data=None, meta_info={"io": "default", "eos": True})
             await self.queues["transcriber"].put(ws_data_packet)
             self.running = False

--- a/bolna/transcriber/deepgram_transcriber.py
+++ b/bolna/transcriber/deepgram_transcriber.py
@@ -892,7 +892,7 @@ class DeepgramTranscriber(BaseTranscriber):
                         self.meta_info["deepgram_duration"] = deepgram_duration
                         logger.info(f"Received Deepgram Metadata with duration: {deepgram_duration}s")
 
-            except Exception as e:
+            except Exception:
                 traceback.print_exc()
                 self.interruption_signalled = False
 

--- a/bolna/transcriber/smallest_transcriber.py
+++ b/bolna/transcriber/smallest_transcriber.py
@@ -542,7 +542,6 @@ class SmallestTranscriber(BaseTranscriber):
 
                 # Get transcript text
                 transcript = data.get("transcript", "").strip()
-                full_transcript = data.get("full_transcript", "").strip()
                 is_final = data.get("is_final", False)
                 is_last = data.get("is_last", False)
                 detected_language = data.get("language")

--- a/local_setup/quickstart_server.py
+++ b/local_setup/quickstart_server.py
@@ -177,12 +177,12 @@ async def websocket_endpoint(agent_id: str, websocket: WebSocket, user_agent: st
     logger.info("Connected to ws")
     await websocket.accept()
     active_websockets.append(websocket)
-    agent_config, context_data = None, None
+    agent_config = None
     try:
         retrieved_agent_config = await redis_client.get(agent_id)
         logger.info(f"Retrieved agent config: {retrieved_agent_config}")
         agent_config = json.loads(retrieved_agent_config)
-    except Exception as e:
+    except Exception:
         traceback.print_exc()
         raise HTTPException(status_code=404, detail="Agent not found")
 

--- a/local_setup/telephony_server/plivo_api_server.py
+++ b/local_setup/telephony_server/plivo_api_server.py
@@ -57,7 +57,7 @@ async def make_call(request: Request):
 
         # adding hangup_url since plivo opens a 2nd websocket once the call is cut.
         # https://github.com/bolna-ai/bolna/issues/148#issuecomment-2127980509
-        call = plivo_client.calls.create(
+        plivo_client.calls.create(
             from_=plivo_phone_number,
             to_=call_details.get("recipient_phone_number"),
             answer_url=f"{telephony_host}/plivo_connect?bolna_host={bolna_host}&agent_id={agent_id}",

--- a/local_setup/telephony_server/twilio_api_server.py
+++ b/local_setup/telephony_server/twilio_api_server.py
@@ -57,7 +57,7 @@ async def make_call(request: Request):
         print(f"bolna_host: {bolna_host}")
 
         try:
-            call = twilio_client.calls.create(
+            twilio_client.calls.create(
                 to=call_details.get("recipient_phone_number"),
                 from_=twilio_phone_number,
                 url=f"{telephony_host}/twilio_connect?bolna_host={bolna_host}&agent_id={agent_id}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ target-version = "py310"
 select = [
     "E721",  # type comparison (use isinstance)
     "F811",  # redefined unused name
+    "F841",  # unused variable assignments
     "ISC",   # implicit string concatenation bugs
 ]
 

--- a/tests/test_expression_routing.py
+++ b/tests/test_expression_routing.py
@@ -68,7 +68,6 @@ def _make_agent(config_overrides=None):
     mock_llm = MagicMock()
     mock_llm.generate_stream = AsyncMock(return_value=_async_iter([]))
     mock_llm.trigger_function_call = False
-    mock_openai_client = MagicMock()
     mock_openai_llm_cls = MagicMock(return_value=mock_llm)
 
     with (

--- a/tests/test_router_nodes.py
+++ b/tests/test_router_nodes.py
@@ -32,7 +32,6 @@ def _make_agent(config):
     mock_llm = MagicMock()
     mock_llm.generate_stream = MagicMock(side_effect=lambda *a, **k: _async_iter([]))
     mock_llm.trigger_function_call = False
-    mock_openai_client = MagicMock()
     mock_openai_llm_cls = MagicMock(return_value=mock_llm)
 
     with (

--- a/tests/test_say_node_and_silence_policy.py
+++ b/tests/test_say_node_and_silence_policy.py
@@ -138,7 +138,6 @@ def _make_agent(config_overrides=None):
     mock_llm = MagicMock()
     mock_llm.generate_stream = AsyncMock(return_value=_async_iter([]))
     mock_llm.trigger_function_call = False
-    mock_openai_client = MagicMock()
     mock_openai_llm_cls = MagicMock(return_value=mock_llm)
 
     with (

--- a/tests/test_ws_responses_stream_reset.py
+++ b/tests/test_ws_responses_stream_reset.py
@@ -159,7 +159,7 @@ async def test_the_next_turn_after_an_abandoned_stream_reconnects():
     await agen.__anext__()
     await agen.aclose()
 
-    events = await _drain(t.stream_response({"input": "b"}))
+    await _drain(t.stream_response({"input": "b"}))
     assert t.connects == 2
     assert t.sockets[0].closed is True
     assert t._needs_reset is False
@@ -426,7 +426,6 @@ async def test_disconnect_does_not_leak_the_socket_a_prewarm_is_still_opening():
     inside that window would find nothing to close, then inherit a live socket nobody owns."""
     t = _transport([completed("r1")], [completed("r2")])
     await t.ensure_connected()
-    first = t._ws
 
     opening = asyncio.Event()
     release = asyncio.Event()


### PR DESCRIPTION
### Summary
Continuing the linting roadmap documented in `pyproject.toml` (`# Roadmap: F541 → UP → F401 → F841 → I → E`).

This PR:
1. Cleans up all 26 unused local variable assignments (`F841`) across `bolna/`, `local_setup/`, and `tests/`.
2. Activates `"F841"` under `[tool.ruff.lint.select]` in `pyproject.toml` so future PRs remain free of dead variables and shadowed exception bindings.

### Testing
- `ruff check .` -> Passed
- `ruff format --check --diff` -> Passed
- `pre-commit run --all-files` -> Passed
- Full test suite: `1474 passed, 1 skipped`
