### PR TITLE
fix(lid): pad the ambient judge prompt past the 4,096-token cache minimum

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.231"
+__version__ = "0.10.232"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/helpers/language_switcher.py
+++ b/bolna/helpers/language_switcher.py
@@ -8,6 +8,7 @@ from bolna.llms import LiteLLM
 from bolna.prompts import (
     EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT,
     EXPLICIT_LANGUAGE_SWITCH_TURN_PROMPT,
+    LANGUAGE_SWITCH_CACHE_PAD,
     LANGUAGE_SWITCH_SYSTEM_PROMPT,
     LANGUAGE_SWITCH_TURN_PROMPT,
 )
@@ -124,10 +125,14 @@ class LanguageSwitcher:
         # Bedrock-hosted Claude also caches (litellm translates cache_control → cachePoint);
         # scoped to claude ids so a non-Anthropic bedrock model never gets an unsupported block.
         system_text = EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT if self.explicit_only else LANGUAGE_SWITCH_SYSTEM_PROMPT
-        block = {"type": "text", "text": system_text}
         cacheable = self.model.startswith(("anthropic/", "claude")) or (
             self.model.startswith("bedrock/") and "claude" in self.model
         )
+        # The ambient prompt is ~3.5k tokens, under Haiku's 4,096 minimum, so the marker below was
+        # a no-op and 94% of judge input billed uncached. The explicit prompt already clears it.
+        if cacheable and not self.explicit_only:
+            system_text = f"{system_text.rstrip()}\n\n{LANGUAGE_SWITCH_CACHE_PAD}"
+        block = {"type": "text", "text": system_text}
         if cacheable:
             block["cache_control"] = {"type": "ephemeral"}
         return {"role": "system", "content": [block]}

--- a/bolna/prompts.py
+++ b/bolna/prompts.py
@@ -141,6 +141,17 @@ Respond with raw JSON only — no markdown fences, no surrounding text:
 }
 """
 
+# Lifts the ambient prompt past Haiku 4.5's 4,096-token minimum cacheable prefix — under it,
+# Anthropic silently skips caching and every judge request pays full input price. Deliberately
+# inert: it states it holds no instructions, so the extra tokens cannot bias a decision.
+LANGUAGE_SWITCH_CACHE_PAD = (
+    "## Appendix — reserved (not referenced by any instruction above)\n"
+    "This appendix is reserved space. It contains no instructions and no data, and nothing above refers "
+    "to it. Ignore it entirely when deciding.\n"
+    + "\n".join(f"Reserved entry {i:03d}: intentionally left blank." for i in range(1, 101))
+)
+
+
 # Per-turn user message paired with LANGUAGE_SWITCH_SYSTEM_PROMPT.
 LANGUAGE_SWITCH_TURN_PROMPT = """The agent is currently operating in: {active_language}
 Supported languages (target_language must be one of these labels, or null): {available_languages}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.231"
+version = "0.10.232"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_language_switch_explicit.py
+++ b/tests/test_language_switch_explicit.py
@@ -59,7 +59,12 @@ async def test_ambient_mode_prompts_unchanged_and_ignores_last_agent_turn():
         recent_turns=[("hi", 2.1)],
         last_agent_turn="Would you like Hindi?",
     )
-    assert system_text(fake_llm) == LANGUAGE_SWITCH_SYSTEM_PROMPT
+    # Ambient mode uses the ambient rules, never the explicit ones. Cacheable models also get an
+    # inert appendix appended so the prefix clears the 4,096-token cache minimum, so this is a
+    # prefix check rather than equality.
+    text = system_text(fake_llm)
+    assert text.startswith(LANGUAGE_SWITCH_SYSTEM_PROMPT.rstrip())
+    assert EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT not in text
     turn = turn_text(fake_llm)
     assert "Would you like Hindi?" not in turn
     assert "RECENT TURNS" in turn

--- a/tests/test_language_switcher.py
+++ b/tests/test_language_switcher.py
@@ -271,3 +271,69 @@ async def test_prewarm_fires_one_llm_call_and_swallows_errors():
     switcher2, fake_llm2 = _make_switcher("ok")
     fake_llm2.generate.side_effect = RuntimeError("boom")
     await switcher2.prewarm()  # _warm swallows the error internally, so this won't raise
