### PR TITLE
feat: opt-in governance middleware for PII, cost caps, and tool auth

### DIFF
--- a/bolna/agent_manager/assistant_manager.py
+++ b/bolna/agent_manager/assistant_manager.py
@@ -7,6 +7,7 @@ from .task_manager import TaskManager
 from bolna.helpers.logger_config import configure_logger
 from bolna.models import AGENT_WELCOME_MESSAGE
 from bolna.helpers.utils import update_prompt_with_context
+from bolna.governance import GovernanceLedger
 
 logger = configure_logger(__name__)
 
@@ -53,6 +54,9 @@ class AssistantManager(BaseManager):
         """
         if run_id:
             self.run_id = run_id
+
+        if self.kwargs.get("governance_ledger") is None:
+            self.kwargs["governance_ledger"] = GovernanceLedger()
 
         input_parameters = None
         for task_id, task in enumerate(self.tasks):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -58,7 +58,16 @@ from bolna.helpers.function_calling_helpers import (
     validate_outbound_url,
 )
 from bolna.helpers.conversation_history import ConversationHistory
+from bolna.governance import GovernanceMiddleware
 from .base_manager import BaseManager
+
+
+def _governance_of(owner):
+    """Stubs used in tests skip TaskManager.__init__ and have no governance attr."""
+    gov = getattr(owner, "governance", None)
+    return gov if gov is not None else GovernanceMiddleware.disabled()
+
+
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
@@ -383,6 +392,11 @@ class TaskManager(BaseManager):
         # Assistant persistance stuff
         self.assistant_id = assistant_id
         self.run_id = kwargs.get("run_id")
+        self.governance = GovernanceMiddleware.from_conversation_config(
+            task.get("task_config") or {},
+            run_id=self.run_id,
+            ledger=self.kwargs.get("governance_ledger"),
+        )
 
         self.mark_event_meta_data = MarkEventMetaData()
         self.sampling_rate = 24000
@@ -955,6 +969,12 @@ class TaskManager(BaseManager):
         latency_dict["cached_tokens"] = actual_cached_tokens
         if response_text:
             latency_dict["response_text"] = response_text.strip()
+        _governance_of(self).record_usage(
+            model=latency_dict.get("model"),
+            input_tokens=actual_input_tokens,
+            output_tokens=actual_output_tokens,
+            meta_info=meta_info,
+        )
 
     @staticmethod
     def _extract_api_call_runtime_args(resp):
@@ -3157,6 +3177,25 @@ class TaskManager(BaseManager):
     async def __execute_function_call(
         self, url, method, param, api_token, headers, model_args, meta_info, next_step, called_fun, **resp
     ):
+        auth = _governance_of(self).authorize_tool(called_fun, resp, meta_info)
+        if not auth.allow:
+            turn_id = meta_info.get("turn_id")
+            tool_result = json.dumps({"status": "denied", "message": auth.reason})
+            if resp.get("model_response") is not None:
+                self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
+            self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), tool_result)
+            convert_to_request_log(
+                tool_result, meta_info, None, "function_call", direction="response", run_id=self.run_id
+            )
+            logger.warning("governance denied tool %s reason=%s run_id=%s", called_fun, auth.reason, self.run_id)
+            # Feed the denial back so the model can tell the caller, instead of going silent.
+            if not self._governance_blocks_generation():
+                messages = self.conversation_history.get_copy()
+                followup_meta_info = self._spawn_followup_meta_info(meta_info)
+                await self.__do_llm_generation(
+                    messages, followup_meta_info, next_step, should_trigger_function_call=False
+                )
+            return
         self.check_if_user_online = False
         function_call_log = None
         turn_id = meta_info.get("turn_id")
@@ -4065,6 +4104,9 @@ class TaskManager(BaseManager):
         )
 
     async def _process_conversation_task(self, message, sequence, meta_info):
+        if self._governance_blocks_generation():
+            logger.info("governance blocked conversation LLM turn run_id=%s", self.run_id)
+            return
         should_bypass_synth = "bypass_synth" in meta_info and meta_info["bypass_synth"] is True
         next_step = self._get_next_step(sequence, "llm")
         meta_info["llm_start_time"] = time.time()
@@ -4628,8 +4670,23 @@ class TaskManager(BaseManager):
             reason,
         )
 
+    def _govern_user_text(self, text, meta_info=None):
+        """Redact PII on the ASR/text path. Always returns a string safe to store and send to the LLM."""
+        redacted, _decision = _governance_of(self).inspect_transcript(text or "", meta_info)
+        return redacted
+
+    def _governance_blocks_generation(self):
+        gov = _governance_of(self)
+        if not gov.allows_llm():
+            return True
+        decision = gov.check_budget()
+        return not decision.allow
+
     def kickoff_llm_generation(self, transcriber_message, meta_info):
         """Start the LLM turn for a final transcript (immediate path and settle-window path)."""
+        if self._governance_blocks_generation():
+            logger.info("governance blocked LLM generation run_id=%s", self.run_id)
+            return
         logger.info(f"Running llm Tasks")
         transcriber_package = create_ws_data_packet(transcriber_message, meta_info)
 
@@ -4767,6 +4824,7 @@ class TaskManager(BaseManager):
             )
 
         self.user_spoke = True
+        transcriber_message = self._govern_user_text(transcriber_message, meta_info)
         # asr_turn_id (int-coerced), not meta_info["turn_id"] — that one counts responses, not ASR turns.
         self.conversation_history.append_user(
             transcriber_message, asr_turn_id=asr_id_to_int(meta_info.get("asr_turn_id"))
@@ -6256,7 +6314,7 @@ class TaskManager(BaseManager):
         else:
             self.user_spoke = True
             # Reply to the caller's LAST utterance, not the whole buffer — with the
-            self.conversation_history.append_user(idle_flush_user_text)
+            self.conversation_history.append_user(self._govern_user_text(idle_flush_user_text))
             logger.info(
                 f"LanguageSwitcher: idle-flush — appended detector transcript as user turn {idle_flush_user_text[:80]!r}"
             )
@@ -7043,6 +7101,9 @@ class TaskManager(BaseManager):
     async def _synthesize(self, message):
         meta_info = message["meta_info"]
         text = message["data"]
+        if isinstance(text, str) and not meta_info.get("is_md5_hash"):
+            text, _dlp = _governance_of(self).inspect_output(text, meta_info)
+            message["data"] = text
         meta_info["type"] = "audio"
         meta_info["synthesizer_start_time"] = time.time()
         meta_info["tts_start_ms"] = round(
@@ -7314,6 +7375,10 @@ class TaskManager(BaseManager):
             logger.error(f"Error in processing message output: {str(e)}")
 
     async def _inject_and_run_llm(self, injected_message: str):
+        injected_message = self._govern_user_text(injected_message)
+        if self._governance_blocks_generation():
+            logger.info("governance blocked injected LLM turn run_id=%s", self.run_id)
+            return
         self.conversation_history.append_user(injected_message)
         meta_info = self.__get_updated_meta_info(
             {
@@ -7981,7 +8046,7 @@ class TaskManager(BaseManager):
                 if event.is_final and event.content:
                     logger.info(f"S2S caller: {event.content[:200]}")
                     self.user_spoke = True
-                    self.conversation_history.append_user(event.content)
+                    self.conversation_history.append_user(self._govern_user_text(event.content))
                     self.time_since_last_spoken_human_word = time.time()
                     # Cleared here rather than in the output loop: the prompt's audio is not
                     # distinguishable from any other turn, but the caller answering is.
@@ -8177,6 +8242,14 @@ class TaskManager(BaseManager):
             args = json.loads(event.arguments or "{}")
         except ValueError:
             args = {}
+
+        auth = _governance_of(self).authorize_tool(event.name, args, meta_info)
+        if not auth.allow:
+            denied = json.dumps({"status": "denied", "message": auth.reason})
+            await s2s.send_function_result(event.call_id, event.name, denied)
+            await s2s.commit_function_results()
+            logger.warning("governance denied s2s tool %s reason=%s run_id=%s", event.name, auth.reason, self.run_id)
+            return
 
         logger.info(f"S2S tool call: {event.name} args={args}")
         convert_to_request_log(
@@ -8584,6 +8657,7 @@ class TaskManager(BaseManager):
                     "conversation_time": time.time() - self.start_time,
                     "label_flow": self.label_flow,
                     "function_tool_api_call_details": copy.deepcopy(self.function_tool_api_call_details),
+                    "governance_receipts": _governance_of(self).receipts(),
                     "lid_detection_events": list(self.__snapshot_lid_events()),
                     "asr_lid_events": self._collect_flux_lid_events(),
                     "language_switch_events": list(self.language_switch_events),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -60,14 +60,6 @@ from bolna.helpers.function_calling_helpers import (
 from bolna.helpers.conversation_history import ConversationHistory
 from bolna.governance import GovernanceMiddleware
 from .base_manager import BaseManager
-
-
-def _governance_of(owner):
-    """Stubs used in tests skip TaskManager.__init__ and have no governance attr."""
-    gov = getattr(owner, "governance", None)
-    return gov if gov is not None else GovernanceMiddleware.disabled()
-
-
 from .interruption_manager import InterruptionManager
 from bolna.agent_types import *
 from bolna.providers import *
@@ -127,6 +119,19 @@ from .models import ComponentLatencies
 from .voicemail_handler import VoicemailHandler
 
 logger = configure_logger(__name__)
+
+
+def _governance_of(owner):
+    """Missing or stub governance must not fail the call."""
+    gov = getattr(owner, "governance", None)
+    if not isinstance(gov, GovernanceMiddleware):
+        return GovernanceMiddleware.disabled()
+    return gov
+
+
+def _govern_text(owner, text, meta_info=None):
+    redacted, _decision = _governance_of(owner).inspect_transcript(text or "", meta_info)
+    return redacted
 
 
 @lru_cache(maxsize=256)
@@ -2722,6 +2727,9 @@ class TaskManager(BaseManager):
             self.webhook_response = await self.tools["webhook_agent"].execute(extraction_details)
             logger.info(f"Response from the server {self.webhook_response}")
         else:
+            if self._governance_blocks_generation():
+                logger.info("governance blocked follow-up task run_id=%s", self.run_id)
+                return
             message = format_messages(
                 self.input_parameters["messages"], include_tools=True
             )  # Remove the initial system prompt
@@ -3177,12 +3185,23 @@ class TaskManager(BaseManager):
     async def __execute_function_call(
         self, url, method, param, api_token, headers, model_args, meta_info, next_step, called_fun, **resp
     ):
-        auth = _governance_of(self).authorize_tool(called_fun, resp, meta_info)
+        runtime_args = self._extract_api_call_runtime_args(resp)
+        runtime_args.pop("tool_call_id", None)
+        runtime_args.pop("resp", None)
+        gov = _governance_of(self)
+        auth = gov.authorize_tool(called_fun, runtime_args, meta_info)
+        if auth.allow:
+            budget = gov.check_budget()
+            if not budget.allow:
+                auth = budget
         if not auth.allow:
             turn_id = meta_info.get("turn_id")
             tool_result = json.dumps({"status": "denied", "message": auth.reason})
             if resp.get("model_response") is not None:
-                self.conversation_history.attach_tool_calls_to_turn(turn_id, resp["model_response"])
+                model_response = resp["model_response"]
+                if isinstance(model_response, str):
+                    model_response, _ = _governance_of(self).inspect_output(model_response)
+                self.conversation_history.attach_tool_calls_to_turn(turn_id, model_response)
             self.conversation_history.append_tool_result(resp.get("tool_call_id", ""), tool_result)
             convert_to_request_log(
                 tool_result, meta_info, None, "function_call", direction="response", run_id=self.run_id
@@ -3594,6 +3613,8 @@ class TaskManager(BaseManager):
         llm_latency=None,
     ):
         self.llm_response_generated = True
+        if isinstance(llm_response, str):
+            llm_response, _ = _governance_of(self).inspect_output(llm_response, meta_info)
         # task 0 only, so aux LLMs (hangup/voicemail) never tally, and never an overflowed turn,
         # which ran on another backend. Cached is exempt and output is weighted by the consumer.
         if self.task_id == 0 and input_tokens:
@@ -4114,6 +4135,7 @@ class TaskManager(BaseManager):
         self._append_eager_llm_stub(meta_info)
 
         if self.turn_based_conversation:
+            message["data"] = self._govern_user_text(message.get("data") or "", meta_info)
             self.history.append({"role": "user", "content": message["data"]})
         messages = self.conversation_history.get_copy()
 
@@ -4672,8 +4694,7 @@ class TaskManager(BaseManager):
 
     def _govern_user_text(self, text, meta_info=None):
         """Redact PII on the ASR/text path. Always returns a string safe to store and send to the LLM."""
-        redacted, _decision = _governance_of(self).inspect_transcript(text or "", meta_info)
-        return redacted
+        return _govern_text(self, text, meta_info)
 
     def _governance_blocks_generation(self):
         gov = _governance_of(self)
@@ -4778,16 +4799,17 @@ class TaskManager(BaseManager):
             self._retire_dropped_response(meta_info, "speech_started_before_welcome_finished")
             return
 
-        if self.conversation_history.is_duplicate_user(transcriber_message):
-            logger.info(f"Skipping duplicate transcript (same content): {transcriber_message}")
-            self._retire_dropped_response(meta_info, "duplicate_user_transcript")
-            return
-
         self._trigger_voicemail_check(transcriber_message, meta_info, is_final=True)
 
         if self.voicemail_handler.detected:
             logger.info("Voicemail already detected - skipping normal transcriber output processing")
             self._retire_dropped_response(meta_info, "voicemail_detected")
+            return
+
+        transcriber_message = self._govern_user_text(transcriber_message, meta_info)
+        if self.conversation_history.is_duplicate_user(transcriber_message):
+            logger.info(f"Skipping duplicate transcript (same content): {transcriber_message}")
+            self._retire_dropped_response(meta_info, "duplicate_user_transcript")
             return
 
         await self.language_detector.collect_transcript(transcriber_message)
@@ -4824,7 +4846,6 @@ class TaskManager(BaseManager):
             )
 
         self.user_spoke = True
-        transcriber_message = self._govern_user_text(transcriber_message, meta_info)
         # asr_turn_id (int-coerced), not meta_info["turn_id"] — that one counts responses, not ASR turns.
         self.conversation_history.append_user(
             transcriber_message, asr_turn_id=asr_id_to_int(meta_info.get("asr_turn_id"))
@@ -5143,7 +5164,7 @@ class TaskManager(BaseManager):
                     elif (
                         isinstance(message.get("data"), dict) and message["data"].get("type", "") == "eager_end_of_turn"
                     ):
-                        eager_transcript = message["data"].get("content", "").strip()
+                        eager_transcript = self._govern_user_text(message["data"].get("content", "").strip())
                         eot_confidence = message["data"].get("confidence")
                         logger.info(f"EagerEndOfTurn received (confidence={eot_confidence}): {eager_transcript}")
 
@@ -6292,7 +6313,12 @@ class TaskManager(BaseManager):
         # produced no turn at all, so append the detector transcript as the user turn.
         transcript_corrected = True
         if active_transcript:
-            replaced = self.conversation_history.replace_last_user(active_transcript, detector_transcript)
+            detector_clean = _govern_text(self, detector_transcript)
+            replaced = self.conversation_history.replace_last_user(active_transcript, detector_clean)
+            if not replaced:
+                replaced = self.conversation_history.replace_last_user(
+                    _govern_text(self, active_transcript), detector_clean
+                )
             if not replaced:
                 # A newer turn landed during decide; the truncate cancelled its generation,
                 transcript_corrected = False
@@ -6314,7 +6340,7 @@ class TaskManager(BaseManager):
         else:
             self.user_spoke = True
             # Reply to the caller's LAST utterance, not the whole buffer — with the
-            self.conversation_history.append_user(self._govern_user_text(idle_flush_user_text))
+            self.conversation_history.append_user(_govern_text(self, idle_flush_user_text))
             logger.info(
                 f"LanguageSwitcher: idle-flush — appended detector transcript as user turn {idle_flush_user_text[:80]!r}"
             )
@@ -6707,11 +6733,19 @@ class TaskManager(BaseManager):
             for i in range(len(messages) - 1, -1, -1):
                 if messages[i].get("role") == "user":
                     if messages[i].get("content", "").strip() == active_transcript.strip():
-                        messages[i] = {"role": "user", "content": detector_transcript}
+                        messages[i] = {
+                            "role": "user",
+                            "content": _govern_text(self, detector_transcript),
+                        }
                     break
         else:
             # Idle-flush: the locked ASR produced no turn — append the SAME trailing-utterance
-            messages.append({"role": "user", "content": idle_user_text or detector_transcript})
+            messages.append(
+                {
+                    "role": "user",
+                    "content": _govern_text(self, idle_user_text or detector_transcript),
+                }
+            )
         spec_meta = {
             "request_id": str(uuid.uuid4()),
             "sequence_id": -1,

--- a/bolna/governance/__init__.py
+++ b/bolna/governance/__init__.py
@@ -1,0 +1,3 @@
+from .middleware import GovernanceDecision, GovernanceLedger, GovernanceMiddleware
+
+__all__ = ["GovernanceDecision", "GovernanceLedger", "GovernanceMiddleware"]

--- a/bolna/governance/middleware.py
+++ b/bolna/governance/middleware.py
@@ -49,6 +49,7 @@ class GovernanceLedger:
     input_tokens: int = 0
     output_tokens: int = 0
     receipts: list[dict] = field(default_factory=list)
+    source_config: dict | None = None
 
 
 class GovernanceMiddleware:
@@ -68,10 +69,22 @@ class GovernanceMiddleware:
         self.usd_per_1m_output = cfg.get("usd_per_1m_output")
         allowed = cfg.get("allowed_tools")
         denied = cfg.get("denied_tools")
-        self.allowed_tools = {str(x) for x in allowed} if allowed else None
+        self.allowed_tools = {str(x) for x in allowed} if allowed is not None else None
         self.denied_tools = {str(x) for x in denied} if denied else set()
         self.run_id = run_id
         self.ledger = ledger or GovernanceLedger()
+        if self.enabled and getattr(self.ledger, "source_config", None) is None:
+            self.ledger.source_config = dict(cfg)
+        elif not self.enabled and getattr(self.ledger, "source_config", None):
+            inherited = dict(self.ledger.source_config)
+            self.enabled = True
+            self.mode = (inherited.get("mode") or "enforce").lower()
+            self.redact_pii = bool(inherited.get("redact_pii", True))
+            self.output_dlp = bool(inherited.get("output_dlp", True))
+            self.max_cost_per_call = None
+            self.max_cost_per_session = inherited.get("max_cost_per_session")
+            self.usd_per_1m_input = inherited.get("usd_per_1m_input")
+            self.usd_per_1m_output = inherited.get("usd_per_1m_output")
         self._call_usd = 0.0
         self._blocked_llm = False
 
@@ -182,11 +195,9 @@ class GovernanceMiddleware:
     def _estimate_usd(self, model, input_tokens, output_tokens) -> float:
         in_tok = int(input_tokens or 0)
         out_tok = int(output_tokens or 0)
-        if self.usd_per_1m_input is not None or self.usd_per_1m_output is not None:
-            in_rate = float(self.usd_per_1m_input or 0)
-            out_rate = float(self.usd_per_1m_output or 0)
-        else:
-            in_rate, out_rate = _DEFAULT_RATES.get(_normalize_model(model), _FALLBACK_RATE)
+        default_in, default_out = _DEFAULT_RATES.get(_normalize_model(model), _FALLBACK_RATE)
+        in_rate = float(self.usd_per_1m_input) if self.usd_per_1m_input is not None else default_in
+        out_rate = float(self.usd_per_1m_output) if self.usd_per_1m_output is not None else default_out
         return (in_tok / 1_000_000.0) * in_rate + (out_tok / 1_000_000.0) * out_rate
 
     def record_usage(self, *, model=None, input_tokens=None, output_tokens=None, meta_info=None) -> GovernanceDecision:
@@ -226,6 +237,10 @@ class GovernanceMiddleware:
     def check_budget(self) -> GovernanceDecision:
         if not self.enabled:
             return GovernanceDecision(True, "allow", "governance_disabled", {})
+        if self._blocked_llm:
+            return GovernanceDecision(
+                not self._enforce(), "deny" if self._enforce() else "monitor_deny", "already_blocked", {}
+            )
         breached = self._budget_breach()
         if not breached:
             return GovernanceDecision(True, "allow", "within_budget", {})

--- a/bolna/governance/middleware.py
+++ b/bolna/governance/middleware.py
@@ -1,0 +1,244 @@
+"""Opt-in governance for the voice pipeline.
+
+Disabled by default. When enabled, every decision is regex/policy only — no extra
+LLM call — and emits a JSON receipt that never contains the original PII span.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass, field
+
+from bolna.helpers.logger_config import configure_logger
+
+from .patterns import DEFAULT_PII_TYPES, find_and_redact
+
+logger = configure_logger(__name__)
+
+# Rough USD / 1M tokens when the agent does not override rates. Estimates only.
+_DEFAULT_RATES = {
+    "gpt-4o-mini": (0.15, 0.60),
+    "gpt-4o": (2.50, 10.00),
+    "gpt-4.1-mini": (0.40, 1.60),
+    "gpt-4.1": (2.00, 8.00),
+    "gpt-4.1-nano": (0.10, 0.40),
+}
+_FALLBACK_RATE = (0.50, 1.50)
+
+
+def _normalize_model(model: str | None) -> str:
+    if not model:
+        return ""
+    return model.split("/")[-1].strip().lower()
+
+
+@dataclass
+class GovernanceDecision:
+    allow: bool
+    action: str
+    reason: str
+    receipt: dict
+
+
+@dataclass
+class GovernanceLedger:
+    """Shared across tasks in one run so per-session caps survive extraction steps."""
+
+    estimated_usd: float = 0.0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    receipts: list[dict] = field(default_factory=list)
+
+
+class GovernanceMiddleware:
+    def __init__(self, config: dict | None, run_id: str | None, ledger: GovernanceLedger | None = None):
+        cfg = dict(config or {})
+        self.enabled = bool(cfg.get("enabled"))
+        self.mode = (cfg.get("mode") or "enforce").lower()
+        if self.mode not in ("enforce", "monitor"):
+            self.mode = "enforce"
+        self.redact_pii = cfg.get("redact_pii", True)
+        self.output_dlp = cfg.get("output_dlp", True)
+        pii_types = cfg.get("pii_types")
+        self.pii_types = tuple(pii_types) if pii_types else DEFAULT_PII_TYPES
+        self.max_cost_per_call = cfg.get("max_cost_per_call")
+        self.max_cost_per_session = cfg.get("max_cost_per_session")
+        self.usd_per_1m_input = cfg.get("usd_per_1m_input")
+        self.usd_per_1m_output = cfg.get("usd_per_1m_output")
+        allowed = cfg.get("allowed_tools")
+        denied = cfg.get("denied_tools")
+        self.allowed_tools = {str(x) for x in allowed} if allowed else None
+        self.denied_tools = {str(x) for x in denied} if denied else set()
+        self.run_id = run_id
+        self.ledger = ledger or GovernanceLedger()
+        self._call_usd = 0.0
+        self._blocked_llm = False
+
+    @classmethod
+    def from_conversation_config(cls, conversation_config, run_id, ledger=None):
+        cfg = conversation_config or {}
+        if hasattr(cfg, "model_dump"):
+            cfg = cfg.model_dump()
+        elif hasattr(cfg, "dict"):
+            cfg = cfg.dict()
+        gov = cfg.get("governance") if isinstance(cfg, dict) else None
+        if hasattr(gov, "model_dump"):
+            gov = gov.model_dump()
+        elif hasattr(gov, "dict"):
+            gov = gov.dict()
+        return cls(gov, run_id, ledger=ledger)
+
+    @classmethod
+    def disabled(cls, run_id=None):
+        return cls({"enabled": False}, run_id)
+
+    def _receipt(self, *, stage, action, reason, extra=None):
+        body = {
+            "id": str(uuid.uuid4()),
+            "ts": round(time.time(), 6),
+            "run_id": self.run_id,
+            "stage": stage,
+            "action": action,
+            "reason": reason,
+            "mode": self.mode,
+        }
+        if extra:
+            body.update(extra)
+        self.ledger.receipts.append(body)
+        return body
+
+    def _enforce(self) -> bool:
+        return self.mode == "enforce"
+
+    def receipts(self) -> list[dict]:
+        return list(self.ledger.receipts)
+
+    def allows_llm(self) -> bool:
+        if not self.enabled:
+            return True
+        return not (self._enforce() and self._blocked_llm)
+
+    def inspect_transcript(self, text: str, meta_info=None) -> tuple[str, GovernanceDecision]:
+        if not self.enabled or not self.redact_pii:
+            return text, GovernanceDecision(True, "allow", "governance_disabled", {})
+        redacted, labels = find_and_redact(text, self.pii_types)
+        if not labels:
+            return text, GovernanceDecision(True, "allow", "no_pii", {})
+        receipt = self._receipt(
+            stage="transcript_pii",
+            action="redact",
+            reason="pii_detected",
+            extra={"pii_types": labels, "origin": (meta_info or {}).get("origin", "transcriber")},
+        )
+        logger.info(f"governance redacted transcript pii={labels} run_id={self.run_id}")
+        return redacted, GovernanceDecision(True, "redact", "pii_detected", receipt)
+
+    def inspect_output(self, text: str, meta_info=None) -> tuple[str, GovernanceDecision]:
+        if not self.enabled or not self.output_dlp:
+            return text, GovernanceDecision(True, "allow", "governance_disabled", {})
+        if not isinstance(text, str):
+            return text, GovernanceDecision(True, "allow", "non_text", {})
+        redacted, labels = find_and_redact(text, self.pii_types)
+        if not labels:
+            return text, GovernanceDecision(True, "allow", "no_pii", {})
+        receipt = self._receipt(
+            stage="output_dlp",
+            action="redact",
+            reason="pii_detected",
+            extra={"pii_types": labels},
+        )
+        logger.info(f"governance redacted synthesizer pii={labels} run_id={self.run_id}")
+        return redacted, GovernanceDecision(True, "redact", "pii_detected", receipt)
+
+    def authorize_tool(self, name: str, arguments=None, meta_info=None) -> GovernanceDecision:
+        if not self.enabled:
+            return GovernanceDecision(True, "allow", "governance_disabled", {})
+        extra = {"tool": name}
+        if name in self.denied_tools:
+            receipt = self._receipt(stage="tool_auth", action="deny", reason="tool_denied", extra=extra)
+            if self._enforce():
+                logger.warning(f"governance denied tool {name} run_id={self.run_id}")
+                return GovernanceDecision(False, "deny", "tool_denied", receipt)
+            return GovernanceDecision(True, "monitor_deny", "tool_denied", receipt)
+        if self.allowed_tools is not None and name not in self.allowed_tools:
+            receipt = self._receipt(stage="tool_auth", action="deny", reason="tool_not_allowlisted", extra=extra)
+            if self._enforce():
+                logger.warning(f"governance blocked non-allowlisted tool {name} run_id={self.run_id}")
+                return GovernanceDecision(False, "deny", "tool_not_allowlisted", receipt)
+            return GovernanceDecision(True, "monitor_deny", "tool_not_allowlisted", receipt)
+        if arguments:
+            blob = arguments if isinstance(arguments, str) else str(arguments)
+            _, labels = find_and_redact(blob, self.pii_types)
+            if labels:
+                extra["pii_types"] = labels
+                receipt = self._receipt(stage="tool_auth", action="deny", reason="tool_args_pii", extra=extra)
+                if self._enforce():
+                    return GovernanceDecision(False, "deny", "tool_args_pii", receipt)
+                return GovernanceDecision(True, "monitor_deny", "tool_args_pii", receipt)
+        receipt = self._receipt(stage="tool_auth", action="allow", reason="tool_authorized", extra=extra)
+        return GovernanceDecision(True, "allow", "tool_authorized", receipt)
+
+    def _estimate_usd(self, model, input_tokens, output_tokens) -> float:
+        in_tok = int(input_tokens or 0)
+        out_tok = int(output_tokens or 0)
+        if self.usd_per_1m_input is not None or self.usd_per_1m_output is not None:
+            in_rate = float(self.usd_per_1m_input or 0)
+            out_rate = float(self.usd_per_1m_output or 0)
+        else:
+            in_rate, out_rate = _DEFAULT_RATES.get(_normalize_model(model), _FALLBACK_RATE)
+        return (in_tok / 1_000_000.0) * in_rate + (out_tok / 1_000_000.0) * out_rate
+
+    def record_usage(self, *, model=None, input_tokens=None, output_tokens=None, meta_info=None) -> GovernanceDecision:
+        if not self.enabled:
+            return GovernanceDecision(True, "allow", "governance_disabled", {})
+        usd = self._estimate_usd(model, input_tokens, output_tokens)
+        self._call_usd += usd
+        self.ledger.estimated_usd += usd
+        self.ledger.input_tokens += int(input_tokens or 0)
+        self.ledger.output_tokens += int(output_tokens or 0)
+        extra = {
+            "model": model,
+            "input_tokens": int(input_tokens or 0),
+            "output_tokens": int(output_tokens or 0),
+            "estimated_usd": round(usd, 8),
+            "call_estimated_usd": round(self._call_usd, 8),
+            "session_estimated_usd": round(self.ledger.estimated_usd, 8),
+        }
+        breached = self._budget_breach()
+        if breached:
+            self._blocked_llm = True
+            receipt = self._receipt(stage="cost_cap", action="deny", reason=breached, extra=extra)
+            if self._enforce():
+                logger.warning(f"governance cost cap {breached} run_id={self.run_id} extra={extra}")
+                return GovernanceDecision(False, "deny", breached, receipt)
+            return GovernanceDecision(True, "monitor_deny", breached, receipt)
+        receipt = self._receipt(stage="cost_cap", action="allow", reason="within_budget", extra=extra)
+        return GovernanceDecision(True, "allow", "within_budget", receipt)
+
+    def _budget_breach(self) -> str | None:
+        if self.max_cost_per_call is not None and self._call_usd >= float(self.max_cost_per_call):
+            return "max_cost_per_call"
+        if self.max_cost_per_session is not None and self.ledger.estimated_usd >= float(self.max_cost_per_session):
+            return "max_cost_per_session"
+        return None
+
+    def check_budget(self) -> GovernanceDecision:
+        if not self.enabled:
+            return GovernanceDecision(True, "allow", "governance_disabled", {})
+        breached = self._budget_breach()
+        if not breached:
+            return GovernanceDecision(True, "allow", "within_budget", {})
+        self._blocked_llm = True
+        receipt = self._receipt(
+            stage="cost_cap",
+            action="deny",
+            reason=breached,
+            extra={
+                "call_estimated_usd": round(self._call_usd, 8),
+                "session_estimated_usd": round(self.ledger.estimated_usd, 8),
+            },
+        )
+        if self._enforce():
+            return GovernanceDecision(False, "deny", breached, receipt)
+        return GovernanceDecision(True, "monitor_deny", breached, receipt)

