### PR TITLE
fix: release the audio gate when the ASR stops producing new words [B…

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.234"
+__version__ = "0.10.235"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/interruption_manager.py
+++ b/bolna/agent_manager/interruption_manager.py
@@ -33,6 +33,7 @@ class InterruptionManager:
         self.incremental_delay: int = incremental_delay
         self.utterance_end_time: float = -1
         self.last_interim_ts: float = -1
+        self.last_interim_text: str = ""
 
         # Configuration
         self.number_of_words_for_interruption: int = number_of_words_for_interruption
@@ -177,6 +178,7 @@ class InterruptionManager:
         self.let_remaining_audio_pass_through = True
         self.time_since_first_interim_result = -1
         self.last_interim_ts = -1
+        self.last_interim_text = ""
 
         now_s = time.time()
         if update_utterance_time:
@@ -468,12 +470,16 @@ class InterruptionManager:
         """Returns current turn ID."""
         return self.turn_id
 
-    def note_user_liveness(self) -> None:
-        """Record that an interim arrived, whether or not this turn acts on it."""
+    def note_user_liveness(self, transcript: str = "") -> None:
+        """Record that an interim arrived, whether or not this turn acts on it. An unchanged
+        transcript is the ASR re-emitting, not new speech, so it must not refresh liveness."""
+        if transcript and transcript == self.last_interim_text:
+            return
+        self.last_interim_text = transcript
         self.last_interim_ts = time.time()
 
     def user_speech_staleness_s(self) -> float:
-        """Seconds since the last interim, or since speech start if none yet, -1 when not speaking."""
+        """Seconds since the last new speech, or since speech start if none yet, -1 when not speaking."""
         if not self.callee_speaking:
             return -1
         anchor = max(self.last_interim_ts, self.callee_speaking_start_time)

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -5035,9 +5035,9 @@ class TaskManager(BaseManager):
                         and message["data"].get("type", "") == "interim_transcript_received"
                     ):
                         self.time_since_last_spoken_human_word = time.time()
-                        # Before every early exit below: an interim is proof the caller is still
-                        # talking, so it must refresh liveness even when this turn ignores it.
-                        self.interruption_manager.note_user_liveness()
+                        # Before every early exit below: a changed interim is proof the caller is
+                        # still talking, so it must refresh liveness even when this turn ignores it.
+                        self.interruption_manager.note_user_liveness(message["data"].get("content", ""))
                         if temp_transcriber_message == message["data"].get("content"):
                             logger.info("Received the same transcript as the previous one we have hence continuing")
                             continue
@@ -7303,7 +7303,7 @@ class TaskManager(BaseManager):
                         if staleness > STUCK_AUDIO_GATE_RELEASE_S:
                             logger.warning(
                                 f"Releasing stuck audio gate: callee_speaking held {staleness:.1f}s "
-                                f"with no interim (sequence_id={sequence_id})"
+                                f"with no new speech (sequence_id={sequence_id})"
                             )
                             self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
                             continue

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -60,9 +60,9 @@ LLM_REGEN_SETTLE_S = 0.7
 # Class-name prefixes whose endpointing rules out an in-window final: they skip the debounce.
 REGEN_SETTLE_EXCLUDED_TRANSCRIBERS = ("deepgram",)
 
-# Past this much caller silence, callee_speaking is stale and held audio ships. Deepgram closes a
-# healthy turn within utterance_end_ms (1s floor), so a real speaker stays well inside this.
-STUCK_AUDIO_GATE_RELEASE_S = 3.0
+# Past this much with no new words from the caller, callee_speaking is stale and held audio ships.
+# Deepgram closes a healthy turn within utterance_end_ms (1s floor), so a real speaker stays inside it.
+STUCK_AUDIO_GATE_RELEASE_S = 2.0
 
 # Above __await_stream_sid's own 10s timeout, so that path is what ends the call.
 S2S_STREAM_SID_TIMEOUT_S = 12.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.234"