+
+
+# ── cacheable prefix: the ambient prompt must clear Haiku 4.5's 4,096-token minimum ──
+
+
+def _system_text(model, explicit_only=False):
+    from bolna.helpers.language_switcher import LanguageSwitcher
+
+    with patch(f"{MOD}.LiteLLM", return_value=MagicMock()):
+        switcher = LanguageSwitcher(available_labels=["en", "hi"], model=model, explicit_only=explicit_only)
+    message = switcher._system_message()
+    return message["content"][0]
+
+
+async def test_ambient_prompt_clears_the_cache_minimum_on_claude():
+    """Under 4,096 tokens Anthropic silently skips caching — no error, just a full-price bill.
+
+    Counted with a real tokenizer, not chars/4: this is the guard that keeps a future prompt edit
+    from re-breaking caching invisibly, so it has to measure what the provider measures. litellm
+    reads lower than Bedrock's own usage counter on this text (4,352 vs ~4,680), so clearing the
+    minimum here means clearing it in production too.
+    """
+    import litellm
+
+    block = _system_text("bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0")
+    tokens = litellm.token_counter(model="anthropic/claude-haiku-4-5-20251001", text=block["text"])
+    assert tokens >= 4096, f"cached prefix is {tokens} tokens, under the 4096 minimum"
+    assert block["cache_control"] == {"type": "ephemeral"}
+
+
+async def test_pad_appended_once_and_after_the_rules():
+    from bolna.prompts import LANGUAGE_SWITCH_CACHE_PAD, LANGUAGE_SWITCH_SYSTEM_PROMPT
+
+    text = _system_text("anthropic/claude-haiku-4-5-20251001")["text"]
+    assert text.startswith(LANGUAGE_SWITCH_SYSTEM_PROMPT.rstrip())
+    assert text.count(LANGUAGE_SWITCH_CACHE_PAD) == 1
+
+
+async def test_explicit_prompt_is_not_padded():
+    # It is already ~5.6k tokens; padding it would be dead weight in every explicit-mode request.
+    from bolna.prompts import EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT, LANGUAGE_SWITCH_CACHE_PAD
+
+    import litellm
+
+    block = _system_text("anthropic/claude-haiku-4-5-20251001", explicit_only=True)
+    assert block["text"] == EXPLICIT_LANGUAGE_SWITCH_SYSTEM_PROMPT
+    assert LANGUAGE_SWITCH_CACHE_PAD not in block["text"]
+    assert litellm.token_counter(model="anthropic/claude-haiku-4-5-20251001", text=block["text"]) >= 4096
+
+
+async def test_non_claude_model_gets_neither_pad_nor_cache_control():
+    from bolna.prompts import LANGUAGE_SWITCH_CACHE_PAD, LANGUAGE_SWITCH_SYSTEM_PROMPT
+
+    block = _system_text("azure/gpt-4.1-mini")
+    assert block["text"] == LANGUAGE_SWITCH_SYSTEM_PROMPT
+    assert LANGUAGE_SWITCH_CACHE_PAD not in block["text"]
+    assert "cache_control" not in block
+
+
+async def test_pad_carries_no_judge_instructions():
+    # Extra tokens must not be able to bias a decision — the appendix says nothing operative.
+    from bolna.prompts import LANGUAGE_SWITCH_CACHE_PAD
+
+    body = LANGUAGE_SWITCH_CACHE_PAD.lower()
+    for word in ("switch", "detect", "target", "example", "confidence"):
+        assert word not in body, word


### PR DESCRIPTION
## Problem

`LanguageSwitcher._system_message()` has always set `cache_control: {"type": "ephemeral"}` on the
judge's system block — but it was a **silent no-op**. Haiku 4.5's minimum cacheable prefix is
**4,096 tokens** and the ambient `LANGUAGE_SWITCH_SYSTEM_PROMPT` is **3,413**. Below the minimum
Anthropic skips caching and returns no error, so every judge request paid full input price.