--- a/bolna/governance/patterns.py
+++ b/bolna/governance/patterns.py
@@ -1,0 +1,80 @@
+"""Compiled PII regexes. Deterministic, no network, no LLM."""
+
+from __future__ import annotations
+
+import re
+
+# Placeholders never contain the original span — receipts only store these labels.
+PLACEHOLDERS = {
+    "ssn": "[SSN]",
+    "credit_card": "[CREDIT_CARD]",
+    "email": "[EMAIL]",
+    "phone": "[PHONE]",
+    "account_number": "[ACCOUNT_NUMBER]",
+}
+
+DEFAULT_PII_TYPES = ("ssn", "credit_card", "email", "phone")
+
+# Dashed / spaced US SSN only. Bare 9-digit runs collide with order ids.
+_SSN = re.compile(r"\b\d{3}[-\s]\d{2}[-\s]\d{4}\b")
+
+# 13–19 digits with optional separators; Luhn-checked at match time.
+_CREDIT_CARD = re.compile(r"\b(?:\d[ -]*?){13,19}\b")
+
+_EMAIL = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+# E.164 or common North-American spoken forms. Require a separator or leading +.
+_PHONE = re.compile(r"(?<!\d)(?:\+?1[-.\s]*)?(?:\(?\d{3}\)?[-.\s]\d{3}[-.\s]\d{4}|\+\d{10,15})(?!\d)")
+
+# Long digit runs that are not phones (12–17). Off unless the agent opts in.
+_ACCOUNT = re.compile(r"\b\d{12,17}\b")
+
+_COMPILED = {
+    "ssn": _SSN,
+    "credit_card": _CREDIT_CARD,
+    "email": _EMAIL,
+    "phone": _PHONE,
+    "account_number": _ACCOUNT,
+}
+
+
+def luhn_ok(number: str) -> bool:
+    digits = [int(c) for c in number if c.isdigit()]
+    if not (13 <= len(digits) <= 19):
+        return False
+    checksum = 0
+    parity = len(digits) % 2
+    for i, d in enumerate(digits):
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        checksum += d
+    return checksum % 10 == 0
+
+
+def find_and_redact(text: str, pii_types: tuple[str, ...] | list[str]) -> tuple[str, list[str]]:
+    """Replace matches with placeholders. Returns (redacted_text, labels_found).
+
+    Labels are unique and ordered by first appearance. Original spans are discarded.
+    """
+    if not text:
+        return text, []
+    found: list[str] = []
+    redacted = text
+    for pii_type in pii_types:
+        pattern = _COMPILED.get(pii_type)
+        if pattern is None:
+            continue
+        placeholder = PLACEHOLDERS[pii_type]
+
+        def _sub(match, _type=pii_type, _ph=placeholder):
+            raw = match.group(0)
+            if _type == "credit_card" and not luhn_ok(raw):
+                return raw
+            if _type not in found:
+                found.append(_type)
+            return _ph
+
+        redacted = pattern.sub(_sub, redacted)
+    return redacted, found

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -673,6 +673,26 @@ class ToolsChainModel(BaseModel):
     pipelines: List[List[str]]
 
 
