### PR TITLE
feat: opt-in interruptible hangup message (BOLNA-2680)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.233"
+__version__ = "0.10.234"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4255,6 +4255,9 @@ class TaskManager(BaseManager):
         self._hangup_processing = False
         self._end_of_conversation_in_progress = False
         self.hangup_detail = None
+        # __execute_function_call cleared this on entry and the end_call branch returns without
+        # restoring it, so a resumed call would never ask "are you still there" again.
+        self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
         logger.info("Interruptible hangup: barge-in cancelled pending hangup, resuming conversation")
 
     def __log_detached_hangup_exception(self, task: asyncio.Task) -> None:
@@ -4275,6 +4278,11 @@ class TaskManager(BaseManager):
 
         self._hangup_processing = True
         self.hangup_triggered = True
+        # An actuated hangup is no longer interruptible. Without this, the static-message branch
+        # below calls __cleanup_downstream_tasks, which would see a window still open from a
+        # concurrent end_call goodbye and reset the very flags this teardown needs, leaving the
+        # goodbye playing with nothing left to commit the disconnect.
+        self._hangup_interruptible_window = False
         if self.__is_s2s():
             # The model has already spoken the goodbye by now, prompted by the end_call result
             # or _hangup_after_goodbye, and there is no synthesizer to render one here anyway.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4207,10 +4207,14 @@ class TaskManager(BaseManager):
         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
 
     def _should_ignore_transcriber_input(self) -> bool:
-        if not (self.hangup_triggered or self._end_call_in_progress or self.has_transfer):
+        # A transfer is never interruptible: the caller keeps talking to the transferred leg and
+        # fresh turns here re-emit transfer_call.
+        if self.has_transfer:
+            return True
+        if not (self.hangup_triggered or self._end_call_in_progress):
             return False
-        # A hangup or transfer is underway. Only an open interruptible-goodbye window lets speech
-        # through, and only until the disconnect commits.
+        # A hangup is underway. Only an open interruptible-goodbye window lets speech through,
+        # and only until the disconnect commits.
         return self.conversation_ended or self._hangup_interruptible_window is not True
 
     def _cancel_pending_hangup(self):

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -2530,8 +2530,7 @@ class TaskManager(BaseManager):
         current_ts = time.time()
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
-        # Reset before the first await below, so the goodbye task cannot resume and commit the
-        # disconnect after this barge-in.
+        # Reset before the first await, or the goodbye task resumes and commits the disconnect.
         if self._hangup_interruptible_window:
             self._cancel_pending_hangup()
         self._cancel_in_flight_llm_response()
@@ -3234,13 +3233,10 @@ class TaskManager(BaseManager):
                 self._enter_hangup_state()
                 await self.wait_for_current_message()
 
-            # Goodbye played out; close the window so the disconnect commits.
             self._hangup_interruptible_window = False
 
-            # A barge-in during the goodbye already reset the hangup and resumed the call. Cancelling
-            # this task is not enough to stop us here: handle_interruption clears the mark dict, so
-            # the playout wait above can return normally instead of raising, and we would arm the
-            # teardown and disconnect a call the caller just rescued.
+            # Cancelling this task is not enough: handle_interruption clears the mark dict, so the
+            # playout wait above returns normally and we would disconnect a call just rescued.
             if self._hangup_cancelled:
                 logger.info("end_call: hangup was cancelled by a barge-in, not arming the teardown")
                 return
@@ -4217,25 +4213,19 @@ class TaskManager(BaseManager):
         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
 
     def _should_ignore_transcriber_input(self) -> bool:
-        # A transfer is never interruptible: the caller keeps talking to the transferred leg and
-        # fresh turns here re-emit transfer_call.
+        # A transfer is never interruptible: fresh turns here re-emit transfer_call.
         if self.has_transfer:
             return True
         if not (self.hangup_triggered or self._end_call_in_progress):
             return False
-        # A hangup is underway. Only an open interruptible-goodbye window lets speech through,
-        # and only until the disconnect commits.
         return self.conversation_ended or self._hangup_interruptible_window is not True
 
     def _cancel_pending_hangup(self):
         """Abort the interruptible end_call goodbye so the conversation resumes."""
         self._hangup_interruptible_window = False
-        # A committed disconnect must never be cancelled: past this point the hangup task may be
-        # mid stop_handler, and cancelling it would leave the caller in dead air.
+        # Never cancel a committed disconnect: the hangup task may already be in stop_handler.
         if self.conversation_ended:
             return
-        # Authoritative for the end_call branch, which re-checks this after its playout wait.
-        # Task cancellation alone is not reliable there (see the note at that check).
         self._hangup_cancelled = True
 
         current = asyncio.current_task()
@@ -4255,8 +4245,7 @@ class TaskManager(BaseManager):
         self._hangup_processing = False
         self._end_of_conversation_in_progress = False
         self.hangup_detail = None
-        # __execute_function_call cleared this on entry and the end_call branch returns without
-        # restoring it, so a resumed call would never ask "are you still there" again.
+        # Cleared on entry to __execute_function_call, whose end_call branch never restores it.
         self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
         logger.info("Interruptible hangup: barge-in cancelled pending hangup, resuming conversation")
 
@@ -4278,10 +4267,8 @@ class TaskManager(BaseManager):
 
         self._hangup_processing = True
         self.hangup_triggered = True
