### PR TITLE
fix: don't show the injected silence nudge as a caller turn

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.235"
+__version__ = "0.10.236"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -7377,7 +7377,9 @@ class TaskManager(BaseManager):
             logger.error(f"Error in processing message output: {str(e)}")
 
     async def _inject_and_run_llm(self, injected_message: str):
-        self.conversation_history.append_user(injected_message)
+        # exclude_from_transcript, not exclude_from_llm: the nudge is the whole point for the
+        # LLM, but the caller never spoke it, so it must not surface as a user turn.
+        self.conversation_history.append_user(injected_message, exclude_from_transcript=True)
         meta_info = self.__get_updated_meta_info(
             {
                 "io": self.tools["output"].get_provider(),

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -148,8 +148,17 @@ class ConversationHistory:
         return popped
 
     def pop_and_merge_user(self, new_content: str) -> str:
+        """Fold a split-utterance tail back into the caller turn it belongs to.
+
+        A row flagged exclude_from_transcript is an engine control token (the silence nudge), not
+        caller speech. Merging it would paste the marker into a real utterance, where it surfaces
+        in the transcript and reads to the LLM as something the caller said, so its content is
+        dropped instead. The row still goes: the turn it was driving is being superseded.
+        """
         if self._messages and self._messages[-1].get("role") == ChatRole.USER:
             prev_user = self._messages.pop()
+            if prev_user.get("exclude_from_transcript"):
+                return new_content
             return prev_user["content"] + " " + new_content
         return new_content
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -412,6 +412,9 @@ def is_s2s_agent(task):
 def format_messages(messages, use_system_prompt=False, include_tools=False):
     formatted_string = ""
     for message in messages:
+        # Control tokens the engine injects for the LLM; the caller never said them.
+        if message.get("exclude_from_transcript"):
+            continue
         role = message["role"]
         content = message.get("content")
         tool_calls = message.get("tool_calls")

--- a/bolna/llms/message_models.py
+++ b/bolna/llms/message_models.py
@@ -29,7 +29,15 @@ class ChatMessage(BaseModel):
 # allowlist so a legitimate provider key (name, cache_control, multimodal parts) is never
 # silently dropped.
 INTERNAL_MESSAGE_KEYS = frozenset(
-    {"turn_id", "response_uid", "asr_turn_id", "sequence_id", "message_category", "exclude_from_llm"}
+    {
+        "turn_id",
+        "response_uid",
+        "asr_turn_id",
+        "sequence_id",
+        "message_category",
+        "exclude_from_llm",
+        "exclude_from_transcript",
+    }
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.235"
+version = "0.10.236"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_silence_marker_hidden_from_transcript.py
+++ b/tests/test_silence_marker_hidden_from_transcript.py
@@ -65,3 +65,65 @@ async def test_the_injection_marks_the_turn():
     assert row["content"] == MARKER
     assert row["exclude_from_transcript"] is True
     assert MARKER not in format_messages(tm.conversation_history.messages)
+
+
+# ── The two visibility flags are independent and point opposite ways ──────────────────────
+#
+#   exclude_from_llm         dropped by get_copy(),      kept by format_messages()
+#   exclude_from_transcript  kept by get_copy(),         dropped by format_messages()
+#
+# The online-check ("are you still there?") relies on the first, the silence nudge on the
+# second. Collapsing them — e.g. teaching format_messages to skip exclude_from_llm too —
+# would silently delete a line the caller actually heard.
+
+ONLINE_CHECK = "Hello, are you still there?"
+
+
+def _history_with_both_flags():
+    h = ConversationHistory()
+    h.append_user("I need help with my order")
+    h.append_assistant(ONLINE_CHECK, exclude_from_llm=True)
+    h.append_user(MARKER, exclude_from_transcript=True)
+    h.append_assistant("Sure, take your time.")
+    return h
+
+
+def test_an_llm_excluded_turn_still_appears_in_the_transcript():
+    """The caller heard the online check, so removing it would misreport the call."""
+    transcript = format_messages(_history_with_both_flags().messages)
+    assert ONLINE_CHECK in transcript
+    assert MARKER not in transcript
+
+
+def test_an_llm_excluded_turn_is_withheld_from_the_llm():
+    contents = [m.get("content") for m in _history_with_both_flags().get_copy()]
+    assert ONLINE_CHECK not in contents
+    assert MARKER in contents  # the nudge is the one thing that must survive to the LLM
+
+
+def test_the_flag_hides_an_assistant_row_too():
+    """The filter keys off the flag, not the role, so it must not be user-only by accident."""
+    h = ConversationHistory()
+    h.append_assistant("internal bookkeeping", exclude_from_transcript=True)
+    h.append_user("hello")
+    transcript = format_messages(h.messages)
+    assert "internal bookkeeping" not in transcript
+    assert "user: hello" in transcript
+
+
+def test_consecutive_nudges_all_stay_hidden():
+    h = ConversationHistory()
+    h.append_assistant("Are you there?")
+    h.append_user("[silence] User was silent for 12.0 seconds", exclude_from_transcript=True)
+    h.append_user("[silence] User was silent for 24.0 seconds", exclude_from_transcript=True)
+    h.append_user("sorry, I am back")
+    transcript = format_messages(h.messages)
+    assert "[silence]" not in transcript
+    assert transcript.count("user:") == 1
+
+
+def test_the_filter_survives_the_other_format_messages_modes():
+    """use_system_prompt / include_tools take different branches inside the loop."""
+    h = _history_with_marker()
+    for kwargs in ({"use_system_prompt": True}, {"include_tools": True}):
+        assert MARKER not in format_messages(h.messages, **kwargs)

--- a/tests/test_silence_marker_hidden_from_transcript.py
+++ b/tests/test_silence_marker_hidden_from_transcript.py
@@ -127,3 +127,54 @@ def test_the_filter_survives_the_other_format_messages_modes():
     h = _history_with_marker()
     for kwargs in ({"use_system_prompt": True}, {"include_tools": True}):
         assert MARKER not in format_messages(h.messages, **kwargs)
+
+
+# ── The merge branch must not launder the marker into caller speech ───────────────────────
+#
+# _inject_and_run_llm sets response_in_pipeline, so a caller final arriving while the nudge is
+# still generating takes the overlapped branch in _handle_transcriber_output, which calls
+# pop_and_merge_user. That helper returns a bare string, so every kwarg on the popped row —
+# including the flag — was being discarded and the marker re-appended as a caller turn.
+
+
+def test_merging_onto_a_nudge_drops_the_marker_instead_of_concatenating_it():
+    h = ConversationHistory()
+    h.append_assistant("Are you still there?")
+    h.append_user(MARKER, exclude_from_transcript=True)
+
+    merged = h.pop_and_merge_user("Hello.")
+
+    assert merged == "Hello."
+    assert "[silence]" not in merged
+
+
+def test_merging_onto_a_real_caller_turn_still_concatenates():
+    """The split-utterance case the branch exists for must keep working."""
+    h = ConversationHistory()
+    h.append_user("my number is")
+
+    assert h.pop_and_merge_user("21 65") == "my number is 21 65"
+
+
+def test_the_nudge_row_leaves_history_on_merge():
+    h = ConversationHistory()
+    h.append_assistant("Are you still there?")
+    h.append_user(MARKER, exclude_from_transcript=True)
+
+    h.pop_and_merge_user("Hello.")
+
+    assert all(MARKER not in (m.get("content") or "") for m in h.messages)
+
+
+def test_the_merged_turn_reaches_neither_transcript_nor_llm_carrying_the_marker():
+    """End to end: what the caller said stands alone, in both views."""
+    h = ConversationHistory()
+    h.append_assistant("Are you still there?")
+    h.append_user(MARKER, exclude_from_transcript=True)
+
+    h.append_user(h.pop_and_merge_user("Hello."), asr_turn_id=7)
+
+    transcript = format_messages(h.messages)
+    assert "user: Hello." in transcript
+    assert "[silence]" not in transcript
+    assert all("[silence]" not in (m.get("content") or "") for m in h.get_copy())

--- a/tests/test_silence_marker_hidden_from_transcript.py
+++ b/tests/test_silence_marker_hidden_from_transcript.py
@@ -1,0 +1,67 @@
+"""The silence nudge is a control token for the LLM, not something the caller said.
+
+_inject_and_run_llm appends "[silence] User was silent for N seconds" as a user turn so the
+agent re-prompts. It has to stay in the LLM's history to do that job, but it must never surface
+as a caller utterance — and the N it prints is the configured threshold, not a measured gap.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.helpers.conversation_history import ConversationHistory
+from bolna.helpers.utils import format_messages
+from bolna.llms.message_models import INTERNAL_MESSAGE_KEYS, strip_internal_keys
+
+MARKER = "[silence] User was silent for 12.0 seconds"
+
+
+def _history_with_marker():
+    h = ConversationHistory()
+    h.append_assistant("Can you provide your Serial Number?")
+    h.append_user(MARKER, exclude_from_transcript=True)
+    h.append_assistant("Sure, take your time.")
+    h.append_user("VI 2.6 37080.")
+    return h
+
+
+def test_the_marker_is_absent_from_the_transcript():
+    transcript = format_messages(_history_with_marker().messages)
+    assert MARKER not in transcript
+    assert "[silence]" not in transcript
+    assert "user: VI 2.6 37080." in transcript  # real caller speech is untouched
+
+
+def test_the_llm_still_sees_the_marker():
+    """Dropping it from history would remove the nudge that makes the agent re-prompt."""
+    copy = _history_with_marker().get_copy()
+    assert any(m.get("content") == MARKER for m in copy)
+
+
+def test_the_marker_key_never_reaches_a_provider():
+    sent = strip_internal_keys(_history_with_marker().get_copy())
+    assert all("exclude_from_transcript" not in m for m in sent)
+    assert "exclude_from_transcript" in INTERNAL_MESSAGE_KEYS
+
+
+def test_an_ordinary_user_turn_is_never_filtered():
+    h = ConversationHistory()
+    h.append_user("I was silent for a while, sorry")
+    assert "user: I was silent for a while, sorry" in format_messages(h.messages)
+
+
+async def test_the_injection_marks_the_turn():
+    tm = TaskManager.__new__(TaskManager)
+    tm.conversation_history = ConversationHistory()
+    tm.tools = {"output": MagicMock()}
+    tm.task_config = {"tools_config": {"output": {"format": "pcm"}}}
+    tm.response_in_pipeline = False
+    tm._TaskManager__get_updated_meta_info = MagicMock(return_value={})
+    tm._run_llm_task = AsyncMock()
+
+    with patch("bolna.agent_manager.task_manager.asyncio.create_task", lambda coro: AsyncMock()()):
+        await TaskManager._inject_and_run_llm(tm, MARKER)
+
+    row = tm.conversation_history.messages[-1]
+    assert row["content"] == MARKER
+    assert row["exclude_from_transcript"] is True
+    assert MARKER not in format_messages(tm.conversation_history.messages)


### PR DESCRIPTION
Problem

user: [silence] User was silent for 12.0 seconds
assistant: Sure, take your time. Tell me when you are ready.

The caller never said that line, and the recording has no matching 12-second silence.

Cause

It's an internal control token. When repeat_after_silence_seconds elapses, task_manager calls

await self._inject_and_run_llm(f"[silence] User was silent for {self.repeat_after_silence_seconds} seconds")

and that helper did conversation_history.append_user(...) — a real user row. That history is what format_messages renders into executions.transcript and what the progression tab renders, so the nudge surfaces as caller speech.

The number is wrong too: it interpolates self.repeat_after_silence_seconds, the configured threshold, never a measurement. On this call the real gaps were 16.87 s, 33.83 s and 15.52 s (from __check_for_completion at 13:28:40 / 13:28:57 / 13:29:58) — never 12.0 s. The agent was also speaking through those gaps, so the audio isn't silent there either.

Change

New exclude_from_transcript message key — the mirror of the existing exclude_from_llm, which keeps a row in the transcript but out of the LLM's view. This one does the inverse:

- added to INTERNAL_MESSAGE_KEYS, so strip_internal_keys drops it before any provider call
- format_messages skips flagged rows
- _inject_and_run_llm sets it

Re-prompt behaviour is unchanged. The conversation LLM reads conversation_history.get_copy(), which filters only exclude_from_llm, so it still sees the nudge and still re-prompts. Only the rendering changes.

Also silenced by the same filter, all reasonable: extraction/summarization input (:2704), one trace log line (:3199), and the check_for_completion prompt (:4142) — a synthetic line shouldn't feed extraction or bias the hangup decision. The conversation path doesn't use format_messages.

Tests — tests/test_silence_marker_hidden_from_transcript.py (5): absent from the transcript; still present for the LLM; the key never reaches a provider; an ordinary user turn mentioning silence is untouched; and the injection marks the turn. 3 of 5 fail at HEAD. Suite 1533 passed, 1 skipped, ruff clean.