### PR TITLE
fix(security): SSRF-guard the graph routing base_url

### DIFF
--- a/bolna/agent_types/graph_agent.py
+++ b/bolna/agent_types/graph_agent.py
@@ -74,6 +74,8 @@ class GraphAgent(BaseAgent):
         self.llm_key = self.config.get("llm_key") or os.getenv("OPENAI_API_KEY")
         self.base_url = self.config.get("base_url")
         self._base_url_validated = False
+        self._routing_base_url = None
+        self._routing_base_url_validated = False
 
         self.node_history = [self.current_node_id]
         self.current_node_entry_index = 0
@@ -292,6 +294,7 @@ class GraphAgent(BaseAgent):
             routing_kwargs["overflow_llm"] = self.config["overflow_llm"]
 
         self._routing_reasoning_effort_used = routing_kwargs.get("reasoning_effort")
+        self._routing_base_url = routing_kwargs.get("base_url")
         self.routing_llm = llm_class(**routing_kwargs)
         logger.info(f"Routing initialized with {self.routing_provider} ({self.routing_model})")
 
@@ -870,6 +873,11 @@ class GraphAgent(BaseAgent):
             user_message = history[-1].get("content", "") if history else ""
             if user_message:
                 messages.append({"role": "user", "content": user_message})
+
+        # The conversation base_url is guarded in generate(); routing carries its own.
+        if self._routing_base_url and not self._routing_base_url_validated:
+            await guard_llm_base_url(self._routing_base_url)
+            self._routing_base_url_validated = True
 
         try:
             result = await self.routing_llm.route(messages, tools)

