### PR TITLE
updated keepalive_expiry for azure/ptu-gpt-4-1-mini connection

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.234"
+__version__ = "0.10.235"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/llms/http_client_pool.py
+++ b/bolna/llms/http_client_pool.py
@@ -12,8 +12,16 @@ def get_shared_http_client(base_url: str | None = None, http2: bool = True) -> h
         with _lock:
             client = _pool.get(key)
             if client is None:
-                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=30)
-                client = httpx.AsyncClient(limits=limits, timeout=httpx.Timeout(600.0, connect=10.0), http2=http2)
+                # A pool entry keyed on a low-traffic base_url (e.g. a PTU deployment mostly hit
+                # by a high-volume channel elsewhere) can go idle for minutes between requests on
+                # this key specifically. 30s let a connection outlive whatever silently drops it
+                # first, and a request handed that connection just hung with no exception until
+                # something eventually unstuck it. 10s keeps connections fresher than any idle
+                # timeout we've seen; retries=1 is the backstop for a stale one slipping through
+                # anyway — it fails fast onto a new connection instead of hanging.
+                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=10)
+                transport = httpx.AsyncHTTPTransport(http2=http2, limits=limits, retries=1)
+                client = httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(600.0, connect=10.0))
                 _pool[key] = client
     return client
 

--- a/bolna/llms/http_client_pool.py
+++ b/bolna/llms/http_client_pool.py
@@ -12,14 +12,9 @@ def get_shared_http_client(base_url: str | None = None, http2: bool = True) -> h
         with _lock:
             client = _pool.get(key)
             if client is None:
-                # A pool entry keyed on a low-traffic base_url (e.g. a PTU deployment mostly hit
-                # by a high-volume channel elsewhere) can go idle for minutes between requests on
-                # this key specifically. 30s let a connection outlive whatever silently drops it
-                # first, and a request handed that connection just hung with no exception until
-                # something eventually unstuck it. 10s keeps connections fresher than any idle
-                # timeout we've seen; retries=1 is the backstop for a stale one slipping through
-                # anyway — it fails fast onto a new connection instead of hanging.
-                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=10)
+                # 30s let idle connections go stale and hang silently on reuse; retries=1 is
+                # the backstop if one still slips through.
+                limits = httpx.Limits(max_connections=200, max_keepalive_connections=200, keepalive_expiry=12)
                 transport = httpx.AsyncHTTPTransport(http2=http2, limits=limits, retries=1)
                 client = httpx.AsyncClient(transport=transport, timeout=httpx.Timeout(600.0, connect=10.0))
                 _pool[key] = client

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.234"
+version = "0.10.235"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }


### PR DESCRIPTION
Summary
- Fix ~30s stalls on webchat replies caused by stale pooled HTTP connections
  to Azure PTU deployments in `get_shared_http_client()`.
- Lower `keepalive_expiry` 30s → 10s so idle connections are discarded before
  they can go stale.
- Add `httpx.AsyncHTTPTransport(retries=1, ...)` as a backstop so a stale
  connection that slips through fails fast onto a fresh one instead of
  hanging silently.

Root cause: this pool is process-local and keyed on (base_url, http2).
Calls generate enough traffic per process to keep connections warm; webchat's
much lower per-pod volume lets connections sit idle past the old 30s window,
go stale, and hang on reuse with no visible exception — landing right around
the observed ~30s stalls. Confirmed via ClickHouse: the same PTU deployment
shows 0% of call turns over 25s (176K turns) vs. 7.1% of webchat turns (126
turns) on the same day, ruling out generic deployment capacity as the cause.

12s was chosen from the actual inter-turn gap distribution on webchat
(p50=9.6s, p75=17.7s, p90=32.0s) for past 17 days - p90 lands almost exactly on the observed
stall value, and roughly matches the observed ~7% stall rate. 12s sits just
above the median so typical-paced turns still reuse a warm connection, with
a wide margin below the zone where staleness actually occurs.

Tradeoff
Connections idle 10-30s are now rebuilt instead of reused, costing one extra
TCP/TLS handshake (~10-50ms). Negligible for calls (rarely idle that long);
closes the staleness window for low-traffic channels like webchat.