+class GovernanceConfig(BaseModel):
+    """Opt-in voice-pipeline governance. Off unless ``enabled`` is true.
+
+    Decisions are regex + policy only (no extra LLM). Receipts never store the
+    original PII span — only labels such as ``ssn`` or ``credit_card``.
+    """
+
+    enabled: bool = False
+    mode: Literal["enforce", "monitor"] = "enforce"
+    redact_pii: bool = True
+    pii_types: Optional[List[str]] = None
+    output_dlp: bool = True
+    max_cost_per_call: Optional[float] = None
+    max_cost_per_session: Optional[float] = None
+    usd_per_1m_input: Optional[float] = None
+    usd_per_1m_output: Optional[float] = None
+    allowed_tools: Optional[List[str]] = None
+    denied_tools: Optional[List[str]] = None
+
+
 class ConversationConfig(BaseModel):
     optimize_latency: Optional[bool] = True  # This will work on in conversation
     hangup_after_silence: Optional[int] = 20
@@ -698,6 +718,7 @@ class ConversationConfig(BaseModel):
     voicemail_detection_duration: Optional[float] = 30.0  # Time window in seconds
     voicemail_check_interval: Optional[float] = 7.0  # Min time between interim checks
     voicemail_min_transcript_length: Optional[int] = 7  # Min words for interim check