+version = "0.10.235"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_stuck_audio_gate_release.py
+++ b/tests/test_stuck_audio_gate_release.py
@@ -1,0 +1,131 @@
+"""A held audio gate must release once the ASR stops producing new words.
+
+Incident 0c64ec07: Deepgram re-emitted an identical non-final "hello" every ~0.6s for 2.4s while a
+fully synthesized reply sat behind callee_speaking. Each duplicate refreshed liveness, so the
+staleness escape never fired and the reply was discarded without playing a frame. Only a *changed*
+transcript counts as new speech.
+"""
+
+import pytest
+
+from unittest.mock import patch
+
+from bolna.agent_manager.interruption_manager import InterruptionManager
+from bolna.constants import STUCK_AUDIO_GATE_RELEASE_S
+
+CLOCK = "bolna.agent_manager.interruption_manager.time.time"
+T0 = 1_000.0
+
+
+def _speaking_at(t0=T0):
+    """A manager with the caller mid-utterance, as the output loop sees it while holding audio."""
+    manager = InterruptionManager()
+    with patch(CLOCK, return_value=t0):
+        manager.on_user_speech_started()
+    return manager
+
+
+def _feed(manager, offsets_and_text):
+    for offset, text in offsets_and_text:
+        with patch(CLOCK, return_value=T0 + offset):
+            manager.note_user_liveness(text)
+
+
+def _staleness_at(manager, offset):
+    with patch(CLOCK, return_value=T0 + offset):
+        return manager.user_speech_staleness_s()
+
+
+def test_repeated_identical_interims_let_the_gate_go_stale():
+    # The 0c64ec07 shape: one word, then the ASR re-emitting it while endpointing lags.
+    manager = _speaking_at()
+    _feed(manager, [(0.0, "hello"), (1.0, "hello"), (1.6, "hello"), (2.2, "hello")])
+
+    assert _staleness_at(manager, 2.4) == pytest.approx(2.4)
+    assert _staleness_at(manager, 2.4) > STUCK_AUDIO_GATE_RELEASE_S
+
+
+def test_new_words_keep_the_gate_held():
+    # A caller genuinely still talking must never be spoken over.
+    manager = _speaking_at()
+    _feed(manager, [(0.0, "hello"), (1.0, "hello there"), (1.6, "hello there I"), (2.2, "hello there I need")])
+
+    assert _staleness_at(manager, 2.4) == pytest.approx(0.2)
+    assert _staleness_at(manager, 2.4) < STUCK_AUDIO_GATE_RELEASE_S
+
+
+def test_the_gate_survives_a_long_utterance_of_new_words():
+    # Staleness must not accumulate across a genuinely long turn.
+    manager = _speaking_at()
+    _feed(manager, [(i * 0.5, f"word {i}") for i in range(20)])
+
+    assert _staleness_at(manager, 9.6) == pytest.approx(0.1)
+    assert _staleness_at(manager, 9.6) < STUCK_AUDIO_GATE_RELEASE_S
+
+
+def test_a_caller_who_goes_silent_still_goes_stale():
+    # The original purpose of the escape: no interims at all after speech started.
+    manager = _speaking_at()
+
+    assert _staleness_at(manager, 2.5) == pytest.approx(2.5)
+    assert _staleness_at(manager, 2.5) > STUCK_AUDIO_GATE_RELEASE_S
+
+
+def test_liveness_without_a_transcript_still_refreshes():
+    # Back-compat: any caller not passing content keeps the old unconditional behaviour.
+    manager = _speaking_at()
+    _feed(manager, [(0.0, ""), (2.2, "")])
+
+    assert _staleness_at(manager, 2.4) == pytest.approx(0.2)
+
+
+def test_speech_ended_clears_the_remembered_transcript():
+    # Otherwise a next utterance opening with the same word would not refresh liveness.
+    manager = _speaking_at()
+    _feed(manager, [(0.0, "hello")])
+
+    with patch(CLOCK, return_value=T0 + 1.0):
+        manager.on_user_speech_ended()
+    assert manager.last_interim_text == ""
+
+    with patch(CLOCK, return_value=T0 + 5.0):
+        manager.on_user_speech_started()
+    _feed(manager, [(5.0, "hello")])
+    assert _staleness_at(manager, 5.2) == pytest.approx(0.2)
+
+
+def test_staleness_is_negative_when_the_caller_is_not_speaking():
+    manager = InterruptionManager()
+    assert manager.user_speech_staleness_s() == -1
+
+
+def test_the_0c64ec07_timeline_releases_before_the_asr_finalizes():
+    """Replay of the incident, offsets relative to callee_speaking_start_time (12:07:51.118).
+
+    Reply was synthesized and waiting at +0.179s; Deepgram finalized "hello" only at +2.601s and the
+    reply was then discarded unplayed. The gate must go stale before that final arrives.
+    """
+    manager = _speaking_at()
+    interims = [(-0.001, "hello"), (1.000, "hello"), (1.601, "hello"), (2.201, "hello")]
+    _feed(manager, interims)
+
+    release_at = next(t / 1000 for t in range(0, 3000) if _staleness_at(manager, t / 1000) > STUCK_AUDIO_GATE_RELEASE_S)
+    asr_final_at = 2.601
+    assert release_at < asr_final_at, f"gate released at +{release_at}s, ASR final at +{asr_final_at}s"
+    assert asr_final_at - release_at == pytest.approx(0.6, abs=0.05)
+
+
+def test_playback_starting_is_what_spares_the_reply_from_the_overlapped_discard():
+    """Why releasing the gate is sufficient for 0c64ec07, with no change to the overlap policy.
+
+    The short final is only routed to the discard path because no audio was playing. Once the gate
+    releases and playback starts, the same final is a false interruption, is ignored, and the guard
+    returns before _handle_transcriber_output (and its overlapped/discard branch) is ever reached.
+    """
+    manager = InterruptionManager(number_of_words_for_interruption=3)
+    incident = dict(word_count=1, transcript="hello", welcome_played=True)
+
+    # What happened: reply stuck in WAIT, so is_audio_playing was False -> not a false interruption.
+    assert manager.is_false_interruption(is_audio_playing=False, **incident) is False
+    # With the gate released the reply is audible, so the same final is correctly ignored.
+    assert manager.is_false_interruption(is_audio_playing=True, **incident) is True


