### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,8 @@ SONIOX_API_KEY=
 ELEVENLABS_API_KEY=
 OPENAI_API_KEY=
 OPENAI_MODEL=gpt-3.5-turbo
+ATLASCLOUD_API_KEY=
+ATLASCLOUD_API_BASE=https://api.atlascloud.ai/v1
 REDIS_URL=redis://redis:6379
 
 # Twilio credentials

--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ For LiteLLM based LLMs, add either of the following to the `.env` file depending
 For LLMs hosted via VLLM, add the following to the `.env` file:<br>
 `VLLM_SERVER_BASE_URL`: URL of the hosted LLM using VLLM
 
+For Atlas Cloud, set `provider="atlascloud"` in the LLM configuration and add:<br>
+`ATLASCLOUD_API_KEY`: Atlas Cloud API key<br>
+`ATLASCLOUD_API_BASE`: Optional API base URL (defaults to `https://api.atlascloud.ai/v1`)<br>
+If no model is specified, the provider uses `qwen/qwen3.5-397b-a17b`.
+
 </details>
 &nbsp;<br>
 

--- a/bolna/enums.py
+++ b/bolna/enums.py
@@ -97,6 +97,7 @@ class LLMProvider(str, Enum):
     """Enum for LLM providers."""
 
     OPENAI = "openai"
+    ATLASCLOUD = "atlascloud"
     COHERE = "cohere"
     OLLAMA = "ollama"
     DEEPINFRA = "deepinfra"

--- a/bolna/llms/__init__.py
+++ b/bolna/llms/__init__.py
@@ -1,4 +1,5 @@
 from bolna.llms.openai_llm import OpenAiLLM
+from bolna.llms.atlascloud_llm import AtlasCloudLLM
 from bolna.llms.litellm import LiteLLM
 from bolna.llms.azure_llm import AzureLLM
 from bolna.llms.gemini_llm import GeminiLLM

--- a/bolna/llms/atlascloud_llm.py
+++ b/bolna/llms/atlascloud_llm.py
@@ -1,0 +1,42 @@
+import os
+
+from bolna.constants import DEFAULT_LANGUAGE_CODE
+from bolna.llms.openai_llm import OpenAiLLM
+
+
+class AtlasCloudLLM(OpenAiLLM):
+    """OpenAI-compatible LLM adapter with Atlas Cloud defaults."""
+
+    DEFAULT_BASE_URL = "https://api.atlascloud.ai/v1"
+    DEFAULT_MODEL = "qwen/qwen3.5-397b-a17b"
+
+    def __init__(
+        self,
+        max_tokens=100,
+        buffer_size=40,
+        model=DEFAULT_MODEL,
+        temperature=0.1,
+        language=DEFAULT_LANGUAGE_CODE,
+        **kwargs,
+    ):
+        kwargs.pop("provider", None)
+        api_key = kwargs.pop("llm_key", None) or os.getenv("ATLASCLOUD_API_KEY")
+        if not api_key:
+            raise ValueError("Please set the ATLASCLOUD_API_KEY environment variable.")
+
+        base_url = kwargs.pop("base_url", None) or os.getenv("ATLASCLOUD_API_BASE", self.DEFAULT_BASE_URL)
+        super().__init__(
+            max_tokens=max_tokens,
+            buffer_size=buffer_size,
+            model=model,
+            temperature=temperature,
+            language=language,
+            provider="custom",
+            llm_key=api_key,
+            base_url=base_url,
+            max_retries=0,
+            **kwargs,
+        )
+
+        # Atlas Cloud's chat-completions endpoint does not use OpenAI service tiers.
+        self.model_args.pop("service_tier", None)

--- a/bolna/llms/openai_llm.py
+++ b/bolna/llms/openai_llm.py
@@ -221,21 +221,36 @@ class OpenAiLLM(OpenAICompatibleLLM):
 
         # http2=False: cancelled h2 requests leak streams until the connection pins at 100 (barge-in)
         http_client = get_shared_http_client(base_url=kwargs.get("base_url"), http2=False)
+        max_retries = kwargs.get("max_retries", 2)
 
         if kwargs.get("provider", "openai") == "custom":
             base_url = kwargs.get("base_url")
             api_key = kwargs.get("llm_key", None)
-            self.async_client = AsyncOpenAI(base_url=base_url, api_key=api_key, http_client=http_client)
+            self.async_client = AsyncOpenAI(
+                base_url=base_url,
+                api_key=api_key,
+                http_client=http_client,
+                max_retries=max_retries,
+            )
         else:
             llm_key = kwargs.get("llm_key", os.getenv("OPENAI_API_KEY"))
             base_url = kwargs.get("base_url")
             if base_url:
-                self.async_client = AsyncOpenAI(base_url=base_url, api_key=llm_key, http_client=http_client)
+                self.async_client = AsyncOpenAI(
+                    base_url=base_url,
+                    api_key=llm_key,
+                    http_client=http_client,
+                    max_retries=max_retries,
+                )
             else:
-                self.async_client = AsyncOpenAI(api_key=llm_key, http_client=http_client)
+                self.async_client = AsyncOpenAI(
+                    api_key=llm_key,
+                    http_client=http_client,
+                    max_retries=max_retries,
+                )
             api_key = llm_key
         self.llm_host = urlparse(base_url).netloc if base_url else None
