### PR TITLE
fix: infer bool as bool, not int, in infer_type()

### DIFF
--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -513,12 +513,15 @@ def has_placeholders(s):
 
 
 def infer_type(value):
-    if isinstance(value, int):
+    # bool must be checked before int: in Python bool is a subclass of int, so
+    # isinstance(True, int) is True. Ordering int first made the bool branch
+    # unreachable and inferred every boolean as int.
+    if isinstance(value, bool):
+        return (bool, ...)
+    elif isinstance(value, int):
         return (int, ...)
     elif isinstance(value, float):
         return (float, ...)
-    elif isinstance(value, bool):
-        return (bool, ...)
     elif isinstance(value, list):
         return (list, ...)
     elif isinstance(value, dict):

--- a/tests/test_infer_type.py
+++ b/tests/test_infer_type.py
@@ -1,0 +1,26 @@
+"""infer_type maps a JSON value to a Pydantic field type for json_to_pydantic_schema.
+
+bool is a subclass of int in Python, so checking int before bool made the bool branch
+unreachable and typed every boolean field as int in the generated schema.
+"""
+
+from bolna.helpers.utils import infer_type
+
+
+def test_bool_is_inferred_as_bool_not_int():
+    # Regression: int was checked first, so isinstance(True, int) matched and the
+    # bool branch never ran.
+    assert infer_type(True) == (bool, ...)
+    assert infer_type(False) == (bool, ...)
+
+
+def test_int_is_still_inferred_as_int():
+    assert infer_type(42) == (int, ...)
+    assert infer_type(0) == (int, ...)
+
+
+def test_other_scalar_and_container_types_are_unchanged():
+    assert infer_type(3.14) == (float, ...)
+    assert infer_type("hello") == (str, ...)
+    assert infer_type([1, 2]) == (list, ...)
+    assert infer_type({"a": 1}) == (dict, ...)


### PR DESCRIPTION
## What

`infer_type()` in `bolna/helpers/utils.py` maps a JSON value to a Pydantic field type for `json_to_pydantic_schema()`. It checks `int` before `bool`:

```python
def infer_type(value):
    if isinstance(value, int):
        return (int, ...)
    ...
    elif isinstance(value, bool):   # unreachable
        return (bool, ...)
```

In Python, `bool` is a subclass of `int`, so `isinstance(True, int)` is `True`. The `bool` branch is therefore **unreachable**, and every boolean value is inferred as `int`:

```python
infer_type(True)   # -> (int, ...)   expected (bool, ...)
infer_type(False)  # -> (int, ...)
```

Because `infer_type` feeds `json_to_pydantic_schema()`, a boolean field in the JSON is described as an integer in the generated Pydantic schema.

## Fix

Check `bool` before `int` — the standard ordering when an isinstance chain needs to tell the two apart:

```python
if isinstance(value, bool):
    return (bool, ...)
elif isinstance(value, int):
    return (int, ...)
...
```

Ints, floats, strings, lists and dicts infer exactly as before; only booleans change (from `int` to the correct `bool`).

## Tests

Added `tests/test_infer_type.py` covering booleans (the regression), ints, and the other scalar/container types.

Before: `infer_type(True) == (int, ...)`
After: `infer_type(True) == (bool, ...)`