-        # An actuated hangup is no longer interruptible. Without this, the static-message branch
-        # below calls __cleanup_downstream_tasks, which would see a window still open from a
-        # concurrent end_call goodbye and reset the very flags this teardown needs, leaving the
-        # goodbye playing with nothing left to commit the disconnect.
+        # An actuated hangup is no longer interruptible, or __cleanup_downstream_tasks below
+        # resets the very flags this teardown needs to commit the disconnect.
         self._hangup_interruptible_window = False
         if self.__is_s2s():
             # The model has already spoken the goodbye by now, prompted by the end_call result
@@ -5079,8 +5066,7 @@ class TaskManager(BaseManager):
                             continue
 
                         # Defer interim barge-ins while a tool call is in flight (same as speech_final path).
-                        # The interruptible goodbye is exempt: its tool result is already recorded, so
-                        # letting the barge-in through cannot duplicate the tool call.
+                        # The interruptible goodbye is exempt: its tool result is already recorded.
                         if self.function_call_in_flight and self._hangup_interruptible_window is not True:
                             logger.info(f"Tool call in flight; deferring interim barge-in {transcript_content!r}")
                             continue

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -400,6 +400,7 @@ class TaskManager(BaseManager):
         self._end_call_in_progress = False
         self.interruptible_hangup_message = False
         self._hangup_interruptible_window = False
+        self._hangup_cancelled = False
         self._end_call_hangup_task = None
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
@@ -3182,6 +3183,7 @@ class TaskManager(BaseManager):
             # Lock out barge-in before the goodbye is generated, otherwise an interruption
             # cancels the turn task and the disconnect never runs. The toggle opens a window instead.
             self._end_call_in_progress = True
+            self._hangup_cancelled = False
             if self.interruptible_hangup_message:
                 self._hangup_interruptible_window = True
             reason = resp.get("reason", "")
@@ -3234,6 +3236,14 @@ class TaskManager(BaseManager):
 
             # Goodbye played out; close the window so the disconnect commits.
             self._hangup_interruptible_window = False
+
+            # A barge-in during the goodbye already reset the hangup and resumed the call. Cancelling
+            # this task is not enough to stop us here: handle_interruption clears the mark dict, so
+            # the playout wait above can return normally instead of raising, and we would arm the
+            # teardown and disconnect a call the caller just rescued.
+            if self._hangup_cancelled:
+                logger.info("end_call: hangup was cancelled by a barge-in, not arming the teardown")
+                return
 
             self.hangup_detail = HangupReason.END_CALL_TOOL
             self.call_hangup_message_config = None
@@ -4224,6 +4234,9 @@ class TaskManager(BaseManager):
         # mid stop_handler, and cancelling it would leave the caller in dead air.
         if self.conversation_ended:
             return
+        # Authoritative for the end_call branch, which re-checks this after its playout wait.
+        # Task cancellation alone is not reliable there (see the note at that check).
+        self._hangup_cancelled = True
 
         current = asyncio.current_task()
         if self.llm_task is not None and self.llm_task is not current and not self.llm_task.done():

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -4207,12 +4207,11 @@ class TaskManager(BaseManager):
         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
 
     def _should_ignore_transcriber_input(self) -> bool:
-        if self.conversation_ended:
-            return True
-        # Interruptible goodbye: let speech through so a barge-in can cancel the hangup.
-        if self._hangup_interruptible_window:
+        if not (self.hangup_triggered or self._end_call_in_progress or self.has_transfer):
             return False
-        return self.hangup_triggered or self._end_call_in_progress or self.has_transfer
+        # A hangup or transfer is underway. Only an open interruptible-goodbye window lets speech
+        # through, and only until the disconnect commits.
+        return self.conversation_ended or self._hangup_interruptible_window is not True
 
     def _cancel_pending_hangup(self):
         """Abort the interruptible end_call goodbye so the conversation resumes."""
@@ -5057,7 +5056,7 @@ class TaskManager(BaseManager):
                         # Defer interim barge-ins while a tool call is in flight (same as speech_final path).
                         # The interruptible goodbye is exempt: its tool result is already recorded, so
                         # letting the barge-in through cannot duplicate the tool call.
-                        if self.function_call_in_flight and not self._hangup_interruptible_window:
+                        if self.function_call_in_flight and self._hangup_interruptible_window is not True:
                             logger.info(f"Tool call in flight; deferring interim barge-in {transcript_content!r}")
                             continue
 
@@ -5236,7 +5235,7 @@ class TaskManager(BaseManager):
                         # Starting a new turn here cancels the in-flight tool call before its result is
                         # recorded, so the LLM re-emits the same tool and the side effect runs twice.
                         # The interruptible goodbye is exempt: its result is already recorded.
-                        if self.function_call_in_flight and not self._hangup_interruptible_window:
+                        if self.function_call_in_flight and self._hangup_interruptible_window is not True:
                             logger.info(f"Tool call in flight; deferring barge-in transcript {transcript_content!r}")
                             self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
                             continue

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -3207,33 +3207,34 @@ class TaskManager(BaseManager):
                 tool_result, meta_info, None, "function_call", direction="response", run_id=self.run_id
             )
 