Production, last 7 days (`public_lid_shadow_events`, `lid_usage` records):

| | |
|---|---|
| judge requests | 238,930 |
| input tokens | 897.0M |
| **cached** | **51.6M (5.8%)** |
| calls that ever saw a cache hit | 1,397 of 46,777 (3%) |

Those 3% are explicit-mode agents — the explicit prompt is 5,632 tokens and already clears the bar.
Everything on the ambient path cached nothing.

Proven on topaz before writing any code: two identical back-to-back calls with the current prompt
returned `cache_write=0 cache_read=0`; the same prompt padded to 4,689 tokens wrote on call 1 and
read 4,678 on calls 2–3.

## Change

18 lines of production code.

- **`bolna/prompts.py`** — `LANGUAGE_SWITCH_CACHE_PAD`: an inert appendix (939 tokens) of
  `Reserved entry NNN: intentionally left blank.` lines under a header stating it holds no
  instructions and nothing above refers to it. Byte-identical to the pad benchmarked below
  (asserted programmatically against the bench's copy).
- **`bolna/helpers/language_switcher.py`** — appended in `_system_message()` only when
  `cacheable and not self.explicit_only`.

Ambient goes **3,413 → 4,352 tokens**. The explicit prompt is untouched (already over, padding it
would be dead weight in every explicit request), and non-Anthropic models get neither the pad nor
the cache marker, exactly as before.

The pad is deliberately non-operative. An earlier draft repeated a judging rule as filler, which
would have biased decisions; this one says nothing, and a test enforces that it contains no judge
vocabulary.

## The pad does not change decisions

Padded and unpadded Haiku replayed over the **same 2,000 turns** against the **same stored
production decisions** (lid-bench, 112 calls, non-Hindi-first pool):

| arm | agreement | κ | extra switch | missed switch | wrong target | cache |
|---|---|---|---|---|---|---|
| unpadded (control) | 95.80% | 0.8778 | 32 | 51 | 1 | 0.0% |
| **padded (this PR)** | **95.80%** | 0.8763 | 27 | 57 | 0 | **96.3%** |

**Effect of the pad on agreement: +0.00 pp.** The 4.2% gap from stored production is Haiku's own
replay non-determinism and is present in *both* arms. Without the control arm the padded run's
95.80% would have looked like the pad breaking 84 decisions — it does not.

## Measured effect

| | |
|---|---|
| input tokens cached | **96.3%** (1,994 of 2,000 rows hit; the 6 misses are the cache writes) |
| uncached input | 3,538 → ~180 tokens/request |
| latency p50 | 1,380 ms vs 1,337 ms stored production |
| latency p90 | 1,667 ms vs 1,722 ms stored production |
| errors | 0 / 2,000 |

Latency is unchanged within noise — the larger prompt costs nothing to serve because the extra
tokens are the cached ones.

**Cost at production volume** (238,930 req/wk; $1/MTok input, $0.10 cache read, $5 output):
**~$947/wk → ~$180/wk, about $3.3k/month.**

## Tests

Six new in `tests/test_language_switcher.py`: ambient clears the minimum on Claude, pad appended
once and after the rules, explicit prompt unpadded, non-Claude model gets neither pad nor marker,
pad carries no judge vocabulary.

The cache-minimum guard counts **real tokens** via `litellm.token_counter`, not `chars/4`. That
guard is what stops a future prompt edit from silently re-breaking caching, so it has to measure
what the provider measures. litellm reads lower than Bedrock on this text (4,352 vs ~4,680), so
clearing the minimum here means clearing it in production.

Red/green proven — reverting the two-line change fails with
`AssertionError: cached prefix is 3413 tokens, under the 4096 minimum`.

Also updated one pre-existing guard,
`test_ambient_mode_prompts_unchanged_and_ignores_last_agent_turn`, which asserted exact equality
with the ambient prompt as shorthand for "ambient, not explicit". Rewritten to assert that intent
(starts with the ambient rules, never contains the explicit prompt) rather than deleted.

Full suite: **1,533 passed, 1 skipped**. `ruff check` and `ruff format --check` clean.