--- a/tests/test_graph_routing_base_url_ssrf.py
+++ b/tests/test_graph_routing_base_url_ssrf.py
@@ -1,0 +1,109 @@
+"""The routing hop's base_url goes through the same SSRF guard as the conversation's.
+
+generate() validates the conversation base_url before any outbound call. Routing carries
+a separate customer-supplied URL, set either as routing_base_url or copied from the
+conversation config, and that one reached the wire unchecked, so a config naming the
+cloud metadata endpoint for routing got the request the conversation LLM is refused.
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bolna.agent_types.graph_agent import GraphAgent
+from bolna.helpers.function_calling_helpers import SSRFError
+
+PLATFORM_ENV = {"OPENAI_API_KEY": "platform-openai-key"}
+
+NODES = [
+    {
+        "id": "start",
+        "prompt": "hi",
+        "edges": [{"to_node_id": "next", "condition": "caller says yes", "function_description": "go next"}],
+    },
+    {"id": "next", "prompt": "bye", "edges": []},
+]
+
+
+def _build(**config_overrides):
+    config = {
+        "agent_information": "Test agent",
+        "model": "gpt-4o-mini",
+        "provider": "openai",
+        "llm_key": "conv-key",
+        "current_node_id": "start",
+        "nodes": NODES,
+    }
+    config.update(config_overrides)
+
+    def make(**kwargs):
+        client = MagicMock()
+        client.captured_kwargs = kwargs
+        client.route = AsyncMock(return_value=None)
+        return client
+
+    with (
+        patch.dict(os.environ, PLATFORM_ENV, clear=True),
+        patch("bolna.agent_types.graph_agent.SUPPORTED_LLM_PROVIDERS", {"openai": make, "custom": make}),
+        patch("bolna.agent_types.graph_agent.OpenAiLLM", side_effect=make),
+    ):
+        return GraphAgent(config)
+
+
+async def _route(agent):
+    node = agent.get_node_by_id("start")
+    return await agent._decide_next_node_llm(node, node["edges"], [{"role": "user", "content": "yes"}], 0.0)
+
+
+@pytest.mark.asyncio
+async def test_a_routing_base_url_is_validated_before_the_routing_call():
+    agent = _build(routing_provider="custom", routing_base_url="http://169.254.169.254/latest/meta-data/")
+
+    with patch(
+        "bolna.agent_types.graph_agent.guard_llm_base_url",
+        AsyncMock(side_effect=SSRFError("Blocked outbound request to a non-public LLM endpoint")),
+    ) as guard:
+        with pytest.raises(SSRFError):
+            await _route(agent)
+
+    guard.assert_awaited_once_with("http://169.254.169.254/latest/meta-data/")
+    agent.routing_llm.route.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_an_allowed_routing_base_url_reaches_the_routing_call():
+    agent = _build(routing_provider="custom", routing_base_url="https://router.example.com/v1")
+
+    with patch("bolna.agent_types.graph_agent.guard_llm_base_url", AsyncMock()) as guard:
+        await _route(agent)
+        await _route(agent)
+
+    guard.assert_awaited_once_with("https://router.example.com/v1")  # validated once, then cached
+    assert agent.routing_llm.route.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_a_base_url_inherited_from_the_conversation_is_validated_too():
+    """Routing copies the conversation credentials when it shares its provider, and that
+    copy is what the routing client dials."""
+    agent = _build(provider="custom", base_url="http://10.0.0.5:8000/v1", routing_provider="custom")
+
+    with patch(
+        "bolna.agent_types.graph_agent.guard_llm_base_url", AsyncMock(side_effect=SSRFError("blocked"))
+    ) as guard:
+        with pytest.raises(SSRFError):
+            await _route(agent)
+
+    guard.assert_awaited_once_with("http://10.0.0.5:8000/v1")
+
+
+@pytest.mark.asyncio
+async def test_routing_without_a_base_url_calls_no_guard():
+    agent = _build()
+
+    with patch("bolna.agent_types.graph_agent.guard_llm_base_url", AsyncMock()) as guard:
+        await _route(agent)
+
+    guard.assert_not_awaited()
+    agent.routing_llm.route.assert_awaited_once()


### PR DESCRIPTION
#988 put an SSRF guard in front of the customer-supplied LLM `base_url`, and `generate()` runs it before anything goes out:

```python
is_custom = (self.config.get("provider") or self.config.get("llm_provider")) == "custom"
if is_custom and self.base_url and not self._base_url_validated:
    await guard_llm_base_url(self.base_url)
    self._base_url_validated = True
```

The routing hop dials a different URL. `_initialize_routing` builds the routing client from its own credentials:

```python
explicit_routing_creds = {
    "llm_key": self.config.get("routing_llm_key"),
    "base_url": self.config.get("routing_base_url"),
    "api_version": self.config.get("routing_api_version"),
}
```

`routing_base_url` appears in exactly two places in the tree, this one and the injection in `task_manager.py`, and neither passes it to `guard_llm_base_url` or `validate_outbound_url`. So the URL the routing client dials never reaches the guard, and the same address the conversation LLM is refused is accepted for routing:

```yaml
routing_provider: custom
routing_base_url: http://169.254.169.254/latest/meta-data/
```

The other half of the same branch has the same hole. When routing shares the conversation's provider it copies `self.config["base_url"]` into `routing_kwargs`, and routing can reach the wire on a turn where `generate()`'s guard has not run.

Worth saying plainly: this needs an agent config the operator already controls, so it is a privilege boundary between whoever authors agent configs and the host, not an anonymous internet path. That is the same boundary #988 decided was worth guarding.

## The change

Remember the `base_url` the routing client was actually built with, and validate it once before the routing call, which is the single place `routing_llm.route(...)` is reached. Same guard, same validated-once caching as the conversation path.

One deliberate difference: the conversation guard only fires when the provider is `custom`, and I did not copy that condition. `routing_base_url` is applied whatever `routing_provider` says, so gating on `custom` would leave `routing_provider: openai` with a metadata-endpoint `routing_base_url` still open, which is the case most worth closing. Guarding a legitimate provider URL costs one cached DNS resolution and passes. A deployment that really does route to an internal address has `BOLNA_TOOL_URL_HOST_ALLOWLIST`, same as it already does for a custom conversation `base_url`.

## Tests

`tests/test_graph_routing_base_url_ssrf.py`, four cases: an explicit `routing_base_url` is validated and the routing call never happens when it is blocked, an allowed one is validated once across two turns and reaches the call, a `base_url` inherited from the conversation is validated too, and routing without any `base_url` calls no guard so the fix does not add a resolution where there is nothing to check.

Three fail on `master`. The fourth passes there and is the guard against over-fixing.

Those two failures are `test_ssrf_validation.py::test_allows_public_ip_literals`, and they fail the same way on a clean `master` here (1612 passed, 2 failed). My network resolves `1.1.1.1` through NAT64 to `64:ff9b::101:101`, which the guard correctly reads as non-public. Nothing to do with this change, and they pass when that file runs on its own.