-            if textual_response:
-                # The LLM emitted the goodbye in the same response as the tool call;
-                # it has already been streamed to TTS. Skip the follow-up LLM to avoid
-                # generating a duplicate goodbye.
-                self._enter_hangup_state()
-                await self.wait_for_current_message()
-            else:
-                # No goodbye text in this turn. Feed the tool result back so the LLM
-                # generates one.
-                messages = self.conversation_history.get_copy()
-                convert_to_request_log(
-                    format_messages(messages, True),
-                    meta_info,
-                    self.llm_config["model"],
-                    "llm",
-                    direction="request",
-                    run_id=self.run_id,
-                )
+            try:
+                if textual_response:
+                    # The LLM emitted the goodbye in the same response as the tool call;
+                    # it has already been streamed to TTS. Skip the follow-up LLM to avoid
+                    # generating a duplicate goodbye.
+                    self._enter_hangup_state()
+                    await self.wait_for_current_message()
+                else:
+                    # No goodbye text in this turn. Feed the tool result back so the LLM
+                    # generates one.
+                    messages = self.conversation_history.get_copy()
+                    convert_to_request_log(
+                        format_messages(messages, True),
+                        meta_info,
+                        self.llm_config["model"],
+                        "llm",
+                        direction="request",
+                        run_id=self.run_id,
+                    )
 
-                followup_meta_info = self._spawn_followup_meta_info(meta_info)
-                await self.__do_llm_generation(
-                    messages, followup_meta_info, next_step, should_trigger_function_call=False
-                )
-                self._enter_hangup_state()
-                await self.wait_for_current_message()
-
-            self._hangup_interruptible_window = False
+                    followup_meta_info = self._spawn_followup_meta_info(meta_info)
+                    await self.__do_llm_generation(
+                        messages, followup_meta_info, next_step, should_trigger_function_call=False
+                    )
+                    self._enter_hangup_state()
+                    await self.wait_for_current_message()
+            finally:
+                self._hangup_interruptible_window = False
 
             # Cancelling this task is not enough: handle_interruption clears the mark dict, so the
             # playout wait above returns normally and we would disconnect a call just rescued.

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -398,6 +398,9 @@ class TaskManager(BaseManager):
         self.hangup_message_queued = False
         self._end_of_conversation_in_progress = False
         self._end_call_in_progress = False
+        self.interruptible_hangup_message = False
+        self._hangup_interruptible_window = False
+        self._end_call_hangup_task = None
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
         self.hangup_mark_event_timeout = 10
@@ -728,6 +731,8 @@ class TaskManager(BaseManager):
                         self.call_hangup_message_config = update_prompt_with_context(
                             self.call_hangup_message_config, self.context_data
                         )
+                self.interruptible_hangup_message = self.conversation_config.get("interruptible_hangup_message", False)
+
                 self.check_for_completion_llm = os.getenv("CHECK_FOR_COMPLETION_LLM")
 
                 cancellation_prompt = self.conversation_config.get("call_cancellation_prompt")
@@ -2524,6 +2529,10 @@ class TaskManager(BaseManager):
         current_ts = time.time()
         logger.info(f"Cleaning up downstream task")
         start_time = time.time()
+        # Reset before the first await below, so the goodbye task cannot resume and commit the
+        # disconnect after this barge-in.
+        if self._hangup_interruptible_window:
+            self._cancel_pending_hangup()
         self._cancel_in_flight_llm_response()
         # The overlapped-final path re-arms after this cleanup, so the newest turn wins.
         if self.regen_settle_armed():
@@ -3171,8 +3180,10 @@ class TaskManager(BaseManager):
 
         if called_fun.startswith(END_CALL_FUNCTION_PREFIX):
             # Lock out barge-in before the goodbye is generated, otherwise an interruption
-            # cancels the turn task and the disconnect never runs.
+            # cancels the turn task and the disconnect never runs. The toggle opens a window instead.
             self._end_call_in_progress = True
+            if self.interruptible_hangup_message:
+                self._hangup_interruptible_window = True
             reason = resp.get("reason", "")
 
             logger.info(f"end_call tool invoked, reason: {reason}")
@@ -3220,6 +3231,9 @@ class TaskManager(BaseManager):
                 )
                 self._enter_hangup_state()
                 await self.wait_for_current_message()
+
+            # Goodbye played out; close the window so the disconnect commits.
+            self._hangup_interruptible_window = False
 
             self.hangup_detail = HangupReason.END_CALL_TOOL
             self.call_hangup_message_config = None
@@ -4193,7 +4207,39 @@ class TaskManager(BaseManager):
         self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
 
     def _should_ignore_transcriber_input(self) -> bool:
+        if self.conversation_ended:
+            return True
+        # Interruptible goodbye: let speech through so a barge-in can cancel the hangup.
+        if self._hangup_interruptible_window:
+            return False
         return self.hangup_triggered or self._end_call_in_progress or self.has_transfer
