### PR TITLE
fix: drop a cancelled end_call from history so the agent can hang up again (BOLNA-2680)

### DIFF
--- a/bolna/__init__.py
+++ b/bolna/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.10.237"
+__version__ = "0.10.238"
 
 import os
 from bolna.helpers.logger_config import configure_logger

--- a/bolna/agent_manager/task_manager.py
+++ b/bolna/agent_manager/task_manager.py
@@ -405,6 +405,7 @@ class TaskManager(BaseManager):
         self.interruptible_hangup_message = False
         self._hangup_interruptible_window = False
         self._hangup_cancelled = False
+        self._end_call_tool_call_id = None
         self._end_call_hangup_task = None
         self._turn_audio_flushed = asyncio.Event()
         self._turn_audio_flushed.set()
@@ -3187,6 +3188,7 @@ class TaskManager(BaseManager):
             # cancels the turn task and the disconnect never runs. The toggle opens a window instead.
             self._end_call_in_progress = True
             self._hangup_cancelled = False
+            self._end_call_tool_call_id = resp.get("tool_call_id", "")
             if self.interruptible_hangup_message:
                 self._hangup_interruptible_window = True
             reason = resp.get("reason", "")
@@ -4250,6 +4252,9 @@ class TaskManager(BaseManager):
         self._hangup_processing = False
         self._end_of_conversation_in_progress = False
         self.hangup_detail = None
+        # The call did not end, so the tool result claiming it did must not survive the cancel.
+        self.conversation_history.drop_tool_call(self._end_call_tool_call_id)
+        self._end_call_tool_call_id = None
         # Cleared on entry to __execute_function_call, whose end_call branch never restores it.
         self.check_if_user_online = self.conversation_config.get("check_if_user_online", True)
         logger.info("Interruptible hangup: barge-in cancelled pending hangup, resuming conversation")

--- a/bolna/helpers/conversation_history.py
+++ b/bolna/helpers/conversation_history.py
@@ -133,6 +133,38 @@ class ConversationHistory:
         )
         self.append_assistant(None, tool_calls=tool_calls, turn_id=turn_id)
 
+    def drop_tool_call(self, tool_call_id: str) -> bool:
+        """Erase a tool call and its result, keeping anything the agent actually said.
+
+        A cancelled end_call otherwise leaves "Call is ending now" in history, and the model reads
+        that as already having hung up: it repeats the goodbye and never re-invokes the tool.
+        """
+        if not tool_call_id:
+            return False
+
+        def call_id(call):
+            return call.get("id") if isinstance(call, dict) else getattr(call, "id", None)
+
+        removed = False
+        for messages in (self._messages, self._interim):
+            messages[:] = [m for m in messages if m.get("tool_call_id") != tool_call_id]
+            for index in range(len(messages) - 1, -1, -1):
+                message = messages[index]
+                calls = message.get("tool_calls")
+                if not calls:
+                    continue
+                kept = [c for c in calls if call_id(c) != tool_call_id]
+                if len(kept) == len(calls):
+                    continue
+                removed = True
+                if kept:
+                    message["tool_calls"] = kept
+                elif message.get("content"):
+                    message.pop("tool_calls", None)
+                else:
+                    messages.pop(index)
+        return removed
+
     def update_system_prompt(self, content: str):
         if self._messages and self._messages[0].get("role") == ChatRole.SYSTEM:
             self._messages[0]["content"] = content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bolna"