+    governance: Optional[GovernanceConfig] = None
 
     @field_validator("hangup_after_silence", mode="before")
     def set_hangup_after_silence(cls, v):

--- a/tests/test_governance_middleware.py
+++ b/tests/test_governance_middleware.py
@@ -1,0 +1,174 @@
+"""Governance middleware: PII redaction, tool auth, cost caps, receipts.
+
+Guards the opt-in path added for issue 933. The original span of any PII match
+must never appear in a receipt. Disabled config is a no-op so existing agents
+do not change behaviour.
+"""
+
+import json
+
+from bolna.governance import GovernanceLedger, GovernanceMiddleware
+from bolna.governance.patterns import find_and_redact, luhn_ok
+from bolna.models import ConversationConfig, GovernanceConfig
+
+
+VALID_VISA = "4111 1111 1111 1111"
+INVALID_CARD = "4111 1111 1111 1112"
+SSN = "123-45-6789"
+
+
+def _enabled(**kwargs):
+    cfg = {"enabled": True, "mode": "enforce"}
+    cfg.update(kwargs)
+    return GovernanceMiddleware(cfg, run_id="run-1")
+
+
+def test_disabled_is_noop():
+    g = GovernanceMiddleware({"enabled": False}, run_id="r")
+    text, decision = g.inspect_transcript(f"my ssn is {SSN}")
+    assert SSN in text
+    assert decision.allow
+    assert g.receipts() == []
+    assert g.allows_llm()
+    assert g.authorize_tool("transfer_call").allow
+
+
+def test_ssn_is_redacted_and_receipt_has_no_raw_span():
+    g = _enabled()
+    text, decision = g.inspect_transcript(f"my social is {SSN}")
+    assert SSN not in text
+    assert "[SSN]" in text
+    assert decision.action == "redact"
+    blob = json.dumps(g.receipts())
+    assert SSN not in blob
+    assert "ssn" in g.receipts()[0]["pii_types"]
+
+
+def test_luhn_valid_card_redacted_invalid_left_alone():
+    g = _enabled()
+    redacted, decision = g.inspect_transcript(f"card {VALID_VISA}")
+    assert VALID_VISA not in redacted
+    assert "[CREDIT_CARD]" in redacted
+    assert decision.action == "redact"
+
+    untouched, skip = g.inspect_transcript(f"order {INVALID_CARD}")
+    assert INVALID_CARD in untouched
+    assert skip.action == "allow"
+
+
+def test_email_and_phone():
+    g = _enabled()
+    text, _ = g.inspect_transcript("reach me at ada@example.com or 415-555-0100")
+    assert "ada@example.com" not in text
+    assert "415-555-0100" not in text
+    assert "[EMAIL]" in text
+    assert "[PHONE]" in text
+
+
+def test_account_number_only_when_opted_in():
+    default = _enabled()
+    text, _ = default.inspect_transcript("acct 12345678901234")
+    assert "12345678901234" in text
+
+    opted = _enabled(pii_types=["account_number"])
+    redacted, _ = opted.inspect_transcript("acct 12345678901234")
+    assert "[ACCOUNT_NUMBER]" in redacted
+
+
+def test_tool_allowlist_and_denylist():
+    g = _enabled(allowed_tools=["lookup_order"], denied_tools=["transfer_call"])
+    assert not g.authorize_tool("transfer_call").allow
+    assert not g.authorize_tool("end_call").allow
+    assert g.authorize_tool("lookup_order").allow
+
+
+def test_tool_args_with_pii_are_denied():
+    g = _enabled()
+    decision = g.authorize_tool("update_account", {"ssn": SSN})
+    assert not decision.allow
+    assert decision.reason == "tool_args_pii"
+    assert SSN not in json.dumps(g.receipts())
+
+
+def test_monitor_mode_logs_but_does_not_block_tools():
+    g = _enabled(mode="monitor", denied_tools=["transfer_call"])
+    decision = g.authorize_tool("transfer_call")
+    assert decision.allow
+    assert decision.action == "monitor_deny"
+    assert g.receipts()[-1]["action"] == "deny"
+
+
+def test_cost_cap_blocks_further_llm_after_breach():
+    g = _enabled(max_cost_per_call=0.0001, usd_per_1m_input=10.0, usd_per_1m_output=10.0)
+    first = g.record_usage(model="gpt-4o-mini", input_tokens=20_000, output_tokens=20_000)
+    assert not first.allow
+    assert first.reason == "max_cost_per_call"
+    assert not g.allows_llm()
+    assert not g.check_budget().allow
+
+
+def test_session_ledger_is_shared_across_middleware_instances():
+    ledger = GovernanceLedger()
+    first = GovernanceMiddleware(
+        {"enabled": True, "max_cost_per_session": 0.0001, "usd_per_1m_input": 10.0, "usd_per_1m_output": 0},
+        run_id="r",
+        ledger=ledger,
+    )
+    first.record_usage(model="x", input_tokens=50_000, output_tokens=0)
+    second = GovernanceMiddleware(
+        {"enabled": True, "max_cost_per_session": 0.0001, "usd_per_1m_input": 10.0, "usd_per_1m_output": 0},
+        run_id="r",
+        ledger=ledger,
+    )
+    assert not second.check_budget().allow
+    assert len(ledger.receipts) >= 2
+
+
+def test_output_dlp_redacts_synthesizer_text():
+    g = _enabled()
+    spoken, decision = g.inspect_output(f"your ssn is {SSN}")
+    assert "[SSN]" in spoken
+    assert decision.action == "redact"
+
+
+def test_from_conversation_config_reads_nested_model():
+    cfg = ConversationConfig(governance=GovernanceConfig(enabled=True, denied_tools=["transfer_call"]))
+    g = GovernanceMiddleware.from_conversation_config(cfg, run_id="r")
+    assert g.enabled
+    assert not g.authorize_tool("transfer_call").allow
+
+
+def test_luhn_helper():
+    assert luhn_ok(VALID_VISA)
+    assert not luhn_ok(INVALID_CARD)
+    assert not luhn_ok("123")
+
+
+def test_find_and_redact_empty():
+    text, labels = find_and_redact("", ["ssn"])
+    assert text == ""
+    assert labels == []
+
+
+def test_missing_governance_key_is_disabled():
+    g = GovernanceMiddleware.from_conversation_config({}, "r")
+    assert not g.enabled
+    text, _ = g.inspect_transcript(f"ssn {SSN}")
+    assert SSN in text
+
+
+def test_task_manager_helpers_redact_and_block():
+    from unittest.mock import MagicMock
+
+    from bolna.agent_manager.task_manager import TaskManager
+
+    tm = MagicMock()
+    tm.run_id = "r"
+    tm.governance = _enabled(max_cost_per_call=0.0001, usd_per_1m_input=10.0, usd_per_1m_output=10.0)
+    tm._govern_user_text = TaskManager._govern_user_text.__get__(tm, TaskManager)
+    tm._governance_blocks_generation = TaskManager._governance_blocks_generation.__get__(tm, TaskManager)
+
+    assert "[SSN]" in tm._govern_user_text(f"ssn {SSN}")
+    assert not tm._governance_blocks_generation()
+    tm.governance.record_usage(model="x", input_tokens=50_000, output_tokens=50_000)
+    assert tm._governance_blocks_generation()