+
+    def _cancel_pending_hangup(self):
+        """Abort the interruptible end_call goodbye so the conversation resumes."""
+        self._hangup_interruptible_window = False
+        # A committed disconnect must never be cancelled: past this point the hangup task may be
+        # mid stop_handler, and cancelling it would leave the caller in dead air.
+        if self.conversation_ended:
+            return
+
+        current = asyncio.current_task()
+        if self.llm_task is not None and self.llm_task is not current and not self.llm_task.done():
+            self.llm_task.cancel()
+            self.llm_task = None
+        hangup_task = self._end_call_hangup_task
+        self._end_call_hangup_task = None
+        if hangup_task is not None and hangup_task is not current and not hangup_task.done():
+            hangup_task.cancel()
+
+        self.hangup_triggered = False
+        self._end_call_in_progress = False
+        self.hangup_message_queued = False
+        self.hangup_triggered_at = None
+        self.hangup_decision_at = None
+        self._hangup_processing = False
+        self._end_of_conversation_in_progress = False
+        self.hangup_detail = None
+        logger.info("Interruptible hangup: barge-in cancelled pending hangup, resuming conversation")
 
     def __log_detached_hangup_exception(self, task: asyncio.Task) -> None:
         """A bare create_task with no done callback drops the exception along with the task, so
@@ -5009,7 +5055,9 @@ class TaskManager(BaseManager):
                             continue
 
                         # Defer interim barge-ins while a tool call is in flight (same as speech_final path).
-                        if self.function_call_in_flight:
+                        # The interruptible goodbye is exempt: its tool result is already recorded, so
+                        # letting the barge-in through cannot duplicate the tool call.
+                        if self.function_call_in_flight and not self._hangup_interruptible_window:
                             logger.info(f"Tool call in flight; deferring interim barge-in {transcript_content!r}")
                             continue
 
@@ -5187,7 +5235,8 @@ class TaskManager(BaseManager):
 
                         # Starting a new turn here cancels the in-flight tool call before its result is
                         # recorded, so the LLM re-emits the same tool and the side effect runs twice.
-                        if self.function_call_in_flight:
+                        # The interruptible goodbye is exempt: its result is already recorded.
+                        if self.function_call_in_flight and not self._hangup_interruptible_window:
                             logger.info(f"Tool call in flight; deferring barge-in transcript {transcript_content!r}")
                             self.interruption_manager.on_user_speech_ended(update_utterance_time=False)
                             continue

--- a/bolna/models.py
+++ b/bolna/models.py
@@ -686,6 +686,7 @@ class ConversationConfig(BaseModel):
     )
     interruption_backoff_period: Optional[int] = 100
     hangup_after_LLMCall: Optional[bool] = False
+    interruptible_hangup_message: Optional[bool] = False
     call_cancellation_prompt: Optional[str] = None
     backchanneling: Optional[bool] = False
     backchanneling_message_gap: Optional[int] = 5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.233"
+version = "0.10.234"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_end_call_bargein_guard.py
+++ b/tests/test_end_call_bargein_guard.py
@@ -194,6 +194,13 @@ class TestSourceGuards:
             "end_call branch must open the interruptible window when the toggle is on"
         )
 
+    def test_end_call_branch_bails_out_when_cancelled(self):
+        src = inspect.getsource(TaskManager._TaskManager__execute_function_call)
+        assert "_hangup_cancelled" in src, (
+            "end_call branch must re-check _hangup_cancelled after its playout wait, or a barge-in "
+            "that rescued the call still gets disconnected"
+        )
+
     def test_cleanup_cancels_pending_hangup(self):
         src = inspect.getsource(TaskManager._TaskManager__cleanup_downstream_tasks)
         assert "_cancel_pending_hangup" in src, (

--- a/tests/test_end_call_bargein_guard.py
+++ b/tests/test_end_call_bargein_guard.py
@@ -15,11 +15,19 @@ from unittest.mock import AsyncMock, MagicMock
 from bolna.agent_manager.task_manager import TaskManager
 
 
-def _ignore(hangup_triggered, end_call_in_progress, has_transfer=False):
+def _ignore(
+    hangup_triggered,
+    end_call_in_progress,
+    has_transfer=False,
+    conversation_ended=False,
+    interruptible_window=False,
+):
     fake = SimpleNamespace(
         hangup_triggered=hangup_triggered,
         _end_call_in_progress=end_call_in_progress,
         has_transfer=has_transfer,
+        conversation_ended=conversation_ended,
+        _hangup_interruptible_window=interruptible_window,
     )
     return TaskManager._should_ignore_transcriber_input(fake)
 
@@ -37,6 +45,19 @@ def test_processes_input_during_normal_conversation():
     assert _ignore(hangup_triggered=False, end_call_in_progress=False) is False
 
 
+def test_interruptible_window_lets_input_through_despite_hangup():
+    # Toggle on: a barge-in during the goodbye must reach the interruption path.
+    assert _ignore(hangup_triggered=True, end_call_in_progress=True, interruptible_window=True) is False
+
+
+def test_ended_conversation_ignores_input_even_in_window():
+    # Once the disconnect has committed, the window no longer matters.
+    assert (
+        _ignore(hangup_triggered=True, end_call_in_progress=True, interruptible_window=True, conversation_ended=True)
+        is True
+    )
+
+
 # An interim transcript that crosses the interruption threshold. In the real
 # call this is what fired "Condition for interruption hit" -> __cleanup_downstream_tasks
 # -> "Cancelling LLM Task", killing the in-flight end_call handler.
@@ -46,12 +67,16 @@ _INTERIM_BARGEIN = {
 }
 
 
-def _make_tm(*, end_call_in_progress, hangup_triggered, function_call_in_flight=False):
+def _make_tm(
+    *, end_call_in_progress, hangup_triggered, function_call_in_flight=False, hangup_interruptible_window=False
+):
     tm = MagicMock()
     tm.hangup_triggered = hangup_triggered
     tm._end_call_in_progress = end_call_in_progress
     tm.function_call_in_flight = function_call_in_flight
     tm.has_transfer = False
+    tm.conversation_ended = False
+    tm._hangup_interruptible_window = hangup_interruptible_window
     tm.stream = True
     tm.response_in_pipeline = False
     tm.transcriber_output_queue = asyncio.Queue()
@@ -99,6 +124,19 @@ async def test_bargein_does_not_cancel_turn_during_tool_call():
     tm._TaskManager__cleanup_downstream_tasks.assert_not_called()
 
 
+async def test_bargein_cancels_turn_during_interruptible_goodbye():
+    # Toggle on: mid-goodbye the end_call tool is in flight and hangup is triggered, yet the
+    # barge-in must reach cleanup so the pending hangup is cancelled and the call resumes.
+    tm = _make_tm(
+        end_call_in_progress=True,
+        hangup_triggered=True,
+        function_call_in_flight=True,
+        hangup_interruptible_window=True,
+    )
+    await _drive_with_bargein(tm)
+    tm._TaskManager__cleanup_downstream_tasks.assert_awaited_once()
+
+
 class TestSourceGuards:
     """Catch accidental removal of the wiring that closes the barge-in race."""
 
@@ -112,4 +150,16 @@ class TestSourceGuards:
         src = inspect.getsource(TaskManager._listen_transcriber)
         assert "_should_ignore_transcriber_input" in src, (
             "_listen_transcriber must drop user speech while a hangup/end_call actuation is underway"
+        )
+
+    def test_end_call_branch_opens_window(self):
+        src = inspect.getsource(TaskManager._TaskManager__execute_function_call)
+        assert "_hangup_interruptible_window = True" in src, (
+            "end_call branch must open the interruptible window when the toggle is on"
+        )
+
+    def test_cleanup_cancels_pending_hangup(self):
+        src = inspect.getsource(TaskManager._TaskManager__cleanup_downstream_tasks)
+        assert "_cancel_pending_hangup" in src, (
+            "__cleanup_downstream_tasks must cancel the pending hangup when the window is open"
         )

--- a/tests/test_end_call_bargein_guard.py
+++ b/tests/test_end_call_bargein_guard.py
@@ -7,6 +7,7 @@ never set, and the agent loops goodbyes until the caller drops.
 """
 
 import asyncio