-version = "0.10.237"
+version = "0.10.238"
 readme = "README.md"
 authors = [
     { name = "Prateek Sachan", email = "ps@prateeksachan.com" }

--- a/tests/test_interruptible_hangup_cancel.py
+++ b/tests/test_interruptible_hangup_cancel.py
@@ -19,6 +19,8 @@ def _target(llm_task=None, hangup_task=None):
         check_if_user_online=False,
         llm_task=llm_task,
         _end_call_hangup_task=hangup_task,
+        _end_call_tool_call_id=None,
+        conversation_history=MagicMock(),
         hangup_triggered=True,
         _end_call_in_progress=True,
         hangup_message_queued=True,
@@ -156,6 +158,8 @@ def _cleanup_target():
     tm.conversation_config = {"check_if_user_online": True}
     tm.check_if_user_online = False
     tm._end_call_hangup_task = None
+    tm._end_call_tool_call_id = None
+    tm.conversation_history = MagicMock()
     tm.hangup_triggered = True
     tm._end_call_in_progress = True
     tm.hangup_message_queued = True

--- a/tests/test_interruptible_hangup_history_repair.py
+++ b/tests/test_interruptible_hangup_history_repair.py
@@ -1,0 +1,115 @@
+"""A cancelled end_call must leave no trace in history.
+
+Prod replay of run 5c5df9f7 showed the model re-invokes end_call 0/8 times while the cancelled
+tool call and its "Call is ending now" result remain, and 8/8 once they are dropped, so the
+caller could not get the agent to hang up.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from bolna.agent_manager.task_manager import TaskManager
+from bolna.enums import ChatRole
+from bolna.helpers.conversation_history import ConversationHistory
+
+TOOL_RESULT = '{"status": "success", "message": "Call is ending now. Say a brief goodbye to the user."}'
+
+
+def _history_with_end_call(call_id="call_1", spoken=None):
+    history = ConversationHistory()
+    history.setup_system_prompt({"role": ChatRole.SYSTEM, "content": "You are Pooja."})
+    history.append_user("no no thank you thank you thank you")
+    history.append_assistant(spoken, turn_id=1)
+    history.attach_tool_calls_to_turn(
+        1, [{"id": call_id, "type": "function", "function": {"name": "end_call", "arguments": "{}"}}]
+    )
+    history.append_tool_result(call_id, TOOL_RESULT)
+    return history
+
+
+def test_drops_the_tool_call_and_its_result():
+    history = _history_with_end_call()
+    assert history.drop_tool_call("call_1") is True
+    assert not any(m.get("tool_call_id") == "call_1" for m in history.messages)
+    assert not any(m.get("tool_calls") for m in history.messages)
+
+
+def test_keeps_a_goodbye_the_agent_actually_spoke():
+    history = _history_with_end_call(spoken="Thank you, goodbye!")
+    history.drop_tool_call("call_1")
+    assert history.last_assistant_content() == "Thank you, goodbye!"
+    assert not any(m.get("tool_calls") for m in history.messages)
+
+
+def test_drops_the_stub_turn_that_only_carried_the_tool_call():
+    history = _history_with_end_call(spoken=None)
+    before = len(history.messages)
+    history.drop_tool_call("call_1")
+    assert len(history.messages) == before - 2
+
+
+def test_leaves_a_sibling_tool_call_on_the_same_turn_alone():
+    history = ConversationHistory()
+    history.append_assistant(None, turn_id=1)
+    history.attach_tool_calls_to_turn(1, [{"id": "a"}, {"id": "b"}])
+    history.append_tool_result("a", "res-a")
+    history.append_tool_result("b", "res-b")
+    history.drop_tool_call("a")
+    assert [c["id"] for m in history.messages for c in (m.get("tool_calls") or [])] == ["b"]
+    assert any(m.get("tool_call_id") == "b" for m in history.messages)
+
+
+def test_is_a_noop_for_an_unknown_or_blank_id():
+    history = _history_with_end_call()
+    assert history.drop_tool_call("") is False
+    assert history.drop_tool_call("nope") is False
+    assert history.drop_tool_call("call_1") is True
+    assert history.drop_tool_call("call_1") is False
+
+
+def test_repair_also_applies_to_the_interim_copy():
+    history = _history_with_end_call()
+    history.sync_interim(history.get_copy())
+    history.drop_tool_call("call_1")
+    assert not any(m.get("tool_call_id") == "call_1" for m in history.interim)
+
+
+def _cancel_target(history):
+    return SimpleNamespace(
+        _hangup_interruptible_window=True,
+        _hangup_cancelled=False,
+        conversation_ended=False,
+        conversation_config={"check_if_user_online": True},
+        check_if_user_online=False,
+        llm_task=None,
+        _end_call_hangup_task=None,
+        _end_call_tool_call_id="call_1",
+        conversation_history=history,
+        hangup_triggered=True,
+        _end_call_in_progress=True,
+        hangup_message_queued=True,
+        hangup_triggered_at=1.0,
+        hangup_decision_at=1.0,
+        _hangup_processing=True,
+        _end_of_conversation_in_progress=True,
+        hangup_detail="END_CALL_TOOL",
+    )
+
+
+async def test_cancelling_the_hangup_repairs_history():
+    history = _history_with_end_call(spoken="Thank you, goodbye!")
+    target = _cancel_target(history)
+    TaskManager._cancel_pending_hangup(target)
+
+    assert not any(m.get("tool_calls") for m in history.messages)
+    assert not any(m.get("tool_call_id") == "call_1" for m in history.messages)
+    assert history.last_assistant_content() == "Thank you, goodbye!"
+    assert target._end_call_tool_call_id is None
+
+
+async def test_cancel_survives_a_missing_tool_call_id():
+    target = _cancel_target(_history_with_end_call())
+    target._end_call_tool_call_id = ""
+    target.conversation_history = MagicMock()
+    TaskManager._cancel_pending_hangup(target)
+    assert target.hangup_triggered is False


### PR DESCRIPTION
When an interruptible hangup is cancelled by a barge-in, the `end_call` tool call and its result stay in the conversation history. That result says `"Call is ending now. Say a brief goodbye to the user."`, which is no longer true: the call did not end. The model reads it as already having hung up, so it repeats the goodbye line on every later turn and never re-invokes the tool.

Callers hit this asking repeatedly to be disconnected ("phone cut कर दो", "can you please cut the call") while the agent kept saying goodbye.

`ConversationHistory.drop_tool_call` erases the cancelled call and its result while keeping anything the agent actually spoke, and `_cancel_pending_hangup` calls it. Sibling tool calls on the same turn are untouched, and the interim copy is repaired alongside the committed history.

Inert unless `interruptible_hangup_message` is on, since nothing else calls it.