--- a/tests/test_governance_middleware.py
+++ b/tests/test_governance_middleware.py
@@ -82,12 +82,50 @@ def test_tool_allowlist_and_denylist():
     assert g.authorize_tool("lookup_order").allow
 
 
+def test_empty_allowlist_denies_every_tool():
+    g = _enabled(allowed_tools=[])
+    assert not g.authorize_tool("lookup_order").allow
+    assert not g.authorize_tool("end_call").allow
+
+
+def test_runtime_args_extractor_drops_spoken_payload():
+    from bolna.agent_manager.task_manager import TaskManager
+
+    resp = {
+        "order_id": "A1",
+        "textual_response": f"ssn {SSN}",
+        "model_response": [{"function": {"arguments": f"ssn {SSN}"}}],
+        "tool_call_id": "c1",
+    }
+    args = TaskManager._extract_api_call_runtime_args(resp)
+    assert "textual_response" not in args
+    assert "model_response" not in args
+    args.pop("tool_call_id", None)
+    g = _enabled()
+    assert g.authorize_tool("lookup_order", args).allow
+
+
 def test_tool_args_with_pii_are_denied():
     g = _enabled()
     decision = g.authorize_tool("update_account", {"ssn": SSN})
     assert not decision.allow
     assert decision.reason == "tool_args_pii"
     assert SSN not in json.dumps(g.receipts())