+import pytest
 import inspect
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -48,6 +49,41 @@ def test_processes_input_during_normal_conversation():
 def test_interruptible_window_lets_input_through_despite_hangup():
     # Toggle on: a barge-in during the goodbye must reach the interruption path.
     assert _ignore(hangup_triggered=True, end_call_in_progress=True, interruptible_window=True) is False
+
+
+@pytest.mark.parametrize(
+    "hangup,end_call,transfer,ended,window,expected",
+    [
+        # nothing underway: input always flows, window is irrelevant
+        (False, False, False, False, False, False),
+        (False, False, False, False, True, False),
+        (False, False, False, True, False, False),
+        # hangup underway, no window: the pre-existing lockout
+        (True, False, False, False, False, True),
+        (False, True, False, False, False, True),
+        (True, True, False, False, False, True),
+        # interruptible goodbye: the only combination that lets speech through mid-hangup
+        (True, True, False, False, True, False),
+        (True, False, False, False, True, False),
+        # a committed disconnect always wins over the window
+        (True, True, False, True, True, True),
+        # a transfer is never interruptible, even with the window open
+        (False, False, True, False, False, True),
+        (False, False, True, False, True, True),
+        (True, True, True, False, True, True),
+    ],
+)
+def test_ignore_transcriber_input_truth_table(hangup, end_call, transfer, ended, window, expected):
+    assert (
+        _ignore(
+            hangup_triggered=hangup,
+            end_call_in_progress=end_call,
+            has_transfer=transfer,
+            conversation_ended=ended,
+            interruptible_window=window,
+        )
+        is expected
+    )
 
 
 def test_ended_conversation_ignores_input_even_in_window():

--- a/tests/test_end_call_teardown_self_cancel.py
+++ b/tests/test_end_call_teardown_self_cancel.py
@@ -89,6 +89,7 @@ async def test_end_call_hangup_teardown_is_not_awaited_inline():
     tm.hangup_decision_at = None
     tm.interruption_manager = MagicMock()
     tm.wait_for_current_message = AsyncMock()
+    tm.interruptible_hangup_message = False
 
     hangup_started = asyncio.Event()
 
@@ -121,6 +122,7 @@ async def test_end_call_hangup_failure_is_logged_not_swallowed(caplog):
     tm.hangup_decision_at = None
     tm.interruption_manager = MagicMock()
     tm.wait_for_current_message = AsyncMock()
