### PR TITLE
bump: version 0.10.233

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.232"
+__version__ = "0.10.233"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.232"
+version = "0.10.233"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Cuts a release that includes the per-call Deepgram host override.

The 0.10.232 release was published just before that change merged, so the 0.10.232 wheel on PyPI does not carry the new `Transcriber` host fields (`deepgram_host`/`deepgram_flux_host`/`deepgram_host_protocol`). This bumps the version above the latest tag so the publish workflow ships a wheel that actually contains them.

No code changes — version bump only.