+
+
+def test_check_budget_does_not_spam_receipts_once_blocked():
+    g = _enabled(mode="monitor", max_cost_per_call=0.0001, usd_per_1m_input=10.0, usd_per_1m_output=10.0)
+    g.record_usage(model="x", input_tokens=50_000, output_tokens=50_000)
+    before = len(g.receipts())
+    g.check_budget()
+    g.check_budget()
+    assert len(g.receipts()) == before
+
+
+def test_partial_rate_override_keeps_the_other_side():
+    g = _enabled(usd_per_1m_input=10.0)
+    usd = g._estimate_usd("gpt-4o-mini", 1_000_000, 1_000_000)
+    assert usd == 10.0 + 0.60
 
 
 def test_monitor_mode_logs_but_does_not_block_tools():
@@ -105,6 +143,19 @@ def test_cost_cap_blocks_further_llm_after_breach():
     assert first.reason == "max_cost_per_call"
     assert not g.allows_llm()
     assert not g.check_budget().allow
+
+
+def test_followup_task_inherits_session_cap_from_ledger():
+    ledger = GovernanceLedger()
+    first = GovernanceMiddleware(
+        {"enabled": True, "max_cost_per_session": 0.0001, "usd_per_1m_input": 10.0, "usd_per_1m_output": 0},
+        run_id="r",
+        ledger=ledger,
+    )
+    first.record_usage(model="x", input_tokens=50_000, output_tokens=0)
+    second = GovernanceMiddleware.from_conversation_config({}, "r", ledger=ledger)
+    assert second.enabled
+    assert not second.check_budget().allow
 
 
 def test_session_ledger_is_shared_across_middleware_instances():


