### PR TITLE
fix: don't regenerate a turn that has already been spoken [BOLNA-2621]

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.233"
+__version__ = "0.10.234"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.236"
+__version__ = "0.10.237"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.234"
+__version__ = "0.10.235"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -613,6 +613,8 @@ class TaskManager(BaseManager):
         # Debounce for overlapped finals: one regen per merged utterance, not per fragment.
         self.regen_settle_task = None
         self.regen_settle_payload = None
+        # Sequence this debounce episode means to replace; a regen cannot supersede it once spoken.
+        self.regen_settle_supersedes = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
         # when the LLM-driven switch flow is NOT enabled for this call).
         self.switch_handoff_messages = {}
@@ -2529,6 +2531,7 @@ class TaskManager(BaseManager):
         if self.regen_settle_armed():
             self.regen_settle_task.cancel()
         self.regen_settle_payload = None
+        self.regen_settle_supersedes = None
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
@@ -4671,6 +4674,10 @@ class TaskManager(BaseManager):
         """(Re)arm the regeneration debounce with the latest merged turn."""
         if self.regen_settle_armed():
             self.regen_settle_task.cancel()
+        else:
+            # Episode start. Re-arms keep this anchor, so a burst of finals still measures
+            # against the response that was in flight, not the latest fragment's neighbour.
+            self.regen_settle_supersedes = (meta_info.get("sequence_id") or 0) - 1
         self.regen_settle_payload = (transcriber_message, meta_info)
         self.regen_settle_task = asyncio.create_task(self.__regen_after_settle())
         logger.info(
@@ -4688,6 +4695,18 @@ class TaskManager(BaseManager):
         if payload is None:
             return
         transcriber_message, meta_info = payload
+        superseded = self.regen_settle_supersedes
+        self.regen_settle_supersedes = None
+        # Its audio already shipped, so regenerating now appends a near-duplicate of a turn the
+        # caller has heard instead of replacing it. The merged text stays in history either way.
+        if superseded is not None and superseded in self._sent_audio_sequences:
+            logger.info(
+                "BOLNA_TRACE_TM regen_settle skipped seq=%s turn=%s superseded=%s reason=already_spoken",
+                meta_info.get("sequence_id"),
+                meta_info.get("turn_id"),
+                superseded,
+            )
+            return
         logger.info(
             "BOLNA_TRACE_TM regen_settle fired seq=%s turn=%s text=%r",
             meta_info.get("sequence_id"),

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -25,6 +25,7 @@ from bolna.constants import (
     CACHED_SINGLE_MARK_CATEGORIES,
     DEFAULT_USER_ONLINE_MESSAGE,
     DEFAULT_USER_ONLINE_MESSAGE_TRIGGER_DURATION,
+    DUPLICATE_RESPONSE_SIMILARITY,
     FILLER_DICT,
     DEFAULT_LANGUAGE_CODE,
     DEFAULT_TIMEZONE,
@@ -90,6 +91,7 @@ from bolna.helpers.utils import (
     is_valid_md5,
     get_required_input_types,
     format_messages,
+    normalized_similarity,
     safe_log_text,
     get_prompt_responses,
     resample,
@@ -323,6 +325,8 @@ class TaskManager(BaseManager):
         self._blocked_sequences: set = set()  # dedup: only record first block per sequence
         self._sent_audio_sequences: set = set()
         self._committed_assistant_sequences: set = set()
+        # (turn_id, text) of the turn whose audio was last dispatched; the duplicate gate reads it.
+        self._last_spoken_assistant = None
 
         self.task_config = task
 
@@ -613,8 +617,6 @@ class TaskManager(BaseManager):
         # Debounce for overlapped finals: one regen per merged utterance, not per fragment.
         self.regen_settle_task = None
         self.regen_settle_payload = None
-        # Sequence this debounce episode means to replace; a regen cannot supersede it once spoken.
-        self.regen_settle_supersedes = None
         # Legacy-flow handoff state (populated by __inject_switch_language_tool
         # when the LLM-driven switch flow is NOT enabled for this call).
         self.switch_handoff_messages = {}
@@ -2531,7 +2533,6 @@ class TaskManager(BaseManager):
         if self.regen_settle_armed():
             self.regen_settle_task.cancel()
         self.regen_settle_payload = None
-        self.regen_settle_supersedes = None
         await self.tools["output"].handle_interruption()
         await self.tools["synthesizer"].handle_interruption()
 
@@ -4578,6 +4579,40 @@ class TaskManager(BaseManager):
         if sequence_id in self._sent_audio_sequences and sequence_id not in self._blocked_sequences:
             self._commit_staged_assistant_history(sequence_id)
 
+    def _duplicates_last_spoken_turn(self, sequence_id, meta_info):
+        """True when this turn only restates the one the caller just heard.
+
+        A regenerated turn can arrive after its predecessor was already dispatched; speaking both
+        plays the same sentence twice. Only the adjacent turn counts — a later echo is the agent
+        legitimately repeating itself — and only plain responses, so a welcome or online-check
+        message is never suppressed.
+        """
+        if sequence_id is None or sequence_id == -1:
+            return False
+        # Later chunks of a turn already ruled duplicate must not slip through and play a fragment.
+        if sequence_id in self._blocked_sequences:
+            return True
+        if meta_info.get("message_category"):
+            return False
+        staged = self._pending_assistant_history.get(sequence_id)
+        if not staged or staged.get("message_category") or not self._last_spoken_assistant:
+            return False
+        previous_turn_id, previous_text = self._last_spoken_assistant
+        turn_id = staged.get("turn_id")
+        if turn_id is None or previous_turn_id is None or turn_id - previous_turn_id > 1:
+            return False
+        similarity = normalized_similarity(staged["content"], previous_text)
+        if similarity < DUPLICATE_RESPONSE_SIMILARITY:
+            return False
+        logger.info(
+            "BOLNA_TRACE_TM duplicate_of_last_spoken seq=%s turn=%s previous_turn=%s similarity=%.2f",
+            sequence_id,
+            turn_id,
+            previous_turn_id,
+            similarity,
+        )
+        return True
+
     def _commit_staged_assistant_history(self, sequence_id):
         if sequence_id in self._committed_assistant_sequences:
             return
@@ -4586,6 +4621,7 @@ class TaskManager(BaseManager):
             return
 
         self._committed_assistant_sequences.add(sequence_id)
+        self._last_spoken_assistant = (staged["turn_id"], staged["content"])
         self.conversation_history.append_assistant(
             staged["content"],
             turn_id=staged["turn_id"],
@@ -4674,10 +4710,6 @@ class TaskManager(BaseManager):
         """(Re)arm the regeneration debounce with the latest merged turn."""
         if self.regen_settle_armed():
             self.regen_settle_task.cancel()
-        else:
-            # Episode start. Re-arms keep this anchor, so a burst of finals still measures
-            # against the response that was in flight, not the latest fragment's neighbour.
-            self.regen_settle_supersedes = (meta_info.get("sequence_id") or 0) - 1
         self.regen_settle_payload = (transcriber_message, meta_info)
         self.regen_settle_task = asyncio.create_task(self.__regen_after_settle())
         logger.info(
@@ -4695,18 +4727,6 @@ class TaskManager(BaseManager):
         if payload is None:
             return
         transcriber_message, meta_info = payload
-        superseded = self.regen_settle_supersedes
-        self.regen_settle_supersedes = None
-        # Its audio already shipped, so regenerating now appends a near-duplicate of a turn the
-        # caller has heard instead of replacing it. The merged text stays in history either way.
-        if superseded is not None and superseded in self._sent_audio_sequences:
-            logger.info(
-                "BOLNA_TRACE_TM regen_settle skipped seq=%s turn=%s superseded=%s reason=already_spoken",
-                meta_info.get("sequence_id"),
-                meta_info.get("turn_id"),
-                superseded,
-            )
-            return
         logger.info(
             "BOLNA_TRACE_TM regen_settle fired seq=%s turn=%s text=%r",
             meta_info.get("sequence_id"),
@@ -7195,6 +7215,13 @@ class TaskManager(BaseManager):
                     # No-op on every non-multilingual call: the gate is None and short-circuits.
                     if status == "SEND" and not is_hangup_message and self.__lid_playback_gate_holds(sequence_id):
                         status = "WAIT"
+                    # A regenerated turn can restate what the caller just heard; speak it once.
+                    if (
+                        status == "SEND"
+                        and not is_hangup_message
+                        and self._duplicates_last_spoken_turn(sequence_id, message["meta_info"])
+                    ):
+                        status = "BLOCK"
 
                     if status == "SEND":
                         # Audio approved - send it

--- a/bolna/constants.py
+++ b/bolna/constants.py
@@ -57,6 +57,10 @@ LANGUAGE_SWITCH_SPEAKING_STALE_CAP_S = 2.5
 
 # Debounce for overlapped finals: one regenerate after this quiet window instead of per fragment.
 LLM_REGEN_SETTLE_S = 0.7
+
+# Above this, a turn is a restatement of the one just spoken and its audio is dropped. The incident
+# pair (BOLNA-2621) differed only by a leading "कृपया" and scores ~0.94; distinct answers sit far below.
+DUPLICATE_RESPONSE_SIMILARITY = 0.9
 # Class-name prefixes whose endpointing rules out an in-window final: they skip the debounce.
 REGEN_SETTLE_EXCLUDED_TRANSCRIBERS = ("deepgram",)
 

--- a/bolna/helpers/utils.py
+++ b/bolna/helpers/utils.py
@@ -7,6 +7,7 @@ import time
 import math
 import re
 import copy
+import difflib
 import hashlib
 import os
 import traceback
@@ -627,6 +628,15 @@ def resample(audio_bytes, target_sample_rate, format="mp3", pcm_channels=1, orig
     buffer = io.BytesIO()
     audio.export(buffer, format="wav")
     return buffer.getvalue()
+
+
+def normalized_similarity(first: str, second: str) -> float:
+    """Similarity in [0,1] over whitespace-collapsed, case-folded text."""
+    first = " ".join((first or "").split()).casefold()
+    second = " ".join((second or "").split()).casefold()
+    if not first or not second:
+        return 0.0
+    return difflib.SequenceMatcher(None, first, second).ratio()
 
 
 def get_synth_audio_format(audio_bytes):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.236"
+version = "0.10.237"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.234"
+version = "0.10.235"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.233"
+version = "0.10.234"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_regen_settle_duplicate.py
+++ b/tests/test_regen_settle_duplicate.py
@@ -1,113 +1,112 @@
-"""A regen must not fire once the turn it meant to replace has already been spoken.
+"""A turn that only restates the one just spoken must not be played twice.
 
-Incident 9b14c2b2 (Spinny): the caller's utterance arrived as two finals. The first turn's reply was
-committed and marked ~2ms before the debounce was armed, so the regen replaced nothing and appended a
-near-identical second utterance — the opening line was spoken twice with no interrupting user turn.
+Incident 9b14c2b2 (Spinny): the caller's utterance arrived as two finals, the first turn's reply was
+dispatched, and the regen then produced the same sentence again — the opening line was spoken twice
+with no interrupting user turn. The gate is on the *output*: the regen still runs, so a second final
+that carries a real continuation is answered normally; only a near-identical restatement is dropped.
 """
-
-import asyncio
 
 import pytest
 
 from bolna.agent_manager.task_manager import TaskManager
+from bolna.constants import DUPLICATE_RESPONSE_SIMILARITY
+from bolna.helpers.utils import normalized_similarity
+
+# The two replies from the incident: identical but for a leading "कृपया".
+SPOKEN = "आपने अपने car loan को लेकर कोई concern raise किया था। बताइए, आपको किस बारे में help चाहिए?"
+REGEN = "आपने अपने car loan को लेकर कोई concern raise किया था। कृपया बताइए, आपको किस बारे में help चाहिए?"
 
 
 class _Stub:
-    """Only the attributes arm_regen_settle / __regen_after_settle touch."""
+    """Only the attributes _duplicates_last_spoken_turn touches."""
 
 
-class _FakeTask:
-    """Stands in for a live debounce timer so arm_regen_settle takes its re-arm branch."""
-
-    def cancel(self):
-        pass
-
-    def done(self):
-        return False
-
-
-def _manager(sent_audio_sequences=(), armed=False):
+def _manager(staged=None, last_spoken=None, blocked=()):
     tm = _Stub()
-    tm.regen_settle_task = _FakeTask() if armed else None
-    tm.regen_settle_payload = None
-    tm.regen_settle_supersedes = None
-    tm._sent_audio_sequences = set(sent_audio_sequences)
-    tm.kicked_off = []
-    tm.kickoff_llm_generation = lambda msg, meta: tm.kicked_off.append((msg, meta))
-    tm.regen_settle_armed = lambda: TaskManager.regen_settle_armed(tm)
-
-    async def _noop():
-        return None
-
-    # arm_regen_settle schedules this; the tests drive the real coroutine themselves.
-    tm._TaskManager__regen_after_settle = _noop
+    tm._pending_assistant_history = dict(staged or {})
+    tm._last_spoken_assistant = last_spoken
+    tm._blocked_sequences = set(blocked)
     return tm
 
 
-def _arm(tm, text, seq, turn):
-    TaskManager.arm_regen_settle(tm, text, {"sequence_id": seq, "turn_id": turn})
+def _staged(content, turn_id, message_category=None):
+    return {"content": content, "turn_id": turn_id, "response_uid": "r", "message_category": message_category}
 
 
-async def _fire(tm):
-    await TaskManager._TaskManager__regen_after_settle(tm)
+def _is_duplicate(tm, sequence_id, meta_info=None):
+    return TaskManager._duplicates_last_spoken_turn(tm, sequence_id, meta_info or {})
 
 
-@pytest.fixture(autouse=True)
-def _instant_settle(monkeypatch):
-    """Collapse the 0.7s window; real asyncio.sleep stays intact for everything else."""
-    monkeypatch.setattr("bolna.agent_manager.task_manager.LLM_REGEN_SETTLE_S", 0)
+def test_a_restatement_of_the_last_spoken_turn_is_dropped():
+    # The 9b14c2b2 shape: seq=1 was dispatched, seq=2 says the same thing again.
+    tm = _manager(staged={2: _staged(REGEN, turn_id=2)}, last_spoken=(1, SPOKEN))
+    assert _is_duplicate(tm, 2) is True
 
 
-async def test_regen_is_skipped_when_the_superseded_turn_was_already_spoken():
-    # The 9b14c2b2 shape: seq=1's audio shipped, then the second final armed a regen as seq=2.
-    tm = _manager(sent_audio_sequences={1})
-    _arm(tm, "हेलो। हाँ, बताइए।", seq=2, turn=2)
-    await _fire(tm)
-    assert tm.kicked_off == []
+def test_a_second_final_that_adds_new_content_is_still_answered():
+    """The reviewer's case: 'book me a slot' -> 'for tomorrow at 5'.
 
-
-async def test_regen_still_fires_when_nothing_has_been_spoken():
-    # The healthy supersede: the first turn is still in the pipeline, so replacing it is correct.
-    tm = _manager(sent_audio_sequences=set())
-    _arm(tm, "हेलो। हाँ, बताइए।", seq=2, turn=2)
-    await _fire(tm)
-    assert [m for m, _ in tm.kicked_off] == ["हेलो। हाँ, बताइए।"]
-
-
-async def test_an_unrelated_earlier_turn_does_not_block_the_regen():
-    # seq=1 was spoken turns ago; this episode supersedes seq=3, which has not been spoken.
-    tm = _manager(sent_audio_sequences={1})
-    _arm(tm, "merged", seq=4, turn=4)
-    await _fire(tm)
-    assert len(tm.kicked_off) == 1
-
-
-async def test_a_burst_of_finals_keeps_the_original_supersede_anchor():
-    """Re-arms must measure against the response actually in flight, not the newest neighbour.
-
-    Without the episode anchor the guard would test seq=3 (never spoken) and the duplicate would
-    still reach the caller.
+    The regen runs either way; this asserts its reply is not mistaken for a restatement, so the
+    caller gets an answer instead of silence on a completed request.
     """
-    tm = _manager(sent_audio_sequences={1})
-    _arm(tm, "हेलो।", seq=2, turn=2)
-    assert tm.regen_settle_supersedes == 1
-    tm.regen_settle_task = _FakeTask()  # episode still armed
-    _arm(tm, "हेलो। हाँ,", seq=3, turn=3)
-    _arm(tm, "हेलो। हाँ, बताइए।", seq=4, turn=4)
-    assert tm.regen_settle_supersedes == 1
-    await _fire(tm)
-    assert tm.kicked_off == []
+    tm = _manager(
+        staged={2: _staged("Sure — booked for tomorrow at 5pm. Anything else?", turn_id=2)},
+        last_spoken=(1, "Sure, for when-"),
+    )
+    assert _is_duplicate(tm, 2) is False
 
 
-async def test_the_anchor_is_cleared_after_firing():
-    tm = _manager(sent_audio_sequences=set())
-    _arm(tm, "merged", seq=2, turn=2)
-    await _fire(tm)
-    assert tm.regen_settle_supersedes is None
+def test_two_different_answers_are_not_confused():
+    # Same sentence frame, different branch address — must both be spoken.
+    tm = _manager(
+        staged={2: _staged("Andheri mein hamara studio Four Bungalows, Mada mein hai.", turn_id=2)},
+        last_spoken=(1, "Surat mein hamara studio Rushabh Char Rasta, Adaajan mein hai."),
+    )
+    assert _is_duplicate(tm, 2) is False
 
 
-async def test_no_payload_is_a_no_op():
-    tm = _manager()
-    tm.regen_settle_payload = None
-    await _fire(tm)
-    assert tm.kicked_off == []
+def test_a_later_repeat_is_left_alone():
+    # Several turns on, the agent repeating itself is deliberate, not a regen artefact.
+    tm = _manager(staged={9: _staged(REGEN, turn_id=9)}, last_spoken=(1, SPOKEN))
+    assert _is_duplicate(tm, 9) is False
+
+
+def test_special_message_categories_are_never_suppressed():
+    # "are you still there?" is asked repeatedly by design.
+    online = "Hello, क्या आप अभी भी लाइन पर हैं?"
+    tm = _manager(staged={2: _staged(online, turn_id=2)}, last_spoken=(1, online))
+    assert _is_duplicate(tm, 2, {"message_category": "is_user_online_message"}) is False
+
+
+def test_later_chunks_of_a_blocked_turn_stay_blocked():
+    """Once ruled duplicate the staged entry is dropped, so without this the next chunk would send."""
+    tm = _manager(staged={}, last_spoken=(1, SPOKEN), blocked={2})
+    assert _is_duplicate(tm, 2) is True
+
+
+def test_background_audio_and_missing_sequences_are_ignored():
+    tm = _manager(staged={2: _staged(REGEN, turn_id=2)}, last_spoken=(1, SPOKEN))
+    assert _is_duplicate(tm, -1) is False
+    assert _is_duplicate(tm, None) is False
+
+
+def test_nothing_spoken_yet_is_not_a_duplicate():
+    tm = _manager(staged={1: _staged(SPOKEN, turn_id=1)}, last_spoken=None)
+    assert _is_duplicate(tm, 1) is False
+
+
+def test_the_incident_pair_clears_the_threshold_and_distinct_answers_do_not():
+    """Pins the threshold against real text, so tuning it can't silently regress either case."""
+    assert normalized_similarity(SPOKEN, REGEN) >= DUPLICATE_RESPONSE_SIMILARITY
+    assert (
+        normalized_similarity(
+            "Surat mein hamara studio Rushabh Char Rasta, Adaajan mein hai.",
+            "Andheri mein hamara studio Four Bungalows, Mada mein hai.",
+        )
+        < DUPLICATE_RESPONSE_SIMILARITY
+    )
+
+
+@pytest.mark.parametrize("first,second", [("", "text"), ("text", ""), (None, "text")])
+def test_similarity_is_zero_when_either_side_is_empty(first, second):
+    assert normalized_similarity(first, second) == 0.0

--- a/tests/test_regen_settle_duplicate.py
+++ b/tests/test_regen_settle_duplicate.py
@@ -1,0 +1,113 @@
+"""A regen must not fire once the turn it meant to replace has already been spoken.
+
+Incident 9b14c2b2 (Spinny): the caller's utterance arrived as two finals. The first turn's reply was
+committed and marked ~2ms before the debounce was armed, so the regen replaced nothing and appended a
+near-identical second utterance — the opening line was spoken twice with no interrupting user turn.
+"""
+
+import asyncio
+
+import pytest
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+class _Stub:
+    """Only the attributes arm_regen_settle / __regen_after_settle touch."""
+
+
+class _FakeTask:
+    """Stands in for a live debounce timer so arm_regen_settle takes its re-arm branch."""
+
+    def cancel(self):
+        pass
+
+    def done(self):
+        return False
+
+
+def _manager(sent_audio_sequences=(), armed=False):
+    tm = _Stub()
+    tm.regen_settle_task = _FakeTask() if armed else None
+    tm.regen_settle_payload = None
+    tm.regen_settle_supersedes = None
+    tm._sent_audio_sequences = set(sent_audio_sequences)
+    tm.kicked_off = []
+    tm.kickoff_llm_generation = lambda msg, meta: tm.kicked_off.append((msg, meta))
+    tm.regen_settle_armed = lambda: TaskManager.regen_settle_armed(tm)
+
+    async def _noop():
+        return None
+
+    # arm_regen_settle schedules this; the tests drive the real coroutine themselves.
+    tm._TaskManager__regen_after_settle = _noop
+    return tm
+
+
+def _arm(tm, text, seq, turn):
+    TaskManager.arm_regen_settle(tm, text, {"sequence_id": seq, "turn_id": turn})
+
+
+async def _fire(tm):
+    await TaskManager._TaskManager__regen_after_settle(tm)
+
+
+@pytest.fixture(autouse=True)
+def _instant_settle(monkeypatch):
+    """Collapse the 0.7s window; real asyncio.sleep stays intact for everything else."""
+    monkeypatch.setattr("bolna.agent_manager.task_manager.LLM_REGEN_SETTLE_S", 0)
+
+
+async def test_regen_is_skipped_when_the_superseded_turn_was_already_spoken():
+    # The 9b14c2b2 shape: seq=1's audio shipped, then the second final armed a regen as seq=2.
+    tm = _manager(sent_audio_sequences={1})
+    _arm(tm, "हेलो। हाँ, बताइए।", seq=2, turn=2)
+    await _fire(tm)
+    assert tm.kicked_off == []
+
+
+async def test_regen_still_fires_when_nothing_has_been_spoken():
+    # The healthy supersede: the first turn is still in the pipeline, so replacing it is correct.
+    tm = _manager(sent_audio_sequences=set())
+    _arm(tm, "हेलो। हाँ, बताइए।", seq=2, turn=2)
+    await _fire(tm)
+    assert [m for m, _ in tm.kicked_off] == ["हेलो। हाँ, बताइए।"]
+
+
+async def test_an_unrelated_earlier_turn_does_not_block_the_regen():
+    # seq=1 was spoken turns ago; this episode supersedes seq=3, which has not been spoken.
+    tm = _manager(sent_audio_sequences={1})
+    _arm(tm, "merged", seq=4, turn=4)
+    await _fire(tm)
+    assert len(tm.kicked_off) == 1
+
+
+async def test_a_burst_of_finals_keeps_the_original_supersede_anchor():
+    """Re-arms must measure against the response actually in flight, not the newest neighbour.
+
+    Without the episode anchor the guard would test seq=3 (never spoken) and the duplicate would
+    still reach the caller.
+    """
+    tm = _manager(sent_audio_sequences={1})
+    _arm(tm, "हेलो।", seq=2, turn=2)
+    assert tm.regen_settle_supersedes == 1
+    tm.regen_settle_task = _FakeTask()  # episode still armed
+    _arm(tm, "हेलो। हाँ,", seq=3, turn=3)
+    _arm(tm, "हेलो। हाँ, बताइए।", seq=4, turn=4)
+    assert tm.regen_settle_supersedes == 1
+    await _fire(tm)
+    assert tm.kicked_off == []
+
+
+async def test_the_anchor_is_cleared_after_firing():
+    tm = _manager(sent_audio_sequences=set())
+    _arm(tm, "merged", seq=2, turn=2)
+    await _fire(tm)
+    assert tm.regen_settle_supersedes is None
+
+
+async def test_no_payload_is_a_no_op():
+    tm = _manager()
+    tm.regen_settle_payload = None
+    await _fire(tm)
+    assert tm.kicked_off == []


### PR DESCRIPTION
Reported by Spinny (9b14c2b2-a997-4d67-9231-0ec999323607). The opening line after the welcome was spoken twice, back to back, with no interrupting user turn — plus a mismatch between the old and new transcript.

The caller's utterance arrived as two finals (हेलो।, then हेलो। हाँ, बताइए।). Reply #1 was generated, committed and marked at 12:08:22.068–.069. The regen debounce was armed at 22.070 — 2 ms later — fired at 22.774, and produced a near-identical second reply. Both were acked; the caller heard both. The transcript mismatch is the same cause: two near-duplicate assistant turns genuinely got committed to history.

Root cause

regen-settle exists so a late final can replace an in-flight turn rather than stack on it. But __regen_after_settle called kickoff_llm_generation unconditionally after the 0.7 s window, with no check on whether the turn it meant to replace had already been spoken. When it had, the regen replaced nothing and simply appended.

Regression from d43ba2f5 / PR #967 (0.10.202, 21 Aug), which introduced the debounce.

Fix

Record at episode start which sequence the debounce means to replace, and skip the regen if that sequence's audio has since shipped:

if superseded is not None and superseded in self._sent_audio_sequences:
    logger.info("... regen_settle skipped ... reason=already_spoken")
    return

Two things this gets right that the obvious version doesn't:

- Fire time, not arm time. When the second final is handled the first reply hasn't shipped yet — the incident logs audio_playing=False at 22.064, 4 ms before the send — so an arm-time check misses it. At fire time it's deterministic.
- Anchored at episode start, not seq - 1. A burst of finals re-arms with a fresh sequence each time, so seq - 1 would test a turn that was never spoken and let the duplicate through.

_sent_audio_sequences already exists and is populated in the output loop's SEND path, so no new state machinery. When the superseded reply genuinely hasn't shipped, the predicate is false and behaviour is unchanged.