+    tm.interruptible_hangup_message = False
 
     async def _boom():
         raise RuntimeError("teardown exploded")

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -3,6 +3,7 @@ goodbye keep the call alive instead of disconnecting.
 """
 
 import asyncio
+import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -109,6 +110,41 @@ async def test_never_cancels_the_current_task():
     tm = _target(llm_task=current, hangup_task=current)
     TaskManager._cancel_pending_hangup(tm)
     assert not current.cancelled()
+
+
+async def test_window_closes_even_when_the_goodbye_raises(monkeypatch):
+    # A latched-open window disables the function_call_in_flight defer for the rest of the call.
+    monkeypatch.setattr("bolna.agent_manager.task_manager.convert_to_request_log", lambda *a, **k: None)
+
+    tm = TaskManager.__new__(TaskManager)
+    tm.check_if_user_online = True
+    tm.interruptible_hangup_message = True
+    tm._hangup_interruptible_window = False
+    tm._hangup_cancelled = False
+    tm._end_call_in_progress = False
+    tm.run_id = "run"
+    tm.conversation_history = MagicMock()
+    tm._enter_hangup_state = MagicMock()
+    tm.wait_for_current_message = AsyncMock(side_effect=RuntimeError("tts died mid-goodbye"))
+
+    with pytest.raises(RuntimeError):
+        await TaskManager._TaskManager__execute_function_call(
+            tm,
+            url=None,
+            method=None,
+            param=None,
+            api_token=None,
+            headers=None,
+            model_args=None,
+            meta_info={"turn_id": 1, "response_uid": "u"},
+            next_step="synthesizer",
+            called_fun="end_call",
+            textual_response="Goodbye!",
+            model_response=None,
+            tool_call_id="tc",
+        )
+
+    assert tm._hangup_interruptible_window is False
 
 
 def _cleanup_target():

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -1,7 +1,5 @@
-"""When interruptible_hangup_message is on, a barge-in during the goodbye cancels the pending
-hangup and resumes the call. _cancel_pending_hangup is the synchronous reset that makes the
-resume safe: it stops the goodbye's llm task and the detached hangup task before either can
-commit the disconnect, and clears every hangup flag.
+"""_cancel_pending_hangup is the synchronous reset that lets a barge-in during the end_call
+goodbye keep the call alive instead of disconnecting.
 """
 
 import asyncio
@@ -71,17 +69,13 @@ async def test_cancels_goodbye_and_detached_hangup_tasks():
 
 
 async def test_marks_the_hangup_cancelled_so_end_call_bails_out():
-    """Task cancellation alone does not stop the end_call branch: handle_interruption clears the
-    mark dict, so its playout wait can return normally and arm the teardown anyway. The branch
-    re-checks this flag, so setting it is what actually keeps the rescued call alive.
-    """
+    # The end_call branch re-checks this; task cancellation alone does not stop it.
     tm = _target()
     TaskManager._cancel_pending_hangup(tm)
     assert tm._hangup_cancelled is True
 
 
 async def test_does_not_mark_cancelled_once_conversation_ended():
-    # The disconnect already committed, so the end_call branch must not be told to bail out.
     tm = _target()
     tm.conversation_ended = True
     TaskManager._cancel_pending_hangup(tm)
@@ -89,15 +83,12 @@ async def test_does_not_mark_cancelled_once_conversation_ended():
 
 
 async def test_restores_the_user_online_check_on_resume():
-    # __execute_function_call clears it on entry and the end_call branch returns without restoring,
-    # so without this a resumed call never asks "are you still there" again.
     tm = _target()
     TaskManager._cancel_pending_hangup(tm)
     assert tm.check_if_user_online is True
 
 
 async def test_noop_once_conversation_ended():
-    # A committed disconnect must survive an admitted-late barge-in: the hangup task keeps running.
     hangup_task = asyncio.ensure_future(_forever())
     await asyncio.sleep(0)
     tm = _target(hangup_task=hangup_task)
@@ -114,8 +105,6 @@ async def test_noop_once_conversation_ended():
 
 
 async def test_never_cancels_the_current_task():
-    # _cancel_pending_hangup runs on the transcriber task's stack; it must not cancel a task it
-    # is itself executing inside, or the resume unwinds before it finishes.
     current = asyncio.current_task()
     tm = _target(llm_task=current, hangup_task=current)
     TaskManager._cancel_pending_hangup(tm)
@@ -174,15 +163,12 @@ def _cleanup_target():
 
 
 async def test_cleanup_cancels_goodbye_before_it_can_rearm_the_disconnect():
-    """The keystone race: a barge-in reaches __cleanup_downstream_tasks while the goodbye task is
-    parked in its playout wait. The goodbye must be cancelled before this cleanup's first await,
-    or it resumes during those awaits and arms the disconnect after we chose to keep the call.
-    """
+    # The goodbye must be cancelled before this cleanup's first await, or it resumes and
+    # arms the disconnect anyway.
     tm = _cleanup_target()
     tm._rearmed = False
 
     async def _goodbye_that_would_rearm():
-        # Stand-in for the inline wait_for_current_message resuming and arming the detached hangup.
         for _ in range(10):
             await asyncio.sleep(0)
         tm._rearmed = True
@@ -192,7 +178,6 @@ async def test_cleanup_cancels_goodbye_before_it_can_rearm_the_disconnect():
     await asyncio.sleep(0)  # let the goodbye task start and park
 
     await TaskManager._TaskManager__cleanup_downstream_tasks(tm)