### PR DESCRIPTION
Fixes #933

Adds an **opt-in** governance layer on the voice pipeline. Existing agents are unchanged unless `task_config.governance.enabled` is true.

```
[ASR] → PII redact → [LLM] → output DLP → [TTS]
                 ↘ tool allow/deny + budget hard-stop
```

## What it does

- **Transcript PII** — regex redaction (SSN, Luhn-checked cards, email, phone; account numbers opt-in) before history/LLM. Placeholders only; receipts never store the original span.
- **Output DLP** — same scan on synthesizer text and stored assistant turns.
- **Tool gate** — allowlist / denylist, plus PII in *runtime args* (not spoken filler / `model_response`). Denied tools get a `status: denied` result and a follow-up LLM turn so the caller is not left in silence. Covers both the LLM tool path and S2S.
- **Cost caps** — estimated USD from token usage, per-call and per-session. Session ledger is shared across conversation → extraction/summarization. `enforce` blocks further LLM/tool work; `monitor` logs only.
- **JSON receipts** — appended to `task_output["governance_receipts"]`.

No extra LLM in the governance path. No new package dependency.

## Config

```json
{
  "task_config": {
    "governance": {
      "enabled": true,
      "mode": "enforce",
      "redact_pii": true,
      "output_dlp": true,
      "max_cost_per_call": 0.50,
      "max_cost_per_session": 2.00,
      "allowed_tools": ["lookup_order", "end_call"],
      "denied_tools": ["transfer_call"]
    }
  }
}
```

`mode` is `enforce` (block) or `monitor` (log, do not block). An empty `allowed_tools` list denies every tool. If you use an allowlist, include injected tools such as `end_call` / `switch_language`.

## Tests

Local: `1561 passed, 1 skipped` (`pytest` in a venv with `pip install -e '.[dev]'`).

## Notes / limits

- Cost is an **estimate** (small built-in table + optional `usd_per_1m_input` / `usd_per_1m_output`). Receipts label it `estimated_usd`.
- Streaming TTS DLP is per-chunk; a match that straddles two synthesizer buffers can be missed. Assembled assistant text is also redacted before it is stored.
- This is a native Bolna hook (regex + policy), not a TealTiger SDK dependency, so CI and the default install stay unchanged. A later adapter could emit the same receipt shape into TealTiger if you want that.