-        # Only a customer endpoint is guarded; platform ones keep the SDK's connection retries.
+        # Only a customer endpoint is guarded; platform endpoints keep standard SDK behavior.
         self._base_url = base_url if kwargs.get("provider", "openai") == "custom" else None
         self._base_url_validated = False
         self.assistant_id = kwargs.get("assistant_id", None)

--- a/bolna/providers.py
+++ b/bolna/providers.py
@@ -46,7 +46,7 @@ from .output_handlers import (
     SipTrunkOutputHandler,
     FreeSwitchOutputHandler,
 )
-from .llms import OpenAiLLM, LiteLLM, AzureLLM, GeminiLLM
+from .llms import AtlasCloudLLM, OpenAiLLM, LiteLLM, AzureLLM, GeminiLLM
 from .s2s import GeminiLiveS2S, OpenAIRealtimeS2S
 from .enums import TelephonyProvider, SynthesizerProvider, TranscriberProvider, LLMProvider, S2SProvider
 
@@ -95,6 +95,7 @@ SUPPORTED_TRANSCRIBER_MODELS = {"deepgram": DeepgramTranscriber}
 
 SUPPORTED_LLM_PROVIDERS = {
     LLMProvider.OPENAI.value: OpenAiLLM,
+    LLMProvider.ATLASCLOUD.value: AtlasCloudLLM,
     LLMProvider.COHERE.value: LiteLLM,
     LLMProvider.OLLAMA.value: LiteLLM,
     LLMProvider.DEEPINFRA.value: LiteLLM,

--- a/tests/test_atlascloud_llm.py
+++ b/tests/test_atlascloud_llm.py
@@ -1,0 +1,74 @@
+from unittest.mock import patch
+
+import pytest
+
+from bolna.enums import LLMProvider
+from bolna.llms.atlascloud_llm import AtlasCloudLLM
+from bolna.providers import SUPPORTED_LLM_PROVIDERS
+
+
+def test_atlascloud_provider_is_registered():
+    assert LLMProvider.ATLASCLOUD.value == "atlascloud"
+    assert SUPPORTED_LLM_PROVIDERS["atlascloud"] is AtlasCloudLLM
+
+
+def test_atlascloud_requires_api_key(monkeypatch):
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="ATLASCLOUD_API_KEY"):
+        AtlasCloudLLM()
+
+
+def test_atlascloud_applies_defaults_without_sdk_retries(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "env-key")
+    captured = {}
+
+    def fake_openai_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        self.model_args = {"service_tier": "default"}
+
+    with patch("bolna.llms.atlascloud_llm.OpenAiLLM.__init__", fake_openai_init):
+        llm = AtlasCloudLLM()
+
+    assert captured["model"] == "qwen/qwen3.5-397b-a17b"
+    assert captured["provider"] == "custom"
+    assert captured["llm_key"] == "env-key"
+    assert captured["base_url"] == "https://api.atlascloud.ai/v1"
+    assert captured["max_retries"] == 0
+    assert "service_tier" not in llm.model_args
+
+
+def test_atlascloud_allows_explicit_credentials_and_endpoint(monkeypatch):
+    monkeypatch.delenv("ATLASCLOUD_API_KEY", raising=False)
+    captured = {}
+
+    def fake_openai_init(self, *args, **kwargs):
+        captured.update(kwargs)
+        self.model_args = {}
+
+    with patch("bolna.llms.atlascloud_llm.OpenAiLLM.__init__", fake_openai_init):
+        AtlasCloudLLM(
+            model="custom/model",
+            llm_key="direct-key",
+            base_url="https://example.com/v1",
+        )
+
+    assert captured["model"] == "custom/model"
+    assert captured["llm_key"] == "direct-key"
+    assert captured["base_url"] == "https://example.com/v1"
+
+
+def test_atlascloud_configures_the_sdk_without_retries(monkeypatch):
+    monkeypatch.setenv("ATLASCLOUD_API_KEY", "test-key")
+
+    with (
+        patch("bolna.llms.openai_llm.get_shared_http_client") as get_http_client,
+        patch("bolna.llms.openai_llm.AsyncOpenAI") as async_openai,
+    ):
+        AtlasCloudLLM()
+
+    async_openai.assert_called_once_with(
+        base_url="https://api.atlascloud.ai/v1",
+        api_key="test-key",
+        http_client=get_http_client.return_value,
+        max_retries=0,
+    )


### PR DESCRIPTION
## Summary

- add an opt-in `atlascloud` LLM provider on top of the existing OpenAI-compatible implementation
- use Atlas Cloud endpoint, key, and model defaults while preserving explicit overrides
- disable SDK retries for Atlas requests and omit unsupported OpenAI service-tier parameters
- document the provider environment variables and add focused registry/configuration tests

## Testing

- `pytest` for Atlas provider, provider registry parity, LLM routing, and reasoning request shape (53 passed)
- `ruff check` and `ruff format --check` on changed Python files
- configured pre-commit hooks, including Bandit
- one live streaming Atlas Cloud chat-completions request returned the expected response