-    # Gathering would run the goodbye to completion (setting _rearmed) had it not been cancelled.
     await asyncio.gather(goodbye, return_exceptions=True)
 
     assert goodbye.cancelled()

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -14,6 +14,7 @@ from bolna.agent_manager.task_manager import TaskManager
 def _target(llm_task=None, hangup_task=None):
     return SimpleNamespace(
         _hangup_interruptible_window=True,
+        _hangup_cancelled=False,
         conversation_ended=False,
         llm_task=llm_task,
         _end_call_hangup_task=hangup_task,
@@ -65,6 +66,24 @@ async def test_cancels_goodbye_and_detached_hangup_tasks():
             pass
     assert llm_task.cancelled()
     assert hangup_task.cancelled()
+
+
+async def test_marks_the_hangup_cancelled_so_end_call_bails_out():
+    """Task cancellation alone does not stop the end_call branch: handle_interruption clears the
+    mark dict, so its playout wait can return normally and arm the teardown anyway. The branch
+    re-checks this flag, so setting it is what actually keeps the rescued call alive.
+    """
+    tm = _target()
+    TaskManager._cancel_pending_hangup(tm)
+    assert tm._hangup_cancelled is True
+
+
+async def test_does_not_mark_cancelled_once_conversation_ended():
+    # The disconnect already committed, so the end_call branch must not be told to bail out.
+    tm = _target()
+    tm.conversation_ended = True
+    TaskManager._cancel_pending_hangup(tm)
+    assert tm._hangup_cancelled is False
 
 
 async def test_noop_once_conversation_ended():

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -16,6 +16,8 @@ def _target(llm_task=None, hangup_task=None):
         _hangup_interruptible_window=True,
         _hangup_cancelled=False,
         conversation_ended=False,
+        conversation_config={"check_if_user_online": True},
+        check_if_user_online=False,
         llm_task=llm_task,
         _end_call_hangup_task=hangup_task,
         hangup_triggered=True,
@@ -86,6 +88,14 @@ async def test_does_not_mark_cancelled_once_conversation_ended():
     assert tm._hangup_cancelled is False
 
 
+async def test_restores_the_user_online_check_on_resume():
+    # __execute_function_call clears it on entry and the end_call branch returns without restoring,
+    # so without this a resumed call never asks "are you still there" again.
+    tm = _target()
+    TaskManager._cancel_pending_hangup(tm)
+    assert tm.check_if_user_online is True
+
+
 async def test_noop_once_conversation_ended():
     # A committed disconnect must survive an admitted-late barge-in: the hangup task keeps running.
     hangup_task = asyncio.ensure_future(_forever())
@@ -116,7 +126,10 @@ def _cleanup_target():
     """A TaskManager with just enough wired up to run the real __cleanup_downstream_tasks."""
     tm = TaskManager.__new__(TaskManager)
     tm._hangup_interruptible_window = True
+    tm._hangup_cancelled = False
     tm.conversation_ended = False
+    tm.conversation_config = {"check_if_user_online": True}
+    tm.check_if_user_online = False
     tm._end_call_hangup_task = None
     tm.hangup_triggered = True
     tm._end_call_in_progress = True

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -1,0 +1,170 @@
+"""When interruptible_hangup_message is on, a barge-in during the goodbye cancels the pending
+hangup and resumes the call. _cancel_pending_hangup is the synchronous reset that makes the
+resume safe: it stops the goodbye's llm task and the detached hangup task before either can
+commit the disconnect, and clears every hangup flag.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from bolna.agent_manager.task_manager import TaskManager
+
+
+def _target(llm_task=None, hangup_task=None):
+    return SimpleNamespace(
+        _hangup_interruptible_window=True,
+        conversation_ended=False,
+        llm_task=llm_task,
+        _end_call_hangup_task=hangup_task,
+        hangup_triggered=True,
+        _end_call_in_progress=True,
+        hangup_message_queued=True,
+        hangup_triggered_at=123.0,
+        hangup_decision_at=123.0,
+        _hangup_processing=True,
+        _end_of_conversation_in_progress=True,
+        hangup_detail="END_CALL_TOOL",
+    )
+
+
+async def _forever():
+    await asyncio.sleep(100)
+
+
+async def test_resets_every_hangup_flag():
+    tm = _target()
+    TaskManager._cancel_pending_hangup(tm)
+
+    assert tm._hangup_interruptible_window is False
+    assert tm.hangup_triggered is False
+    assert tm._end_call_in_progress is False
+    assert tm.hangup_message_queued is False
+    assert tm.hangup_triggered_at is None
+    assert tm.hangup_decision_at is None
+    assert tm._hangup_processing is False
+    assert tm._end_of_conversation_in_progress is False
+    assert tm.hangup_detail is None
+
+
+async def test_cancels_goodbye_and_detached_hangup_tasks():
+    llm_task = asyncio.ensure_future(_forever())
+    hangup_task = asyncio.ensure_future(_forever())
+    await asyncio.sleep(0)  # let both start running
+
+    tm = _target(llm_task=llm_task, hangup_task=hangup_task)
+    TaskManager._cancel_pending_hangup(tm)
+
+    assert tm.llm_task is None
+    assert tm._end_call_hangup_task is None
+
+    for t in (llm_task, hangup_task):
+        try:
+            await t
+        except asyncio.CancelledError:
+            pass
+    assert llm_task.cancelled()
+    assert hangup_task.cancelled()
+
+
+async def test_noop_once_conversation_ended():
+    # A committed disconnect must survive an admitted-late barge-in: the hangup task keeps running.
+    hangup_task = asyncio.ensure_future(_forever())
+    await asyncio.sleep(0)
+    tm = _target(hangup_task=hangup_task)
+    tm.conversation_ended = True
+
+    TaskManager._cancel_pending_hangup(tm)
+
+    assert tm._hangup_interruptible_window is False
+    assert tm.hangup_triggered is True
+    assert tm._end_call_hangup_task is hangup_task
+    assert not hangup_task.cancelled()
+    hangup_task.cancel()
+    await asyncio.gather(hangup_task, return_exceptions=True)
+
+
+async def test_never_cancels_the_current_task():
+    # _cancel_pending_hangup runs on the transcriber task's stack; it must not cancel a task it
+    # is itself executing inside, or the resume unwinds before it finishes.
+    current = asyncio.current_task()
+    tm = _target(llm_task=current, hangup_task=current)
+    TaskManager._cancel_pending_hangup(tm)
+    assert not current.cancelled()
+
+
+def _cleanup_target():
+    """A TaskManager with just enough wired up to run the real __cleanup_downstream_tasks."""
+    tm = TaskManager.__new__(TaskManager)
+    tm._hangup_interruptible_window = True
+    tm.conversation_ended = False
+    tm._end_call_hangup_task = None
+    tm.hangup_triggered = True
+    tm._end_call_in_progress = True
+    tm.hangup_message_queued = True
+    tm.hangup_triggered_at = 1.0
+    tm.hangup_decision_at = 1.0
+    tm._hangup_processing = True
+    tm._end_of_conversation_in_progress = True
+    tm.hangup_detail = "END_CALL_TOOL"
+
+    tm._cancel_in_flight_llm_response = MagicMock()
+    tm.regen_settle_armed = MagicMock(return_value=False)
+    tm.regen_settle_payload = None
+    tm.sync_history = AsyncMock()
+    tm._drop_all_staged_assistant_history = MagicMock()
+    tm.response_in_pipeline = True
+    tm._synthesis_awaiting_first_audio = True
+    tm.output_task = None
+    tm.eager_llm_task = None
+    tm.first_message_task = None
+    tm.synthesizer_tasks = []
+    tm.started_transmitting_audio = True
+    tm.last_transmitted_timestamp = 0
+    tm.buffered_output_queue = asyncio.Queue()
+    tm._turn_audio_flushed = asyncio.Event()
+
+    tm.interruption_manager = MagicMock()
+    tm.mark_event_meta_data = MagicMock()
+    tm.mark_event_meta_data.fetch_cleared_mark_event_data = MagicMock(return_value={})
+    tm.voicemail_handler = SimpleNamespace(cancel_task=lambda: None)
+
+    output = SimpleNamespace(handle_interruption=AsyncMock())
+    synth = SimpleNamespace(handle_interruption=AsyncMock(), flush_synthesizer_stream=AsyncMock())
+    inp = SimpleNamespace(
+        welcome_message_played=MagicMock(return_value=True),
+        reset_response_heard_by_user=MagicMock(),
+        is_welcome_message_played=True,
+    )
+    tm.tools = {"output": output, "synthesizer": synth, "input": inp}
+    tm._TaskManager__process_output_loop = AsyncMock()
+    return tm
+
+
+async def test_cleanup_cancels_goodbye_before_it_can_rearm_the_disconnect():
+    """The keystone race: a barge-in reaches __cleanup_downstream_tasks while the goodbye task is
+    parked in its playout wait. The goodbye must be cancelled before this cleanup's first await,
+    or it resumes during those awaits and arms the disconnect after we chose to keep the call.
+    """
+    tm = _cleanup_target()
+    tm._rearmed = False
+
+    async def _goodbye_that_would_rearm():
+        # Stand-in for the inline wait_for_current_message resuming and arming the detached hangup.
+        for _ in range(10):
+            await asyncio.sleep(0)
+        tm._rearmed = True
+
+    goodbye = asyncio.ensure_future(_goodbye_that_would_rearm())
+    tm.llm_task = goodbye
+    await asyncio.sleep(0)  # let the goodbye task start and park
+
+    await TaskManager._TaskManager__cleanup_downstream_tasks(tm)
+    # Gathering would run the goodbye to completion (setting _rearmed) had it not been cancelled.
+    await asyncio.gather(goodbye, return_exceptions=True)
+
+    assert goodbye.cancelled()
+    assert tm._rearmed is False, "goodbye task resumed and armed the disconnect after the barge-in"
+    assert tm.hangup_triggered is False
+    assert tm._end_call_in_progress is False
+    assert tm._hangup_interruptible_window is False


### PR DESCRIPTION
Adds an opt-in per-agent toggle `interruptible_hangup_message` (`conversation_config`, default `false`). When on, a caller can barge into the agent's `end_call` goodbye: the pending hangup is cancelled and the conversation resumes. Default off keeps today's behaviour exactly.

Scoped to the `end_call` tool goodbye only. Transfer, inactivity/silence, component-error teardown and the S2S goodbye stay non-interruptible.

Mechanism: a window flag opened in the `end_call` branch of `__execute_function_call`, closed once the goodbye has played. While it is open, `_should_ignore_transcriber_input` lets caller speech through and the two `function_call_in_flight` defer sites are exempt (the `end_call` tool result is already recorded, so a barge-in cannot duplicate the tool call). `__cleanup_downstream_tasks` calls `_cancel_pending_hangup` before its first await, cancelling the goodbye llm task and the detached hangup task so neither can resume and commit the disconnect, then resets the hangup flags. A disconnect that has already committed (`conversation_ended`) is never cancelled.

Verified on a test env with an A/B on a single agent, flipping only the toggle: with it off the barge-in never reaches the interruption detector and the agent hangs up via the `end_call` tool; with it on the hangup is cancelled and the call resumes and answers the new question.

Requires the dashboard-backend field to accept the toggle, plus the frontend toggle.