### PR DESCRIPTION
The agent went silent after the caller said हां जी and the call was abandoned. The reply was generated (2.66s) and synthesized (113ms) — but never played.

The caller started saying "hello" while the reply was still generating, so the audio gate held it (Audio status=WAIT - user is speaking) for 2.42s. When Deepgram finally finalized "hello", the overlap path merged the utterances and discarded the reply. sync_history logged marks=0, response_heard len=0 — zero frames reached the caller.

Root cause

The gate has an escape that releases held audio once the caller goes stale, but it could never fire. note_user_liveness() refreshed last_interim_ts on every interim, and Deepgram re-emitted an identical non-final hello every ~0.6s, so staleness kept resetting.

A duplicate interim means the ASR has nothing new — not that the caller is still talking.

Fix

Refresh liveness only when the transcript actually changes:

def note_user_liveness(self, transcript: str = "") -> None:
    if transcript and transcript == self.last_interim_text:
        return
    self.last_interim_text = transcript
    self.last_interim_ts = time.time()

STUCK_AUDIO_GATE_RELEASE_S 3.0 → 2.0. Needed, not cosmetic: with content-aware liveness the anchor sits at the first hello and Deepgram finalized 2.601s later, so 3.0s still missed by ~0.4s. 2.0s releases with 0.6s margin and stays above Deepgram's 1s utterance_end_ms floor, so healthy turns are unaffected.

This doesn't talk over a real speaker — new words reset the timer, so only a frozen transcript trips it. And once audio plays, the short hello final is correctly classified a false interruption and ignored, so the reply completes.

Tests

tests/test_stuck_audio_gate_release.py (9 cases): replay of the incident's real timings asserting release lands before the ASR final; the inverse guard (new words every 0.5s for 10s never goes stale); silent-caller case still works; back-compat for the no-arg call.

Full unit suite: 1561 passed, 1 skipped. ruff clean.